### PR TITLE
Add over-the-air software updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "icon-import"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "image"
@@ -187,14 +187,14 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kobo-abi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "kobo-audiobook"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-doc",
  "kobo-json",
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-brief"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-chat"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-image",
  "kobo-net",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-html",
  "miniz_oxide 0.9.1",
@@ -238,7 +238,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doctor"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -246,14 +246,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-gallery"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-guard"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gutenbird"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-hal"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-abi",
  "kobo-doc",
@@ -284,21 +284,21 @@ dependencies = [
 
 [[package]]
 name = "kobo-handoff"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-hello"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-hn"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -308,22 +308,22 @@ dependencies = [
 
 [[package]]
 name = "kobo-html"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "kobo-image"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "image",
 ]
 
 [[package]]
 name = "kobo-json"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "kobo-launcher"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-magnet"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-net"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "http",
  "httparse",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-policy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-abi",
  "kobo-protocol",
@@ -359,18 +359,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-profile"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "kobo-protocol"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-ui",
 ]
 
 [[package]]
 name = "kobo-read"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-doc",
  "kobo-sdk",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-rss"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sdk"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-policy",
  "kobo-protocol",
@@ -399,14 +399,15 @@ dependencies = [
 
 [[package]]
 name = "kobo-settings"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
+ "kobo-json",
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-shell"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-abi",
  "kobo-policy",
@@ -415,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekick"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -424,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekickd"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -432,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sim"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-net",
  "kobo-policy",
@@ -445,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-smoke"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -454,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tap"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -463,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-term"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-ui",
  "vt100",
@@ -471,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-terminal"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-policy",
  "kobo-sdk",
@@ -482,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-text"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "fontdue",
  "kobo-ui",
@@ -492,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tictactoe"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -500,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-todo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -508,11 +509,11 @@ dependencies = [
 
 [[package]]
 name = "kobo-ui"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "kobod"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-abi",
  "kobo-hal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.85"
 license = "AGPL-3.0-only"

--- a/crates/kobo-abi/src/lib.rs
+++ b/crates/kobo-abi/src/lib.rs
@@ -651,6 +651,12 @@ pub mod sandbox {
 
         /// Enters the prepared sandbox in the freshly forked child.
         ///
+        /// # Errors
+        ///
+        /// Returns the operating system's error when any step of the descent
+        /// is refused: the process group, the root change, the privilege
+        /// ceiling, the syscall filter or the identity drop.
+        ///
         /// # Safety
         ///
         /// This must only run from `Command::pre_exec`: it changes the process
@@ -720,6 +726,13 @@ pub mod sandbox {
             }
         }
 
+        /// A syscall number as the 32-bit immediate a BPF instruction holds.
+        /// Every number this filter names is far below the ceiling; the
+        /// fallback matches no syscall, like the length clamp below it.
+        fn syscall(number: libc::c_long) -> u32 {
+            u32::try_from(number).unwrap_or(u32::MAX)
+        }
+
         // seccomp_data.nr is at byte 0 and args[0] at byte 16 on the little-
         // endian ARM and x86 Linux targets supported by this workspace. SDK
         // applications are single-process event loops; their asynchronous work
@@ -728,15 +741,15 @@ pub mod sandbox {
         // behind without changing any shipped application.
         let filter = [
             statement(LD_W_ABS, 0),
-            jump(libc::SYS_socket as u32, 9, 0),
-            jump(libc::SYS_setsid as u32, 10, 0),
-            jump(libc::SYS_setpgid as u32, 9, 0),
-            jump(libc::SYS_unshare as u32, 8, 0),
-            jump(libc::SYS_setns as u32, 7, 0),
-            jump(libc::SYS_fork as u32, 6, 0),
-            jump(libc::SYS_vfork as u32, 5, 0),
-            jump(libc::SYS_clone as u32, 4, 0),
-            jump(libc::SYS_clone3 as u32, 3, 0),
+            jump(syscall(libc::SYS_socket), 9, 0),
+            jump(syscall(libc::SYS_setsid), 10, 0),
+            jump(syscall(libc::SYS_setpgid), 9, 0),
+            jump(syscall(libc::SYS_unshare), 8, 0),
+            jump(syscall(libc::SYS_setns), 7, 0),
+            jump(syscall(libc::SYS_fork), 6, 0),
+            jump(syscall(libc::SYS_vfork), 5, 0),
+            jump(syscall(libc::SYS_clone), 4, 0),
+            jump(syscall(libc::SYS_clone3), 3, 0),
             statement(RET_K, libc::SECCOMP_RET_ALLOW),
             statement(LD_W_ABS, 16),
             jump(libc::AF_UNIX as u32, 1, 0),

--- a/crates/kobo-guard/src/main.rs
+++ b/crates/kobo-guard/src/main.rs
@@ -252,11 +252,7 @@ impl fmt::Display for Outcome {
 /// input is detached as well, so a child can never consume the owner's SSH
 /// session out from under the guardian.
 fn supervise(request: &Request) -> Result<Outcome, String> {
-    let mut child = Command::new(&request.program)
-        .env_clear()
-        .stdin(Stdio::null())
-        .spawn()
-        .map_err(|error| format!("start {}: {error}", request.program))?;
+    let mut child = start(&request.program)?;
 
     let deadline = Instant::now() + request.timeout;
     loop {
@@ -277,6 +273,36 @@ fn supervise(request: &Request) -> Result<Outcome, String> {
         sleep(POLL_INTERVAL);
     }
 }
+
+/// Starts the program, riding out the one refusal that cures itself.
+///
+/// "Text file busy" means some other process still holds the executable open
+/// for writing — an installer finishing a copy, or on a busy host a child
+/// forked between another thread's write and its exec. The writer is done in
+/// a moment, so a short retry is the difference between a supervisor that
+/// works and one that fails by timing.
+fn start(program: &str) -> Result<Child, String> {
+    let deadline = Instant::now() + KILL_GRACE;
+    loop {
+        let refused = match Command::new(program)
+            .env_clear()
+            .stdin(Stdio::null())
+            .spawn()
+        {
+            Ok(child) => return Ok(child),
+            Err(error) => error,
+        };
+        let busy = refused.raw_os_error() == Some(TEXT_FILE_BUSY);
+        if !busy || Instant::now() >= deadline {
+            return Err(format!("start {program}: {refused}"));
+        }
+        sleep(POLL_INTERVAL);
+    }
+}
+
+/// ETXTBSY, without pulling a crate in for one number. It is 26 on Linux,
+/// where the guardian runs, and 26 on the host this is tested on.
+const TEXT_FILE_BUSY: i32 = 26;
 
 /// Stops exactly the child this process created.
 ///

--- a/crates/kobo-net/src/lib.rs
+++ b/crates/kobo-net/src/lib.rs
@@ -27,6 +27,7 @@
 pub mod gzip;
 pub mod pem;
 pub mod serve;
+pub mod sha256;
 
 use kobo_protocol::{Credential, SecretHeader, TaskError};
 use std::borrow::Cow;

--- a/crates/kobo-net/src/sha256.rs
+++ b/crates/kobo-net/src/sha256.rs
@@ -1,0 +1,196 @@
+//! A small, dependency-free SHA-256.
+//!
+//! Hashing is done in process so a downloaded artifact can be verified
+//! against its published digest before anything is written to disk, and so
+//! the workspace keeps its zero-dependency guarantee.
+
+const ROUND_CONSTANTS: [u32; 64] = [
+    0x428a_2f98,
+    0x7137_4491,
+    0xb5c0_fbcf,
+    0xe9b5_dba5,
+    0x3956_c25b,
+    0x59f1_11f1,
+    0x923f_82a4,
+    0xab1c_5ed5,
+    0xd807_aa98,
+    0x1283_5b01,
+    0x2431_85be,
+    0x550c_7dc3,
+    0x72be_5d74,
+    0x80de_b1fe,
+    0x9bdc_06a7,
+    0xc19b_f174,
+    0xe49b_69c1,
+    0xefbe_4786,
+    0x0fc1_9dc6,
+    0x240c_a1cc,
+    0x2de9_2c6f,
+    0x4a74_84aa,
+    0x5cb0_a9dc,
+    0x76f9_88da,
+    0x983e_5152,
+    0xa831_c66d,
+    0xb003_27c8,
+    0xbf59_7fc7,
+    0xc6e0_0bf3,
+    0xd5a7_9147,
+    0x06ca_6351,
+    0x1429_2967,
+    0x27b7_0a85,
+    0x2e1b_2138,
+    0x4d2c_6dfc,
+    0x5338_0d13,
+    0x650a_7354,
+    0x766a_0abb,
+    0x81c2_c92e,
+    0x9272_2c85,
+    0xa2bf_e8a1,
+    0xa81a_664b,
+    0xc24b_8b70,
+    0xc76c_51a3,
+    0xd192_e819,
+    0xd699_0624,
+    0xf40e_3585,
+    0x106a_a070,
+    0x19a4_c116,
+    0x1e37_6c08,
+    0x2748_774c,
+    0x34b0_bcb5,
+    0x391c_0cb3,
+    0x4ed8_aa4a,
+    0x5b9c_ca4f,
+    0x682e_6ff3,
+    0x748f_82ee,
+    0x78a5_636f,
+    0x84c8_7814,
+    0x8cc7_0208,
+    0x90be_fffa,
+    0xa450_6ceb,
+    0xbef9_a3f7,
+    0xc671_78f2,
+];
+
+const INITIAL_STATE: [u32; 8] = [
+    0x6a09_e667,
+    0xbb67_ae85,
+    0x3c6e_f372,
+    0xa54f_f53a,
+    0x510e_527f,
+    0x9b05_688c,
+    0x1f83_d9ab,
+    0x5be0_cd19,
+];
+
+/// Returns the lowercase hexadecimal SHA-256 digest of `message`.
+#[must_use]
+pub fn hex_digest(message: &[u8]) -> String {
+    let mut state = INITIAL_STATE;
+    for chunk in padded(message).chunks_exact(64) {
+        compress(&mut state, chunk);
+    }
+
+    let mut digest = String::with_capacity(64);
+    for word in state {
+        for byte in word.to_be_bytes() {
+            digest.push(char::from(b"0123456789abcdef"[usize::from(byte >> 4)]));
+            digest.push(char::from(b"0123456789abcdef"[usize::from(byte & 0x0f)]));
+        }
+    }
+    digest
+}
+
+fn padded(message: &[u8]) -> Vec<u8> {
+    let bit_length = (message.len() as u64).wrapping_mul(8);
+    let mut blocks = message.to_vec();
+    blocks.push(0x80);
+    while blocks.len() % 64 != 56 {
+        blocks.push(0);
+    }
+    blocks.extend_from_slice(&bit_length.to_be_bytes());
+    blocks
+}
+
+fn schedule(chunk: &[u8]) -> [u32; 64] {
+    let mut words = [0_u32; 64];
+    for (index, word) in chunk.chunks_exact(4).enumerate() {
+        words[index] = u32::from_be_bytes([word[0], word[1], word[2], word[3]]);
+    }
+    for index in 16..64 {
+        let previous = words[index - 15];
+        let recent = words[index - 2];
+        let sigma0 = previous.rotate_right(7) ^ previous.rotate_right(18) ^ (previous >> 3);
+        let sigma1 = recent.rotate_right(17) ^ recent.rotate_right(19) ^ (recent >> 10);
+        words[index] = words[index - 16]
+            .wrapping_add(sigma0)
+            .wrapping_add(words[index - 7])
+            .wrapping_add(sigma1);
+    }
+    words
+}
+
+fn compress(state: &mut [u32; 8], chunk: &[u8]) {
+    let words = schedule(chunk);
+    let mut working = *state;
+    for (index, word) in words.iter().enumerate() {
+        let [alpha, beta, gamma, delta, epsilon, zeta, eta, theta] = working;
+        let sum1 = epsilon.rotate_right(6) ^ epsilon.rotate_right(11) ^ epsilon.rotate_right(25);
+        let choose = (epsilon & zeta) ^ ((!epsilon) & eta);
+        let temp1 = theta
+            .wrapping_add(sum1)
+            .wrapping_add(choose)
+            .wrapping_add(ROUND_CONSTANTS[index])
+            .wrapping_add(*word);
+        let sum0 = alpha.rotate_right(2) ^ alpha.rotate_right(13) ^ alpha.rotate_right(22);
+        let majority = (alpha & beta) ^ (alpha & gamma) ^ (beta & gamma);
+        working = [
+            temp1.wrapping_add(sum0.wrapping_add(majority)),
+            alpha,
+            beta,
+            gamma,
+            delta.wrapping_add(temp1),
+            epsilon,
+            zeta,
+            eta,
+        ];
+    }
+    for (slot, value) in state.iter_mut().zip(working) {
+        *slot = slot.wrapping_add(value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hex_digest;
+
+    #[test]
+    fn matches_the_published_test_vectors() {
+        assert_eq!(
+            hex_digest(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            hex_digest(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(
+            hex_digest(b"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"),
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"
+        );
+        assert_eq!(
+            hex_digest(&vec![0x61_u8; 1_000_000]),
+            "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0"
+        );
+    }
+
+    #[test]
+    fn digests_are_always_sixty_four_lowercase_hex_characters() {
+        for length in [0_usize, 1, 55, 56, 63, 64, 65, 1000] {
+            let digest = hex_digest(&vec![0x5a_u8; length]);
+            assert_eq!(digest.len(), 64);
+            assert!(digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)));
+        }
+    }
+}

--- a/crates/kobo-net/src/sha256.rs
+++ b/crates/kobo-net/src/sha256.rs
@@ -83,10 +83,18 @@ const INITIAL_STATE: [u32; 8] = [
 ];
 
 /// Returns the lowercase hexadecimal SHA-256 digest of `message`.
+///
+/// The message is read in place; the only allocation is the final block or
+/// two of padding, so hashing a whole downloaded archive costs no second
+/// copy of it.
 #[must_use]
 pub fn hex_digest(message: &[u8]) -> String {
     let mut state = INITIAL_STATE;
-    for chunk in padded(message).chunks_exact(64) {
+    let whole = message.len() - message.len() % 64;
+    for chunk in message[..whole].chunks_exact(64) {
+        compress(&mut state, chunk);
+    }
+    for chunk in tail(&message[whole..], message.len()).chunks_exact(64) {
         compress(&mut state, chunk);
     }
 
@@ -100,9 +108,12 @@ pub fn hex_digest(message: &[u8]) -> String {
     digest
 }
 
-fn padded(message: &[u8]) -> Vec<u8> {
-    let bit_length = (message.len() as u64).wrapping_mul(8);
-    let mut blocks = message.to_vec();
+/// The padded end of a message: whatever bytes did not fill a block, the
+/// 0x80 marker, zeros up to the length field, and the whole message's length
+/// in bits. At most two blocks, whatever the message weighed.
+fn tail(rest: &[u8], total: usize) -> Vec<u8> {
+    let bit_length = (total as u64).wrapping_mul(8);
+    let mut blocks = rest.to_vec();
     blocks.push(0x80);
     while blocks.len() % 64 != 56 {
         blocks.push(0);

--- a/crates/kobo-policy/src/services.rs
+++ b/crates/kobo-policy/src/services.rs
@@ -273,6 +273,12 @@ impl DeviceServices {
             | DeviceRequest::SeekAudio { .. }
             | DeviceRequest::StopAudio
             | DeviceRequest::SetAudioVolume { .. }) => self.handle_audio(&request),
+            // Only a real reader has an installation to replace; the daemon
+            // answers this itself before the policy fallback is consulted.
+            DeviceRequest::Update { .. } => DeviceResult::Denied(
+                self.refusal(Capability::Network)
+                    .unwrap_or(DenyReason::Unsupported),
+            ),
         }
     }
 
@@ -523,6 +529,10 @@ fn request_capability(request: &DeviceRequest) -> Capability {
         | DeviceRequest::SeekAudio { .. }
         | DeviceRequest::StopAudio
         | DeviceRequest::SetAudioVolume { .. } => Capability::BluetoothAudio,
+        // An update is fetched from the network and applied to the
+        // installation the requester is already running from, so the network
+        // permission is the one that governs it.
+        DeviceRequest::Update { .. } => Capability::Network,
     }
 }
 

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -880,6 +880,14 @@ pub enum DeviceRequest {
     StopAudio,
     /// Set software playback volume as a percentage.
     SetAudioVolume { percent: u8 },
+    /// Replace the installed Cobalt with a downloaded release archive.
+    ///
+    /// The runtime fetches `url`, refuses the bytes unless their SHA-256
+    /// digest is exactly `sha256`, unpacks them beside the install and swaps
+    /// the folders, keeping the old install for one step of rollback. The
+    /// root filesystem is never written, so the worst a bad archive can do
+    /// is fail to start; the reader itself cannot be harmed.
+    Update { url: String, sha256: String },
 }
 
 /// Everything the gauge publishes that is worth putting in front of a reader.
@@ -1109,6 +1117,8 @@ pub enum DeviceError {
     Unreachable = 4,
     InvalidInput = 5,
     Backend = 6,
+    /// Downloaded bytes did not match the digest they were promised under.
+    Integrity = 7,
 }
 
 impl DeviceError {
@@ -1121,6 +1131,7 @@ impl DeviceError {
             Self::Unreachable => "the device or network is unreachable",
             Self::InvalidInput => "the address or credentials are invalid",
             Self::Backend => "the system radio service failed",
+            Self::Integrity => "the download did not match its published digest",
         }
     }
 }
@@ -1142,6 +1153,7 @@ impl TryFrom<u8> for DeviceError {
             4 => Ok(Self::Unreachable),
             5 => Ok(Self::InvalidInput),
             6 => Ok(Self::Backend),
+            7 => Ok(Self::Integrity),
             _ => Err(ProtocolError::InvalidValue("device error")),
         }
     }
@@ -1915,8 +1927,29 @@ fn encode_device_request(
         DeviceRequest::SetAudioVolume { .. } => {
             return Err(ProtocolError::InvalidValue("audio volume"));
         }
+        DeviceRequest::Update { url, sha256 } => {
+            if !url.starts_with("https://") || url.len() > MAX_URL_LEN {
+                return Err(ProtocolError::InvalidValue("update url"));
+            }
+            if !is_hex_digest(sha256) {
+                return Err(ProtocolError::InvalidValue("update digest"));
+            }
+            output.push(31);
+            push_string(output, url)?;
+            push_string(output, sha256)?;
+        }
     }
     Ok(())
+}
+
+/// Sixty-four lowercase hex characters: the only shape a SHA-256 hex digest
+/// has. Checked at both ends of the wire, so a digest that cannot possibly
+/// match anything is refused before a download is spent on it.
+fn is_hex_digest(digest: &str) -> bool {
+    digest.len() == 64
+        && digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
 }
 
 fn fixed_device_request(output: &mut Vec<u8>, tag: u8, argument: u32) {
@@ -2124,8 +2157,23 @@ fn decode_device_request(reader: &mut Reader<'_>) -> Result<DeviceRequest, Proto
                 Err(ProtocolError::InvalidValue("audio volume"))
             }
         }
+        31 => decode_update(reader),
         _ => Err(ProtocolError::InvalidValue("device request")),
     }
+}
+
+/// Both fields are checked here as well as at the encoder, so a peer that
+/// skipped the encoder cannot hand the runtime an unverifiable job.
+fn decode_update(reader: &mut Reader<'_>) -> Result<DeviceRequest, ProtocolError> {
+    let url = reader.string()?;
+    if !url.starts_with("https://") || url.len() > MAX_URL_LEN {
+        return Err(ProtocolError::InvalidValue("update url"));
+    }
+    let sha256 = reader.string()?;
+    if !is_hex_digest(&sha256) {
+        return Err(ProtocolError::InvalidValue("update digest"));
+    }
+    Ok(DeviceRequest::Update { url, sha256 })
 }
 
 fn fixed_argument(reader: &mut Reader<'_>, expected: u32) -> Result<(), ProtocolError> {
@@ -4982,6 +5030,10 @@ mod tests {
             DeviceRequest::SetAudioVolume { percent: 65 },
             DeviceRequest::ReadBatteryDetail,
             DeviceRequest::ReadCover,
+            DeviceRequest::Update {
+                url: "https://github.com/o/r/releases/download/v0.1.1/KoboRoot.tgz".to_owned(),
+                sha256: "a".repeat(64),
+            },
         ];
         for request in requests {
             let frame = Frame {
@@ -4990,6 +5042,31 @@ mod tests {
             };
             let bytes = encode(&frame).expect("encode");
             assert_eq!(decode(&bytes).expect("decode"), frame);
+        }
+    }
+
+    #[test]
+    fn an_update_that_could_not_be_verified_is_refused_at_the_encoder() {
+        let cases = [
+            // Plaintext could be rewritten in flight, digest or no digest.
+            ("http://github.com/a.tgz".to_owned(), "a".repeat(64)),
+            // A digest of the wrong length matches nothing.
+            ("https://github.com/a.tgz".to_owned(), "a".repeat(63)),
+            // Uppercase is somebody's formatting, not this wire's.
+            (
+                "https://github.com/a.tgz".to_owned(),
+                format!("{}F", "a".repeat(63)),
+            ),
+        ];
+        for (url, sha256) in cases {
+            let frame = Frame {
+                request_id: 9,
+                message: Message::DeviceRequest(DeviceRequest::Update {
+                    url: url.clone(),
+                    sha256,
+                }),
+            };
+            assert!(encode(&frame).is_err(), "{url} was encoded");
         }
     }
 
@@ -5049,6 +5126,7 @@ mod tests {
                 volume: 70,
             },
             DeviceResult::Failed(DeviceError::Authentication),
+            DeviceResult::Failed(DeviceError::Integrity),
             DeviceResult::BatteryDetail(BatteryDetail {
                 percent: Some(28),
                 status: Some("Discharging".to_owned()),

--- a/crates/kobo-sdk/src/audio.rs
+++ b/crates/kobo-sdk/src/audio.rs
@@ -814,7 +814,12 @@ fn audio_error(error: DeviceError) -> &'static str {
         DeviceError::InvalidInput => "This audio source is not a supported bounded MP3 or MP3Z",
         DeviceError::NotFound => "The audio source is no longer on this device",
         DeviceError::TimedOut => "The Bluetooth audio service stopped responding",
-        DeviceError::Authentication | DeviceError::Backend => "Audio playback failed",
+        // Integrity is spelled out rather than folded into a wildcard so
+        // that the next device error added is routed here deliberately. An
+        // audio load never verifies a digest, so this is unreachable today.
+        DeviceError::Authentication | DeviceError::Backend | DeviceError::Integrity => {
+            "Audio playback failed"
+        }
     }
 }
 

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -978,24 +978,22 @@ impl ScreenBuilder {
         N: AsRef<str>,
         L: Into<String>,
     {
-        let actions: Vec<(String, String)> = actions
+        let mut actions = actions
             .into_iter()
             .take(MAX_BAND_SLOTS)
-            .map(|(name, label)| (name.as_ref().to_owned(), label.into()))
-            .collect();
-        match actions.len() {
-            0 => self,
+            .map(|(name, label)| (name.as_ref().to_owned(), label.into()));
+        match (actions.next(), actions.next()) {
+            (None, _) => self,
             // One action side by side with nothing is a button, and going
             // through a band would only cost a node and read the same.
-            1 => {
-                let (name, label) = actions.into_iter().next().expect("one action");
-                self.button(name, label)
-            }
-            _ => self.band(
+            (Some((name, label)), None) => self.button(name, label),
+            (Some(first), Some(second)) => self.band(
                 BandAlign::Middle,
-                actions.into_iter().map(|(name, label)| {
-                    (SlotWidth::Fill, move |slot: Self| slot.button(name, label))
-                }),
+                [first, second].into_iter().chain(actions).map(
+                    |(name, label): (String, String)| {
+                        (SlotWidth::Fill, move |slot: Self| slot.button(name, label))
+                    },
+                ),
             ),
         }
     }
@@ -3752,6 +3750,32 @@ impl Device<'_> {
         });
     }
 
+    /// Replaces the installed Cobalt with a published release archive.
+    ///
+    /// The runtime downloads `url`, refuses the bytes unless their SHA-256
+    /// digest is exactly `sha256`, and swaps the new install into place while
+    /// keeping the old one beside it. The reply is [`DeviceResult::Done`] or
+    /// a [`DeviceResult::Failed`] naming what went wrong.
+    ///
+    /// Returns `false` without queueing for a malformed URL or a string that
+    /// is not a sixty-four character lowercase hex digest.
+    pub fn update(&mut self, url: impl Into<String>, sha256: impl Into<String>) -> bool {
+        let url = url.into();
+        let sha256 = sha256.into();
+        if !url.starts_with("https://") || url.len() > MAX_URL_LEN {
+            return false;
+        }
+        if sha256.len() != 64
+            || !sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        {
+            return false;
+        }
+        self.request(DeviceRequest::Update { url, sha256 });
+        true
+    }
+
     fn bluetooth_address(
         &mut self,
         address: impl Into<String>,
@@ -4448,6 +4472,36 @@ impl Client {
 mod tests {
     use super::*;
     use std::thread;
+
+    #[test]
+    fn an_update_that_could_not_possibly_verify_is_refused_before_the_wire() {
+        struct Updater;
+        impl KoboApp for Updater {
+            fn on_start(&mut self, context: &mut Context) {
+                let good_digest = "a".repeat(64);
+                assert!(
+                    !context
+                        .device()
+                        .update("http://plain.example", &good_digest),
+                    "an update must not travel over plain HTTP"
+                );
+                assert!(
+                    !context.device().update("https://good.example", "DEADBEEF"),
+                    "a string that is not a digest can never match a download"
+                );
+                assert!(context
+                    .device()
+                    .update("https://good.example", &good_digest));
+            }
+            fn on_action(&mut self, _context: &mut Context, _action: ActionId) {}
+        }
+        let queued = AppRunner::new(Updater)
+            .start()
+            .into_iter()
+            .filter(|command| matches!(command, Command::Device(DeviceRequest::Update { .. })))
+            .count();
+        assert_eq!(queued, 1, "only the well-formed request may be queued");
+    }
 
     #[test]
     fn a_screen_identical_to_the_one_showing_is_not_sent_again() {

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -1649,6 +1649,21 @@ fn host_applications(
                                             },
                                         )
                                     }
+                                    // Blocks the message loop like a
+                                    // Bluetooth scan does. The application
+                                    // paints its progress screen before
+                                    // asking, and nothing else is served
+                                    // while the installation is replaced,
+                                    // which is exactly the quiet wanted.
+                                    kobo_protocol::DeviceRequest::Update { url, sha256 } => {
+                                        match crate::update::apply(url, sha256) {
+                                            Ok(()) => kobo_protocol::DeviceResult::Done,
+                                            Err(error) => {
+                                                trace(&format!("update refused: {error}"));
+                                                kobo_protocol::DeviceResult::Failed(error)
+                                            }
+                                        }
+                                    }
                                     _ => services.handle(request.clone()),
                                 }
                             };

--- a/crates/kobod/src/main.rs
+++ b/crates/kobod/src/main.rs
@@ -15,6 +15,7 @@ use std::process::ExitCode;
 mod blackbox;
 #[cfg(feature = "device-write")]
 mod device;
+mod update;
 
 fn main() -> ExitCode {
     let arguments = env::args().skip(1).collect::<Vec<_>>();

--- a/crates/kobod/src/update.rs
+++ b/crates/kobod/src/update.rs
@@ -143,13 +143,24 @@ fn unpack(tar: &[u8], staging: &Path) -> Result<(), DeviceError> {
 fn swap(adds: &Path, staging: &Path) -> Result<(), DeviceError> {
     let current = adds.join("cobalt");
     let previous = adds.join("cobalt.prev");
+    let mut retired = false;
     if current.exists() {
         if previous.exists() {
             fs::remove_dir_all(&previous).map_err(|_| DeviceError::Backend)?;
         }
         fs::rename(&current, &previous).map_err(|_| DeviceError::Backend)?;
+        retired = true;
     }
-    fs::rename(staging, &current).map_err(|_| DeviceError::Backend)?;
+    if fs::rename(staging, &current).is_err() {
+        // The old installation was already stepped aside, and leaving the
+        // launcher pointing at nothing is the one outcome worse than any
+        // failure. Put it back; both names are on the same filesystem, so
+        // this rename is as likely to work as the one that just did.
+        if retired {
+            let _ignored = fs::rename(&previous, &current);
+        }
+        return Err(DeviceError::Backend);
+    }
     Ok(())
 }
 
@@ -177,12 +188,14 @@ fn installed_path(path: &str) -> Option<&Path> {
 
 /// Applies the executable bits a member carries, where the filesystem has
 /// them to apply. The book partition is FAT32 and has none, so failure here
-/// is the expected case on a reader and is not reported.
+/// is the expected case on a reader and is not reported. Only the plain
+/// permission bits are taken: setuid, setgid and the sticky bit are nothing
+/// an application archive has any business carrying.
 fn set_mode(path: &Path, field: &[u8]) {
     #[cfg(unix)]
     if let Ok(mode) = read_octal(field) {
         use std::os::unix::fs::PermissionsExt;
-        let mode = u32::try_from(mode & 0o7777).unwrap_or(0o644);
+        let mode = u32::try_from(mode & 0o777).unwrap_or(0o644);
         let _ignored = fs::set_permissions(path, fs::Permissions::from_mode(mode));
     }
     #[cfg(not(unix))]

--- a/crates/kobod/src/update.rs
+++ b/crates/kobod/src/update.rs
@@ -1,0 +1,438 @@
+//! Applies a published update to the installation on the book partition.
+//!
+//! The archive a release publishes is the same `KoboRoot.tgz` a person would
+//! copy over USB, and every path in it lives under the installation folder on
+//! the FAT32 book partition. Nothing here writes anywhere else, which is what
+//! makes an update safe to apply on a running reader: the worst possible
+//! outcome is a broken folder that the previous copy, kept beside it, undoes.
+//!
+//! The sequence is deliberate. The archive is fetched whole and verified
+//! against its published digest before a single byte lands on disk. It is
+//! then unpacked next to the installation, not over it, and only a complete
+//! unpack is swapped in. The swap itself is two renames on one filesystem,
+//! which is as small as that window gets.
+
+use kobo_protocol::DeviceError;
+use std::fs;
+use std::path::{Component, Path};
+
+/// Where an update may write, as recorded inside the archive. The same
+/// invariant the packager enforces on the way in is enforced again here on
+/// the way out, so a doctored archive cannot reach the rest of the device.
+const PREFIX: &str = "mnt/onboard/.adds/cobalt";
+
+/// The folder that holds the installation, the staging copy and the previous
+/// copy on a real reader.
+#[cfg(feature = "device-write")]
+const ADDS: &str = "/mnt/onboard/.adds";
+
+/// The most compressed bytes a release is allowed to be. The real artifact is
+/// a few megabytes; a reply ten times that size is not the artifact.
+#[cfg(feature = "device-write")]
+const ARCHIVE_LIMIT: u32 = 32 * 1024 * 1024;
+
+/// The most the archive may expand to. The device has half a gigabyte of
+/// memory in total, so the unpacked tree is held to a fraction of it.
+const EXPANDED_LIMIT: u32 = 128 * 1024 * 1024;
+
+/// One tar header or payload block.
+const BLOCK: usize = 512;
+
+/// Downloads a release archive, verifies it, and swaps it in.
+///
+/// # Errors
+///
+/// [`DeviceError::Integrity`] when the download does not match `sha256`,
+/// transport errors translated as the audio streamer translates them, and
+/// [`DeviceError::Backend`] when the book partition refuses a write.
+#[cfg(feature = "device-write")]
+pub fn apply(url: &str, sha256: &str) -> Result<(), DeviceError> {
+    let archive = kobo_net::fetch(url, ARCHIVE_LIMIT).map_err(|error| match error {
+        kobo_protocol::TaskError::Offline | kobo_protocol::TaskError::Unreachable => {
+            DeviceError::Unreachable
+        }
+        kobo_protocol::TaskError::TimedOut => DeviceError::TimedOut,
+        kobo_protocol::TaskError::NotFound => DeviceError::NotFound,
+        kobo_protocol::TaskError::TooLarge | kobo_protocol::TaskError::Denied => {
+            DeviceError::InvalidInput
+        }
+        kobo_protocol::TaskError::NoCredential => DeviceError::Authentication,
+    })?;
+    install(&archive, sha256, Path::new(ADDS))
+}
+
+/// Verifies `archive` against `sha256` and installs it under `adds`.
+///
+/// The staging copy is written to `adds/cobalt.next`, and only after every
+/// member has been written is it renamed into place. The copy it replaces is
+/// kept at `adds/cobalt.prev` so a bad release can be undone by hand.
+fn install(archive: &[u8], sha256: &str, adds: &Path) -> Result<(), DeviceError> {
+    if kobo_net::sha256::hex_digest(archive) != sha256 {
+        return Err(DeviceError::Integrity);
+    }
+    // The digest matched, so these bytes are exactly what was published. A
+    // failure past this point means the release itself is malformed, which is
+    // an input problem, not a transport or a disk problem.
+    let tar =
+        kobo_net::gzip::expand(archive, EXPANDED_LIMIT).map_err(|_| DeviceError::InvalidInput)?;
+    let staging = adds.join("cobalt.next");
+    if staging.exists() {
+        fs::remove_dir_all(&staging).map_err(|_| DeviceError::Backend)?;
+    }
+    let unpacked = unpack(&tar, &staging);
+    if unpacked.is_err() {
+        // A half-written staging folder is not left behind to be mistaken
+        // for progress by the next attempt.
+        let _ignored = fs::remove_dir_all(&staging);
+    }
+    unpacked?;
+    swap(adds, &staging)
+}
+
+/// Writes every member of `tar` under `staging`, refusing anything that is
+/// not a plain file or folder inside the installation prefix.
+fn unpack(tar: &[u8], staging: &Path) -> Result<(), DeviceError> {
+    let mut members = 0usize;
+    let mut offset = 0usize;
+    while offset + BLOCK <= tar.len() {
+        let block = &tar[offset..offset + BLOCK];
+        if block.iter().all(|&byte| byte == 0) {
+            break;
+        }
+        verify_checksum(block)?;
+        let path = read_string(&block[0..100]);
+        let relative = installed_path(&path).ok_or(DeviceError::InvalidInput)?;
+        let size = read_octal(&block[124..136])?;
+        let size = usize::try_from(size).map_err(|_| DeviceError::InvalidInput)?;
+        let kind = block[156];
+        let payload = match kind {
+            b'5' => 0,
+            b'0' => size,
+            // A symbolic link, a hard link or a device node has no business
+            // in this archive, and unpacked as root they are exactly the
+            // members an attacker would want.
+            _ => return Err(DeviceError::InvalidInput),
+        };
+        let end = offset
+            .checked_add(BLOCK)
+            .and_then(|start| start.checked_add(payload))
+            .ok_or(DeviceError::InvalidInput)?;
+        if end > tar.len() {
+            return Err(DeviceError::InvalidInput);
+        }
+        let destination = staging.join(relative);
+        if kind == b'5' {
+            fs::create_dir_all(&destination).map_err(|_| DeviceError::Backend)?;
+        } else {
+            if let Some(parent) = destination.parent() {
+                fs::create_dir_all(parent).map_err(|_| DeviceError::Backend)?;
+            }
+            fs::write(&destination, &tar[offset + BLOCK..end]).map_err(|_| DeviceError::Backend)?;
+            set_mode(&destination, &block[100..108]);
+        }
+        members += 1;
+        offset = end.div_ceil(BLOCK) * BLOCK;
+    }
+    if members == 0 {
+        return Err(DeviceError::InvalidInput);
+    }
+    Ok(())
+}
+
+/// Retires the current installation and moves the staged one into place.
+fn swap(adds: &Path, staging: &Path) -> Result<(), DeviceError> {
+    let current = adds.join("cobalt");
+    let previous = adds.join("cobalt.prev");
+    if current.exists() {
+        if previous.exists() {
+            fs::remove_dir_all(&previous).map_err(|_| DeviceError::Backend)?;
+        }
+        fs::rename(&current, &previous).map_err(|_| DeviceError::Backend)?;
+    }
+    fs::rename(staging, &current).map_err(|_| DeviceError::Backend)?;
+    Ok(())
+}
+
+/// Returns the path relative to the installation folder, or `None` for a
+/// member that names anything outside it.
+fn installed_path(path: &str) -> Option<&Path> {
+    let rest = path.strip_prefix(PREFIX)?;
+    // "cobalt-else/…" also survives the prefix strip; only the folder itself
+    // or something inside it may pass.
+    if !rest.is_empty() && !rest.starts_with('/') {
+        return None;
+    }
+    let candidate = Path::new(rest.trim_start_matches('/'));
+    // The prefix guarantees where the member claims to live; this guarantees
+    // it cannot climb back out of it.
+    if candidate
+        .components()
+        .all(|component| matches!(component, Component::Normal(_)))
+    {
+        Some(candidate)
+    } else {
+        None
+    }
+}
+
+/// Applies the executable bits a member carries, where the filesystem has
+/// them to apply. The book partition is FAT32 and has none, so failure here
+/// is the expected case on a reader and is not reported.
+fn set_mode(path: &Path, field: &[u8]) {
+    #[cfg(unix)]
+    if let Ok(mode) = read_octal(field) {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = u32::try_from(mode & 0o7777).unwrap_or(0o644);
+        let _ignored = fs::set_permissions(path, fs::Permissions::from_mode(mode));
+    }
+    #[cfg(not(unix))]
+    let _ignored = (path, field);
+}
+
+fn verify_checksum(block: &[u8]) -> Result<(), DeviceError> {
+    let stated = read_octal(&block[148..156])?;
+    let computed: u64 = block
+        .iter()
+        .enumerate()
+        .map(|(index, &byte)| {
+            if (148..156).contains(&index) {
+                u64::from(b' ')
+            } else {
+                u64::from(byte)
+            }
+        })
+        .sum();
+    if computed == stated {
+        Ok(())
+    } else {
+        Err(DeviceError::InvalidInput)
+    }
+}
+
+fn read_string(field: &[u8]) -> String {
+    let end = field
+        .iter()
+        .position(|&byte| byte == 0)
+        .unwrap_or(field.len());
+    String::from_utf8_lossy(&field[..end]).into_owned()
+}
+
+fn read_octal(field: &[u8]) -> Result<u64, DeviceError> {
+    let text = read_string(field);
+    let digits = text.trim_matches(|character: char| character == ' ' || character == '\0');
+    if digits.is_empty() {
+        return Ok(0);
+    }
+    u64::from_str_radix(digits, 8).map_err(|_| DeviceError::InvalidInput)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{install, PREFIX};
+    use kobo_protocol::DeviceError;
+    use std::fs;
+
+    /// A tar member for the archives these tests publish.
+    struct Member<'a> {
+        path: String,
+        kind: u8,
+        payload: &'a [u8],
+    }
+
+    fn folder(path: &str) -> Member<'static> {
+        Member {
+            path: format!("{PREFIX}/{path}"),
+            kind: b'5',
+            payload: &[],
+        }
+    }
+
+    fn file<'a>(path: &str, payload: &'a [u8]) -> Member<'a> {
+        Member {
+            path: format!("{PREFIX}/{path}"),
+            kind: b'0',
+            payload,
+        }
+    }
+
+    fn tar(members: &[Member<'_>]) -> Vec<u8> {
+        let mut archive = Vec::new();
+        for member in members {
+            let mut block = [0u8; 512];
+            block[..member.path.len()].copy_from_slice(member.path.as_bytes());
+            block[100..107].copy_from_slice(b"0000755");
+            let size = format!("{:011o}", member.payload.len());
+            block[124..135].copy_from_slice(size.as_bytes());
+            block[156] = member.kind;
+            block[148..156].copy_from_slice(b"        ");
+            let sum: u64 = block.iter().map(|&byte| u64::from(byte)).sum();
+            let checksum = format!("{sum:06o}\0 ");
+            block[148..156].copy_from_slice(checksum.as_bytes());
+            archive.extend_from_slice(&block);
+            archive.extend_from_slice(member.payload);
+            let padding = member.payload.len().div_ceil(512) * 512 - member.payload.len();
+            archive.extend(std::iter::repeat_n(0u8, padding));
+        }
+        archive.extend(std::iter::repeat_n(0u8, 1024));
+        archive
+    }
+
+    /// Wraps bytes in a gzip container using stored deflate blocks, which is
+    /// all the tests need and keeps them free of a compressor.
+    fn gzip(bytes: &[u8]) -> Vec<u8> {
+        let mut container = vec![0x1f, 0x8b, 8, 0, 0, 0, 0, 0, 0, 0xff];
+        let mut chunks = bytes.chunks(0xffff).peekable();
+        while let Some(chunk) = chunks.next() {
+            let length = u16::try_from(chunk.len()).expect("chunked to fit");
+            container.push(u8::from(chunks.peek().is_none()));
+            container.extend_from_slice(&length.to_le_bytes());
+            container.extend_from_slice(&(!length).to_le_bytes());
+            container.extend_from_slice(chunk);
+        }
+        // The reader stops at the final deflate block, so the trailer only
+        // has to be present.
+        container.extend_from_slice(&[0u8; 8]);
+        container
+    }
+
+    fn published(members: &[Member<'_>]) -> (Vec<u8>, String) {
+        let archive = gzip(&tar(members));
+        let digest = kobo_net::sha256::hex_digest(&archive);
+        (archive, digest)
+    }
+
+    fn scratch(name: &str) -> std::path::PathBuf {
+        let folder =
+            std::env::temp_dir().join(format!("kobod-update-{name}-{}", std::process::id()));
+        let _ignored = fs::remove_dir_all(&folder);
+        fs::create_dir_all(&folder).expect("scratch folder");
+        folder
+    }
+
+    #[test]
+    fn a_verified_archive_is_unpacked_and_swapped_in() {
+        let adds = scratch("swap");
+        let (archive, digest) = published(&[
+            folder(""),
+            folder("bin"),
+            file("bin/kobod", b"new daemon"),
+            file("start.sh", b"#!/bin/sh\n"),
+        ]);
+        install(&archive, &digest, &adds).expect("install succeeds");
+        let read = |path: &str| fs::read(adds.join("cobalt").join(path)).expect("installed file");
+        assert_eq!(read("bin/kobod"), b"new daemon");
+        assert_eq!(read("start.sh"), b"#!/bin/sh\n");
+        assert!(!adds.join("cobalt.next").exists());
+        let _ignored = fs::remove_dir_all(&adds);
+    }
+
+    #[test]
+    fn the_replaced_installation_is_kept_beside_the_new_one() {
+        let adds = scratch("previous");
+        fs::create_dir_all(adds.join("cobalt")).expect("current installation");
+        fs::write(adds.join("cobalt/start.sh"), b"old").expect("current file");
+        let (archive, digest) = published(&[file("start.sh", b"new")]);
+        install(&archive, &digest, &adds).expect("install succeeds");
+        assert_eq!(
+            fs::read(adds.join("cobalt/start.sh")).expect("new file"),
+            b"new"
+        );
+        assert_eq!(
+            fs::read(adds.join("cobalt.prev/start.sh")).expect("kept file"),
+            b"old"
+        );
+        let _ignored = fs::remove_dir_all(&adds);
+    }
+
+    #[test]
+    fn a_download_that_does_not_match_its_digest_writes_nothing() {
+        let adds = scratch("digest");
+        let (archive, _) = published(&[file("start.sh", b"payload")]);
+        let wrong = kobo_net::sha256::hex_digest(b"something else");
+        assert_eq!(
+            install(&archive, &wrong, &adds),
+            Err(DeviceError::Integrity)
+        );
+        assert!(!adds.join("cobalt").exists());
+        assert!(!adds.join("cobalt.next").exists());
+        let _ignored = fs::remove_dir_all(&adds);
+    }
+
+    #[test]
+    fn a_member_outside_the_installation_prefix_is_refused() {
+        let adds = scratch("outside");
+        let stray = Member {
+            path: "mnt/onboard/.kobo/Kobo/Kobo eReader.conf".to_owned(),
+            kind: b'0',
+            payload: b"tampered",
+        };
+        let (archive, digest) = published(&[file("start.sh", b"fine"), stray]);
+        assert_eq!(
+            install(&archive, &digest, &adds),
+            Err(DeviceError::InvalidInput)
+        );
+        assert!(!adds.join("cobalt").exists());
+        assert!(!adds.join("cobalt.next").exists());
+        let _ignored = fs::remove_dir_all(&adds);
+    }
+
+    #[test]
+    fn a_member_that_climbs_out_with_dot_dot_is_refused() {
+        let adds = scratch("climb");
+        let climbing = Member {
+            path: format!("{PREFIX}/../escape"),
+            kind: b'0',
+            payload: b"tampered",
+        };
+        let (archive, digest) = published(&[climbing]);
+        assert_eq!(
+            install(&archive, &digest, &adds),
+            Err(DeviceError::InvalidInput)
+        );
+        let _ignored = fs::remove_dir_all(&adds);
+    }
+
+    #[test]
+    fn a_symbolic_link_is_refused() {
+        let adds = scratch("symlink");
+        let link = Member {
+            path: format!("{PREFIX}/link"),
+            kind: b'2',
+            payload: &[],
+        };
+        let (archive, digest) = published(&[link]);
+        assert_eq!(
+            install(&archive, &digest, &adds),
+            Err(DeviceError::InvalidInput)
+        );
+        let _ignored = fs::remove_dir_all(&adds);
+    }
+
+    #[test]
+    fn a_sibling_folder_sharing_the_prefix_spelling_is_refused() {
+        let adds = scratch("sibling");
+        let sibling = Member {
+            path: format!("{PREFIX}-else/file"),
+            kind: b'0',
+            payload: b"tampered",
+        };
+        let (archive, digest) = published(&[sibling]);
+        assert_eq!(
+            install(&archive, &digest, &adds),
+            Err(DeviceError::InvalidInput)
+        );
+        let _ignored = fs::remove_dir_all(&adds);
+    }
+
+    #[test]
+    fn an_empty_archive_is_refused() {
+        let adds = scratch("empty");
+        let archive = gzip(&[0u8; 1024]);
+        let digest = kobo_net::sha256::hex_digest(&archive);
+        assert_eq!(
+            install(&archive, &digest, &adds),
+            Err(DeviceError::InvalidInput)
+        );
+        let _ignored = fs::remove_dir_all(&adds);
+    }
+}

--- a/examples/settings/Cargo.toml
+++ b/examples/settings/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
+kobo-json = { path = "../../crates/kobo-json" }
 kobo-sdk = { path = "../../crates/kobo-sdk" }
 
 [lints]

--- a/examples/settings/src/main.rs
+++ b/examples/settings/src/main.rs
@@ -617,7 +617,13 @@ impl Settings {
         // shows it while the runtime blocks on the download and the swap.
         self.update = UpdateFlow::Installing { version };
         self.show(context);
-        context.device().update(url, sha256);
+        if !context.device().update(url, sha256) {
+            // Nothing was queued, so no reply will ever arrive to move the
+            // screen on; the refusal is reported here instead.
+            self.update =
+                UpdateFlow::Failed("The release names a download that cannot be used.".to_owned());
+            self.show(context);
+        }
     }
 
     /// Takes the reply to whichever update fetch was in flight: the release
@@ -1070,7 +1076,7 @@ fn latest_release(body: &str) -> Result<Release, String> {
 /// sixty-four hex characters, whitespace, a file name per line.
 fn digest_for(listing: &str, asset: &str) -> Option<String> {
     listing.lines().find_map(|line| {
-        let (digest, name) = line.split_once(' ')?;
+        let (digest, name) = line.split_once(char::is_whitespace)?;
         let named = name.trim_start().trim_start_matches('*') == asset;
         let plausible = digest.len() == 64
             && digest

--- a/examples/settings/src/main.rs
+++ b/examples/settings/src/main.rs
@@ -1,5 +1,6 @@
 //! Radio settings implemented entirely through the public SDK.
 
+use kobo_json::Value;
 use kobo_sdk::keyboard::{Keyboard, Pressed};
 use kobo_sdk::{
     action_id, ActionId, BatteryDetail, BluetoothDevice, Context, DeviceRequest, DeviceResult,
@@ -11,6 +12,9 @@ use std::process::ExitCode;
 const BLUETOOTH: &str = "bluetooth";
 const WIFI: &str = "wifi";
 const BATTERY: &str = "battery";
+const UPDATE: &str = "update";
+const CHECK: &str = "check";
+const INSTALL: &str = "install";
 const TOGGLE: &str = "toggle";
 const RESCAN: &str = "rescan";
 const MORE: &str = "more";
@@ -24,6 +28,14 @@ const NETWORK_ACTIONS: [&str; 10] = [
     "wifi-9",
 ];
 
+/// The version this binary was compiled as, which is the version installed:
+/// the binaries and the installer travel together.
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+/// Where releases are published.
+const RELEASES: &str = "https://api.github.com/repos/BandarLabs/Cobalt/releases/latest";
+/// The device profile this build is packaged for, as release assets name it.
+const DEVICE: &str = "ClaraBW";
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 enum View {
     #[default]
@@ -32,6 +44,7 @@ enum View {
     Wifi,
     WifiPassword,
     Battery,
+    Update,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -61,6 +74,37 @@ enum Pending {
     BluetoothRefresh,
     WifiRefresh,
     ConnectAfterPair(String),
+}
+
+/// Where the software update stands. One journey, told left to right:
+/// nothing asked, asking GitHub, reading the digest file, ready to install,
+/// installing, installed, or stopped with a reason.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+enum UpdateFlow {
+    #[default]
+    Idle,
+    Checking,
+    UpToDate {
+        latest: String,
+    },
+    /// The release is newer; its digest file is being fetched so the
+    /// download can be verified before it is installed.
+    Digest {
+        version: String,
+        url: String,
+    },
+    Ready {
+        version: String,
+        url: String,
+        sha256: String,
+    },
+    Installing {
+        version: String,
+    },
+    Installed {
+        version: String,
+    },
+    Failed(String),
 }
 
 /// Which row a failure belongs to.
@@ -117,6 +161,8 @@ struct Settings {
     selected_ssid: Option<String>,
     password: Keyboard,
     battery: Option<BatteryDetail>,
+    update: UpdateFlow,
+    update_task: Option<TaskId>,
     pending: Option<Pending>,
     delayed: Option<TaskId>,
     trouble: Option<(Topic, String)>,
@@ -131,6 +177,7 @@ impl Settings {
             View::Wifi => self.wifi(),
             View::WifiPassword => self.wifi_password(),
             View::Battery => self.battery(),
+            View::Update => self.update(),
         };
         context.set_screen(screen);
     }
@@ -191,12 +238,83 @@ impl Settings {
                 (WIFI, "Wi-Fi", wifi, RowLead::from(Glyph::Wifi)),
             ])
             .section("Device")
-            .rows([(
-                BATTERY,
-                "Battery",
-                self.battery_summary(),
-                RowLead::from(Glyph::Battery),
-            )]);
+            .rows([
+                (
+                    BATTERY,
+                    "Battery",
+                    self.battery_summary(),
+                    RowLead::from(Glyph::Battery),
+                ),
+                (
+                    UPDATE,
+                    "Software update",
+                    self.update_summary(),
+                    RowLead::from(Glyph::Download),
+                ),
+            ])
+            // The installed build's own version, baked in at compile time.
+            // The binaries and the installer travel together, so what this
+            // binary was compiled as is what is installed.
+            .section_with_value("Cobalt", VERSION);
+        screen.build()
+    }
+
+    /// One line for the home row: where the update journey stands, or an
+    /// invitation to start it.
+    fn update_summary(&self) -> String {
+        match &self.update {
+            UpdateFlow::Idle => format!("Cobalt {VERSION}"),
+            UpdateFlow::Checking | UpdateFlow::Digest { .. } => "Checking".to_owned(),
+            UpdateFlow::UpToDate { .. } => "Up to date".to_owned(),
+            UpdateFlow::Ready { version, .. } => format!("{version} available"),
+            UpdateFlow::Installing { .. } => "Installing".to_owned(),
+            UpdateFlow::Installed { version } => format!("Updated to {version}"),
+            UpdateFlow::Failed(_) => "Update failed".to_owned(),
+        }
+    }
+
+    fn update(&self) -> Screen {
+        let mut screen = ScreenBuilder::new("settings-update")
+            .top_bar("Software update")
+            .owns_back(true)
+            .section_with_value("Installed", VERSION);
+        match &self.update {
+            UpdateFlow::Idle => {
+                screen = screen
+                    .text("Checking asks GitHub for the newest published release. Nothing is downloaded until you choose to install it.")
+                    .button(CHECK, "Check for updates");
+            }
+            UpdateFlow::Checking | UpdateFlow::Digest { .. } => {
+                screen = screen.text("Checking for the newest release.");
+            }
+            UpdateFlow::UpToDate { latest } => {
+                screen = screen
+                    .text(format!("{latest} is the newest published release, and it is what this reader is running."))
+                    .button(CHECK, "Check again");
+            }
+            UpdateFlow::Ready { version, .. } => {
+                screen = screen
+                    .text(
+                        "The download is checked against its published digest before anything is replaced, and the release you are running now is kept for one step back.",
+                    )
+                    .button(INSTALL, format!("Update to {version}"));
+            }
+            UpdateFlow::Installing { version } => {
+                screen = screen.text(format!(
+                    "Installing {version}. Keep the reader awake; this screen will change when it is done."
+                ));
+            }
+            UpdateFlow::Installed { version } => {
+                screen = screen.text(format!(
+                    "Updated to {version}. Close Cobalt and open it again from the menu to run the new release."
+                ));
+            }
+            UpdateFlow::Failed(reason) => {
+                screen = screen
+                    .banner(kobo_sdk::BannerLevel::Attention, reason.clone())
+                    .button(CHECK, "Try again");
+            }
+        }
         screen.build()
     }
 
@@ -471,6 +589,83 @@ impl Settings {
         context.device().read_battery_detail();
     }
 
+    /// Asks GitHub what the newest published release is. Nothing is
+    /// downloaded beyond the release description until the reader chooses to
+    /// install.
+    fn check_for_update(&mut self, context: &mut Context) {
+        self.update = UpdateFlow::Checking;
+        self.update_task = context.spawn(Task::Fetch {
+            url: RELEASES.to_owned(),
+            offset: 0,
+            max_bytes: 256 * 1024,
+        });
+        if self.update_task.is_none() {
+            self.update = UpdateFlow::Failed("This build was refused the network.".to_owned());
+        }
+    }
+
+    fn install_update(&mut self, context: &mut Context) {
+        let UpdateFlow::Ready {
+            version,
+            url,
+            sha256,
+        } = self.update.clone()
+        else {
+            return;
+        };
+        // The progress screen is queued ahead of the request, so the panel
+        // shows it while the runtime blocks on the download and the swap.
+        self.update = UpdateFlow::Installing { version };
+        self.show(context);
+        context.device().update(url, sha256);
+    }
+
+    /// Takes the reply to whichever update fetch was in flight: the release
+    /// description first, then the digest file that lets the download be
+    /// verified.
+    fn took_update_reply(&mut self, context: &mut Context, bytes: &[u8]) {
+        let body = String::from_utf8_lossy(bytes);
+        match self.update.clone() {
+            UpdateFlow::Checking => match latest_release(&body) {
+                Err(reason) => self.update = UpdateFlow::Failed(reason),
+                Ok(release) if release.newer_than(VERSION) => {
+                    self.update_task = context.spawn(Task::Fetch {
+                        url: release.digest,
+                        offset: 0,
+                        max_bytes: 16 * 1024,
+                    });
+                    self.update = if self.update_task.is_none() {
+                        UpdateFlow::Failed("This build was refused the network.".to_owned())
+                    } else {
+                        UpdateFlow::Digest {
+                            version: release.version,
+                            url: release.archive,
+                        }
+                    };
+                }
+                Ok(release) => {
+                    self.update = UpdateFlow::UpToDate {
+                        latest: release.version,
+                    };
+                }
+            },
+            UpdateFlow::Digest { version, url } => {
+                self.update = match digest_for(&body, &archive_name(&version)) {
+                    Some(sha256) => UpdateFlow::Ready {
+                        version,
+                        url,
+                        sha256,
+                    },
+                    None => UpdateFlow::Failed(
+                        "The release does not publish a digest for this reader's download."
+                            .to_owned(),
+                    ),
+                };
+            }
+            _ => {}
+        }
+    }
+
     fn delay_refresh(&mut self, context: &mut Context, pending: Pending) {
         self.pending = Some(pending);
         self.delayed = context.spawn(Task::Sleep { seconds: 3 });
@@ -500,7 +695,7 @@ impl Settings {
         let (page, pages) = match self.view {
             View::Bluetooth => (&mut self.bluetooth_page, page_count(self.devices.len())),
             View::Wifi => (&mut self.wifi_page, page_count(self.networks.len())),
-            View::Home | View::WifiPassword | View::Battery => return,
+            View::Home | View::WifiPassword | View::Battery | View::Update => return,
         };
         *page = if forward {
             (*page + 1).min(pages - 1)
@@ -595,13 +790,21 @@ impl KoboApp for Settings {
             self.view = View::Battery;
             context.device().read_battery_detail();
             self.show(context);
+        } else if action == action_id(UPDATE) {
+            self.view = View::Update;
+            self.show(context);
+        } else if action == action_id(CHECK) {
+            self.check_for_update(context);
+            self.show(context);
+        } else if action == action_id(INSTALL) {
+            self.install_update(context);
         } else if action == action_id(TOGGLE) {
             match self.view {
                 View::Bluetooth => context
                     .device()
                     .set_bluetooth(!self.bluetooth_state.enabled()),
                 View::Wifi => context.device().set_wifi(!self.wifi_state.enabled()),
-                View::Home | View::WifiPassword | View::Battery => {}
+                View::Home | View::WifiPassword | View::Battery | View::Update => {}
             }
         } else if action == action_id(RESCAN) {
             match self.view {
@@ -616,7 +819,7 @@ impl KoboApp for Settings {
                     self.delay_refresh(context, Pending::WifiRefresh);
                 }
                 View::Battery => context.device().read_battery_detail(),
-                View::Home | View::WifiPassword => {}
+                View::Home | View::WifiPassword | View::Update => {}
             }
             self.show(context);
         } else if action == action_id(MORE) {
@@ -689,12 +892,16 @@ impl KoboApp for Settings {
             // is not one of the three rows, there is nowhere honest to show it,
             // so it is dropped rather than shown under an unrelated heading.
             DeviceResult::Failed(error) => {
-                if let Some(topic) = Topic::of(&request) {
+                if matches!(request, DeviceRequest::Update { .. }) {
+                    self.update = UpdateFlow::Failed(error.to_string());
+                } else if let Some(topic) = Topic::of(&request) {
                     self.fail(topic, error.to_string());
                 }
             }
             DeviceResult::Denied(reason) => {
-                if let Some(topic) = Topic::of(&request) {
+                if matches!(request, DeviceRequest::Update { .. }) {
+                    self.update = UpdateFlow::Failed(reason.to_string());
+                } else if let Some(topic) = Topic::of(&request) {
                     self.fail(topic, reason.to_string());
                 }
             }
@@ -711,6 +918,11 @@ impl KoboApp for Settings {
                 | DeviceRequest::ScanWifi
                 | DeviceRequest::JoinWifi { .. }
                 | DeviceRequest::DisconnectWifi => context.device().read_wifi(),
+                DeviceRequest::Update { .. } => {
+                    if let UpdateFlow::Installing { version } = self.update.clone() {
+                        self.update = UpdateFlow::Installed { version };
+                    }
+                }
                 _ => {}
             },
             DeviceResult::Granted { .. }
@@ -730,6 +942,16 @@ impl KoboApp for Settings {
                 self.scanning = true;
                 context.device().scan_wifi();
             }
+            return;
+        }
+        if self.update_task == Some(task) {
+            self.update_task = None;
+            match outcome {
+                TaskOutcome::Completed(bytes) => self.took_update_reply(context, &bytes),
+                TaskOutcome::Failed(error) => self.update = UpdateFlow::Failed(error.to_string()),
+                TaskOutcome::Cancelled => self.update = UpdateFlow::Idle,
+            }
+            self.show(context);
             return;
         }
         if self.delayed != Some(task) {
@@ -774,6 +996,88 @@ fn paging(page: usize, pages: usize) -> Vec<(&'static str, &'static str, Glyph)>
 
 fn page_count(items: usize) -> usize {
     items.div_ceil(PAGE_SIZE).max(1)
+}
+
+/// The newest published release, as its assets name this device's download.
+#[derive(Debug)]
+struct Release {
+    version: String,
+    /// Where the installable archive is.
+    archive: String,
+    /// Where the digest file that vouches for it is.
+    digest: String,
+}
+
+impl Release {
+    /// Strictly newer, so the same version and anything unparseable both
+    /// answer no and nothing is offered.
+    fn newer_than(&self, installed: &str) -> bool {
+        match (numbers(&self.version), numbers(installed)) {
+            (Some(latest), Some(installed)) => latest > installed,
+            _ => false,
+        }
+    }
+}
+
+fn numbers(version: &str) -> Option<(u64, u64, u64)> {
+    let mut parts = version.split('.').map(str::parse::<u64>);
+    match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some(Ok(major)), Some(Ok(minor)), Some(Ok(patch)), None) => Some((major, minor, patch)),
+        _ => None,
+    }
+}
+
+fn archive_name(version: &str) -> String {
+    format!("cobalt-{version}-{DEVICE}-KoboRoot.tgz")
+}
+
+/// Reads the GitHub "latest release" reply down to the two URLs this device
+/// needs. The failure strings face the reader, so they say what is missing
+/// rather than where in the JSON it was not.
+fn latest_release(body: &str) -> Result<Release, String> {
+    let value = kobo_json::parse(body)
+        .map_err(|_| "GitHub sent something that is not a release.".to_owned())?;
+    let tag = value
+        .get("tag_name")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "The newest release does not name a version.".to_owned())?;
+    let version = tag.trim_start_matches('v').to_owned();
+    let empty = [];
+    let assets = value
+        .get("assets")
+        .and_then(Value::as_array)
+        .unwrap_or(&empty);
+    let url_of = |name: &str| {
+        assets
+            .iter()
+            .find(|asset| asset.get("name").and_then(Value::as_str) == Some(name))
+            .and_then(|asset| asset.get("browser_download_url"))
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+    };
+    let archive = url_of(&archive_name(&version))
+        .ok_or_else(|| "The newest release has no download for this reader.".to_owned())?;
+    let digest = url_of(&format!("cobalt-{version}-{DEVICE}.sha256"))
+        .ok_or_else(|| "The newest release publishes no digest to verify against.".to_owned())?;
+    Ok(Release {
+        version,
+        archive,
+        digest,
+    })
+}
+
+/// Finds the digest vouching for `asset` in a `sha256sum` style listing:
+/// sixty-four hex characters, whitespace, a file name per line.
+fn digest_for(listing: &str, asset: &str) -> Option<String> {
+    listing.lines().find_map(|line| {
+        let (digest, name) = line.split_once(' ')?;
+        let named = name.trim_start().trim_start_matches('*') == asset;
+        let plausible = digest.len() == 64
+            && digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
+        (named && plausible).then(|| digest.to_owned())
+    })
 }
 
 /// Hours and minutes, because "412 minutes" is arithmetic a reader should not
@@ -1072,5 +1376,138 @@ mod tests {
             Some(super::Topic::Bluetooth)
         );
         assert_eq!(super::Topic::of(&DeviceRequest::ReadFrontlight), None);
+    }
+
+    fn release_json(version: &str, with_digest: bool) -> String {
+        let archive = format!(
+            r#"{{"name":"cobalt-{version}-ClaraBW-KoboRoot.tgz","browser_download_url":"https://example.test/{version}/KoboRoot.tgz"}}"#
+        );
+        let digest = if with_digest {
+            format!(
+                r#",{{"name":"cobalt-{version}-ClaraBW.sha256","browser_download_url":"https://example.test/{version}/checksums"}}"#
+            )
+        } else {
+            String::new()
+        };
+        format!(r#"{{"tag_name":"v{version}","assets":[{archive}{digest}]}}"#)
+    }
+
+    #[test]
+    fn a_release_is_read_down_to_the_two_urls_this_reader_needs() {
+        let release = super::latest_release(&release_json("9.9.9", true)).expect("a full release");
+        assert_eq!(release.version, "9.9.9");
+        assert_eq!(release.archive, "https://example.test/9.9.9/KoboRoot.tgz");
+        assert_eq!(release.digest, "https://example.test/9.9.9/checksums");
+        assert!(release.newer_than(super::VERSION));
+    }
+
+    #[test]
+    fn a_release_without_a_digest_to_verify_against_is_not_offered() {
+        assert!(super::latest_release(&release_json("9.9.9", false))
+            .expect_err("no digest, no offer")
+            .contains("digest"));
+    }
+
+    #[test]
+    fn the_installed_release_and_an_unreadable_tag_are_both_not_newer() {
+        let same = super::latest_release(&release_json(super::VERSION, true)).expect("release");
+        assert!(!same.newer_than(super::VERSION));
+        let strange = super::Release {
+            version: "nightly".to_owned(),
+            archive: String::new(),
+            digest: String::new(),
+        };
+        assert!(
+            !strange.newer_than(super::VERSION),
+            "a version that cannot be compared must not be offered as an upgrade"
+        );
+    }
+
+    #[test]
+    fn the_digest_is_found_beside_the_other_files_in_the_listing() {
+        let digest = "a".repeat(64);
+        let listing = format!(
+            "{}  THIRD-PARTY.md\n{digest}  cobalt-9.9.9-ClaraBW-KoboRoot.tgz\n",
+            "b".repeat(64)
+        );
+        assert_eq!(
+            super::digest_for(&listing, "cobalt-9.9.9-ClaraBW-KoboRoot.tgz"),
+            Some(digest)
+        );
+        assert_eq!(
+            super::digest_for(&listing, "cobalt-9.9.9-ClaraBW.tgz"),
+            None,
+            "a digest for a different file vouches for nothing"
+        );
+        assert_eq!(
+            super::digest_for("not a listing", "cobalt-9.9.9-ClaraBW-KoboRoot.tgz"),
+            None
+        );
+    }
+
+    #[test]
+    fn every_stop_on_the_update_journey_fits_the_panel() {
+        let flows = [
+            super::UpdateFlow::Idle,
+            super::UpdateFlow::Checking,
+            super::UpdateFlow::UpToDate {
+                latest: "0.1.0".to_owned(),
+            },
+            super::UpdateFlow::Ready {
+                version: "9.9.9".to_owned(),
+                url: "https://example.test/KoboRoot.tgz".to_owned(),
+                sha256: "a".repeat(64),
+            },
+            super::UpdateFlow::Installing {
+                version: "9.9.9".to_owned(),
+            },
+            super::UpdateFlow::Installed {
+                version: "9.9.9".to_owned(),
+            },
+            super::UpdateFlow::Failed("The download did not match its digest.".to_owned()),
+        ];
+        for flow in flows {
+            let settings = Settings {
+                view: super::View::Update,
+                update: flow.clone(),
+                ..Settings::default()
+            };
+            let issues = settings.update().validate(&CLARA_BW_METRICS);
+            assert!(issues.is_empty(), "{flow:?}: {issues:?}");
+        }
+    }
+
+    #[test]
+    fn only_a_release_that_is_ready_offers_the_install_button() {
+        let ready = Settings {
+            view: super::View::Update,
+            update: super::UpdateFlow::Ready {
+                version: "9.9.9".to_owned(),
+                url: "https://example.test/KoboRoot.tgz".to_owned(),
+                sha256: "a".repeat(64),
+            },
+            ..Settings::default()
+        };
+        let layout = ready
+            .update()
+            .layout_with(&CLARA_BW_METRICS, &Chrome::with_back(true));
+        assert!(layout.rect_of_action(action_id(super::INSTALL)).is_some());
+
+        let checking = Settings {
+            view: super::View::Update,
+            update: super::UpdateFlow::Checking,
+            ..Settings::default()
+        };
+        let layout = checking
+            .update()
+            .layout_with(&CLARA_BW_METRICS, &Chrome::with_back(true));
+        assert!(
+            layout.rect_of_action(action_id(super::INSTALL)).is_none(),
+            "nothing may be installed before it is verified"
+        );
+        assert!(
+            layout.rect_of_action(action_id(super::CHECK)).is_none(),
+            "a check that is already running must not be restartable"
+        );
     }
 }


### PR DESCRIPTION
Settings gains a **Software update** screen: it asks GitHub for the newest published release, compares it with the installed version, and offers the newer one. Nothing is downloaded until the reader chooses to install.

## How an update is applied

1. The app fetches `releases/latest`, finds this device's `KoboRoot.tgz` asset and its `.sha256` companion (both already published by the release workflow).
2. The app sends the runtime a new `DeviceRequest::Update { url, sha256 }` (wire tag 31, validated at both ends: HTTPS only, sixty-four lowercase hex).
3. `kobod` downloads the archive, refuses it unless its SHA-256 matches, unpacks it to `.adds/cobalt.next`, then swaps folders: the running install becomes `cobalt.prev`, the new one becomes `cobalt`.

## Why this cannot brick a reader

- Every archive member must live under `mnt/onboard/.adds/cobalt/`; symlinks, hard links, device nodes, `..` components and sibling-prefix paths are all refused. The root filesystem is never written.
- The digest is verified before a single byte lands on disk, and a half-written staging folder is removed rather than left behind.
- The previous release is kept beside the new one for one step of rollback.
- The NickelMenu entry points at `start.sh`, whose path survives the swap, so the launcher keeps working after an update.

## Changes

- `kobo-protocol`: `DeviceRequest::Update`, `DeviceError::Integrity`, validation on both encode and decode
- `kobo-net`: dependency-free `sha256` module (published test vectors included)
- `kobod`: new `update` module — download, verify, unpack, swap; wired into the device request loop
- `kobo-sdk`: `context.device().update(url, sha256)`, refused before the wire when malformed
- `kobo-policy`: update maps to the network capability; hosts without an installer answer Unsupported
- `settings`: Software update row and screen with check → verify → install → done/failed states
- Workspace version bumped to 0.1.1

Tests cover the wire format round trip, the unpack/swap engine (temp-dir archives, rollback, digest mismatch, path escapes), release JSON parsing, digest-listing parsing, and every screen state.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788259786&installation_model_id=20525&pr_number=2&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F2&signature=b758e00d792e7b92afe5d027d9547123df7fbdb28c169676833f2145b14de984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->