### PR TITLE
Add native sleep and Settings activity monitoring

### DIFF
--- a/SDK.md
+++ b/SDK.md
@@ -1086,6 +1086,16 @@ mechanism prevents an explicit power-button press or sleep-cover closure.
 Applications cannot rewrite the persistent global value; that request is
 reserved for the built-in Settings app.
 
+### Activity diagnostics
+
+Settings includes a one-second Activity Monitor for CPU, memory, free disk
+space and the busiest processes. The runtime reads Linux counters on its behalf
+because Settings is sandboxed and cannot walk `/proc` itself. Sampling stops as
+soon as the owner leaves that screen, process names are sanitised, and the
+bounded snapshot contains at most twelve rows. This system-wide diagnostic is
+reserved for the built-in Settings app rather than exposed as an application
+capability.
+
 `shell` is the one that is different in kind. Every other capability is undone
 by a reboot; a shell on this device is root on a writable root filesystem, so
 it is the first thing the platform hosts that a power cycle cannot repair. It

--- a/SDK.md
+++ b/SDK.md
@@ -218,6 +218,11 @@ Only the first two are required. Every callback is handed a `&mut Context`,
 which is the only way to affect the outside world; a method that does not take
 one cannot.
 
+`on_suspend` is a short, bounded chance to save state before Linux freezes
+userspace. Store requests queued by that callback are sent before the SDK's
+automatic readiness acknowledgement. After wake, the process and its in-memory
+state continue and `on_resume` runs; the application is not relaunched.
+
 `fn main` is `kobo_sdk::run("name", app)`, which reads the socket path from
 `KOBO_SOCKET`. Use `run_on` to name a socket yourself.
 
@@ -1062,6 +1067,24 @@ Unknown names are rejected rather than ignored, dependencies are enforced
 `PowerPolicy` the application cannot raise imposes a minimum wake interval, a
 maximum Wi-Fi hold, and withdrawal of the expensive capabilities below fifteen
 percent battery unless the device is charging.
+
+### Sleep policy
+
+The owner chooses the global inactivity timeout in Settings; a fresh install
+uses fifteen minutes. An application follows that value by default. A
+foreground app declaring `keep-awake` can replace it for its current process:
+
+```rust
+context.device().override_sleep_timeout(Duration::from_secs(30 * 60));
+// Later, return to the owner-selected value.
+context.device().use_global_sleep_timeout();
+```
+
+The runtime clamps overrides to platform policy. `keep_awake(duration)` is a
+temporary hold for active work and `allow_sleep()` releases it early. Neither
+mechanism prevents an explicit power-button press or sleep-cover closure.
+Applications cannot rewrite the persistent global value; that request is
+reserved for the built-in Settings app.
 
 `shell` is the one that is different in kind. Every other capability is undone
 by a reboot; a shell on this device is root on a writable root filesystem, so

--- a/crates/kobo-abi/src/lib.rs
+++ b/crates/kobo-abi/src/lib.rs
@@ -424,6 +424,9 @@ pub mod input {
     /// A press means the magnet arrived, a release means it left.
     pub const KEY_COVER: u16 = 35;
 
+    /// The physical power button, as the `bd71828-pwrkey` input node reports it.
+    pub const KEY_POWER: u16 = 116;
+
     /// Builds an `EVIOCGKEY` query for a key bitmap of `bytes` bytes.
     ///
     /// # Panics

--- a/crates/kobo-hal/src/lib.rs
+++ b/crates/kobo-hal/src/lib.rs
@@ -28,6 +28,9 @@ pub mod input;
 #[cfg(feature = "device-write")]
 pub mod network;
 pub mod observe;
+/// Physical power-button events and system suspend-to-RAM.
+#[cfg(feature = "device-write")]
+pub mod power;
 pub mod probe;
 /// Stopping and restarting the stock reader. Available only with
 /// `device-write`, because it acts on a process this program did not create.

--- a/crates/kobo-hal/src/power.rs
+++ b/crates/kobo-hal/src/power.rs
@@ -1,0 +1,227 @@
+//! Physical sleep control for a Cobalt-owned panel session.
+//!
+//! Nickel normally owns both halves of this operation: it listens to the PMIC
+//! power-key input and writes `mem` to `/sys/power/state`. A Cobalt session has
+//! deliberately stopped Nickel, so it must do both itself or the button becomes
+//! inert and an idle session can only hand the reader back.
+
+use crate::touch::InputEvent32;
+use kobo_abi::input;
+use std::fmt;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+
+const INPUT_DIR: &str = "/dev/input";
+const POWER_KEY_NAME: &str = "bd71828-pwrkey";
+const POWER_STATE: &str = "/sys/power/state";
+const EVENT_BYTES: usize = 16;
+const READ_CHUNK_EVENTS: usize = 16;
+
+#[derive(Debug)]
+pub enum PowerError {
+    NoPowerKey,
+    SuspendUnsupported,
+    SyncFailed,
+    Io(io::Error),
+}
+
+impl fmt::Display for PowerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoPowerKey => formatter.write_str("no bd71828-pwrkey input device was found"),
+            Self::SuspendUnsupported => {
+                formatter.write_str("the kernel does not advertise mem in /sys/power/state")
+            }
+            Self::SyncFailed => formatter.write_str("sync failed before suspend"),
+            Self::Io(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for PowerError {}
+
+impl From<io::Error> for PowerError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+/// A release of the physical power button.
+///
+/// Sleeping on release avoids carrying the press that requested sleep into the
+/// wake transition as a pending wake interrupt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PowerButtonReleased;
+
+pub struct PowerButton {
+    releases: Option<Receiver<PowerButtonReleased>>,
+}
+
+impl PowerButton {
+    /// Finds the PMIC power-key input by name and starts watching it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error or [`PowerError::NoPowerKey`] when the named evdev
+    /// source is unavailable.
+    pub fn open() -> Result<Self, PowerError> {
+        let path = find_power_key(Path::new(INPUT_DIR)).ok_or(PowerError::NoPowerKey)?;
+        Self::open_path(&path)
+    }
+
+    fn open_path(path: &Path) -> Result<Self, PowerError> {
+        let file = File::open(path)?;
+        let (sender, releases) = mpsc::channel();
+        thread::Builder::new()
+            .name("power-button".to_owned())
+            .spawn(move || read_power_key(file, &sender))?;
+        Ok(Self {
+            releases: Some(releases),
+        })
+    }
+
+    /// Hands the release stream to a runtime multiplexing several event sources.
+    pub fn take_events(&mut self) -> Option<Receiver<PowerButtonReleased>> {
+        self.releases.take()
+    }
+}
+
+/// The kernel system-suspend endpoint.
+pub struct SystemSuspend {
+    state: PathBuf,
+}
+
+impl SystemSuspend {
+    /// Refuses construction unless suspend-to-RAM is advertised.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error or [`PowerError::SuspendUnsupported`] when the
+    /// kernel does not advertise the `mem` state.
+    pub fn open() -> Result<Self, PowerError> {
+        Self::open_path(Path::new(POWER_STATE))
+    }
+
+    fn open_path(path: &Path) -> Result<Self, PowerError> {
+        let states = fs::read_to_string(path)?;
+        if !states.split_ascii_whitespace().any(|state| state == "mem") {
+            return Err(PowerError::SuspendUnsupported);
+        }
+        Ok(Self {
+            state: path.to_path_buf(),
+        })
+    }
+
+    /// Flushes filesystems and enters suspend-to-RAM.
+    ///
+    /// The write returns only after the kernel has resumed userspace, so a
+    /// successful return is also the resume boundary for the caller.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when filesystem synchronisation fails or the kernel
+    /// rejects the suspend request.
+    pub fn suspend(&self) -> Result<(), PowerError> {
+        let status = Command::new("/bin/sync").status()?;
+        if !status.success() {
+            return Err(PowerError::SyncFailed);
+        }
+        self.write_state()
+    }
+
+    fn write_state(&self) -> Result<(), PowerError> {
+        let mut state = OpenOptions::new().write(true).open(&self.state)?;
+        state.write_all(b"mem\n")?;
+        state.flush()?;
+        Ok(())
+    }
+}
+
+fn read_power_key(mut file: File, sender: &mpsc::Sender<PowerButtonReleased>) {
+    let mut buffer = [0_u8; EVENT_BYTES * READ_CHUNK_EVENTS];
+    loop {
+        let read = match file.read(&mut buffer) {
+            Ok(0) => return,
+            Ok(read) => read,
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+            Err(_) => return,
+        };
+        for event in buffer[..read].chunks_exact(EVENT_BYTES) {
+            if power_button_released(event) && sender.send(PowerButtonReleased).is_err() {
+                return;
+            }
+        }
+    }
+}
+
+fn power_button_released(bytes: &[u8]) -> bool {
+    InputEvent32::decode(bytes).is_some_and(|event| {
+        event.kind == input::EV_KEY && event.code == input::KEY_POWER && event.value == 0
+    })
+}
+
+fn find_power_key(directory: &Path) -> Option<PathBuf> {
+    let mut nodes = fs::read_dir(directory)
+        .ok()?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("event"))
+        })
+        .collect::<Vec<_>>();
+    nodes.sort();
+    nodes.into_iter().find(|path| {
+        File::open(path).is_ok_and(|file| {
+            input::device_name(&file).is_ok_and(|name| name.trim() == POWER_KEY_NAME)
+        })
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{power_button_released, PowerError, SystemSuspend};
+    use std::fs;
+
+    fn event(kind: u16, code: u16, value: i32) -> [u8; 16] {
+        let mut bytes = [0_u8; 16];
+        bytes[8..10].copy_from_slice(&kind.to_le_bytes());
+        bytes[10..12].copy_from_slice(&code.to_le_bytes());
+        bytes[12..16].copy_from_slice(&value.to_le_bytes());
+        bytes
+    }
+
+    #[test]
+    fn only_a_power_button_release_requests_sleep() {
+        assert!(power_button_released(&event(1, 116, 0)));
+        assert!(!power_button_released(&event(1, 116, 1)));
+        assert!(!power_button_released(&event(1, 35, 0)));
+        assert!(!power_button_released(&event(3, 116, 0)));
+    }
+
+    #[test]
+    fn suspend_refuses_a_kernel_without_mem() {
+        let path = std::env::temp_dir().join(format!("cobalt-power-state-{}", std::process::id()));
+        fs::write(&path, b"freeze\n").expect("write states");
+        assert!(matches!(
+            SystemSuspend::open_path(&path),
+            Err(PowerError::SuspendUnsupported)
+        ));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn the_suspend_write_is_exactly_mem() {
+        let path = std::env::temp_dir().join(format!("cobalt-power-mem-{}", std::process::id()));
+        fs::write(&path, b"mem\n").expect("write states");
+        let suspend = SystemSuspend::open_path(&path).expect("mem is supported");
+        suspend.write_state().expect("write suspend state");
+        assert_eq!(fs::read(&path).expect("read state"), b"mem\n");
+        let _ = fs::remove_file(path);
+    }
+}

--- a/crates/kobo-policy/src/lib.rs
+++ b/crates/kobo-policy/src/lib.rs
@@ -157,6 +157,7 @@ impl fmt::Display for Capability {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PowerPolicy {
     pub minimum_wake_interval: Duration,
+    pub minimum_foreground_sleep: Duration,
     pub maximum_foreground_awake: Duration,
     pub maximum_wifi_hold: Duration,
     pub low_battery_percent: u8,
@@ -166,6 +167,7 @@ impl PowerPolicy {
     /// The default policy applied to every application.
     pub const DEFAULT: Self = Self {
         minimum_wake_interval: Duration::from_secs(15 * 60),
+        minimum_foreground_sleep: Duration::from_secs(60),
         maximum_foreground_awake: Duration::from_secs(60 * 60),
         maximum_wifi_hold: Duration::from_secs(10 * 60),
         low_battery_percent: 15,

--- a/crates/kobo-policy/src/services.rs
+++ b/crates/kobo-policy/src/services.rs
@@ -222,9 +222,9 @@ impl DeviceServices {
                 self.sleep_timeout = None;
                 DeviceResult::Done
             }
-            DeviceRequest::ReadSystemSleepTimeout | DeviceRequest::SetSystemSleepTimeout { .. } => {
-                DeviceResult::Failed(DeviceError::InvalidInput)
-            }
+            DeviceRequest::ReadSystemSleepTimeout
+            | DeviceRequest::SetSystemSleepTimeout { .. }
+            | DeviceRequest::ReadSystemActivity => DeviceResult::Failed(DeviceError::InvalidInput),
             DeviceRequest::ScheduleWake { seconds } => self.schedule_wake(seconds),
             DeviceRequest::CancelWake => {
                 self.wake_scheduled_in = None;
@@ -559,7 +559,9 @@ pub fn request_capability(request: &DeviceRequest) -> Option<Capability> {
         | DeviceRequest::AllowSleep
         | DeviceRequest::SetSleepTimeout { .. }
         | DeviceRequest::UseGlobalSleepTimeout => Capability::KeepAwake,
-        DeviceRequest::ReadSystemSleepTimeout | DeviceRequest::SetSystemSleepTimeout { .. } => {
+        DeviceRequest::ReadSystemSleepTimeout
+        | DeviceRequest::SetSystemSleepTimeout { .. }
+        | DeviceRequest::ReadSystemActivity => {
             return None;
         }
         DeviceRequest::ScheduleWake { .. } | DeviceRequest::CancelWake => Capability::ScheduledWake,

--- a/crates/kobo-policy/src/services.rs
+++ b/crates/kobo-policy/src/services.rs
@@ -83,6 +83,7 @@ pub struct DeviceServices {
     state: DeviceState,
     wifi_held_for: Option<Duration>,
     awake_held_for: Option<Duration>,
+    sleep_timeout: Option<Duration>,
     wake_scheduled_in: Option<Duration>,
     bluetooth_enabled: bool,
     wifi_enabled: bool,
@@ -121,6 +122,7 @@ impl DeviceServices {
             state: DeviceState::default(),
             wifi_held_for: None,
             awake_held_for: None,
+            sleep_timeout: None,
             wake_scheduled_in: None,
             bluetooth_enabled: false,
             wifi_enabled: true,
@@ -187,6 +189,12 @@ impl DeviceServices {
         self.awake_held_for
     }
 
+    /// Foreground inactivity timeout explicitly selected by the application.
+    #[must_use]
+    pub const fn sleep_timeout(&self) -> Option<Duration> {
+        self.sleep_timeout
+    }
+
     /// Currently scheduled wake delay, if any.
     #[must_use]
     pub const fn scheduled_wake(&self) -> Option<Duration> {
@@ -208,6 +216,14 @@ impl DeviceServices {
             DeviceRequest::AllowSleep => {
                 self.awake_held_for = None;
                 DeviceResult::Done
+            }
+            DeviceRequest::SetSleepTimeout { seconds } => self.set_sleep_timeout(seconds),
+            DeviceRequest::UseGlobalSleepTimeout => {
+                self.sleep_timeout = None;
+                DeviceResult::Done
+            }
+            DeviceRequest::ReadSystemSleepTimeout | DeviceRequest::SetSystemSleepTimeout { .. } => {
+                DeviceResult::Failed(DeviceError::InvalidInput)
             }
             DeviceRequest::ScheduleWake { seconds } => self.schedule_wake(seconds),
             DeviceRequest::CancelWake => {
@@ -496,6 +512,24 @@ impl DeviceServices {
         }
     }
 
+    fn set_sleep_timeout(&mut self, seconds: u32) -> DeviceResult {
+        if seconds == 0 {
+            return DeviceResult::Denied(DenyReason::PolicyRejected);
+        }
+        if let Some(reason) = self.refusal(Capability::KeepAwake) {
+            return DeviceResult::Denied(reason);
+        }
+        let policy = self.grants.policy();
+        let granted = Duration::from_secs(u64::from(seconds)).clamp(
+            policy.minimum_foreground_sleep,
+            policy.maximum_foreground_awake,
+        );
+        self.sleep_timeout = Some(granted);
+        DeviceResult::Granted {
+            seconds: clamp_seconds(granted),
+        }
+    }
+
     fn schedule_wake(&mut self, seconds: u32) -> DeviceResult {
         if let Some(reason) = self.refusal(Capability::ScheduledWake) {
             return DeviceResult::Denied(reason);
@@ -521,7 +555,13 @@ pub fn request_capability(request: &DeviceRequest) -> Option<Capability> {
         DeviceRequest::ReadBattery | DeviceRequest::ReadBatteryDetail => Capability::BatteryRead,
         DeviceRequest::ReadCover => Capability::CoverSensor,
         DeviceRequest::HoldWifi { .. } | DeviceRequest::ReleaseWifi => Capability::HoldWifi,
-        DeviceRequest::KeepAwake { .. } | DeviceRequest::AllowSleep => Capability::KeepAwake,
+        DeviceRequest::KeepAwake { .. }
+        | DeviceRequest::AllowSleep
+        | DeviceRequest::SetSleepTimeout { .. }
+        | DeviceRequest::UseGlobalSleepTimeout => Capability::KeepAwake,
+        DeviceRequest::ReadSystemSleepTimeout | DeviceRequest::SetSystemSleepTimeout { .. } => {
+            return None;
+        }
         DeviceRequest::ScheduleWake { .. } | DeviceRequest::CancelWake => Capability::ScheduledWake,
         DeviceRequest::SetFrontlight { .. } | DeviceRequest::ReadFrontlight => {
             Capability::FrontlightControl
@@ -742,6 +782,30 @@ mod tests {
         assert_eq!(services.wifi_hold(), None);
         assert_eq!(services.wake_hold(), None);
         assert_eq!(services.scheduled_wake(), None);
+    }
+
+    #[test]
+    fn an_app_timeout_is_bounded_and_can_return_to_global() {
+        let mut services = DeviceServices::new(
+            declared(&["keep-awake"]),
+            PowerPolicy::DEFAULT,
+            Backends::with([Capability::KeepAwake]),
+        );
+        assert_eq!(
+            services.handle(DeviceRequest::SetSleepTimeout { seconds: 1 }),
+            DeviceResult::Granted {
+                seconds: seconds_of(PowerPolicy::DEFAULT.minimum_foreground_sleep),
+            }
+        );
+        assert_eq!(
+            services.sleep_timeout(),
+            Some(PowerPolicy::DEFAULT.minimum_foreground_sleep)
+        );
+        assert_eq!(
+            services.handle(DeviceRequest::UseGlobalSleepTimeout),
+            DeviceResult::Done
+        );
+        assert_eq!(services.sleep_timeout(), None);
     }
 
     #[test]

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -31,7 +31,7 @@ pub const MAGIC: [u8; 4] = *b"KOBO";
 ///
 /// Went to 6 for the runtime-owned app catalog and app transaction requests,
 /// whose new result variant carries a bounded list of application metadata.
-pub const VERSION: u8 = 6;
+pub const VERSION: u8 = 7;
 pub const HEADER_LEN: usize = 14;
 /// The largest single frame either side will read.
 ///
@@ -516,6 +516,12 @@ pub enum Message {
     StoreRequest(StoreRequest),
     /// Sent by the runtime when an application gains or loses the panel.
     Lifecycle(Lifecycle),
+    /// Sent by an application after it has handled a lifecycle transition.
+    ///
+    /// Suspend uses this as a barrier: the runtime does not freeze userspace
+    /// until every responsive application has saved and answered, or until the
+    /// bounded preparation deadline expires.
+    LifecycleReady(Lifecycle),
     /// The runtime's answer to exactly one store request.
     StoreResult(StoreResult),
     /// An application driving a terminal the runtime owns.
@@ -710,6 +716,12 @@ pub enum Lifecycle {
     /// Something else owns the panel. Keep working, but nothing drawn now will
     /// be seen until this comes back, so this is the moment to save.
     Background,
+    /// The whole system is about to enter suspend-to-RAM.
+    Suspend,
+    /// The system returned from suspend-to-RAM with this process intact.
+    Resume,
+    /// An RTC wake happened so background work may refresh before sleeping.
+    ScheduledWake,
 }
 
 /// The runtime's answer to exactly one [`StoreRequest`].
@@ -860,6 +872,17 @@ pub enum DeviceRequest {
     KeepAwake { seconds: u32 },
     /// Release a wake hold early.
     AllowSleep,
+    /// Use this timeout while the application is in the foreground.
+    ///
+    /// The runtime clamps it to system policy. It is not persistent and affects
+    /// no other application.
+    SetSleepTimeout { seconds: u32 },
+    /// Remove the foreground override and follow the owner-selected timeout.
+    UseGlobalSleepTimeout,
+    /// Read the owner-selected global timeout. Settings-only.
+    ReadSystemSleepTimeout,
+    /// Persist the owner-selected global timeout. Settings-only.
+    SetSystemSleepTimeout { seconds: u32 },
     /// Ask to be woken again after this many seconds.
     ScheduleWake { seconds: u32 },
     /// Cancel a pending scheduled wake.
@@ -1010,6 +1033,8 @@ pub enum DeviceResult {
     Done,
     /// A time-bounded request was granted, possibly for less than was asked.
     Granted { seconds: u32 },
+    /// The global inactivity timeout currently selected by the owner.
+    SleepTimeout { seconds: u32 },
     /// Battery state.
     Battery { percent: u8, charging: bool },
     /// Everything the gauge publishes. See [`BatteryDetail`].
@@ -1430,9 +1455,12 @@ pub fn encode(frame: &Frame) -> Result<Vec<u8>, ProtocolError> {
         Message::CommitPicture { handle } | Message::DropPicture { handle } => {
             push_u32(&mut payload, handle.0);
         }
-        Message::Lifecycle(state) => payload.push(match state {
+        Message::Lifecycle(state) | Message::LifecycleReady(state) => payload.push(match state {
             Lifecycle::Foreground => 0,
             Lifecycle::Background => 1,
+            Lifecycle::Suspend => 2,
+            Lifecycle::Resume => 3,
+            Lifecycle::ScheduledWake => 4,
         }),
         Message::CoverChanged { magnet_present } => payload.push(u8::from(*magnet_present)),
     }
@@ -1901,6 +1929,7 @@ fn encoded_message_layout(message: &Message) -> Result<(u8, usize), ProtocolErro
         }
         Message::CommitPicture { .. } => Ok((22, 4)),
         Message::CoverChanged { .. } => Ok((23, 1)),
+        Message::LifecycleReady(_) => Ok((24, 1)),
     }
 }
 
@@ -1927,6 +1956,14 @@ fn encode_device_request(
         DeviceRequest::ReleaseWifi => fixed_device_request(output, 3, 0),
         DeviceRequest::KeepAwake { seconds } => fixed_device_request(output, 4, *seconds),
         DeviceRequest::AllowSleep => fixed_device_request(output, 5, 0),
+        DeviceRequest::SetSleepTimeout { seconds } => {
+            fixed_device_request(output, 37, *seconds);
+        }
+        DeviceRequest::UseGlobalSleepTimeout => fixed_device_request(output, 38, 0),
+        DeviceRequest::ReadSystemSleepTimeout => fixed_device_request(output, 39, 0),
+        DeviceRequest::SetSystemSleepTimeout { seconds } => {
+            fixed_device_request(output, 40, *seconds);
+        }
         DeviceRequest::ScheduleWake { seconds } => fixed_device_request(output, 6, *seconds),
         DeviceRequest::CancelWake => fixed_device_request(output, 7, 0),
         DeviceRequest::SetFrontlight { percent } => {
@@ -2183,6 +2220,14 @@ fn decode_device_request(reader: &mut Reader<'_>) -> Result<DeviceRequest, Proto
             seconds: reader.u32()?,
         }),
         5 => fixed_argument(reader, 0).map(|()| DeviceRequest::AllowSleep),
+        37 => Ok(DeviceRequest::SetSleepTimeout {
+            seconds: reader.u32()?,
+        }),
+        38 => fixed_argument(reader, 0).map(|()| DeviceRequest::UseGlobalSleepTimeout),
+        39 => fixed_argument(reader, 0).map(|()| DeviceRequest::ReadSystemSleepTimeout),
+        40 => Ok(DeviceRequest::SetSystemSleepTimeout {
+            seconds: reader.u32()?,
+        }),
         6 => Ok(DeviceRequest::ScheduleWake {
             seconds: reader.u32()?,
         }),
@@ -2321,6 +2366,10 @@ fn encode_device_result(output: &mut Vec<u8>, result: &DeviceResult) -> Result<(
         DeviceResult::Done => output.push(1),
         DeviceResult::Granted { seconds } => {
             output.push(2);
+            push_u32(output, *seconds);
+        }
+        DeviceResult::SleepTimeout { seconds } => {
+            output.push(13);
             push_u32(output, *seconds);
         }
         DeviceResult::Battery { percent, charging } => {
@@ -2492,6 +2541,9 @@ fn decode_device_result(reader: &mut Reader<'_>) -> Result<DeviceResult, Protoco
     match reader.u8()? {
         1 => Ok(DeviceResult::Done),
         2 => Ok(DeviceResult::Granted {
+            seconds: reader.u32()?,
+        }),
+        13 => Ok(DeviceResult::SleepTimeout {
             seconds: reader.u32()?,
         }),
         3 => {
@@ -3297,6 +3349,9 @@ pub fn decode(bytes: &[u8]) -> Result<Frame, ProtocolError> {
         15 => Message::Lifecycle(match reader.u8()? {
             0 => Lifecycle::Foreground,
             1 => Lifecycle::Background,
+            2 => Lifecycle::Suspend,
+            3 => Lifecycle::Resume,
+            4 => Lifecycle::ScheduledWake,
             _ => return Err(ProtocolError::InvalidValue("lifecycle state")),
         }),
         16 => Message::ShellRequest(match reader.u8()? {
@@ -3380,6 +3435,14 @@ pub fn decode(bytes: &[u8]) -> Result<Frame, ProtocolError> {
         23 => Message::CoverChanged {
             magnet_present: read_boolean(&mut reader, "cover magnet present")?,
         },
+        24 => Message::LifecycleReady(match reader.u8()? {
+            0 => Lifecycle::Foreground,
+            1 => Lifecycle::Background,
+            2 => Lifecycle::Suspend,
+            3 => Lifecycle::Resume,
+            4 => Lifecycle::ScheduledWake,
+            _ => return Err(ProtocolError::InvalidValue("lifecycle state")),
+        }),
         value => return Err(ProtocolError::UnknownMessageType(value)),
     };
     if !reader.is_finished() {
@@ -5235,6 +5298,10 @@ mod tests {
             DeviceRequest::ReleaseWifi,
             DeviceRequest::KeepAwake { seconds: u32::MAX },
             DeviceRequest::AllowSleep,
+            DeviceRequest::SetSleepTimeout { seconds: 300 },
+            DeviceRequest::UseGlobalSleepTimeout,
+            DeviceRequest::ReadSystemSleepTimeout,
+            DeviceRequest::SetSystemSleepTimeout { seconds: 900 },
             DeviceRequest::ScheduleWake { seconds: 900 },
             DeviceRequest::CancelWake,
             DeviceRequest::SetFrontlight { percent: 100 },
@@ -5333,6 +5400,7 @@ mod tests {
         let results = vec![
             DeviceResult::Done,
             DeviceResult::Granted { seconds: 300 },
+            DeviceResult::SleepTimeout { seconds: 900 },
             DeviceResult::Battery {
                 percent: 100,
                 charging: true,
@@ -6642,6 +6710,10 @@ mod store_tests {
             Message::StoreResult(StoreResult::Denied(StoreError::BadKey)),
             Message::Lifecycle(Lifecycle::Foreground),
             Message::Lifecycle(Lifecycle::Background),
+            Message::Lifecycle(Lifecycle::Suspend),
+            Message::Lifecycle(Lifecycle::Resume),
+            Message::Lifecycle(Lifecycle::ScheduledWake),
+            Message::LifecycleReady(Lifecycle::Suspend),
             Message::CoverChanged {
                 magnet_present: true,
             },

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -29,9 +29,9 @@ pub const MAGIC: [u8; 4] = *b"KOBO";
 /// a flag byte inside the repeated part of tag 14, which an old runtime would
 /// have read as the next row's action.
 ///
-/// Went to 6 for the runtime-owned app catalog and app transaction requests,
-/// whose new result variant carries a bounded list of application metadata.
-pub const VERSION: u8 = 7;
+/// Went to 8 for the Settings-only activity snapshot. Its process list is
+/// bounded and carries CPU and resident-memory readings from the runtime.
+pub const VERSION: u8 = 8;
 pub const HEADER_LEN: usize = 14;
 /// The largest single frame either side will read.
 ///
@@ -108,6 +108,12 @@ pub const MAX_APP_VERSION_LEN: usize = 64;
 /// Capability declarations are drawn as a short list and are also bounded by
 /// the complete capability vocabulary.
 pub const MAX_APP_CAPABILITIES: usize = 16;
+
+/// The process table in one activity snapshot is deliberately a top list, not
+/// an unbounded copy of `/proc`.
+pub const MAX_ACTIVITY_PROCESSES: usize = 12;
+/// Process names occupy one fixed-width table column in Settings.
+pub const MAX_PROCESS_NAME_LEN: usize = 48;
 
 /// Human-readable radio identifiers are deliberately shorter than an ordinary
 /// protocol string. They are drawn on one row and are also accepted from local
@@ -883,6 +889,8 @@ pub enum DeviceRequest {
     ReadSystemSleepTimeout,
     /// Persist the owner-selected global timeout. Settings-only.
     SetSystemSleepTimeout { seconds: u32 },
+    /// Read a bounded system and process activity sample. Settings-only.
+    ReadSystemActivity,
     /// Ask to be woken again after this many seconds.
     ScheduleWake { seconds: u32 },
     /// Cancel a pending scheduled wake.
@@ -1026,6 +1034,28 @@ impl BatteryDetail {
     }
 }
 
+/// One process in a bounded system activity snapshot.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProcessActivity {
+    pub pid: u32,
+    pub name: String,
+    /// CPU contribution in tenths of one system-wide percent.
+    pub cpu_tenths: u16,
+    /// Resident memory currently held by this process.
+    pub memory_bytes: u64,
+}
+
+/// CPU, memory, disk, and top-process readings sampled by the runtime.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct SystemActivity {
+    /// Busy CPU in tenths of a percent.
+    pub cpu_tenths: u16,
+    pub memory_used_bytes: u64,
+    pub memory_total_bytes: u64,
+    pub disk_free_bytes: Option<u64>,
+    pub processes: Vec<ProcessActivity>,
+}
+
 /// The runtime's answer to a device request.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DeviceResult {
@@ -1035,6 +1065,8 @@ pub enum DeviceResult {
     Granted { seconds: u32 },
     /// The global inactivity timeout currently selected by the owner.
     SleepTimeout { seconds: u32 },
+    /// A bounded system activity sample for the built-in Settings app.
+    SystemActivity(SystemActivity),
     /// Battery state.
     Battery { percent: u8, charging: bool },
     /// Everything the gauge publishes. See [`BatteryDetail`].
@@ -1964,6 +1996,7 @@ fn encode_device_request(
         DeviceRequest::SetSystemSleepTimeout { seconds } => {
             fixed_device_request(output, 40, *seconds);
         }
+        DeviceRequest::ReadSystemActivity => fixed_device_request(output, 41, 0),
         DeviceRequest::ScheduleWake { seconds } => fixed_device_request(output, 6, *seconds),
         DeviceRequest::CancelWake => fixed_device_request(output, 7, 0),
         DeviceRequest::SetFrontlight { percent } => {
@@ -2228,6 +2261,7 @@ fn decode_device_request(reader: &mut Reader<'_>) -> Result<DeviceRequest, Proto
         40 => Ok(DeviceRequest::SetSystemSleepTimeout {
             seconds: reader.u32()?,
         }),
+        41 => fixed_argument(reader, 0).map(|()| DeviceRequest::ReadSystemActivity),
         6 => Ok(DeviceRequest::ScheduleWake {
             seconds: reader.u32()?,
         }),
@@ -2371,6 +2405,40 @@ fn encode_device_result(output: &mut Vec<u8>, result: &DeviceResult) -> Result<(
         DeviceResult::SleepTimeout { seconds } => {
             output.push(13);
             push_u32(output, *seconds);
+        }
+        DeviceResult::SystemActivity(activity) => {
+            if activity.cpu_tenths > 1000
+                || activity.memory_used_bytes > activity.memory_total_bytes
+                || activity.processes.len() > MAX_ACTIVITY_PROCESSES
+            {
+                return Err(ProtocolError::InvalidValue("system activity"));
+            }
+            output.push(14);
+            push_u16(output, activity.cpu_tenths);
+            push_u64(output, activity.memory_used_bytes);
+            push_u64(output, activity.memory_total_bytes);
+            match activity.disk_free_bytes {
+                Some(bytes) => {
+                    output.push(1);
+                    push_u64(output, bytes);
+                }
+                None => output.push(0),
+            }
+            output.push(
+                u8::try_from(activity.processes.len()).map_err(|_| ProtocolError::FrameTooLarge)?,
+            );
+            for process in &activity.processes {
+                if process.name.is_empty()
+                    || process.name.len() > MAX_PROCESS_NAME_LEN
+                    || process.cpu_tenths > 1000
+                {
+                    return Err(ProtocolError::InvalidValue("process activity"));
+                }
+                push_u32(output, process.pid);
+                push_string(output, &process.name)?;
+                push_u16(output, process.cpu_tenths);
+                push_u64(output, process.memory_bytes);
+            }
         }
         DeviceResult::Battery { percent, charging } => {
             output.push(3);
@@ -2546,18 +2614,8 @@ fn decode_device_result(reader: &mut Reader<'_>) -> Result<DeviceResult, Protoco
         13 => Ok(DeviceResult::SleepTimeout {
             seconds: reader.u32()?,
         }),
-        3 => {
-            let percent = reader.u8()?;
-            if percent > 100 {
-                return Err(ProtocolError::InvalidValue("battery percent"));
-            }
-            let charging = match reader.u8()? {
-                0 => false,
-                1 => true,
-                _ => return Err(ProtocolError::InvalidValue("charging flag")),
-            };
-            Ok(DeviceResult::Battery { percent, charging })
-        }
+        14 => decode_system_activity(reader).map(DeviceResult::SystemActivity),
+        3 => decode_battery_result(reader),
         10 => battery_detail(reader).map(DeviceResult::BatteryDetail),
         11 => Ok(DeviceResult::Cover {
             available: read_boolean(reader, "cover sensor available")?,
@@ -2638,6 +2696,58 @@ fn decode_device_result(reader: &mut Reader<'_>) -> Result<DeviceResult, Protoco
         12 => decode_apps_result(reader),
         _ => Err(ProtocolError::InvalidValue("device result")),
     }
+}
+
+fn decode_battery_result(reader: &mut Reader<'_>) -> Result<DeviceResult, ProtocolError> {
+    let percent = reader.u8()?;
+    if percent > 100 {
+        return Err(ProtocolError::InvalidValue("battery percent"));
+    }
+    let charging = match reader.u8()? {
+        0 => false,
+        1 => true,
+        _ => return Err(ProtocolError::InvalidValue("charging flag")),
+    };
+    Ok(DeviceResult::Battery { percent, charging })
+}
+
+fn decode_system_activity(reader: &mut Reader<'_>) -> Result<SystemActivity, ProtocolError> {
+    let cpu_tenths = reader.u16()?;
+    let memory_used_bytes = reader.u64()?;
+    let memory_total_bytes = reader.u64()?;
+    let disk_free_bytes = match reader.u8()? {
+        0 => None,
+        1 => Some(reader.u64()?),
+        _ => return Err(ProtocolError::InvalidValue("disk availability")),
+    };
+    let count = usize::from(reader.u8()?);
+    if cpu_tenths > 1000 || memory_used_bytes > memory_total_bytes || count > MAX_ACTIVITY_PROCESSES
+    {
+        return Err(ProtocolError::InvalidValue("system activity"));
+    }
+    let mut processes = Vec::with_capacity(count);
+    for _ in 0..count {
+        let pid = reader.u32()?;
+        let name = reader.string()?;
+        let process_cpu_tenths = reader.u16()?;
+        let memory_bytes = reader.u64()?;
+        if name.is_empty() || name.len() > MAX_PROCESS_NAME_LEN || process_cpu_tenths > 1000 {
+            return Err(ProtocolError::InvalidValue("process activity"));
+        }
+        processes.push(ProcessActivity {
+            pid,
+            name,
+            cpu_tenths: process_cpu_tenths,
+            memory_bytes,
+        });
+    }
+    Ok(SystemActivity {
+        cpu_tenths,
+        memory_used_bytes,
+        memory_total_bytes,
+        disk_free_bytes,
+        processes,
+    })
 }
 
 fn decode_apps_result(reader: &mut Reader<'_>) -> Result<DeviceResult, ProtocolError> {
@@ -5302,6 +5412,7 @@ mod tests {
             DeviceRequest::UseGlobalSleepTimeout,
             DeviceRequest::ReadSystemSleepTimeout,
             DeviceRequest::SetSystemSleepTimeout { seconds: 900 },
+            DeviceRequest::ReadSystemActivity,
             DeviceRequest::ScheduleWake { seconds: 900 },
             DeviceRequest::CancelWake,
             DeviceRequest::SetFrontlight { percent: 100 },
@@ -5395,12 +5506,28 @@ mod tests {
         }
     }
 
+    fn activity_sample() -> SystemActivity {
+        SystemActivity {
+            cpu_tenths: 427,
+            memory_used_bytes: 128 * 1024 * 1024,
+            memory_total_bytes: 512 * 1024 * 1024,
+            disk_free_bytes: Some(3 * 1024 * 1024 * 1024),
+            processes: vec![ProcessActivity {
+                pid: 42,
+                name: "kobod".to_owned(),
+                cpu_tenths: 103,
+                memory_bytes: 12 * 1024 * 1024,
+            }],
+        }
+    }
+
     #[test]
     fn every_device_result_round_trips() {
         let results = vec![
             DeviceResult::Done,
             DeviceResult::Granted { seconds: 300 },
             DeviceResult::SleepTimeout { seconds: 900 },
+            DeviceResult::SystemActivity(activity_sample()),
             DeviceResult::Battery {
                 percent: 100,
                 charging: true,

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -3646,6 +3646,36 @@ impl Device<'_> {
         self.request(DeviceRequest::AllowSleep);
     }
 
+    /// Overrides the global inactivity timeout while this application is in
+    /// the foreground. The grant is clamped by system policy and lasts for this
+    /// running application only.
+    pub fn override_sleep_timeout(&mut self, duration: Duration) {
+        self.request(DeviceRequest::SetSleepTimeout {
+            seconds: whole_seconds(duration),
+        });
+    }
+
+    /// Removes this application's timeout override and follows Settings again.
+    pub fn use_global_sleep_timeout(&mut self) {
+        self.request(DeviceRequest::UseGlobalSleepTimeout);
+    }
+
+    /// Reads the owner-selected global inactivity timeout.
+    ///
+    /// This platform request is reserved for the built-in Settings app.
+    pub fn read_system_sleep_timeout(&mut self) {
+        self.request(DeviceRequest::ReadSystemSleepTimeout);
+    }
+
+    /// Persists the global inactivity timeout selected by the owner.
+    ///
+    /// This platform request is reserved for the built-in Settings app.
+    pub fn set_system_sleep_timeout(&mut self, duration: Duration) {
+        self.request(DeviceRequest::SetSystemSleepTimeout {
+            seconds: whole_seconds(duration),
+        });
+    }
+
     /// Asks to be woken after `delay` to refresh content.
     ///
     /// The runtime coalesces wakes across applications and enforces a minimum
@@ -3881,8 +3911,12 @@ pub trait KoboApp {
     fn on_start(&mut self, context: &mut Context);
     fn on_action(&mut self, context: &mut Context, action: ActionId);
 
+    /// Called after the device resumes into the same running application.
     fn on_resume(&mut self, _context: &mut Context) {}
 
+    /// Called immediately before suspend so short state saves can be queued.
+    /// The runtime proceeds after a bounded grace period even if an
+    /// application does not answer.
     fn on_suspend(&mut self, _context: &mut Context) {}
 
     fn on_scheduled_wake(&mut self, _context: &mut Context) {}
@@ -4197,6 +4231,9 @@ impl<A: KoboApp> AppRunner<A> {
                 self.displayed = None;
                 self.dispatch(KoboApp::on_background)
             }
+            Lifecycle::Suspend => self.dispatch(KoboApp::on_suspend),
+            Lifecycle::Resume => self.dispatch(KoboApp::on_resume),
+            Lifecycle::ScheduledWake => self.dispatch(KoboApp::on_scheduled_wake),
         }
     }
 
@@ -4530,6 +4567,10 @@ impl Client {
             },
         )?;
         Ok(())
+    }
+
+    fn lifecycle_ready(&mut self, state: Lifecycle) -> Result<(), ClientError> {
+        self.send(Message::LifecycleReady(state))
     }
 }
 
@@ -5149,6 +5190,14 @@ mod tests {
         fn on_action(&mut self, context: &mut Context, action: ActionId) {
             context.log(LogLevel::Info, format!("action {}", action.0));
         }
+
+        fn on_suspend(&mut self, context: &mut Context) {
+            context.store().save("state", b"safe".to_vec());
+        }
+
+        fn on_resume(&mut self, context: &mut Context) {
+            context.log(LogLevel::Info, "resumed");
+        }
     }
 
     struct Tofu;
@@ -5207,6 +5256,15 @@ mod tests {
         assert!(runner.start().is_empty());
         assert!(matches!(
             runner.action(ActionId(9)).as_slice(),
+            [Command::Log { .. }]
+        ));
+        assert!(matches!(
+            runner.lifecycle(Lifecycle::Suspend).as_slice(),
+            [Command::Store(StoreRequest::Save { key, value })]
+                if key == "state" && value == b"safe"
+        ));
+        assert!(matches!(
+            runner.lifecycle(Lifecycle::Resume).as_slice(),
             [Command::Log { .. }]
         ));
     }
@@ -5891,6 +5949,7 @@ pub fn run_on<A: KoboApp>(name: &str, app: A, socket: &Path) -> Result<(), Clien
                 }
                 ClientEvent::Lifecycle(state) => {
                     client.send_commands(runner.lifecycle(state))?;
+                    client.lifecycle_ready(state)?;
                 }
                 ClientEvent::Shell(event) => {
                     client.send_commands(runner.shell_event(event))?;
@@ -5906,14 +5965,14 @@ pub fn run_on<A: KoboApp>(name: &str, app: A, socket: &Path) -> Result<(), Clien
     }
 
     loop {
-        let commands = match client.next_event()? {
-            ClientEvent::Action(action) => runner.action(action),
-            ClientEvent::Device(result) => runner.device_result(result),
-            ClientEvent::Task { task, outcome } => runner.task_outcome(task, outcome),
-            ClientEvent::Store(result) => runner.store_result(result),
-            ClientEvent::Lifecycle(state) => runner.lifecycle(state),
-            ClientEvent::Shell(event) => runner.shell_event(event),
-            ClientEvent::CoverChanged(present) => runner.cover_changed(present),
+        let (commands, lifecycle_ready) = match client.next_event()? {
+            ClientEvent::Action(action) => (runner.action(action), None),
+            ClientEvent::Device(result) => (runner.device_result(result), None),
+            ClientEvent::Task { task, outcome } => (runner.task_outcome(task, outcome), None),
+            ClientEvent::Store(result) => (runner.store_result(result), None),
+            ClientEvent::Lifecycle(state) => (runner.lifecycle(state), Some(state)),
+            ClientEvent::Shell(event) => (runner.shell_event(event), None),
+            ClientEvent::CoverChanged(present) => (runner.cover_changed(present), None),
             ClientEvent::Exit => {
                 // The runtime is taking the screen back. Give the application
                 // its exit callback, then go, rather than arguing about it.
@@ -5925,6 +5984,9 @@ pub fn run_on<A: KoboApp>(name: &str, app: A, socket: &Path) -> Result<(), Clien
             .iter()
             .any(|command| matches!(command, Command::Exit));
         client.send_commands(commands)?;
+        if let Some(state) = lifecycle_ready {
+            client.lifecycle_ready(state)?;
+        }
         if leaving {
             return Ok(());
         }

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -8,12 +8,12 @@
 pub use kobo_protocol::{
     AppInfo, AudioPlaybackState, AudioSource, BatteryDetail, BluetoothDevice, BluetoothDeviceKind,
     Credential, DenyReason, DeviceError, DeviceRequest, DeviceResult, Frame, Header, Lifecycle,
-    LogLevel, Message, SecretHeader, ShellError, ShellEvent, ShellRequest, StoreError,
-    StoreRequest, StoreResult, StreamError, Task, TaskError, TaskId, TaskOutcome, WifiNetwork,
-    CACHE_PREFIX, MAX_CACHE_KEYS, MAX_HEADERS, MAX_HEADER_NAME, MAX_HEADER_VALUE,
-    MAX_INLINE_PICTURE_BYTES, MAX_PICTURE_BYTES, MAX_PICTURE_CHUNK_BYTES, MAX_RADIO_DEVICES,
-    MAX_RADIO_NAME, MAX_SHELF_CHUNK, MAX_SHELL_CHUNK, MAX_STORE_KEYS, MAX_STORE_VALUE,
-    MAX_TASK_BYTES, MAX_URL_LEN,
+    LogLevel, Message, ProcessActivity, SecretHeader, ShellError, ShellEvent, ShellRequest,
+    StoreError, StoreRequest, StoreResult, StreamError, SystemActivity, Task, TaskError, TaskId,
+    TaskOutcome, WifiNetwork, CACHE_PREFIX, MAX_ACTIVITY_PROCESSES, MAX_CACHE_KEYS, MAX_HEADERS,
+    MAX_HEADER_NAME, MAX_HEADER_VALUE, MAX_INLINE_PICTURE_BYTES, MAX_PICTURE_BYTES,
+    MAX_PICTURE_CHUNK_BYTES, MAX_PROCESS_NAME_LEN, MAX_RADIO_DEVICES, MAX_RADIO_NAME,
+    MAX_SHELF_CHUNK, MAX_SHELL_CHUNK, MAX_STORE_KEYS, MAX_STORE_VALUE, MAX_TASK_BYTES, MAX_URL_LEN,
 };
 pub use kobo_ui::QuoteRole;
 pub use kobo_ui::{
@@ -51,9 +51,10 @@ pub mod prelude {
         AudioMetadata, AudioPlaybackState, AudioPlayer, AudioSource, BluetoothDevice,
         BluetoothDeviceKind, Capability, Client, ClientEvent, Command, Context, ControlState,
         DenyReason, Device, DeviceError, DeviceRequest, DeviceResult, DialogAction, Failure, Grant,
-        Grants, Heartbeat, KoboApp, Lifecycle, Navigator, Node, NodeId, PowerPolicy, Screen,
-        ScreenBuilder, ShelfDownload, ShelfProgress, ShelfUpload, ShellError, ShellEvent,
-        ShellRequest, StandardState, StoreError, StoreRequest, StoreResult, WifiNetwork,
+        Grants, Heartbeat, KoboApp, Lifecycle, Navigator, Node, NodeId, PowerPolicy,
+        ProcessActivity, Screen, ScreenBuilder, ShelfDownload, ShelfProgress, ShelfUpload,
+        ShellError, ShellEvent, ShellRequest, StandardState, StoreError, StoreRequest, StoreResult,
+        SystemActivity, WifiNetwork,
     };
 }
 
@@ -3674,6 +3675,13 @@ impl Device<'_> {
         self.request(DeviceRequest::SetSystemSleepTimeout {
             seconds: whole_seconds(duration),
         });
+    }
+
+    /// Reads a bounded CPU, memory, disk, and top-process activity sample.
+    ///
+    /// This platform request is reserved for the built-in Settings app.
+    pub fn read_system_activity(&mut self) {
+        self.request(DeviceRequest::ReadSystemActivity);
     }
 
     /// Asks to be woken after `delay` to refresh content.

--- a/crates/kobo-sim/src/lib.rs
+++ b/crates/kobo-sim/src/lib.rs
@@ -789,6 +789,7 @@ struct AppState {
     lifecycle: Lifecycle,
     last_touch: Option<SimulatedTouch>,
     apps: Arc<Mutex<SimulatedApps>>,
+    system_sleep_seconds: u32,
 }
 
 impl Default for AppState {
@@ -810,6 +811,7 @@ impl AppState {
             lifecycle: Lifecycle::Foreground,
             last_touch: None,
             apps,
+            system_sleep_seconds: 15 * 60,
         }
     }
 }
@@ -1304,6 +1306,9 @@ fn simulation_json(
     let lifecycle = match lifecycle {
         Lifecycle::Foreground => "foreground",
         Lifecycle::Background => "background",
+        Lifecycle::Suspend => "suspend",
+        Lifecycle::Resume => "resume",
+        Lifecycle::ScheduledWake => "scheduled-wake",
     };
     format!(
         concat!(
@@ -1339,6 +1344,9 @@ fn parse_lifecycle(bytes: &[u8]) -> Option<Lifecycle> {
     match std::str::from_utf8(bytes).ok()?.trim() {
         "foreground" => Some(Lifecycle::Foreground),
         "background" => Some(Lifecycle::Background),
+        "suspend" => Some(Lifecycle::Suspend),
+        "resume" => Some(Lifecycle::Resume),
+        "scheduled-wake" => Some(Lifecycle::ScheduledWake),
         _ => None,
     }
 }
@@ -1745,6 +1753,7 @@ fn read_app_messages(
             }
             message if is_picture_message(&message) => hold(state, message)?,
             Message::Log { level, message } => note(state, &format!("{level:?}: {message}"))?,
+            Message::LifecycleReady(_) => {}
             Message::DeviceRequest(request) => {
                 let scenario = current_scenario(state);
                 services.observe_battery(
@@ -1866,7 +1875,12 @@ fn simulated_platform_request_allowed(
     caller: &str,
     request: &kobo_protocol::DeviceRequest,
 ) -> bool {
-    !matches!(request, kobo_protocol::DeviceRequest::Update { .. }) || caller == "settings"
+    !matches!(
+        request,
+        kobo_protocol::DeviceRequest::Update { .. }
+            | kobo_protocol::DeviceRequest::ReadSystemSleepTimeout
+            | kobo_protocol::DeviceRequest::SetSystemSleepTimeout { .. }
+    ) || caller == "settings"
 }
 
 fn simulated_app_request(
@@ -1878,6 +1892,9 @@ fn simulated_app_request(
     use kobo_protocol::{DenyReason, DeviceError, DeviceRequest, DeviceResult};
 
     let authorized = match request {
+        DeviceRequest::ReadSystemSleepTimeout | DeviceRequest::SetSystemSleepTimeout { .. } => {
+            caller == "settings"
+        }
         DeviceRequest::ListInstalledApps => matches!(caller, "launcher" | "store"),
         DeviceRequest::ReadAppCatalog
         | DeviceRequest::RefreshAppCatalog
@@ -1887,6 +1904,26 @@ fn simulated_app_request(
     };
     if !authorized || scenario == Scenario::PermissionDenied {
         return Ok(Some(DeviceResult::Denied(DenyReason::NotDeclared)));
+    }
+    match request {
+        DeviceRequest::ReadSystemSleepTimeout => {
+            let seconds = state
+                .lock()
+                .map_err(|_| io::Error::other("app state lock poisoned"))?
+                .system_sleep_seconds;
+            return Ok(Some(DeviceResult::SleepTimeout { seconds }));
+        }
+        DeviceRequest::SetSystemSleepTimeout { seconds } => {
+            if !(60..=60 * 60).contains(seconds) {
+                return Ok(Some(DeviceResult::Failed(DeviceError::InvalidInput)));
+            }
+            state
+                .lock()
+                .map_err(|_| io::Error::other("app state lock poisoned"))?
+                .system_sleep_seconds = *seconds;
+            return Ok(Some(DeviceResult::SleepTimeout { seconds: *seconds }));
+        }
+        _ => {}
     }
     let apps = state
         .lock()

--- a/crates/kobo-sim/src/lib.rs
+++ b/crates/kobo-sim/src/lib.rs
@@ -1880,6 +1880,7 @@ fn simulated_platform_request_allowed(
         kobo_protocol::DeviceRequest::Update { .. }
             | kobo_protocol::DeviceRequest::ReadSystemSleepTimeout
             | kobo_protocol::DeviceRequest::SetSystemSleepTimeout { .. }
+            | kobo_protocol::DeviceRequest::ReadSystemActivity
     ) || caller == "settings"
 }
 
@@ -1892,9 +1893,9 @@ fn simulated_app_request(
     use kobo_protocol::{DenyReason, DeviceError, DeviceRequest, DeviceResult};
 
     let authorized = match request {
-        DeviceRequest::ReadSystemSleepTimeout | DeviceRequest::SetSystemSleepTimeout { .. } => {
-            caller == "settings"
-        }
+        DeviceRequest::ReadSystemSleepTimeout
+        | DeviceRequest::SetSystemSleepTimeout { .. }
+        | DeviceRequest::ReadSystemActivity => caller == "settings",
         DeviceRequest::ListInstalledApps => matches!(caller, "launcher" | "store"),
         DeviceRequest::ReadAppCatalog
         | DeviceRequest::RefreshAppCatalog
@@ -1922,6 +1923,9 @@ fn simulated_app_request(
                 .map_err(|_| io::Error::other("app state lock poisoned"))?
                 .system_sleep_seconds = *seconds;
             return Ok(Some(DeviceResult::SleepTimeout { seconds: *seconds }));
+        }
+        DeviceRequest::ReadSystemActivity => {
+            return Ok(Some(simulated_activity()));
         }
         _ => {}
     }
@@ -1985,6 +1989,29 @@ fn simulated_app_request(
         _ => return Ok(None),
     };
     Ok(Some(result))
+}
+
+fn simulated_activity() -> kobo_protocol::DeviceResult {
+    kobo_protocol::DeviceResult::SystemActivity(kobo_protocol::SystemActivity {
+        cpu_tenths: 284,
+        memory_used_bytes: 236 * 1024 * 1024,
+        memory_total_bytes: 512 * 1024 * 1024,
+        disk_free_bytes: Some(3 * 1024 * 1024 * 1024),
+        processes: vec![
+            kobo_protocol::ProcessActivity {
+                pid: 310,
+                name: "kobo-settings".to_owned(),
+                cpu_tenths: 92,
+                memory_bytes: 18 * 1024 * 1024,
+            },
+            kobo_protocol::ProcessActivity {
+                pid: 201,
+                name: "kobod".to_owned(),
+                cpu_tenths: 61,
+                memory_bytes: 31 * 1024 * 1024,
+            },
+        ],
+    })
 }
 
 /// Delivers a finished task as soon as it finishes.
@@ -2641,6 +2668,14 @@ mod tests {
         };
         assert!(simulated_platform_request_allowed("settings", &update));
         assert!(!simulated_platform_request_allowed("store", &update));
+        assert!(simulated_platform_request_allowed(
+            "settings",
+            &kobo_protocol::DeviceRequest::ReadSystemActivity
+        ));
+        assert!(!simulated_platform_request_allowed(
+            "store",
+            &kobo_protocol::DeviceRequest::ReadSystemActivity
+        ));
         assert!(simulated_platform_request_allowed(
             "store",
             &kobo_protocol::DeviceRequest::RefreshAppCatalog

--- a/crates/kobod/src/activity.rs
+++ b/crates/kobod/src/activity.rs
@@ -1,0 +1,286 @@
+//! Bounded Linux activity samples for the built-in Settings application.
+
+use kobo_protocol::MAX_PROCESS_NAME_LEN;
+#[cfg(feature = "device-write")]
+use kobo_protocol::{ProcessActivity, SystemActivity, MAX_ACTIVITY_PROCESSES};
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::Path;
+#[cfg(feature = "device-write")]
+use std::path::PathBuf;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CpuTimes {
+    total: u64,
+    idle: u64,
+}
+
+#[derive(Debug)]
+struct RawProcess {
+    pid: u32,
+    name: String,
+    ticks: u64,
+    memory_bytes: u64,
+}
+
+/// Samples procfs deltas while retaining only the previous process counters.
+#[cfg(feature = "device-write")]
+pub struct ActivityMonitor {
+    proc_root: PathBuf,
+    disk_root: PathBuf,
+    previous_cpu: Option<CpuTimes>,
+    previous_process_ticks: BTreeMap<u32, u64>,
+}
+
+#[cfg(feature = "device-write")]
+impl ActivityMonitor {
+    #[must_use]
+    pub fn system(disk_root: &Path) -> Self {
+        Self::new(Path::new("/proc"), disk_root)
+    }
+
+    #[must_use]
+    fn new(proc_root: &Path, disk_root: &Path) -> Self {
+        Self {
+            proc_root: proc_root.to_path_buf(),
+            disk_root: disk_root.to_path_buf(),
+            previous_cpu: None,
+            previous_process_ticks: BTreeMap::new(),
+        }
+    }
+
+    /// Reads one system sample and computes CPU from the interval since the
+    /// previous call.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the aggregate CPU or memory readings are missing.
+    /// Individual processes may disappear while `/proc` is being walked and
+    /// are skipped rather than failing the complete sample.
+    pub fn sample(&mut self) -> io::Result<SystemActivity> {
+        let cpu = cpu_times(&fs::read_to_string(self.proc_root.join("stat"))?)?;
+        let (memory_used_bytes, memory_total_bytes) =
+            memory(&fs::read_to_string(self.proc_root.join("meminfo"))?)?;
+        let processes = read_processes(&self.proc_root);
+        let interval = self
+            .previous_cpu
+            .map_or(0, |previous| cpu.total.saturating_sub(previous.total));
+        let cpu_tenths = self.previous_cpu.map_or(0, |previous| {
+            let total = cpu.total.saturating_sub(previous.total);
+            let idle = cpu.idle.saturating_sub(previous.idle);
+            percent_tenths(total.saturating_sub(idle), total)
+        });
+
+        let mut next_ticks = BTreeMap::new();
+        let mut reported = processes
+            .into_iter()
+            .map(|process| {
+                next_ticks.insert(process.pid, process.ticks);
+                let changed = self
+                    .previous_process_ticks
+                    .get(&process.pid)
+                    .map_or(0, |previous| process.ticks.saturating_sub(*previous));
+                ProcessActivity {
+                    pid: process.pid,
+                    name: process.name,
+                    cpu_tenths: percent_tenths(changed, interval),
+                    memory_bytes: process.memory_bytes,
+                }
+            })
+            .collect::<Vec<_>>();
+        reported.sort_by(|left, right| {
+            right
+                .cpu_tenths
+                .cmp(&left.cpu_tenths)
+                .then_with(|| right.memory_bytes.cmp(&left.memory_bytes))
+                .then_with(|| left.pid.cmp(&right.pid))
+        });
+        reported.truncate(MAX_ACTIVITY_PROCESSES);
+
+        self.previous_cpu = Some(cpu);
+        self.previous_process_ticks = next_ticks;
+        Ok(SystemActivity {
+            cpu_tenths,
+            memory_used_bytes,
+            memory_total_bytes,
+            disk_free_bytes: kobo_abi::free_space(&self.disk_root),
+            processes: reported,
+        })
+    }
+}
+
+fn cpu_times(stat: &str) -> io::Result<CpuTimes> {
+    let line = stat
+        .lines()
+        .find(|line| line.starts_with("cpu "))
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing aggregate CPU"))?;
+    let values = line
+        .split_ascii_whitespace()
+        .skip(1)
+        .map(str::parse::<u64>)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid aggregate CPU"))?;
+    if values.len() < 4 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "short aggregate CPU",
+        ));
+    }
+    // Guest and guest_nice are already included in user and nice respectively.
+    let total = values
+        .iter()
+        .take(8)
+        .copied()
+        .fold(0_u64, u64::saturating_add);
+    let idle = values[3].saturating_add(values.get(4).copied().unwrap_or(0));
+    Ok(CpuTimes { total, idle })
+}
+
+fn memory(meminfo: &str) -> io::Result<(u64, u64)> {
+    let values = meminfo
+        .lines()
+        .filter_map(|line| {
+            let (name, rest) = line.split_once(':')?;
+            let kib = rest.split_ascii_whitespace().next()?.parse::<u64>().ok()?;
+            Some((name, kib.saturating_mul(1024)))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let total = values
+        .get("MemTotal")
+        .copied()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing total memory"))?;
+    let available = values.get("MemAvailable").copied().unwrap_or_else(|| {
+        ["MemFree", "Buffers", "Cached"]
+            .into_iter()
+            .filter_map(|name| values.get(name).copied())
+            .fold(0_u64, u64::saturating_add)
+    });
+    Ok((total.saturating_sub(available.min(total)), total))
+}
+
+#[cfg(feature = "device-write")]
+fn read_processes(proc_root: &Path) -> Vec<RawProcess> {
+    let Ok(entries) = fs::read_dir(proc_root) else {
+        return Vec::new();
+    };
+    entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let pid = entry.file_name().to_str()?.parse::<u32>().ok()?;
+            read_process(&entry.path(), pid)
+        })
+        .collect()
+}
+
+fn read_process(path: &Path, pid: u32) -> Option<RawProcess> {
+    let stat = fs::read_to_string(path.join("stat")).ok()?;
+    let after_name = stat.rsplit_once(") ")?.1;
+    let fields = after_name.split_ascii_whitespace().collect::<Vec<_>>();
+    let user = fields.get(11)?.parse::<u64>().ok()?;
+    let system = fields.get(12)?.parse::<u64>().ok()?;
+    let status = fs::read_to_string(path.join("status")).ok()?;
+    let memory_bytes = status
+        .lines()
+        .find_map(|line| {
+            let rest = line.strip_prefix("VmRSS:")?;
+            rest.split_ascii_whitespace()
+                .next()?
+                .parse::<u64>()
+                .ok()
+                .map(|kib| kib.saturating_mul(1024))
+        })
+        .unwrap_or(0);
+    let name = fs::read_to_string(path.join("comm"))
+        .ok()
+        .map_or_else(|| format!("pid-{pid}"), |name| safe_name(&name));
+    Some(RawProcess {
+        pid,
+        name,
+        ticks: user.saturating_add(system),
+        memory_bytes,
+    })
+}
+
+fn safe_name(name: &str) -> String {
+    let cleaned = name
+        .trim()
+        .chars()
+        .map(|character| {
+            if character.is_ascii_graphic() || character == ' ' {
+                character
+            } else {
+                '?'
+            }
+        })
+        .take(MAX_PROCESS_NAME_LEN)
+        .collect::<String>();
+    if cleaned.is_empty() {
+        "unknown".to_owned()
+    } else {
+        cleaned
+    }
+}
+
+fn percent_tenths(part: u64, whole: u64) -> u16 {
+    if whole == 0 {
+        return 0;
+    }
+    let tenths = u128::from(part).saturating_mul(1000) / u128::from(whole);
+    u16::try_from(tenths.min(1000)).unwrap_or(1000)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{cpu_times, memory, percent_tenths, read_process, safe_name, CpuTimes};
+    use std::fs;
+
+    #[test]
+    fn aggregate_cpu_counts_idle_and_iowait_as_idle() {
+        assert_eq!(
+            cpu_times("cpu  100 2 30 400 8 3 4 1\n").expect("cpu"),
+            CpuTimes {
+                total: 548,
+                idle: 408,
+            }
+        );
+    }
+
+    #[test]
+    fn memory_prefers_the_kernels_available_estimate() {
+        let (used, total) =
+            memory("MemTotal: 512000 kB\nMemAvailable: 128000 kB\n").expect("memory");
+        assert_eq!(total, 512_000 * 1024);
+        assert_eq!(used, 384_000 * 1024);
+    }
+
+    #[test]
+    fn percentages_are_bounded_and_names_are_safe_for_the_panel() {
+        assert_eq!(percent_tenths(1, 4), 250);
+        assert_eq!(percent_tenths(8, 4), 1000);
+        assert_eq!(safe_name("worker\n"), "worker");
+        assert_eq!(safe_name("\u{2603}"), "?");
+    }
+
+    #[test]
+    fn a_process_stat_yields_cpu_memory_name_and_pid() {
+        let root =
+            std::env::temp_dir().join(format!("cobalt-activity-process-{}", std::process::id()));
+        let process = root.join("42");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&process).expect("process directory");
+        fs::write(
+            process.join("stat"),
+            "42 (worker name) S 1 1 1 0 0 0 0 0 0 0 25 5\n",
+        )
+        .expect("stat");
+        fs::write(process.join("status"), "Name:\tworker\nVmRSS:\t123 kB\n").expect("status");
+        fs::write(process.join("comm"), "worker name\n").expect("comm");
+        let sampled = read_process(&process, 42).expect("process sample");
+        assert_eq!(sampled.pid, 42);
+        assert_eq!(sampled.name, "worker name");
+        assert_eq!(sampled.ticks, 30);
+        assert_eq!(sampled.memory_bytes, 123 * 1024);
+        let _ = fs::remove_dir_all(root);
+    }
+}

--- a/crates/kobod/src/app_store.rs
+++ b/crates/kobod/src/app_store.rs
@@ -136,7 +136,7 @@ const SYSTEM_APPS: &[BuiltinApp] = &[
         id: "settings",
         title: "Settings",
         label: "Settings",
-        summary: "Connect Wi-Fi, manage hardware and update the Cobalt platform.",
+        summary: "Set sleep, connect Wi-Fi, manage hardware and update the platform.",
         version: env!("CARGO_PKG_VERSION"),
         glyph: Glyph::Settings,
         capabilities: &[

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -32,6 +32,7 @@
 //! unwinding is therefore explicit and centralised in one function rather than
 //! spread across returns.
 
+use crate::activity::ActivityMonitor;
 use crate::blackbox::{self, trace};
 use crate::power::{AppSleep, GlobalSleep, DEFAULT_SLEEP_TIMEOUT};
 use kobo_hal::display::{DisplaySession, OWNER_UNLOCK_PHRASE};
@@ -968,6 +969,7 @@ fn host_applications(
     let (sender, events) = mpsc::channel();
     touch.set(Some(sender.clone()));
     let mut global_sleep = GlobalSleep::load(Path::new(COBALT_ROOT), limits.idle);
+    let mut activity = ActivityMonitor::system(Path::new(COBALT_ROOT));
     let system_suspend = match SystemSuspend::open() {
         Ok(suspend) => Some(suspend),
         Err(error) => {
@@ -1820,6 +1822,21 @@ fn host_applications(
                                         }
                                         Err(error) => kobo_protocol::DeviceResult::Failed(error),
                                     },
+                                    kobo_protocol::DeviceRequest::ReadSystemActivity => {
+                                        match activity.sample() {
+                                            Ok(sample) => {
+                                                kobo_protocol::DeviceResult::SystemActivity(sample)
+                                            }
+                                            Err(error) => {
+                                                trace(&format!(
+                                                    "system activity unavailable: {error}"
+                                                ));
+                                                kobo_protocol::DeviceResult::Failed(
+                                                    kobo_protocol::DeviceError::Backend,
+                                                )
+                                            }
+                                        }
+                                    }
                                     // Blocks the message loop like a
                                     // Bluetooth scan does. The application
                                     // paints its progress screen before
@@ -2211,7 +2228,8 @@ fn system_request_allowed(app: &str, request: &kobo_protocol::DeviceRequest) -> 
     match request {
         kobo_protocol::DeviceRequest::Update { .. }
         | kobo_protocol::DeviceRequest::ReadSystemSleepTimeout
-        | kobo_protocol::DeviceRequest::SetSystemSleepTimeout { .. } => app == "settings",
+        | kobo_protocol::DeviceRequest::SetSystemSleepTimeout { .. }
+        | kobo_protocol::DeviceRequest::ReadSystemActivity => app == "settings",
         kobo_protocol::DeviceRequest::ListInstalledApps => matches!(app, "launcher" | "store"),
         kobo_protocol::DeviceRequest::ReadAppCatalog
         | kobo_protocol::DeviceRequest::RefreshAppCatalog
@@ -3356,6 +3374,11 @@ mod hosting_tests {
         assert!(super::system_request_allowed("settings", &sleep));
         assert!(!super::system_request_allowed("store", &sleep));
         assert!(!super::system_request_allowed("todo", &sleep));
+
+        let activity = DeviceRequest::ReadSystemActivity;
+        assert!(super::system_request_allowed("settings", &activity));
+        assert!(!super::system_request_allowed("store", &activity));
+        assert!(!super::system_request_allowed("todo", &activity));
 
         let install = DeviceRequest::InstallApp {
             id: "word-count".to_owned(),

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -33,8 +33,10 @@
 //! spread across returns.
 
 use crate::blackbox::{self, trace};
+use crate::power::{AppSleep, GlobalSleep, DEFAULT_SLEEP_TIMEOUT};
 use kobo_hal::display::{DisplaySession, OWNER_UNLOCK_PHRASE};
 use kobo_hal::input::TouchSession;
+use kobo_hal::power::{PowerButton, SystemSuspend};
 use kobo_hal::reader::{Reader, Watchdog, WATCHDOG_CHECK};
 use kobo_hal::soc_watchdog::SocWatchdog;
 use kobo_hal::supervisor::Suspended;
@@ -47,6 +49,7 @@ use kobo_ui::{
     display_metrics_from_env, render_all, ActionId, Chrome, FramePlanner, PanelWaveform,
     PictureCache, Screen, Surface,
 };
+use std::collections::BTreeSet;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -134,22 +137,15 @@ const START_GRACE: Duration = Duration::from_secs(45);
 /// This used to be half an hour and used to be the *only* way a session ended,
 /// which meant the panel was taken away from somebody in the middle of using
 /// it. It is now a backstop rather than a policy: a session ends when the
-/// reader asks to go back, or when nothing has happened for [`IDLE_LIMIT`].
+/// reader asks to go back or the runtime itself has been unhealthy for too
+/// long. Ordinary inactivity suspends and resumes this same session.
 const MAX_SESSION: Duration = Duration::from_secs(2 * 60 * 60);
-/// How long the panel may sit with nothing happening before the reader gets it
-/// back.
+/// The inactivity timeout used until the owner saves a choice in Settings.
 ///
 /// Every tap and every repaint restarts this, so it measures genuine
-/// abandonment rather than the pace of use. A device left on a screen nobody
-/// is looking at should be an e-reader again, because that is what somebody
-/// picking it up will expect it to be.
-///
-/// An hour rather than the fifteen minutes this started as. Fifteen sounds
-/// generous and is not: a panel session is something the owner starts and then
-/// puts down, and a session that had never been touched ended itself while its
-/// owner was still deciding what to open. The point of this limit is a device
-/// left behind, not a device being thought about.
-const IDLE_LIMIT: Duration = Duration::from_secs(60 * 60);
+/// inactivity rather than the pace of use. The persistent Settings value takes
+/// precedence; this remains an environment-configurable installation fallback.
+const IDLE_LIMIT: Duration = DEFAULT_SLEEP_TIMEOUT;
 /// The longest the loop waits between passes even when nothing is happening,
 /// which bounds how stale the recovery watchdog's heartbeat can get.
 const BEAT_INTERVAL: Duration = Duration::from_secs(10);
@@ -169,6 +165,9 @@ const BACK_GRACE: Duration = Duration::from_secs(2);
 /// has not finished handing anything back. Ten times a second is far below
 /// what a panel refresh costs and far above what anybody can perceive.
 const POLL_FOR_STOP: Duration = Duration::from_millis(100);
+
+/// Long enough for every SDK callback's 250 ms deadline plus one socket turn.
+const SUSPEND_PREPARE_GRACE: Duration = Duration::from_secs(1);
 
 /// How stale a battery reading may be before it is taken again.
 ///
@@ -229,6 +228,12 @@ impl StatusSource {
             polled: None,
             bluetooth: false,
         }
+    }
+
+    /// Forces the clock, radio and battery to be re-read after system resume.
+    fn invalidate(&mut self) {
+        self.taken = None;
+        self.polled = None;
     }
 
     /// Records what the daemon just learned about Bluetooth.
@@ -410,12 +415,38 @@ enum Event {
     /// way so the panel, the touch device, the reader and the freeze watchdog
     /// all go back.
     Stopping(i32),
+    /// The physical power button was released.
+    PowerButton,
 }
 
-/// How long a session may run, and how long it may be ignored.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SleepReason {
+    Idle,
+    PowerButton,
+    Cover,
+}
+
+impl SleepReason {
+    const fn description(self) -> &'static str {
+        match self {
+            Self::Idle => "the inactivity timer expired",
+            Self::PowerButton => "the power button was pressed",
+            Self::Cover => "the sleep cover closed",
+        }
+    }
+}
+
+struct SleepPreparation {
+    reason: SleepReason,
+    waiting: BTreeSet<u64>,
+    deadline: Instant,
+}
+
+/// How long a session may run, and its fallback sleep timeout.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Limits {
-    /// Ends the session when nothing has happened for this long.
+    /// Suspends when nothing has happened for this long unless Settings or the
+    /// foreground application supplies another timeout.
     pub idle: Duration,
     /// Ends the session however busy it is.
     pub ceiling: Duration,
@@ -430,8 +461,8 @@ impl Default for Limits {
     }
 }
 
-/// Runs `application` on the panel until it asks to leave, is left alone for
-/// `limits.idle`, or reaches `limits.ceiling`.
+/// Runs `application` on the panel until it asks to leave or reaches
+/// `limits.ceiling`. Inactivity suspends and resumes the same hosted session.
 ///
 /// Deliberately one function. Every step here takes something away from the
 /// device and has to give it back in the exact reverse order, and that
@@ -804,6 +835,8 @@ struct Hosted {
     tasks: TaskRunner,
     /// Capabilities declared by this installed application.
     declared: Declared,
+    /// This application's foreground departure from the global sleep timer.
+    sleep: AppSleep,
     /// The terminal this application may run a program on, or a refusal.
     shells: kobo_shell::Shells,
     /// The last screen this application drew, foreground or not.
@@ -934,6 +967,32 @@ fn host_applications(
     let home = application.to_path_buf();
     let (sender, events) = mpsc::channel();
     touch.set(Some(sender.clone()));
+    let mut global_sleep = GlobalSleep::load(Path::new(COBALT_ROOT), limits.idle);
+    let system_suspend = match SystemSuspend::open() {
+        Ok(suspend) => Some(suspend),
+        Err(error) => {
+            println!("system suspend unavailable ({error}); sleep falls back to Nickel");
+            None
+        }
+    };
+    match PowerButton::open() {
+        Ok(mut button) => {
+            if let Some(releases) = button.take_events() {
+                let power_events = sender.clone();
+                thread::Builder::new()
+                    .name("power-events".to_owned())
+                    .spawn(move || {
+                        while releases.recv().is_ok() {
+                            if power_events.send(Event::PowerButton).is_err() {
+                                return;
+                            }
+                        }
+                    })
+                    .map_err(|error| format!("watch power button: {error}"))?;
+            }
+        }
+        Err(error) => println!("power button unavailable ({error})"),
+    }
 
     let mut apps: Vec<Hosted> = Vec::new();
     let mut next_id = 1_u64;
@@ -1014,7 +1073,7 @@ fn host_applications(
         }
     }
     // A guard rather than a line at the end of the loop, because the loop has
-    // several exits (the session clock, an idle reader, a failed write to an
+    // several exits (the session clock, a requested return, a failed write to an
     // application) and a front light left bright by whichever path was taken
     // is exactly the kind of change a reboot should not have to fix.
     let _restore_light = FrontlightGuard(frontlight.clone());
@@ -1040,8 +1099,9 @@ fn host_applications(
         let front = start_application(&mut apps, &mut next_id, &home, whole_screen, &sender)?;
         let mut front = front;
         let mut visited: Vec<String> = Vec::new();
-        let ceiling = Instant::now() + limits.ceiling;
+        let mut ceiling = Instant::now() + limits.ceiling;
         let mut last_activity = Instant::now();
+        let mut preparing_sleep: Option<SleepPreparation> = None;
         // Set when Back has been handed to an application that asked for it,
         // and cleared by the next screen that application draws. The reader's
         // way out is never left waiting on an application: if this is still
@@ -1061,6 +1121,38 @@ fn host_applications(
             // the runtime is still serving the panel rather than merely that
             // the process has not been reaped.
             watchdog.beat();
+            if preparing_sleep.as_ref().is_some_and(|preparation| {
+                preparation.waiting.is_empty() || now >= preparation.deadline
+            }) {
+                let preparation = preparing_sleep.take().expect("sleep preparation exists");
+                trace(&format!(
+                    "suspending because {} ({} application(s) missed the preparation deadline)",
+                    preparation.reason.description(),
+                    preparation.waiting.len()
+                ));
+                let Some(suspend) = system_suspend.as_ref() else {
+                    return Ok(finish(
+                        &apps,
+                        &visited,
+                        "system suspend disappeared, so the reader has the device back",
+                    ));
+                };
+                watchdog.beat();
+                suspend.suspend().map_err(|error| {
+                    format!("enter system suspend: {error}; the reader will be restored")
+                })?;
+                // This line executes after resume, in the same process and with
+                // every hosted application still in memory.
+                watchdog.beat();
+                last_activity = Instant::now();
+                ceiling = last_activity + limits.ceiling;
+                status.invalidate();
+                for app in &mut apps {
+                    app.send(Message::Lifecycle(Lifecycle::Resume))?;
+                }
+                trace("resumed into Cobalt");
+                continue;
+            }
             // The band is the only thing on the panel that changes without
             // anybody touching it, so the loop has to notice it on its own.
             // Repainting is conditional on the reading having moved, and the
@@ -1088,6 +1180,16 @@ fn host_applications(
                             magnet_present: magnet == kobo_hal::cover::Magnet::Present,
                         })?;
                     }
+                    if magnet == kobo_hal::cover::Magnet::Present && preparing_sleep.is_none() {
+                        let Some(_) = system_suspend.as_ref() else {
+                            return Ok(finish(
+                                &apps,
+                                &visited,
+                                "the cover closed but system suspend is unavailable, so the reader has the device back",
+                            ));
+                        };
+                        preparing_sleep = Some(prepare_sleep(&mut apps, SleepReason::Cover)?);
+                    }
                 }
             }
             if now >= ceiling {
@@ -1097,16 +1199,22 @@ fn host_applications(
                     &format!("the {} session limit was reached", describe(limits.ceiling)),
                 ));
             }
-            let idle_at = last_activity + limits.idle;
-            if now >= idle_at {
-                return Ok(finish(
-                    &apps,
-                    &visited,
-                    &format!(
-                        "nothing was touched for {}, so the reader has it back",
-                        describe(limits.idle)
-                    ),
-                ));
+            let Some(front_index) = index_of(&apps, front) else {
+                return Ok(finish(&apps, &visited, "nothing is on the panel"));
+            };
+            let idle_at =
+                apps[front_index]
+                    .sleep
+                    .deadline(last_activity, global_sleep.timeout(), now);
+            if now >= idle_at && preparing_sleep.is_none() {
+                let Some(_) = system_suspend.as_ref() else {
+                    return Ok(finish(
+                        &apps,
+                        &visited,
+                        "the sleep timer expired but system suspend is unavailable, so the reader has the device back",
+                    ));
+                };
+                preparing_sleep = Some(prepare_sleep(&mut apps, SleepReason::Idle)?);
             }
             // An application that was offered Back and drew nothing has had
             // its turn. This is what keeps the guarantee: the way out belongs
@@ -1137,7 +1245,10 @@ fn host_applications(
             // session nobody is touching still proves it is alive.
             let wait = ceiling
                 .saturating_duration_since(now)
-                .min(idle_at.saturating_duration_since(now))
+                .min(preparing_sleep.as_ref().map_or_else(
+                    || idle_at.saturating_duration_since(now),
+                    |preparation| preparation.deadline.saturating_duration_since(now),
+                ))
                 .min(BEAT_INTERVAL)
                 // So a charger pulled out while nobody is touching the panel
                 // is noticed in seconds rather than at the next heartbeat.
@@ -1162,6 +1273,18 @@ fn host_applications(
                 Err(RecvTimeoutError::Timeout) | Ok(Event::TaskReady) => {}
                 Err(RecvTimeoutError::Disconnected) => {
                     return Ok(finish(&apps, &visited, "the runtime ran out of work"));
+                }
+                Ok(Event::PowerButton) => {
+                    if preparing_sleep.is_none() {
+                        let Some(_) = system_suspend.as_ref() else {
+                            return Ok(finish(
+                                &apps,
+                                &visited,
+                                "the power button was pressed but system suspend is unavailable, so the reader has the device back",
+                            ));
+                        };
+                        preparing_sleep = Some(prepare_sleep(&mut apps, SleepReason::PowerButton)?);
+                    }
                 }
                 Ok(Event::AppGone(id)) => {
                     let Some(index) = index_of(&apps, id) else {
@@ -1403,6 +1526,13 @@ fn host_applications(
                         }
                         Message::DropPicture { handle } => apps[index].pictures.remove(handle),
                         Message::Log { .. } => {}
+                        Message::LifecycleReady(state) => {
+                            if state == Lifecycle::Suspend {
+                                if let Some(preparation) = preparing_sleep.as_mut() {
+                                    preparation.waiting.remove(&apps[index].id);
+                                }
+                            }
+                        }
                         Message::DeviceRequest(request) => {
                             let not_declared = !system_request_allowed(&apps[index].name, &request)
                                 || kobo_policy::request_capability(&request).is_some_and(
@@ -1670,6 +1800,26 @@ fn host_applications(
                                             },
                                         )
                                     }
+                                    kobo_protocol::DeviceRequest::ReadSystemSleepTimeout => {
+                                        kobo_protocol::DeviceResult::SleepTimeout {
+                                            seconds: u32::try_from(
+                                                global_sleep.timeout().as_secs(),
+                                            )
+                                            .unwrap_or(u32::MAX),
+                                        }
+                                    }
+                                    kobo_protocol::DeviceRequest::SetSystemSleepTimeout {
+                                        seconds,
+                                    } => match global_sleep.set_seconds(*seconds) {
+                                        Ok(timeout) => {
+                                            last_activity = Instant::now();
+                                            kobo_protocol::DeviceResult::SleepTimeout {
+                                                seconds: u32::try_from(timeout.as_secs())
+                                                    .unwrap_or(u32::MAX),
+                                            }
+                                        }
+                                        Err(error) => kobo_protocol::DeviceResult::Failed(error),
+                                    },
                                     // Blocks the message loop like a
                                     // Bluetooth scan does. The application
                                     // paints its progress screen before
@@ -1719,6 +1869,30 @@ fn host_applications(
                                     _ => services.handle(request.clone()),
                                 }
                             };
+                            match (&request, &result) {
+                                (
+                                    kobo_protocol::DeviceRequest::KeepAwake { .. },
+                                    kobo_protocol::DeviceResult::Granted { seconds },
+                                ) => apps[index].sleep.keep_awake(
+                                    Instant::now(),
+                                    Duration::from_secs(u64::from(*seconds)),
+                                ),
+                                (
+                                    kobo_protocol::DeviceRequest::AllowSleep,
+                                    kobo_protocol::DeviceResult::Done,
+                                ) => apps[index].sleep.allow_sleep(),
+                                (
+                                    kobo_protocol::DeviceRequest::SetSleepTimeout { .. },
+                                    kobo_protocol::DeviceResult::Granted { seconds },
+                                ) => apps[index]
+                                    .sleep
+                                    .override_timeout(Duration::from_secs(u64::from(*seconds))),
+                                (
+                                    kobo_protocol::DeviceRequest::UseGlobalSleepTimeout,
+                                    kobo_protocol::DeviceResult::Done,
+                                ) => apps[index].sleep.use_global_timeout(),
+                                _ => {}
+                            }
                             // Every Bluetooth reply passes through here, so
                             // this is the one place that has to know the band
                             // shows a Bluetooth mark. A reply that changes the
@@ -1900,6 +2074,23 @@ fn host_applications(
     result
 }
 
+/// Gives every live application one bounded chance to save before userspace is
+/// frozen. Applications acknowledge only after their callback's commands have
+/// been written, so store requests already sit ahead of the acknowledgement in
+/// the same ordered socket stream.
+fn prepare_sleep(apps: &mut [Hosted], reason: SleepReason) -> Result<SleepPreparation, String> {
+    let mut waiting = BTreeSet::new();
+    for app in apps {
+        app.send(Message::Lifecycle(Lifecycle::Suspend))?;
+        waiting.insert(app.id);
+    }
+    Ok(SleepPreparation {
+        reason,
+        waiting,
+        deadline: Instant::now() + SUSPEND_PREPARE_GRACE,
+    })
+}
+
 fn index_of(apps: &[Hosted], id: u64) -> Option<usize> {
     apps.iter().position(|app| app.id == id)
 }
@@ -2018,7 +2209,9 @@ fn repaint(
 /// identities even while both travel over the same bounded device channel.
 fn system_request_allowed(app: &str, request: &kobo_protocol::DeviceRequest) -> bool {
     match request {
-        kobo_protocol::DeviceRequest::Update { .. } => app == "settings",
+        kobo_protocol::DeviceRequest::Update { .. }
+        | kobo_protocol::DeviceRequest::ReadSystemSleepTimeout
+        | kobo_protocol::DeviceRequest::SetSystemSleepTimeout { .. } => app == "settings",
         kobo_protocol::DeviceRequest::ListInstalledApps => matches!(app, "launcher" | "store"),
         kobo_protocol::DeviceRequest::ReadAppCatalog
         | kobo_protocol::DeviceRequest::RefreshAppCatalog
@@ -2239,6 +2432,7 @@ fn start_application(
         stream,
         tasks,
         declared,
+        sleep: AppSleep::default(),
         screen: None,
         pictures: PictureCache::default(),
         painted: 0,
@@ -3157,6 +3351,11 @@ mod hosting_tests {
         assert!(super::system_request_allowed("settings", &platform));
         assert!(!super::system_request_allowed("store", &platform));
         assert!(!super::system_request_allowed("todo", &platform));
+
+        let sleep = DeviceRequest::SetSystemSleepTimeout { seconds: 900 };
+        assert!(super::system_request_allowed("settings", &sleep));
+        assert!(!super::system_request_allowed("store", &sleep));
+        assert!(!super::system_request_allowed("todo", &sleep));
 
         let install = DeviceRequest::InstallApp {
             id: "word-count".to_owned(),

--- a/crates/kobod/src/main.rs
+++ b/crates/kobod/src/main.rs
@@ -11,6 +11,8 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
+#[cfg(any(feature = "device-write", test))]
+mod activity;
 mod app_store;
 #[cfg(feature = "device-write")]
 mod blackbox;

--- a/crates/kobod/src/main.rs
+++ b/crates/kobod/src/main.rs
@@ -16,6 +16,8 @@ mod app_store;
 mod blackbox;
 #[cfg(feature = "device-write")]
 mod device;
+#[cfg(any(feature = "device-write", test))]
+mod power;
 mod update;
 
 fn main() -> ExitCode {
@@ -131,10 +133,10 @@ fn present_on_panel(application: &Path) -> Result<(), Box<dyn Error>> {
     if env::var(UNLOCK_ENV).ok().as_deref() != Some(UNLOCK_PHRASE) {
         return Err("owner-attended panel session unlock is missing or incorrect".into());
     }
-    // The session used to end on a timer, which took the panel away from
-    // somebody in the middle of using it. It now ends when the reader taps the
-    // way out, or when the device has been left alone; the environment is only
-    // an escape hatch for testing, and both values are clamped inside.
+    // The session no longer ends on inactivity: the runtime suspends and comes
+    // back to the same applications. This environment value is only the
+    // installation fallback until Settings persists an owner-selected timeout;
+    // both limits are clamped inside.
     let limits = device::Limits {
         idle: env::var("KOBO_IDLE_SECONDS")
             .ok()
@@ -480,6 +482,7 @@ fn serve_application(
                 .lock()
                 .map_err(|_| "the task lock was poisoned")?
                 .cancel(task),
+            Message::LifecycleReady(_) => {}
             Message::Exit => {
                 // Nothing an application started may outlive it.
                 tasks

--- a/crates/kobod/src/power.rs
+++ b/crates/kobod/src/power.rs
@@ -1,0 +1,214 @@
+//! Persistent global sleep settings and per-application overrides.
+
+use kobo_protocol::DeviceError;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+pub const DEFAULT_SLEEP_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+pub const MINIMUM_SLEEP_TIMEOUT: Duration = Duration::from_secs(60);
+pub const MAXIMUM_SLEEP_TIMEOUT: Duration = Duration::from_secs(60 * 60);
+const STATE_DIRECTORY: &str = "state";
+const DIRECTORY: &str = "power";
+const FILE: &str = "sleep-after-seconds";
+
+/// The owner-selected timeout shared by applications that do not override it.
+pub struct GlobalSleep {
+    directory: PathBuf,
+    path: PathBuf,
+    timeout: Duration,
+}
+
+impl GlobalSleep {
+    /// Loads the saved value, falling back when this reader has never saved one.
+    #[must_use]
+    pub fn load(root: &Path, fallback: Duration) -> Self {
+        // `state` is carried into every in-place platform update, so the
+        // owner's choice survives replacement of the runtime binaries.
+        let directory = root.join(STATE_DIRECTORY).join(DIRECTORY);
+        let path = directory.join(FILE);
+        let timeout = fs::read_to_string(&path)
+            .ok()
+            .and_then(|value| value.trim().parse::<u64>().ok())
+            .map(Duration::from_secs)
+            .filter(|value| valid_timeout(*value))
+            .unwrap_or_else(|| clamp_timeout(fallback));
+        Self {
+            directory,
+            path,
+            timeout,
+        }
+    }
+
+    #[must_use]
+    pub const fn timeout(&self) -> Duration {
+        self.timeout
+    }
+
+    /// Atomically publishes a validated timeout on the user-visible partition.
+    pub fn set_seconds(&mut self, seconds: u32) -> Result<Duration, DeviceError> {
+        let timeout = Duration::from_secs(u64::from(seconds));
+        if !valid_timeout(timeout) {
+            return Err(DeviceError::InvalidInput);
+        }
+        fs::create_dir_all(&self.directory).map_err(|_| DeviceError::Backend)?;
+        let temporary = self.directory.join(format!(".{FILE}.writing"));
+        let mut file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&temporary)
+            .map_err(|_| DeviceError::Backend)?;
+        writeln!(file, "{}", timeout.as_secs()).map_err(|_| DeviceError::Backend)?;
+        file.sync_all().map_err(|_| DeviceError::Backend)?;
+        fs::rename(&temporary, &self.path).map_err(|_| DeviceError::Backend)?;
+        OpenOptions::new()
+            .read(true)
+            .open(&self.directory)
+            .and_then(|directory| directory.sync_all())
+            .map_err(|_| DeviceError::Backend)?;
+        self.timeout = timeout;
+        Ok(timeout)
+    }
+}
+
+/// A foreground application's departure from the global timeout.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct AppSleep {
+    timeout: Option<Duration>,
+    awake_until: Option<Instant>,
+}
+
+impl AppSleep {
+    pub fn override_timeout(&mut self, timeout: Duration) {
+        self.timeout = Some(clamp_timeout(timeout));
+    }
+
+    pub fn use_global_timeout(&mut self) {
+        self.timeout = None;
+    }
+
+    pub fn keep_awake(&mut self, now: Instant, duration: Duration) {
+        self.awake_until = now.checked_add(duration);
+    }
+
+    pub fn allow_sleep(&mut self) {
+        self.awake_until = None;
+    }
+
+    #[must_use]
+    pub fn deadline(&self, last_activity: Instant, global: Duration, now: Instant) -> Instant {
+        let idle = last_activity + self.timeout.unwrap_or(global);
+        self.awake_until
+            .filter(|until| *until > now)
+            .map_or(idle, |until| idle.max(until))
+    }
+}
+
+#[must_use]
+pub fn clamp_timeout(timeout: Duration) -> Duration {
+    timeout.clamp(MINIMUM_SLEEP_TIMEOUT, MAXIMUM_SLEEP_TIMEOUT)
+}
+
+#[must_use]
+pub fn valid_timeout(timeout: Duration) -> bool {
+    (MINIMUM_SLEEP_TIMEOUT..=MAXIMUM_SLEEP_TIMEOUT).contains(&timeout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AppSleep, GlobalSleep, DEFAULT_SLEEP_TIMEOUT, MAXIMUM_SLEEP_TIMEOUT, MINIMUM_SLEEP_TIMEOUT,
+    };
+    use kobo_protocol::DeviceError;
+    use std::fs;
+    use std::time::{Duration, Instant};
+
+    fn root(name: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!("cobalt-power-{name}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&path);
+        path
+    }
+
+    #[test]
+    fn a_reader_with_no_setting_uses_the_global_default() {
+        let root = root("default");
+        assert_eq!(
+            GlobalSleep::load(&root, DEFAULT_SLEEP_TIMEOUT).timeout(),
+            DEFAULT_SLEEP_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn a_saved_timeout_survives_a_new_runtime() {
+        let root = root("saved");
+        let mut settings = GlobalSleep::load(&root, DEFAULT_SLEEP_TIMEOUT);
+        settings.set_seconds(30 * 60).expect("save timeout");
+        assert!(root.join("state/power/sleep-after-seconds").is_file());
+        assert_eq!(
+            GlobalSleep::load(&root, DEFAULT_SLEEP_TIMEOUT).timeout(),
+            Duration::from_secs(30 * 60)
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_global_timeout_outside_the_safe_range_is_refused() {
+        let root = root("range");
+        let mut settings = GlobalSleep::load(&root, DEFAULT_SLEEP_TIMEOUT);
+        assert_eq!(settings.set_seconds(0), Err(DeviceError::InvalidInput));
+        assert_eq!(
+            settings.set_seconds(u32::try_from(MAXIMUM_SLEEP_TIMEOUT.as_secs() + 1).unwrap()),
+            Err(DeviceError::InvalidInput)
+        );
+        assert_eq!(settings.timeout(), DEFAULT_SLEEP_TIMEOUT);
+    }
+
+    #[test]
+    fn an_app_uses_global_until_it_explicitly_overrides() {
+        let now = Instant::now();
+        let mut app = AppSleep::default();
+        assert_eq!(
+            app.deadline(now, Duration::from_secs(15 * 60), now),
+            now + Duration::from_secs(15 * 60)
+        );
+        app.override_timeout(Duration::from_secs(5 * 60));
+        assert_eq!(
+            app.deadline(now, Duration::from_secs(15 * 60), now),
+            now + Duration::from_secs(5 * 60)
+        );
+        app.use_global_timeout();
+        assert_eq!(
+            app.deadline(now, Duration::from_secs(15 * 60), now),
+            now + Duration::from_secs(15 * 60)
+        );
+    }
+
+    #[test]
+    fn a_wake_hold_delays_but_does_not_replace_the_timeout() {
+        let now = Instant::now();
+        let mut app = AppSleep::default();
+        app.keep_awake(now, Duration::from_secs(20 * 60));
+        assert_eq!(
+            app.deadline(now, Duration::from_secs(15 * 60), now),
+            now + Duration::from_secs(20 * 60)
+        );
+        app.allow_sleep();
+        assert_eq!(
+            app.deadline(now, Duration::from_secs(15 * 60), now),
+            now + Duration::from_secs(15 * 60)
+        );
+    }
+
+    #[test]
+    fn app_overrides_are_clamped_to_the_same_global_bounds() {
+        let now = Instant::now();
+        let mut app = AppSleep::default();
+        app.override_timeout(Duration::ZERO);
+        assert_eq!(
+            app.deadline(now, DEFAULT_SLEEP_TIMEOUT, now),
+            now + MINIMUM_SLEEP_TIMEOUT
+        );
+    }
+}

--- a/docs/DEVICES.md
+++ b/docs/DEVICES.md
@@ -557,6 +557,26 @@ suspends at all.
 `kobo session --hold [minutes]` still exists and renews the wake lock, but it is
 not sufficient on its own on this firmware and is documented as such.
 
+### Sleeping while Cobalt owns the panel
+
+Nickel cannot request suspend while it is stopped, so the device runtime owns
+that transition for an active Cobalt session. The owner sets a global
+inactivity timeout in Settings (fifteen minutes on a fresh install), and the
+foreground application follows it unless it has declared `keep-awake` and
+explicitly selected a process-local override.
+
+When the timeout expires, the power button is released, or the sleep cover
+closes, the runtime sends every hosted application a bounded suspend callback.
+It synchronises pending writes, writes `mem` to `/sys/power/state`, and blocks
+there while Linux suspends. Wake returns from that write, refreshes device
+status, and sends resume callbacks to the same processes. Cobalt therefore
+returns to the same app and in-memory state instead of restarting Nickel.
+
+If the kernel does not advertise `mem`, the runtime returns the device to
+Nickel rather than remaining awake indefinitely. Radio connectivity is not
+promised across suspend; applications must treat resume as a fresh opportunity
+to observe network state.
+
 ### One audited path for every settings change
 
 Settings are described rather than hand-written, so there is a single reviewed

--- a/docs/DEVICES.md
+++ b/docs/DEVICES.md
@@ -577,6 +577,14 @@ Nickel rather than remaining awake indefinitely. Radio connectivity is not
 promised across suspend; applications must treat resume as a fresh opportunity
 to observe network state.
 
+The built-in Settings Activity Monitor samples aggregate CPU, memory, free
+disk space and a bounded process list once per second while its screen is open.
+It keeps two minutes of CPU and memory history. Each new declarative screen
+still goes through the pixel frame planner, so the panel receives only the
+changed rectangle and identical samples cause no refresh at all. Leaving the
+screen stops the timer and its activity wakeups, allowing the normal inactivity
+policy to resume.
+
 ### One audited path for every settings change
 
 Settings are described rather than hand-written, so there is a single reviewed

--- a/examples/settings/src/main.rs
+++ b/examples/settings/src/main.rs
@@ -8,10 +8,12 @@ use kobo_sdk::{
     WifiNetwork,
 };
 use std::process::ExitCode;
+use std::time::Duration;
 
 const BLUETOOTH: &str = "bluetooth";
 const WIFI: &str = "wifi";
 const BATTERY: &str = "battery";
+const SLEEP: &str = "sleep";
 const UPDATE: &str = "update";
 const CHECK: &str = "check";
 const INSTALL: &str = "install";
@@ -19,6 +21,13 @@ const TOGGLE: &str = "toggle";
 const RESCAN: &str = "rescan";
 const MORE: &str = "more";
 const PREVIOUS: &str = "previous";
+const SLEEP_CHOICES: [(&str, u32); 5] = [
+    ("sleep-5", 5),
+    ("sleep-10", 10),
+    ("sleep-15", 15),
+    ("sleep-30", 30),
+    ("sleep-60", 60),
+];
 const PAGE_SIZE: usize = 4;
 const DEVICE_ACTIONS: [&str; 10] = [
     "bt-0", "bt-1", "bt-2", "bt-3", "bt-4", "bt-5", "bt-6", "bt-7", "bt-8", "bt-9",
@@ -44,6 +53,7 @@ enum View {
     Wifi,
     WifiPassword,
     Battery,
+    Sleep,
     Update,
 }
 
@@ -118,6 +128,7 @@ enum Topic {
     Bluetooth,
     Wifi,
     Battery,
+    Sleep,
 }
 
 impl Topic {
@@ -136,6 +147,9 @@ impl Topic {
             | DeviceRequest::JoinWifi { .. }
             | DeviceRequest::DisconnectWifi => Some(Self::Wifi),
             DeviceRequest::ReadBattery | DeviceRequest::ReadBatteryDetail => Some(Self::Battery),
+            DeviceRequest::ReadSystemSleepTimeout | DeviceRequest::SetSystemSleepTimeout { .. } => {
+                Some(Self::Sleep)
+            }
             _ => None,
         }
     }
@@ -161,6 +175,7 @@ struct Settings {
     selected_ssid: Option<String>,
     password: Keyboard,
     battery: Option<BatteryDetail>,
+    sleep_timeout_seconds: Option<u32>,
     update: UpdateFlow,
     update_task: Option<TaskId>,
     pending: Option<Pending>,
@@ -177,6 +192,7 @@ impl Settings {
             View::Wifi => self.wifi(),
             View::WifiPassword => self.wifi_password(),
             View::Battery => self.battery(),
+            View::Sleep => self.sleep(),
             View::Update => self.update(),
         };
         context.set_screen(screen);
@@ -246,6 +262,12 @@ impl Settings {
                     RowLead::from(Glyph::Battery),
                 ),
                 (
+                    SLEEP,
+                    "Sleep",
+                    self.sleep_summary(),
+                    RowLead::from(Glyph::Power),
+                ),
+                (
                     UPDATE,
                     "Software update",
                     self.update_summary(),
@@ -257,6 +279,45 @@ impl Settings {
             // binary was compiled as is what is installed.
             .section_with_value("Cobalt", VERSION);
         screen.build()
+    }
+
+    fn sleep_summary(&self) -> String {
+        self.sleep_timeout_seconds.map_or_else(
+            || "Reading".to_owned(),
+            |seconds| format!("After {} minutes", seconds / 60),
+        )
+    }
+
+    fn sleep(&self) -> Screen {
+        let mut screen = ScreenBuilder::new("settings-sleep")
+            .top_bar("Sleep")
+            .owns_back(true);
+        if let Some(trouble) = self.banner_for(Topic::Sleep) {
+            screen = screen.banner(kobo_sdk::BannerLevel::Attention, trouble);
+        }
+        screen
+            .section("Sleep after")
+            .rows(SLEEP_CHOICES.into_iter().map(|(action, minutes)| {
+                let selected = self.sleep_timeout_seconds == Some(minutes * 60);
+                (
+                    action,
+                    format!("{minutes} minutes"),
+                    if selected { "Selected" } else { "" },
+                    RowLead::from(if selected {
+                        Glyph::Check
+                    } else {
+                        Glyph::Circle
+                    }),
+                )
+            }))
+            .build()
+    }
+
+    fn sleep_timeout_for_action(action: ActionId) -> Option<Duration> {
+        SLEEP_CHOICES
+            .iter()
+            .find(|(name, _)| action == action_id(name))
+            .map(|(_, minutes)| Duration::from_secs(u64::from(*minutes) * 60))
     }
 
     /// One line for the home row: where the update journey stands, or an
@@ -587,6 +648,7 @@ impl Settings {
         context.device().read_bluetooth();
         context.device().read_wifi();
         context.device().read_battery_detail();
+        context.device().read_system_sleep_timeout();
     }
 
     /// Asks GitHub what the newest published release is. Nothing is
@@ -701,7 +763,7 @@ impl Settings {
         let (page, pages) = match self.view {
             View::Bluetooth => (&mut self.bluetooth_page, page_count(self.devices.len())),
             View::Wifi => (&mut self.wifi_page, page_count(self.networks.len())),
-            View::Home | View::WifiPassword | View::Battery | View::Update => return,
+            View::Home | View::WifiPassword | View::Battery | View::Sleep | View::Update => return,
         };
         *page = if forward {
             (*page + 1).min(pages - 1)
@@ -796,6 +858,10 @@ impl KoboApp for Settings {
             self.view = View::Battery;
             context.device().read_battery_detail();
             self.show(context);
+        } else if action == action_id(SLEEP) {
+            self.view = View::Sleep;
+            context.device().read_system_sleep_timeout();
+            self.show(context);
         } else if action == action_id(UPDATE) {
             self.view = View::Update;
             self.show(context);
@@ -810,7 +876,7 @@ impl KoboApp for Settings {
                     .device()
                     .set_bluetooth(!self.bluetooth_state.enabled()),
                 View::Wifi => context.device().set_wifi(!self.wifi_state.enabled()),
-                View::Home | View::WifiPassword | View::Battery | View::Update => {}
+                View::Home | View::WifiPassword | View::Battery | View::Sleep | View::Update => {}
             }
         } else if action == action_id(RESCAN) {
             match self.view {
@@ -825,7 +891,7 @@ impl KoboApp for Settings {
                     self.delay_refresh(context, Pending::WifiRefresh);
                 }
                 View::Battery => context.device().read_battery_detail(),
-                View::Home | View::WifiPassword | View::Update => {}
+                View::Home | View::WifiPassword | View::Sleep | View::Update => {}
             }
             self.show(context);
         } else if action == action_id(MORE) {
@@ -834,6 +900,8 @@ impl KoboApp for Settings {
         } else if action == action_id(PREVIOUS) {
             self.turn_page(false);
             self.show(context);
+        } else if let Some(timeout) = Self::sleep_timeout_for_action(action) {
+            context.device().set_system_sleep_timeout(timeout);
         } else if let Some(index) = DEVICE_ACTIONS
             .iter()
             .position(|name| action == action_id(name))
@@ -893,6 +961,10 @@ impl KoboApp for Settings {
             DeviceResult::BatteryDetail(detail) => {
                 self.battery = Some(detail);
                 self.settled(Topic::Battery);
+            }
+            DeviceResult::SleepTimeout { seconds } => {
+                self.sleep_timeout_seconds = Some(seconds);
+                self.settled(Topic::Sleep);
             }
             // A failure belongs to whatever was asked for. When the request
             // is not one of the three rows, there is nowhere honest to show it,
@@ -1312,6 +1384,34 @@ mod tests {
         assert!(issues.is_empty(), "{issues:?}");
         let layout = screen.layout_with(&CLARA_BW_METRICS, &Chrome::with_back(true));
         assert!(layout.rect_of_action(action_id(RESCAN)).is_some());
+    }
+
+    #[test]
+    fn every_global_sleep_choice_fits_and_the_current_one_is_marked() {
+        let settings = Settings {
+            view: super::View::Sleep,
+            sleep_timeout_seconds: Some(15 * 60),
+            ..Settings::default()
+        };
+        let screen = settings.sleep();
+        let issues = screen.validate(&CLARA_BW_METRICS);
+        assert!(issues.is_empty(), "{issues:?}");
+        let actions = screen
+            .nodes
+            .iter()
+            .flat_map(|node| match node {
+                kobo_sdk::Node::Rows { rows, .. } => rows.iter().map(|row| row.action).collect(),
+                _ => Vec::new(),
+            })
+            .collect::<Vec<_>>();
+        for (action, _) in super::SLEEP_CHOICES {
+            assert!(actions.contains(&action_id(action)), "{action}");
+        }
+        assert!(screen.nodes.iter().any(|node| matches!(
+            node,
+            kobo_sdk::Node::Rows { rows, .. }
+                if rows.iter().any(|row| row.summary == "Selected")
+        )));
     }
 
     #[test]

--- a/examples/settings/src/main.rs
+++ b/examples/settings/src/main.rs
@@ -4,9 +4,10 @@ use kobo_json::Value;
 use kobo_sdk::keyboard::{Keyboard, Pressed};
 use kobo_sdk::{
     action_id, ActionId, BatteryDetail, BluetoothDevice, Context, DeviceRequest, DeviceResult,
-    Glyph, Heartbeat, KoboApp, RowLead, Screen, ScreenBuilder, Task, TaskId, TaskOutcome,
-    WifiNetwork,
+    Glyph, Heartbeat, KoboApp, PictureHandle, RowLead, Screen, ScreenBuilder, SystemActivity, Task,
+    TaskId, TaskOutcome, TilePicture, WifiNetwork,
 };
+use std::collections::VecDeque;
 use std::process::ExitCode;
 use std::time::Duration;
 
@@ -14,6 +15,7 @@ const BLUETOOTH: &str = "bluetooth";
 const WIFI: &str = "wifi";
 const BATTERY: &str = "battery";
 const SLEEP: &str = "sleep";
+const ACTIVITY: &str = "activity";
 const UPDATE: &str = "update";
 const CHECK: &str = "check";
 const INSTALL: &str = "install";
@@ -28,6 +30,10 @@ const SLEEP_CHOICES: [(&str, u32); 5] = [
     ("sleep-30", 30),
     ("sleep-60", 60),
 ];
+const ACTIVITY_HISTORY: usize = 120;
+const ACTIVITY_GRAPH_HEIGHT: u32 = 180;
+const ACTIVITY_GRAPH_MAX_WIDTH: u32 = 900;
+const VISIBLE_PROCESSES: usize = 6;
 const PAGE_SIZE: usize = 4;
 const DEVICE_ACTIONS: [&str; 10] = [
     "bt-0", "bt-1", "bt-2", "bt-3", "bt-4", "bt-5", "bt-6", "bt-7", "bt-8", "bt-9",
@@ -54,6 +60,7 @@ enum View {
     WifiPassword,
     Battery,
     Sleep,
+    Activity,
     Update,
 }
 
@@ -129,6 +136,7 @@ enum Topic {
     Wifi,
     Battery,
     Sleep,
+    Activity,
 }
 
 impl Topic {
@@ -150,6 +158,7 @@ impl Topic {
             DeviceRequest::ReadSystemSleepTimeout | DeviceRequest::SetSystemSleepTimeout { .. } => {
                 Some(Self::Sleep)
             }
+            DeviceRequest::ReadSystemActivity => Some(Self::Activity),
             _ => None,
         }
     }
@@ -176,6 +185,11 @@ struct Settings {
     password: Keyboard,
     battery: Option<BatteryDetail>,
     sleep_timeout_seconds: Option<u32>,
+    activity: Option<SystemActivity>,
+    activity_history: VecDeque<(u16, u16)>,
+    activity_picture: Option<TilePicture>,
+    activity_picture_generation: u32,
+    activity_clock: Heartbeat,
     update: UpdateFlow,
     update_task: Option<TaskId>,
     pending: Option<Pending>,
@@ -186,6 +200,7 @@ struct Settings {
 impl Settings {
     fn show(&mut self, context: &mut Context) {
         self.keep_scanning(context);
+        self.keep_activity_monitoring(context);
         let screen = match self.view {
             View::Home => self.home(),
             View::Bluetooth => self.bluetooth(),
@@ -193,6 +208,7 @@ impl Settings {
             View::WifiPassword => self.wifi_password(),
             View::Battery => self.battery(),
             View::Sleep => self.sleep(),
+            View::Activity => self.activity(),
             View::Update => self.update(),
         };
         context.set_screen(screen);
@@ -215,6 +231,20 @@ impl Settings {
         } else {
             self.scan_clock.stop(context);
             self.scanning = false;
+        }
+    }
+
+    /// Samples only while this screen is visible. Leaving it cancels the next
+    /// tick, so the process table costs no background wakeups.
+    fn keep_activity_monitoring(&mut self, context: &mut Context) {
+        if self.view == View::Activity {
+            if !self.activity_clock.is_running() {
+                self.activity_clock = Heartbeat::every(1);
+                self.activity_clock.start(context);
+                context.device().read_system_activity();
+            }
+        } else {
+            self.activity_clock.stop(context);
         }
     }
 
@@ -268,6 +298,12 @@ impl Settings {
                     RowLead::from(Glyph::Power),
                 ),
                 (
+                    ACTIVITY,
+                    "Activity Monitor",
+                    self.activity_summary(),
+                    RowLead::from(Glyph::Chart),
+                ),
+                (
                     UPDATE,
                     "Software update",
                     self.update_summary(),
@@ -318,6 +354,72 @@ impl Settings {
             .iter()
             .find(|(name, _)| action == action_id(name))
             .map(|(_, minutes)| Duration::from_secs(u64::from(*minutes) * 60))
+    }
+
+    fn activity_summary(&self) -> String {
+        self.activity.as_ref().map_or_else(
+            || "CPU, memory, disk and processes".to_owned(),
+            |activity| {
+                format!(
+                    "CPU {} · RAM {}",
+                    format_percent(activity.cpu_tenths),
+                    format_percent(memory_percent(activity))
+                )
+            },
+        )
+    }
+
+    fn activity(&self) -> Screen {
+        let mut screen = ScreenBuilder::new("settings-activity")
+            .top_bar("Activity Monitor")
+            .owns_back(true);
+        if let Some(trouble) = self.banner_for(Topic::Activity) {
+            screen = screen.banner(kobo_sdk::BannerLevel::Attention, trouble);
+        }
+        let Some(activity) = self.activity.as_ref() else {
+            return screen.text("Taking the first one-second sample.").build();
+        };
+        screen = screen.section_with_value(
+            "CPU black / RAM gray",
+            format!(
+                "{} / {}",
+                format_percent(activity.cpu_tenths),
+                format_percent(memory_percent(activity))
+            ),
+        );
+        if let Some(picture) = self.activity_picture {
+            screen = screen.picture(picture, 18);
+        }
+        screen
+            .secondary(format!(
+                "Disk available: {}",
+                activity
+                    .disk_free_bytes
+                    .map_or_else(|| "Unavailable".to_owned(), format_bytes)
+            ))
+            .section("Top processes")
+            .terminal(process_rows(activity), None)
+            .build()
+    }
+
+    fn record_activity(&mut self, context: &mut Context, activity: SystemActivity) {
+        self.activity_history
+            .push_back((activity.cpu_tenths, memory_percent(&activity)));
+        while self.activity_history.len() > ACTIVITY_HISTORY {
+            self.activity_history.pop_front();
+        }
+        let width = u32::try_from(context.metrics().width.saturating_sub(160))
+            .unwrap_or(ACTIVITY_GRAPH_MAX_WIDTH)
+            .clamp(480, ACTIVITY_GRAPH_MAX_WIDTH);
+        self.activity_picture_generation = self.activity_picture_generation.wrapping_add(1);
+        let handle = PictureHandle(700 + self.activity_picture_generation % 2);
+        self.activity_picture = context.put_picture(
+            handle,
+            width,
+            ACTIVITY_GRAPH_HEIGHT,
+            activity_graph(&self.activity_history, width, ACTIVITY_GRAPH_HEIGHT),
+        );
+        self.activity = Some(activity);
     }
 
     /// One line for the home row: where the update journey stands, or an
@@ -763,7 +865,12 @@ impl Settings {
         let (page, pages) = match self.view {
             View::Bluetooth => (&mut self.bluetooth_page, page_count(self.devices.len())),
             View::Wifi => (&mut self.wifi_page, page_count(self.networks.len())),
-            View::Home | View::WifiPassword | View::Battery | View::Sleep | View::Update => return,
+            View::Home
+            | View::WifiPassword
+            | View::Battery
+            | View::Sleep
+            | View::Activity
+            | View::Update => return,
         };
         *page = if forward {
             (*page + 1).min(pages - 1)
@@ -804,6 +911,30 @@ impl Settings {
         } else {
             context.device().join_wifi(network.ssid, "");
         }
+    }
+
+    fn open_destination(&mut self, context: &mut Context, action: ActionId) -> bool {
+        self.view = if action == action_id(BLUETOOTH) {
+            context.device().read_bluetooth();
+            View::Bluetooth
+        } else if action == action_id(WIFI) {
+            context.device().read_wifi();
+            View::Wifi
+        } else if action == action_id(BATTERY) {
+            context.device().read_battery_detail();
+            View::Battery
+        } else if action == action_id(SLEEP) {
+            context.device().read_system_sleep_timeout();
+            View::Sleep
+        } else if action == action_id(ACTIVITY) {
+            View::Activity
+        } else if action == action_id(UPDATE) {
+            View::Update
+        } else {
+            return false;
+        };
+        self.show(context);
+        true
     }
 }
 
@@ -846,26 +977,12 @@ impl KoboApp for Settings {
         if action == ActionId::BACK {
             self.view = View::Home;
             self.show(context);
-        } else if action == action_id(BLUETOOTH) {
-            self.view = View::Bluetooth;
-            context.device().read_bluetooth();
-            self.show(context);
-        } else if action == action_id(WIFI) {
-            self.view = View::Wifi;
-            context.device().read_wifi();
-            self.show(context);
-        } else if action == action_id(BATTERY) {
-            self.view = View::Battery;
-            context.device().read_battery_detail();
-            self.show(context);
-        } else if action == action_id(SLEEP) {
-            self.view = View::Sleep;
-            context.device().read_system_sleep_timeout();
-            self.show(context);
-        } else if action == action_id(UPDATE) {
-            self.view = View::Update;
-            self.show(context);
-        } else if action == action_id(CHECK) {
+            return;
+        }
+        if self.open_destination(context, action) {
+            return;
+        }
+        if action == action_id(CHECK) {
             self.check_for_update(context);
             self.show(context);
         } else if action == action_id(INSTALL) {
@@ -876,7 +993,12 @@ impl KoboApp for Settings {
                     .device()
                     .set_bluetooth(!self.bluetooth_state.enabled()),
                 View::Wifi => context.device().set_wifi(!self.wifi_state.enabled()),
-                View::Home | View::WifiPassword | View::Battery | View::Sleep | View::Update => {}
+                View::Home
+                | View::WifiPassword
+                | View::Battery
+                | View::Sleep
+                | View::Activity
+                | View::Update => {}
             }
         } else if action == action_id(RESCAN) {
             match self.view {
@@ -891,7 +1013,7 @@ impl KoboApp for Settings {
                     self.delay_refresh(context, Pending::WifiRefresh);
                 }
                 View::Battery => context.device().read_battery_detail(),
-                View::Home | View::WifiPassword | View::Sleep | View::Update => {}
+                View::Home | View::WifiPassword | View::Sleep | View::Activity | View::Update => {}
             }
             self.show(context);
         } else if action == action_id(MORE) {
@@ -966,6 +1088,10 @@ impl KoboApp for Settings {
                 self.sleep_timeout_seconds = Some(seconds);
                 self.settled(Topic::Sleep);
             }
+            DeviceResult::SystemActivity(activity) => {
+                self.record_activity(context, activity);
+                self.settled(Topic::Activity);
+            }
             // A failure belongs to whatever was asked for. When the request
             // is not one of the three rows, there is nowhere honest to show it,
             // so it is dropped rather than shown under an unrelated heading.
@@ -1023,6 +1149,12 @@ impl KoboApp for Settings {
             }
             return;
         }
+        if self.activity_clock.on_task(context, task, &outcome) {
+            if self.view == View::Activity {
+                context.device().read_system_activity();
+            }
+            return;
+        }
         if self.update_task == Some(task) {
             self.update_task = None;
             match outcome {
@@ -1053,6 +1185,169 @@ impl KoboApp for Settings {
             TaskOutcome::Cancelled => {}
         }
         self.show(context);
+    }
+}
+
+fn memory_percent(activity: &SystemActivity) -> u16 {
+    if activity.memory_total_bytes == 0 {
+        return 0;
+    }
+    let tenths = u128::from(activity.memory_used_bytes).saturating_mul(1000)
+        / u128::from(activity.memory_total_bytes);
+    u16::try_from(tenths.min(1000)).unwrap_or(1000)
+}
+
+fn format_percent(tenths: u16) -> String {
+    format!("{}.{:01}%", tenths / 10, tenths % 10)
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 4] = ["B", "KB", "MB", "GB"];
+    let mut divisor = 1_u64;
+    let mut unit = 0;
+    while bytes / divisor >= 1024 && unit + 1 < UNITS.len() {
+        divisor = divisor.saturating_mul(1024);
+        unit += 1;
+    }
+    if unit == 0 {
+        return format!("{bytes} B");
+    }
+    let tenths =
+        (u128::from(bytes).saturating_mul(10) / u128::from(divisor)).min(u128::from(u64::MAX));
+    let tenths = u64::try_from(tenths).unwrap_or(u64::MAX);
+    format!("{}.{:01} {}", tenths / 10, tenths % 10, UNITS[unit])
+}
+
+fn compact_bytes(bytes: u64) -> String {
+    format_bytes(bytes).replace(' ', "")
+}
+
+fn process_rows(activity: &SystemActivity) -> Vec<String> {
+    let mut rows = vec!["  PID PROCESS             CPU     MEM".to_owned()];
+    rows.extend(
+        activity
+            .processes
+            .iter()
+            .take(VISIBLE_PROCESSES)
+            .map(|process| {
+                let name = process.name.chars().take(16).collect::<String>();
+                format!(
+                    "{:>5} {:<16} {:>6} {:>7}",
+                    process.pid,
+                    name,
+                    format_percent(process.cpu_tenths),
+                    compact_bytes(process.memory_bytes)
+                )
+            }),
+    );
+    rows
+}
+
+fn activity_graph(history: &VecDeque<(u16, u16)>, width: u32, height: u32) -> Vec<u8> {
+    let Some(length) = usize::try_from(width)
+        .ok()
+        .and_then(|width| width.checked_mul(usize::try_from(height).ok()?))
+    else {
+        return Vec::new();
+    };
+    let mut pixels = vec![255; length];
+    if width < 2 || height < 2 {
+        return pixels;
+    }
+    for quarter in 0..=4 {
+        let y = (height - 1).saturating_mul(quarter) / 4;
+        draw_line(&mut pixels, width, height, 0, y, width - 1, y, 228);
+    }
+    for slot in [30_usize, 60, 90, 119] {
+        let x = u32::try_from(slot).unwrap_or(0).saturating_mul(width - 1)
+            / u32::try_from(ACTIVITY_HISTORY - 1).unwrap_or(1);
+        draw_line(&mut pixels, width, height, x, 0, x, height - 1, 238);
+    }
+    draw_activity_series(&mut pixels, width, height, history, 1, 120);
+    draw_activity_series(&mut pixels, width, height, history, 0, 0);
+    pixels
+}
+
+fn draw_activity_series(
+    pixels: &mut [u8],
+    width: u32,
+    height: u32,
+    history: &VecDeque<(u16, u16)>,
+    value_index: usize,
+    tone: u8,
+) {
+    let mut previous = None;
+    for (index, values) in history.iter().enumerate() {
+        let value = if value_index == 0 { values.0 } else { values.1 }.min(1000);
+        let x = u32::try_from(index)
+            .unwrap_or(u32::MAX)
+            .saturating_mul(width - 1)
+            / u32::try_from(ACTIVITY_HISTORY - 1).unwrap_or(1);
+        let y = (height - 1).saturating_sub(u32::from(value).saturating_mul(height - 1) / 1000);
+        if let Some((last_x, last_y)) = previous {
+            draw_line(pixels, width, height, last_x, last_y, x, y, tone);
+        } else {
+            set_graph_pixel(pixels, width, height, x, y, tone);
+        }
+        previous = Some((x, y));
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draw_line(
+    pixels: &mut [u8],
+    width: u32,
+    height: u32,
+    from_x: u32,
+    from_y: u32,
+    to_x: u32,
+    to_y: u32,
+    tone: u8,
+) {
+    let (mut x, mut y) = (i64::from(from_x), i64::from(from_y));
+    let (to_x, to_y) = (i64::from(to_x), i64::from(to_y));
+    let dx = (to_x - x).abs();
+    let step_x = if x < to_x { 1 } else { -1 };
+    let dy = -(to_y - y).abs();
+    let step_y = if y < to_y { 1 } else { -1 };
+    let mut error = dx + dy;
+    loop {
+        set_graph_pixel(
+            pixels,
+            width,
+            height,
+            u32::try_from(x).unwrap_or(0),
+            u32::try_from(y).unwrap_or(0),
+            tone,
+        );
+        if x == to_x && y == to_y {
+            break;
+        }
+        let twice = error.saturating_mul(2);
+        if twice >= dy {
+            error += dy;
+            x += step_x;
+        }
+        if twice <= dx {
+            error += dx;
+            y += step_y;
+        }
+    }
+}
+
+fn set_graph_pixel(pixels: &mut [u8], width: u32, height: u32, x: u32, y: u32, tone: u8) {
+    if x >= width || y >= height {
+        return;
+    }
+    let Some(index) = usize::try_from(y)
+        .ok()
+        .and_then(|y| y.checked_mul(usize::try_from(width).ok()?))
+        .and_then(|row| row.checked_add(usize::try_from(x).ok()?))
+    else {
+        return;
+    };
+    if let Some(pixel) = pixels.get_mut(index) {
+        *pixel = tone;
     }
 }
 
@@ -1209,9 +1504,10 @@ fn main() -> ExitCode {
 mod tests {
     use super::{RadioState, Settings, DEVICE_ACTIONS, MORE, NETWORK_ACTIONS, PREVIOUS, RESCAN};
     use kobo_sdk::{
-        action_id, BatteryDetail, BluetoothDevice, BluetoothDeviceKind, Chrome, WifiNetwork,
-        CLARA_BW_METRICS,
+        action_id, BatteryDetail, BluetoothDevice, BluetoothDeviceKind, Chrome, PictureHandle,
+        ProcessActivity, SystemActivity, TilePicture, WifiNetwork, CLARA_BW_METRICS,
     };
+    use std::collections::VecDeque;
 
     fn bluetooth_device(index: usize) -> BluetoothDevice {
         BluetoothDevice {
@@ -1412,6 +1708,49 @@ mod tests {
             kobo_sdk::Node::Rows { rows, .. }
                 if rows.iter().any(|row| row.summary == "Selected")
         )));
+    }
+
+    #[test]
+    fn activity_graph_and_top_processes_fit_the_clara_panel() {
+        let activity = SystemActivity {
+            cpu_tenths: 427,
+            memory_used_bytes: 230 * 1024 * 1024,
+            memory_total_bytes: 512 * 1024 * 1024,
+            disk_free_bytes: Some(3 * 1024 * 1024 * 1024),
+            processes: (0_u32..12)
+                .map(|index| ProcessActivity {
+                    pid: 100 + index,
+                    name: format!("process-{index}"),
+                    cpu_tenths: u16::try_from(300_u32.saturating_sub(index * 10)).unwrap_or(0),
+                    memory_bytes: u64::from(index + 1) * 1024 * 1024,
+                })
+                .collect(),
+        };
+        let settings = Settings {
+            view: super::View::Activity,
+            activity: Some(activity),
+            activity_history: VecDeque::from([(427, 449), (510, 451)]),
+            activity_picture: Some(TilePicture::new(PictureHandle(700), 900, 180)),
+            ..Settings::default()
+        };
+        let screen = settings.activity();
+        let issues = screen.validate(&CLARA_BW_METRICS);
+        assert!(issues.is_empty(), "{issues:?}");
+        let table = screen.nodes.iter().find_map(|node| match node {
+            kobo_sdk::Node::Terminal { rows, .. } => Some(rows),
+            _ => None,
+        });
+        assert_eq!(table.map(Vec::len), Some(super::VISIBLE_PROCESSES + 1));
+    }
+
+    #[test]
+    fn activity_history_draws_black_cpu_and_gray_memory_from_left_to_right() {
+        let history = VecDeque::from([(100, 800), (900, 200)]);
+        let graph = super::activity_graph(&history, 120, 40);
+        assert_eq!(graph.len(), 120 * 40);
+        assert!(graph.contains(&0), "CPU line is absent");
+        assert!(graph.contains(&120), "memory line is absent");
+        assert!(graph.contains(&255), "unused future is not blank");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- suspend the active session on inactivity, power-button release, or sleep-cover closure and resume the same processes after wake
- add a persistent global timeout to Settings with 5, 10, 15, 30, and 60 minute choices
- let foreground apps with `keep-awake` explicitly override the timeout or return to the global setting
- add a bounded suspend lifecycle barrier so apps can queue state saves before userspace freezes
- return control to Nickel when suspend-to-RAM is unavailable instead of risking an always-awake device
- add a one-second Settings Activity Monitor with CPU and RAM history, free disk space, and the top processes by CPU and memory
- keep activity telemetry Settings-only and bounded to twelve sanitised process rows; sampling stops when the screen closes
- render Activity updates through the existing pixel frame planner so only the changed panel rectangle refreshes and identical frames are skipped

## Verification

- `cargo test --workspace`
- `cargo test -p kobo-hal --features device-write`
- `cargo test -p kobod --features device-write`
- `cargo clippy -p kobod --features device-write --all-targets -- -D warnings`
- `cargo clippy -p kobo-protocol -p kobo-policy -p kobo-sdk -p kobo-sim -p kobo-settings --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## Hardware validation

- [ ] Confirm timed sleep enters suspend-to-RAM on a supported Kobo
- [ ] Confirm power-button and cover sleep both resume into the same application
- [ ] Confirm Wi-Fi and status recover correctly after wake
- [ ] Confirm the Activity graph and process table update once per second without distracting full-panel flashes
- [ ] Confirm leaving Activity Monitor stops sampling and the normal inactivity timer sleeps the device
