### PR TITLE
Fix six defects found reading on the panel

### DIFF
--- a/crates/kobo-image/src/lib.rs
+++ b/crates/kobo-image/src/lib.rs
@@ -12,6 +12,7 @@
 //! reader with it.
 
 use image::imageops::FilterType;
+use image::metadata::Orientation;
 use image::{DynamicImage, ImageDecoder, ImageEncoder, ImageReader};
 use std::fmt;
 use std::io::Cursor;
@@ -399,6 +400,90 @@ fn nearest_level(value: i32, levels: u32) -> i32 {
     (step * 255 + steps / 2) / steps
 }
 
+/// How large a picture will be, without decoding it.
+///
+/// Reads the header and stops. Every format here states its own dimensions in
+/// the first few dozen bytes, so this costs microseconds where [`decode`] costs
+/// a hundred milliseconds for a plate off a Kobo's processor -- and a layout
+/// that only needs to know how much room to leave should not be paying for
+/// pixels it is not going to draw yet. The reader uses it to measure an
+/// illustrated book at the moment it opens and decode the plates afterwards,
+/// which is the difference between a book opening at once and the panel
+/// freezing for three seconds.
+///
+/// Orientation is applied, so a photograph the camera wrote sideways is
+/// reported the way it will be drawn rather than the way it was stored.
+///
+/// # Errors
+///
+/// The same refusals as [`decode`], for the same reasons: a header claiming
+/// more than [`MAX_PIXELS`] is a header worth refusing before anyone acts on
+/// it.
+pub fn size(bytes: &[u8]) -> Result<(u32, u32), ImageError> {
+    if bytes.len() > MAX_SOURCE_BYTES {
+        return Err(ImageError::TooManyBytes { bytes: bytes.len() });
+    }
+    let reader = ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .map_err(|error| ImageError::Undecodable(error.to_string()))?;
+    if reader.format().is_none() {
+        return Err(ImageError::UnknownFormat);
+    }
+    let mut decoder = reader
+        .into_decoder()
+        .map_err(|error| ImageError::Undecodable(error.to_string()))?;
+    let orientation = decoder
+        .orientation()
+        .map_err(|error| ImageError::Undecodable(error.to_string()))?;
+    let (width, height) = decoder.dimensions();
+    let pixels = u64::from(width) * u64::from(height);
+    if pixels > MAX_PIXELS {
+        return Err(ImageError::TooManyPixels { pixels });
+    }
+    // A quarter turn swaps the two. Everything else -- the flips, and no
+    // orientation at all -- leaves them as they were stored.
+    Ok(match orientation {
+        Orientation::Rotate90
+        | Orientation::Rotate270
+        | Orientation::Rotate90FlipH
+        | Orientation::Rotate270FlipH => (height, width),
+        _ => (width, height),
+    })
+}
+
+/// What [`Picture::fit`] will make of a picture `source` pixels across.
+///
+/// Answered from dimensions alone, so a caller holding nothing but the reply
+/// from [`size`] can work out how much room the picture will take before
+/// deciding to decode it. That is what lets an illustrated book be measured
+/// the moment it opens and drawn a plate at a time afterwards, with no page
+/// changing size when the pixels arrive.
+///
+/// Not the same answer as [`Picture::size_within`], which scales a small
+/// picture up to its box. `fit` deliberately leaves one alone, so this does
+/// too: this predicts `fit`, and a prediction that disagreed with the thing it
+/// predicts would be worse than none.
+#[must_use]
+pub fn fitted_size(source: (u32, u32), width: u32, height: u32) -> (u32, u32) {
+    let (source_width, source_height) = source;
+    if source_width == 0 || source_height == 0 || width == 0 || height == 0 {
+        return (0, 0);
+    }
+    // A picture already inside the box is left alone, the way `fit` leaves it.
+    if source_width <= width && source_height <= height {
+        return source;
+    }
+    let by_width = u64::from(width) * u64::from(source_height);
+    let by_height = u64::from(height) * u64::from(source_width);
+    if by_width <= by_height {
+        let scaled = by_width / u64::from(source_width);
+        (width, u32::try_from(scaled).unwrap_or(height).max(1))
+    } else {
+        let scaled = by_height / u64::from(source_height);
+        (u32::try_from(scaled).unwrap_or(width).max(1), height)
+    }
+}
+
 /// Reads a picture that arrived over the network.
 ///
 /// # Errors
@@ -460,7 +545,10 @@ pub fn decode(bytes: &[u8]) -> Result<Picture, ImageError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{decode, FitMode, ImageError, Picture, MAX_ENLARGEMENT, MAX_PIXELS, PANEL_GREYS};
+    use super::{
+        decode, fitted_size, size, FitMode, ImageError, Picture, MAX_ENLARGEMENT, MAX_PIXELS,
+        PANEL_GREYS,
+    };
     use image::{DynamicImage, ImageFormat, RgbImage, RgbaImage};
     use std::io::Cursor;
 
@@ -660,6 +748,44 @@ mod tests {
         let picture = Picture::from_grey(1000, 1000, vec![9; 1_000_000]).expect("build");
         let filled = picture.fit_enlarging(100, 100).expect("fit");
         assert_eq!((filled.width(), filled.height()), (100, 100));
+    }
+
+    /// The whole point of reading a header: the answer has to be the same one
+    /// decoding would have given, or a page measured from it moves when the
+    /// pixels turn up -- which is the thing this was written to stop.
+    #[test]
+    fn the_size_read_from_a_header_is_the_size_the_decoder_returns() {
+        let jpeg = tiny_jpeg();
+        let decoded = decode(&jpeg).expect("decode");
+        assert_eq!(
+            size(&jpeg).expect("header"),
+            (decoded.width(), decoded.height())
+        );
+
+        let png = png(37, 91, vec![200; 37 * 91 * 4]);
+        let decoded = decode(&png).expect("decode");
+        assert_eq!(
+            size(&png).expect("header"),
+            (decoded.width(), decoded.height())
+        );
+    }
+
+    /// And the same for the size it will be drawn at, which is what a layout
+    /// actually reserves room for.
+    #[test]
+    fn a_predicted_fit_is_the_fit_that_happens() {
+        for (width, height) in [(37, 91), (400, 200), (16, 16)] {
+            let picture = Picture::from_grey(width, height, vec![64; (width * height) as usize])
+                .expect("build");
+            for (box_width, box_height) in [(100, 100), (945, 1063), (10, 4000)] {
+                let fitted = picture.fit(box_width, box_height).expect("fit");
+                assert_eq!(
+                    fitted_size((width, height), box_width, box_height),
+                    (fitted.width(), fitted.height()),
+                    "a {width} by {height} picture in a {box_width} by {box_height} box"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -2896,9 +2896,18 @@ fn encoded_node_len(node: &Node, depth: usize, count: &mut usize) -> Result<usiz
     }
 
     let length = match node {
-        Node::Heading { text, .. } | Node::Text { text, .. } | Node::Secondary { text, .. } => {
+        Node::Heading { text, .. } | Node::Secondary { text, .. } => {
             let mut length = 5;
             add_encoded_len(&mut length, encoded_string_len(text)?)?;
+            length
+        }
+        Node::Text { text, links, .. } => {
+            // id, the text, the count, then an action and two offsets each.
+            let mut length = 6;
+            add_encoded_len(&mut length, encoded_string_len(text)?)?;
+            for _ in links.iter().take(kobo_ui::MAX_TEXT_LINKS) {
+                add_encoded_len(&mut length, 12)?;
+            }
             length
         }
         Node::Section { title, value, .. } => {
@@ -3808,10 +3817,17 @@ fn encode_node(
             push_u32(output, id.0);
             push_string(output, text)?;
         }
-        Node::Text { id, text } => {
+        Node::Text { id, text, links } => {
+            let links = &links[..links.len().min(kobo_ui::MAX_TEXT_LINKS)];
             output.push(2);
             push_u32(output, id.0);
             push_string(output, text)?;
+            output.push(u8::try_from(links.len()).map_err(|_| ProtocolError::TooManyNodes)?);
+            for link in links {
+                push_u32(output, link.action.0);
+                push_u32(output, u32::try_from(link.start).unwrap_or(u32::MAX));
+                push_u32(output, u32::try_from(link.end).unwrap_or(u32::MAX));
+            }
         }
         Node::Secondary { id, text } => {
             output.push(19);
@@ -4634,10 +4650,27 @@ fn decode_node(
             id,
             text: reader.string()?,
         }),
-        2 => Ok(Node::Text {
-            id,
-            text: reader.string()?,
-        }),
+        2 => {
+            let text = reader.string()?;
+            let count = usize::from(reader.u8()?);
+            let mut links = Vec::with_capacity(count.min(kobo_ui::MAX_TEXT_LINKS));
+            for _ in 0..count {
+                let action = ActionId(reader.u32()?);
+                let start = reader.u32()? as usize;
+                let end = reader.u32()? as usize;
+                // Checked here rather than trusted, because these index a
+                // string that came off the same wire and a bad pair would
+                // panic the renderer rather than draw something wrong.
+                if start < end
+                    && end <= text.len()
+                    && text.is_char_boundary(start)
+                    && text.is_char_boundary(end)
+                {
+                    links.push(kobo_ui::TextLink { action, start, end });
+                }
+            }
+            Ok(Node::Text { id, text, links })
+        }
         18 => {
             let depth = reader.u8()?;
             let role = reader.u8()?;
@@ -5800,6 +5833,7 @@ mod tests {
             vec![Node::Text {
                 id: NodeId(1),
                 text: "Chapter one".into(),
+                links: Vec::new(),
             }],
         );
         assert!(!screen.owns_back, "not asking for it is the default");
@@ -5907,6 +5941,7 @@ mod tests {
             .map(|id| Node::Text {
                 id: NodeId(id),
                 text: "x".repeat(MAX_STRING_LEN),
+                links: Vec::new(),
             })
             .collect();
         assert_eq!(
@@ -5942,6 +5977,7 @@ mod node_coverage_tests {
             Node::Text {
                 id: NodeId(2),
                 text: "Body".into(),
+                links: Vec::new(),
             },
             Node::Quote {
                 id: NodeId(30),
@@ -5962,6 +5998,7 @@ mod node_coverage_tests {
                 children: vec![Node::Text {
                     id: NodeId(5),
                     text: "Nested".into(),
+                    links: Vec::new(),
                 }],
             },
             Node::Divider { id: NodeId(6) },
@@ -6036,6 +6073,7 @@ mod node_coverage_tests {
                         vec![Node::Text {
                             id: NodeId(26),
                             text: "Cover".into(),
+                            links: Vec::new(),
                         }],
                     ),
                     BandSlot::fill(vec![
@@ -6285,6 +6323,7 @@ mod node_coverage_tests {
             vec![Node::Text {
                 id: NodeId(1),
                 text: "Underneath".to_owned(),
+                links: Vec::new(),
             }],
         )
         .with_overlay(kobo_ui::Overlay::modal(

--- a/crates/kobo-read/src/lib.rs
+++ b/crates/kobo-read/src/lib.rs
@@ -978,7 +978,9 @@ impl Reader {
                 }
                 Kind::Rule => screen.divider(),
                 Kind::Break => screen.spacer(kobo_ui::Space::Small),
-                Kind::Body | Kind::Preformatted => screen.text(piece.text.clone()),
+                Kind::Body | Kind::Preformatted => {
+                    screen.text_linking(piece.text.clone(), self.links_in(piece))
+                }
             };
         }
         if let Some(problem) = &self.problem {
@@ -1119,12 +1121,13 @@ impl Reader {
 
     /// Where this page points, each line a way there.
     ///
-    /// A list rather than words a finger finds in the middle of a paragraph.
-    /// A footnote marker is a single character set above the line, which is
-    /// smaller than any tap this panel can tell apart, and making the prose
-    /// tappable would put a hit target over every sentence a reader is trying
-    /// to read past. The links on the page they are on is the same answer the
-    /// marking screen already gives for choosing a paragraph.
+    /// The words themselves are tappable now, and this is still here: a
+    /// footnote marker is a single character set above the line, and a finger
+    /// on a reflective panel is a poor instrument for one. What the underlined
+    /// run gives is a target the width of the words rather than the width of
+    /// the marker; what this gives is every destination on the page at a size
+    /// nobody has to aim at, which is the same answer the marking screen
+    /// already gives for choosing a paragraph.
     fn links_screen(&self, title: &str) -> Screen {
         let mut screen = ScreenBuilder::new("reader-links").top_bar(title);
         let here = self.links_here();
@@ -1137,6 +1140,41 @@ impl Reader {
             screen = screen.button(format!("{}{block}", action::GO), text);
         }
         screen.build()
+    }
+
+    /// Where inside one paragraph the links are, and what each one answers.
+    ///
+    /// Found by the words rather than by an offset, because a paragraph cut
+    /// across a page break arrives here as a piece of itself with its lines
+    /// rejoined, so an offset into the block would land in the wrong place or
+    /// off the end. A link whose words cannot be found in this piece -- cut in
+    /// half by the break, or rewritten by the parser -- is simply left out, and
+    /// the list under "Links on this page" still has it.
+    ///
+    /// Only links that land inside this book, on the same reasoning as that
+    /// list: there is no browser here, and a run of underlined words that
+    /// cannot do anything is worse than prose.
+    fn links_in(&self, piece: &Piece) -> Vec<(String, usize, usize)> {
+        let mut found: Vec<(String, usize, usize)> = Vec::new();
+        for link in &self.document.links {
+            if Locator::try_from(link.block) != Ok(piece.block) {
+                continue;
+            }
+            let Some(block) = self.document.destination(link) else {
+                continue;
+            };
+            let Some(start) = piece.text.find(&link.text) else {
+                continue;
+            };
+            let end = start + link.text.len();
+            // Two links over the same words would draw two underlines in the
+            // same place and give the second one a target the first covers.
+            if found.iter().any(|(_, from, to)| start < *to && *from < end) {
+                continue;
+            }
+            found.push((format!("{}{block}", action::GO), start, end));
+        }
+        found
     }
 
     /// The links whose words are on the page being read, and where they go.
@@ -1335,6 +1373,41 @@ impl Reader {
             }
         }
         wanted
+    }
+
+    /// Every picture the page being read refers to, in the order it does.
+    ///
+    /// The subset of [`Self::pictures_wanted`] that is actually on screen, and
+    /// what an application decodes first. A book of plates is a book of
+    /// hundred-millisecond decodes, and doing all of them before the first page
+    /// appears is how opening one froze the panel for three seconds; the page
+    /// being looked at needs one or two of them and nothing else needs to be
+    /// waited for.
+    #[must_use]
+    pub fn pictures_on_page(&self) -> Vec<&str> {
+        let mut wanted = Vec::new();
+        for piece in self.page() {
+            let Some(at) = usize::try_from(piece.block).ok() else {
+                continue;
+            };
+            if let Some(Block::Picture { name, .. }) = self.document.blocks.get(at) {
+                if !wanted.contains(&name.as_str()) {
+                    wanted.push(name.as_str());
+                }
+            }
+        }
+        wanted
+    }
+
+    /// The picture handed over under a name, if one was.
+    ///
+    /// What an application asks in order to fill a picture in later. The room
+    /// a plate takes is settled when the book is measured; the pixels can
+    /// arrive against the same handle afterwards, and this is how the caller
+    /// finds out which handle that is.
+    #[must_use]
+    pub fn picture_named(&self, name: &str) -> Option<kobo_ui::TilePicture> {
+        self.pictures.get(name).copied()
     }
 
     /// The picture to draw for a block, when one has been handed over.
@@ -1879,6 +1952,58 @@ mod tests {
             reader.act(&format!("{}1", action::GO), &panel()),
             Outcome::Save
         );
+    }
+
+    /// The words of a cross-reference answer a finger put on them.
+    ///
+    /// A book's own links were set into the paragraph exactly like the prose
+    /// around them and did nothing at all: reaching one meant opening the
+    /// controls and finding it in a list. A tap on the words themselves is
+    /// what a link is for.
+    #[test]
+    fn a_tap_on_the_words_of_a_link_goes_where_the_link_goes() {
+        let document = Document {
+            blocks: vec![
+                Block::Paragraph("As set out in the appendix, rabbits are numerous.".into()),
+                Block::Paragraph("The appendix itself.".into()),
+            ],
+            anchors: [("appendix".to_owned(), 1usize)].into_iter().collect(),
+            links: vec![kobo_doc::Link {
+                block: 0,
+                text: "the appendix".into(),
+                target: "appendix".into(),
+            }],
+            ..Document::default()
+        };
+        let reader = Reader::open(document, Memory::default(), &panel());
+        let layout = reader
+            .screen("A Book")
+            .layout_with(&panel(), &kobo_ui::Chrome::with_back(true));
+        let run = layout
+            .nodes
+            .iter()
+            .find(|node| matches!(node.kind, kobo_ui::LayoutKind::InlineLink(_)))
+            .expect("the words of the link were not given a target");
+        assert!(
+            run.rect.width > 0 && run.rect.height > 0,
+            "a target with no area is not one: {:?}",
+            run.rect
+        );
+
+        // A finger in the middle of the words, and the same action the list
+        // under the controls would have sent.
+        let touched = layout
+            .hit_test(
+                run.rect.x + run.rect.width / 2,
+                run.rect.y + run.rect.height / 2,
+            )
+            .expect("the tap fell through to the page turn underneath");
+        assert_eq!(touched, kobo_sdk::action_id(&format!("{}1", action::GO)));
+
+        // And the prose either side of it still turns the page, which is the
+        // thing a hit target over a whole paragraph would have taken away.
+        let elsewhere = layout.hit_test(layout.content.x + layout.content.width - 4, run.rect.y);
+        assert_eq!(elsewhere, Some(kobo_sdk::action_id(action::FORWARD)));
     }
 
     #[test]

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -487,6 +487,54 @@ impl ScreenBuilder {
         self.nodes.push(Node::Text {
             id,
             text: text.into(),
+            links: Vec::new(),
+        });
+        self
+    }
+
+    /// A paragraph with runs inside it that go somewhere.
+    ///
+    /// Each link is an action name and the half-open range of the paragraph's
+    /// own bytes that names it. Ranges rather than the words themselves,
+    /// because a paragraph often says the same words twice and only one of
+    /// them is the link; a caller that has the words rather than the offsets
+    /// should use `str::find` on the paragraph it is about to pass in, and
+    /// leave out anything it cannot locate.
+    ///
+    /// A range outside the text, or landing inside a character, is dropped
+    /// rather than drawn somewhere approximate: a link in the wrong place is
+    /// worse than a link that is only in the list.
+    #[must_use]
+    pub fn text_linking<I, N>(mut self, text: impl Into<String>, links: I) -> Self
+    where
+        I: IntoIterator<Item = (N, usize, usize)>,
+        N: AsRef<str>,
+    {
+        let id = self.next_id();
+        let text = text.into();
+        let mut runs = Vec::new();
+        let mut source = links.into_iter();
+        for (name, start, end) in source.by_ref().take(kobo_ui::MAX_TEXT_LINKS) {
+            if start >= end
+                || end > text.len()
+                || !text.is_char_boundary(start)
+                || !text.is_char_boundary(end)
+            {
+                continue;
+            }
+            runs.push(kobo_ui::TextLink {
+                action: self.register(name.as_ref()),
+                start,
+                end,
+            });
+        }
+        if source.next().is_some() {
+            self.warn_limit(id, "text links", kobo_ui::MAX_TEXT_LINKS);
+        }
+        self.nodes.push(Node::Text {
+            id,
+            text,
+            links: runs,
         });
         self
     }
@@ -5164,9 +5212,14 @@ mod tests {
 
     impl KoboApp for Tofu {
         fn on_start(&mut self, context: &mut Context) {
+            // An ideograph, and not a tick: neither face on the device carries
+            // one, whereas the tick this used to say has been drawn from the
+            // grid face ever since the interface face got somewhere to fall
+            // back to. A label that comes out fine is not a label worth
+            // failing a build over.
             context.set_screen(
                 ScreenBuilder::new("tofu")
-                    .button("ok", "Chosen \u{2713}")
+                    .button("ok", "Chosen \u{4e2d}")
                     .build(),
             );
         }

--- a/crates/kobo-sim/src/lib.rs
+++ b/crates/kobo-sim/src/lib.rs
@@ -281,6 +281,7 @@ impl Simulator {
                 Node::Text {
                     id: NodeId(2),
                     text: format!("Value: {}", self.counter),
+                    links: Vec::new(),
                 },
                 Node::Button {
                     id: NodeId(3),
@@ -2867,6 +2868,7 @@ mod tests {
                 .map(|index| Node::Text {
                     id: NodeId(index + 1),
                     text: "One visible line".into(),
+                    links: Vec::new(),
                 })
                 .collect(),
         );

--- a/crates/kobo-text/src/lib.rs
+++ b/crates/kobo-text/src/lib.rs
@@ -348,12 +348,21 @@ impl Typeface {
         })
     }
 
-    /// What this face should actually draw for `character`.
+    /// Whether this face carries a glyph for `character`.
     ///
-    /// Returns the character itself when the face has a glyph for it, a near
-    /// equivalent when it does not but one is available, `None` when the
-    /// character is meant to be invisible, and the original otherwise so that
-    /// the empty box still appears for anything genuinely unrepresentable.
+    /// Index zero is `.notdef`, the empty box, which is the thing worth
+    /// catching before it reaches a panel.
+    fn has(&self, character: char) -> bool {
+        self.font.lookup_glyph_index(character) != 0
+    }
+
+    /// Which face draws `character`, and what it draws.
+    ///
+    /// Returns the character in this face when it has a glyph for it, a near
+    /// equivalent when it does not but one is available, the same character in
+    /// `fallback` when another face carries it, `None` when the character is
+    /// meant to be invisible, and the original otherwise so that the empty box
+    /// still appears for anything genuinely unrepresentable.
     ///
     /// Text off the network is full of characters a text face has no reason to
     /// carry. Atkinson Hyperlegible, the face the reader ships and the one
@@ -362,16 +371,30 @@ impl Typeface {
     /// hyphen drawn for a hyphen is right in every way that matters: it is what
     /// the author wrote, and the only thing lost is that it may now be broken
     /// across lines.
-    fn resolve(&self, character: char) -> Option<char> {
-        if self.font.lookup_glyph_index(character) != 0 {
-            return Some(character);
+    ///
+    /// The other face is the step after that, and it is the one a name needs.
+    /// Atkinson carries eighty-four of the hundred and twenty-eight letters in
+    /// Latin Extended-A and none of the two hundred and fifty-six in Cyrillic,
+    /// so a Project Gutenberg shelf drew the transliterated "Evgeniĭ" with a
+    /// box for its last letter and a Russian title as a row of them. No
+    /// substitution can help there, because there is no near equivalent of a
+    /// letter: an unaccented `i` is a different name and a question mark is an
+    /// apology. Another face that has the letter is the only answer that draws
+    /// what the author wrote, and one is compiled in already.
+    fn pick<'a>(&'a self, character: char, fallback: Option<&'a Self>) -> Option<(&'a Self, char)> {
+        if self.has(character) {
+            return Some((self, character));
         }
         if is_invisible(character) {
             return None;
         }
-        substitute(character)
-            .filter(|glyph| self.font.lookup_glyph_index(*glyph) != 0)
-            .or(Some(character))
+        if let Some(glyph) = substitute(character).filter(|glyph| self.has(*glyph)) {
+            return Some((self, glyph));
+        }
+        if let Some(other) = fallback.filter(|other| other.has(character)) {
+            return Some((other, character));
+        }
+        Some((self, character))
     }
 
     /// The distance from the top of a line to the baseline.
@@ -392,7 +415,13 @@ impl Typeface {
     /// of a line the drift is several pixels. That drift is visible twice over:
     /// as uneven word spacing, and as a disagreement between what wrapping
     /// measured and what the renderer then drew.
-    fn measure_run(&self, text: &str, size: FontSize, cell: Option<i32>) -> (i32, i32) {
+    fn measure_run(
+        &self,
+        text: &str,
+        size: FontSize,
+        cell: Option<i32>,
+        fallback: Option<&Self>,
+    ) -> (i32, i32) {
         if let Some(cell) = cell {
             // A grid is measured by counting, not by adding. The exact sum of
             // 16 advances of 25.875 is 414, but the sixteenth column is drawn
@@ -404,16 +433,20 @@ impl Typeface {
         }
         let pixels = self.pixels(size);
         let mut width = 0f32;
-        let mut previous = None;
+        let mut previous: Option<(&Self, char)> = None;
         for character in text.chars() {
-            let Some(character) = self.resolve(character) else {
+            let Some((face, glyph)) = self.pick(character, fallback) else {
                 continue;
             };
-            if let Some(previous) = previous {
-                width += kern(&self.font, previous, character, pixels);
+            // Kerning is a pair drawn by one designer. Across a face boundary
+            // there is no pair, so there is nothing to ask and nothing to add.
+            if let Some((before, previous)) = previous {
+                if std::ptr::eq(before, face) {
+                    width += kern(&face.font, previous, glyph, pixels);
+                }
             }
-            width += self.font.metrics(character, pixels).advance_width;
-            previous = Some(character);
+            width += face.font.metrics(glyph, pixels).advance_width;
+            previous = Some((face, glyph));
         }
         (width.round() as i32, self.height(size))
     }
@@ -431,6 +464,13 @@ impl Typeface {
     ///
     /// Accumulates the same way [`Self::measure_run`] does, so a run drawn here
     /// ends exactly where measuring said it would.
+    ///
+    /// Eight arguments, and every one of them is a fact about this one run:
+    /// what to draw, where, at what size, on what grid, out of which faces, and
+    /// what to call for each pixel. Gathering the middle three into a struct
+    /// would name the pieces of a run rather than a run, and the only caller is
+    /// twenty lines away.
+    #[allow(clippy::too_many_arguments)]
     fn draw_run(
         &self,
         text: &str,
@@ -438,14 +478,18 @@ impl Typeface {
         y: i32,
         size: FontSize,
         cell: Option<i32>,
+        fallback: Option<&Self>,
         plot: &mut dyn FnMut(i32, i32, u8),
     ) {
         let pixels = self.pixels(size);
+        // Taken from this face rather than from whichever one draws each
+        // glyph, so a letter borrowed from another face sits on the same line
+        // as the letters around it instead of a line of its own.
         let baseline = y.saturating_add(self.ascent(pixels));
         let mut pen = x as f32;
-        let mut previous = None;
+        let mut previous: Option<(&Self, char)> = None;
         for character in text.chars() {
-            let Some(character) = self.resolve(character) else {
+            let Some((face, character)) = self.pick(character, fallback) else {
                 // An invisible character owns a column in a grid and nothing
                 // at all in a proportional run. Advancing here in both cases
                 // would open a hole in the middle of a word.
@@ -456,10 +500,12 @@ impl Typeface {
             };
             // Kerning is a proportional idea. Applying it in a grid would move
             // a character out of its own column depending on its neighbour.
-            if let (Some(previous), None) = (previous, cell) {
-                pen += kern(&self.font, previous, character, pixels);
+            if let (Some((before, previous)), None) = (previous, cell) {
+                if std::ptr::eq(before, face) {
+                    pen += kern(&face.font, previous, character, pixels);
+                }
             }
-            if let Some(raster) = self.raster(character, pixels) {
+            if let Some(raster) = face.raster(character, pixels) {
                 let origin_x = (pen.round() as i32).saturating_add(raster.left);
                 let origin_y = baseline.saturating_add(raster.top);
                 for row in 0..raster.height {
@@ -479,7 +525,7 @@ impl Typeface {
                     }
                 }
                 pen += cell.map_or_else(
-                    || self.font.metrics(character, pixels).advance_width,
+                    || face.font.metrics(character, pixels).advance_width,
                     |cell| cell as f32,
                 );
             } else if let Some(cell) = cell {
@@ -487,7 +533,7 @@ impl Typeface {
                 // its column. Skipping it would shift the rest of the row left.
                 pen += cell as f32;
             }
-            previous = Some(character);
+            previous = Some((face, character));
         }
     }
 
@@ -594,12 +640,30 @@ impl SystemFonts {
             Face::Mono => Some(self.cell_width(size)),
         }
     }
+
+    /// The face asked for a letter the chosen one does not have.
+    ///
+    /// The compiled-in grid face, which is the widest-covering thing on the
+    /// device: every letter of Latin Extended-A, most of Latin Extended-B, and
+    /// the Greek and Cyrillic the interface face has none of. It is a
+    /// monospace cut and one letter of it inside a proportional word is
+    /// visibly a different design -- which is still the right trade, because
+    /// the alternative on screen was an empty box.
+    ///
+    /// Nothing stands behind the grid face itself. It is the end of the chain,
+    /// and there is nothing here that covers more than it does.
+    const fn fallback(&self, face: Face) -> Option<&Typeface> {
+        match face {
+            Face::Text | Face::Reading => Some(&self.mono),
+            Face::Mono => None,
+        }
+    }
 }
 
 impl Typesetter for SystemFonts {
     fn measure(&self, text: &str, size: FontSize, face: Face) -> (i32, i32) {
         self.cut(size, face)
-            .measure_run(text, size, self.cell(size, face))
+            .measure_run(text, size, self.cell(size, face), self.fallback(face))
     }
 
     fn line_height(&self, size: FontSize, face: Face) -> i32 {
@@ -626,21 +690,27 @@ impl Typesetter for SystemFonts {
         face: Face,
         plot: &mut dyn FnMut(i32, i32, u8),
     ) {
-        self.cut(size, face)
-            .draw_run(text, x, y, size, self.cell(size, face), plot);
+        self.cut(size, face).draw_run(
+            text,
+            x,
+            y,
+            size,
+            self.cell(size, face),
+            self.fallback(face),
+            plot,
+        );
     }
 
     fn has_glyph(&self, character: char, face: Face) -> bool {
         // Answers for what would actually reach the panel, not for what the
-        // face happens to contain. A character that is substituted or that is
-        // deliberately invisible draws no empty box, so reporting it as
-        // missing would condemn text that comes out perfectly readable.
+        // face happens to contain. A character that is substituted, borrowed
+        // from another face, or deliberately invisible draws no empty box, so
+        // reporting it as missing would condemn text that comes out perfectly
+        // readable.
         let typeface = self.face(face);
-        // Index zero is `.notdef`, the empty box, which is exactly the thing
-        // worth catching before it reaches a panel.
         typeface
-            .resolve(character)
-            .is_none_or(|glyph| typeface.font.lookup_glyph_index(glyph) != 0)
+            .pick(character, self.fallback(face))
+            .is_none_or(|(drawn, glyph)| drawn.has(glyph))
     }
 
     fn line_breaks(&self, text: &str) -> Vec<(usize, BreakOpportunity)> {
@@ -666,7 +736,7 @@ impl Typesetter for SystemFonts {
         // is very nearly fixed pitch still produces a usable grid.
         self.mono
             .fixed_advance(size)
-            .unwrap_or_else(|| self.mono.measure_run("0", size, None).0.max(1))
+            .unwrap_or_else(|| self.mono.measure_run("0", size, None, None).0.max(1))
     }
 }
 
@@ -979,7 +1049,7 @@ mod tests {
         let at = |scale| {
             kobo_ui::with_text_scale(scale, || {
                 (
-                    face.measure_run("Readable", FontSize::Body, None).0,
+                    face.measure_run("Readable", FontSize::Body, None, None).0,
                     face.height(FontSize::Body),
                 )
             })
@@ -1121,12 +1191,86 @@ mod tests {
             "this test is pointless unless the face really lacks the character"
         );
 
-        let (plain, _) = face.measure_run("one-to-one", FontSize::Body, None);
-        let (fancy, _) = face.measure_run("one\u{2011}to\u{2011}one", FontSize::Body, None);
+        let (plain, _) = face.measure_run("one-to-one", FontSize::Body, None, None);
+        let (fancy, _) = face.measure_run("one\u{2011}to\u{2011}one", FontSize::Body, None, None);
         assert_eq!(plain, fancy, "the substitute must measure as what it draws");
         assert_eq!(
             ink(&face, "one\u{2011}to\u{2011}one"),
             ink(&face, "one-to-one")
+        );
+    }
+
+    /// A letter the interface face lacks is borrowed rather than boxed.
+    ///
+    /// An author shelf drew "Evgeniĭ" with an empty box where the last letter
+    /// belongs, because Atkinson Hyperlegible carries eighty-four of the
+    /// hundred and twenty-eight letters of Latin Extended-A and this is one of
+    /// the forty-four it does not. There is no near equivalent to substitute:
+    /// an unaccented `i` is a different name. The compiled-in grid face has
+    /// the letter, so the letter is what gets drawn.
+    #[test]
+    fn a_letter_missing_from_one_face_is_drawn_from_another() {
+        let face = Typeface::from_bytes(TEXT_FONT, "bundled", CLARA).expect("the compiled-in face");
+        let other = Typeface::from_bytes(MONO_FONT, "grid", CLARA).expect("the compiled-in grid");
+        for missing in ['\u{12d}', '\u{439}', '\u{169}'] {
+            assert_eq!(
+                face.font.lookup_glyph_index(missing),
+                0,
+                "{missing:?} would not exercise the fallback"
+            );
+            let (drawn, glyph) = face
+                .pick(missing, Some(&other))
+                .expect("a letter is not invisible");
+            assert!(
+                std::ptr::eq(drawn, &other) && glyph == missing,
+                "{missing:?} was not borrowed from the face that has it"
+            );
+            let boxed = ink(&face, &missing.to_string());
+            let mut borrowed = Vec::new();
+            face.draw_run(
+                &missing.to_string(),
+                0,
+                0,
+                FontSize::Body,
+                None,
+                Some(&other),
+                &mut |x, y, coverage| {
+                    if coverage > 0 {
+                        borrowed.push((x, y));
+                    }
+                },
+            );
+            assert_ne!(
+                boxed, borrowed,
+                "{missing:?} drew the same marks with and without a face that has it"
+            );
+        }
+    }
+
+    /// Borrowing a letter must not make the line disagree with itself.
+    ///
+    /// Wrapping measures a line and the renderer then draws it. If the two
+    /// consult different faces for the same character the line is measured at
+    /// one width and drawn at another, which puts the end of a page past the
+    /// margin -- the failure that is invisible until it is on hardware.
+    #[test]
+    fn a_borrowed_letter_is_measured_in_the_face_that_draws_it() {
+        let Some(fonts) = fonts() else {
+            return;
+        };
+        let name = "Evgeni\u{12d}";
+        let (measured, _) = fonts.measure(name, FontSize::Body, Face::Text);
+        let mut rightmost = 0;
+        fonts.draw(name, 0, 0, FontSize::Body, Face::Text, &mut |x, _, _| {
+            rightmost = rightmost.max(x);
+        });
+        assert!(
+            rightmost <= measured,
+            "the name was measured at {measured} and drawn to {rightmost}"
+        );
+        assert!(
+            fonts.has_glyph('\u{12d}', Face::Text),
+            "a letter that reaches the panel intact is not a missing one"
         );
     }
 
@@ -1145,8 +1289,8 @@ mod tests {
             );
             let text = format!("wo{invisible}rd");
             assert_eq!(
-                face.measure_run(&text, FontSize::Body, None),
-                face.measure_run("word", FontSize::Body, None),
+                face.measure_run(&text, FontSize::Body, None, None),
+                face.measure_run("word", FontSize::Body, None, None),
                 "{invisible:?} widened the line it should have left alone"
             );
             assert_eq!(ink(&face, &text), ink(&face, "word"));
@@ -1164,7 +1308,7 @@ mod tests {
         let cell = mono.fixed_advance(FontSize::Body).expect("a fixed advance");
         let text = "a\u{200b}b";
         assert_eq!(
-            mono.measure_run(text, FontSize::Body, Some(cell)).0,
+            mono.measure_run(text, FontSize::Body, Some(cell), None).0,
             cell * 3
         );
         let mut columns = Vec::new();
@@ -1174,6 +1318,7 @@ mod tests {
             0,
             FontSize::Body,
             Some(cell),
+            None,
             &mut |x, _, coverage| {
                 if coverage > 0 {
                     columns.push(x);
@@ -1239,11 +1384,19 @@ mod tests {
     /// Every pixel a run puts down, so two runs can be compared exactly.
     fn ink(face: &Typeface, text: &str) -> Vec<(i32, i32)> {
         let mut marks = Vec::new();
-        face.draw_run(text, 0, 0, FontSize::Body, None, &mut |x, y, coverage| {
-            if coverage > 0 {
-                marks.push((x, y));
-            }
-        });
+        face.draw_run(
+            text,
+            0,
+            0,
+            FontSize::Body,
+            None,
+            None,
+            &mut |x, y, coverage| {
+                if coverage > 0 {
+                    marks.push((x, y));
+                }
+            },
+        );
         marks
     }
 
@@ -1252,8 +1405,8 @@ mod tests {
         let Some(face) = face() else {
             return;
         };
-        let lower = face.measure_run("aaaa", FontSize::Body, None);
-        let upper = face.measure_run("AAAA", FontSize::Body, None);
+        let lower = face.measure_run("aaaa", FontSize::Body, None, None);
+        let upper = face.measure_run("AAAA", FontSize::Body, None, None);
         // The built-in bitmap folded case away entirely, so these were equal.
         assert_ne!(lower, upper, "case is still being folded away");
     }
@@ -1263,8 +1416,8 @@ mod tests {
         let Some(face) = face() else {
             return;
         };
-        let narrow = face.measure_run("iiii", FontSize::Body, None);
-        let wide = face.measure_run("mmmm", FontSize::Body, None);
+        let narrow = face.measure_run("iiii", FontSize::Body, None, None);
+        let wide = face.measure_run("mmmm", FontSize::Body, None, None);
         assert!(narrow.0 < wide.0, "text is still monospaced");
     }
 
@@ -1273,8 +1426,8 @@ mod tests {
         let Some(face) = face() else {
             return;
         };
-        let once = face.measure_run("kobo", FontSize::Body, None).0;
-        let twice = face.measure_run("kobokobo", FontSize::Body, None).0;
+        let once = face.measure_run("kobo", FontSize::Body, None, None).0;
+        let twice = face.measure_run("kobokobo", FontSize::Body, None, None).0;
         let drift = (twice - once * 2).abs();
         assert!(
             drift <= once / 10,
@@ -1288,9 +1441,9 @@ mod tests {
             return;
         };
         let text = "Reading";
-        let (width, height) = face.measure_run(text, FontSize::Body, None);
+        let (width, height) = face.measure_run(text, FontSize::Body, None, None);
         let mut out_of_bounds = 0;
-        face.draw_run(text, 0, 0, FontSize::Body, None, &mut |x, y, _| {
+        face.draw_run(text, 0, 0, FontSize::Body, None, None, &mut |x, y, _| {
             if x < 0 || y < 0 || x > width || y > height {
                 out_of_bounds += 1;
             }
@@ -1310,6 +1463,7 @@ mod tests {
             0,
             FontSize::Body,
             None,
+            None,
             &mut |_, _, coverage| {
                 if coverage > 0 {
                     covered += 1;
@@ -1325,11 +1479,19 @@ mod tests {
             return;
         };
         let mut partial = 0;
-        face.draw_run("Ss", 0, 0, FontSize::Title, None, &mut |_, _, coverage| {
-            if coverage > 0 && coverage < 255 {
-                partial += 1;
-            }
-        });
+        face.draw_run(
+            "Ss",
+            0,
+            0,
+            FontSize::Title,
+            None,
+            None,
+            &mut |_, _, coverage| {
+                if coverage > 0 && coverage < 255 {
+                    partial += 1;
+                }
+            },
+        );
         assert!(partial > 0, "no antialiased edge pixels were produced");
     }
 
@@ -1338,8 +1500,8 @@ mod tests {
         let Some(face) = face() else {
             return;
         };
-        let caption = face.measure_run("Chapter", FontSize::Caption, None);
-        let heading = face.measure_run("Chapter", FontSize::Heading, None);
+        let caption = face.measure_run("Chapter", FontSize::Caption, None, None);
+        let heading = face.measure_run("Chapter", FontSize::Heading, None, None);
         assert!(caption.0 < heading.0);
         assert!(caption.1 < heading.1);
     }
@@ -1400,7 +1562,7 @@ mod tests {
         let mono = Typeface::from_bytes(MONO_FONT, "mono", CLARA).expect("mono");
         let cell = mono.fixed_advance(FontSize::Body).expect("fixed pitch");
         for probe in ["i", "m", "W", ".", "0", "|"] {
-            let (width, _) = mono.measure_run(probe, FontSize::Body, Some(cell));
+            let (width, _) = mono.measure_run(probe, FontSize::Body, Some(cell), None);
             assert_eq!(width, cell, "{probe} is not one cell wide");
         }
     }
@@ -1411,7 +1573,7 @@ mod tests {
         let cell = mono.fixed_advance(FontSize::Body).expect("fixed pitch");
         // A grid is addressed by column, so this has to hold exactly rather
         // than approximately, or column 60 is not where column 60 was drawn.
-        let (width, _) = mono.measure_run("cat /proc/uptime", FontSize::Body, Some(cell));
+        let (width, _) = mono.measure_run("cat /proc/uptime", FontSize::Body, Some(cell), None);
         assert_eq!(width, cell * 16);
     }
 
@@ -1453,7 +1615,7 @@ mod tests {
             .chars()
             .map(|character| face.font.metrics(character, pixels).advance_width)
             .sum();
-        let measured = face.measure_run(&line, FontSize::Body, None).0;
+        let measured = face.measure_run(&line, FontSize::Body, None, None).0;
         assert!(
             (measured as f32 - exact).abs() <= 1.0,
             "measured {measured} against an exact {exact}"
@@ -1566,6 +1728,7 @@ mod tests {
                 vec![kobo_ui::Node::Text {
                     id: kobo_ui::NodeId(1),
                     text: "a page".into(),
+                    links: Vec::new(),
                 }],
             );
             let mut surface = kobo_ui::Surface::new(width, height);
@@ -1693,7 +1856,7 @@ mod tests {
         let regular = Typeface::from_bytes(TEXT_FONT, "regular", CLARA).expect("regular");
         for size in [FontSize::Title, FontSize::Heading] {
             let (bold_width, _) = fonts.measure("Connections", size, Face::Text);
-            let (plain_width, _) = regular.measure_run("Connections", size, None);
+            let (plain_width, _) = regular.measure_run("Connections", size, None, None);
             assert!(
                 bold_width > plain_width,
                 "{size:?} was set no wider than the regular cut: {bold_width} against {plain_width}"
@@ -1703,7 +1866,7 @@ mod tests {
         // a screen shouting every word of itself.
         for size in [FontSize::Caption, FontSize::Body] {
             let (through, _) = fonts.measure("Connections", size, Face::Text);
-            let (plain, _) = regular.measure_run("Connections", size, None);
+            let (plain, _) = regular.measure_run("Connections", size, None, None);
             assert_eq!(through, plain, "{size:?} was not set in the regular cut");
         }
     }

--- a/crates/kobo-ui/src/lib.rs
+++ b/crates/kobo-ui/src/lib.rs
@@ -2149,6 +2149,36 @@ fn layout_nav_bar(nav_bar: &NavBar, metrics: &DisplayMetrics, layout: &mut Layou
     }
 }
 
+/// A run of characters inside a paragraph that goes somewhere.
+///
+/// A footnote marker, a cross-reference, an address: all of them are set into
+/// the line exactly like the words around them, and before this the reader drew
+/// them as text and nothing else. A book's own cross-references were decoration.
+///
+/// Byte offsets into the paragraph's own string, and half-open. Offsets rather
+/// than a copy of the words because the same words often appear twice in a
+/// paragraph and only one of them is the link, and because the layout has to
+/// measure the run against what precedes it on its line to know where it is.
+///
+/// The whole run gets a tap target, which is what makes this workable on a
+/// panel that cannot resolve a superscript: the words of a footnote marker are
+/// a few millimetres wide even where the marker itself is not.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TextLink {
+    pub action: ActionId,
+    /// Where the run starts, as a byte offset into the paragraph.
+    pub start: usize,
+    /// Where it ends, exclusive.
+    pub end: usize,
+}
+
+/// The most links one paragraph may carry.
+///
+/// An annotated edition links every other sentence, and each link is a node in
+/// the layout and a tap target in the hit test. Sixteen is far past any
+/// paragraph anybody reads and well short of a paragraph that costs anything.
+pub const MAX_TEXT_LINKS: usize = 16;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Node {
     Heading {
@@ -2158,6 +2188,14 @@ pub enum Node {
     Text {
         id: NodeId,
         text: String,
+        /// Runs of this paragraph that go somewhere when they are touched.
+        ///
+        /// Empty for almost every paragraph in the system, which is why this
+        /// is a list on the node rather than a node of its own: a link is a
+        /// property of a few characters inside prose, and a paragraph that had
+        /// to be split into three nodes to carry one would wrap, measure and
+        /// paginate as three separate paragraphs.
+        links: Vec<TextLink>,
     },
     /// A line about the content rather than the content: a date, an author, a
     /// size, a count, a status.
@@ -3364,6 +3402,12 @@ pub enum LayoutKind {
     StatusBattery(Option<Percent>, bool),
     Heading,
     Text,
+    /// A run inside a paragraph that goes somewhere.
+    ///
+    /// Drawn as an underline under words the paragraph node has already set,
+    /// and hit-tested ahead of the page turn beneath it because it is pushed
+    /// after the paragraph. One of these per line the run covers.
+    InlineLink(ActionId),
     /// A line of metadata: smaller than the body, and in the muted tone.
     Secondary,
     /// The name of a group, with a hairline to the right margin and an
@@ -3531,6 +3575,7 @@ impl LayoutKind {
             | Self::ChoiceFreeform(action)
             | Self::QuoteFold(action, _)
             | Self::PagePrevious(action)
+            | Self::InlineLink(action)
             | Self::PageNext(action) => Some(action),
             Self::Back | Self::OverlayClose => Some(ActionId::BACK),
             _ => None,
@@ -4343,8 +4388,16 @@ fn layout_node(
             });
             y.saturating_add(height)
         }
-        Node::Text { id, text } => {
-            let lines = wrap_text_in(text, width, FontSize::Body, prose);
+        Node::Text { id, text, links } => {
+            let ranges = wrap_ranges(text, width, FontSize::Body, prose);
+            let lines: Vec<String> = if ranges.is_empty() {
+                vec![String::new()]
+            } else {
+                ranges
+                    .iter()
+                    .map(|line| text[line.0..line.1].to_owned())
+                    .collect()
+            };
             let height = max(
                 MIN_TEXT_HEIGHT,
                 lines.len() as i32 * FontSize::Body.line_height_in(prose),
@@ -4360,6 +4413,36 @@ fn layout_node(
                 kind: LayoutKind::Text,
                 text_lines: lines,
             });
+            // After the paragraph, so the hit test -- which reads the nodes
+            // backwards, on the principle that what is drawn last is what the
+            // finger touched -- finds a link before the page turn underneath
+            // it. A run split across a line break becomes two rectangles, both
+            // naming the same action, which is what a link that wraps should
+            // feel like.
+            for link in links.iter().take(MAX_TEXT_LINKS) {
+                for (index, &(from, to)) in ranges.iter().enumerate() {
+                    let start = max(from, link.start);
+                    let end = min(to, link.end);
+                    if start >= end || !text.is_char_boundary(start) || !text.is_char_boundary(end)
+                    {
+                        continue;
+                    }
+                    let before = measure_text_in(&text[from..start], FontSize::Body, prose).0;
+                    let through = measure_text_in(&text[from..end], FontSize::Body, prose).0;
+                    let line_height = FontSize::Body.line_height_in(prose);
+                    layout.nodes.push(LayoutNode {
+                        id: *id,
+                        rect: Rect {
+                            x: x.saturating_add(before),
+                            y: y.saturating_add(index as i32 * line_height),
+                            width: through.saturating_sub(before),
+                            height: line_height,
+                        },
+                        kind: LayoutKind::InlineLink(link.action),
+                        text_lines: Vec::new(),
+                    });
+                }
+            }
             y.saturating_add(height)
         }
         Node::Secondary { id, text } => {
@@ -7178,8 +7261,29 @@ pub fn wrap_text(text: &str, max_width: i32, size: FontSize) -> Vec<String> {
 /// other puts lines past the margin and loses the end of a page.
 #[must_use]
 pub fn wrap_text_in(text: &str, max_width: i32, size: FontSize, face: Face) -> Vec<String> {
-    if text.is_empty() || max_width <= 0 {
+    let lines = wrap_ranges(text, max_width, size, face);
+    if lines.is_empty() {
         return vec![String::new()];
+    }
+    lines
+        .into_iter()
+        .map(|line| text[line.0..line.1].to_owned())
+        .collect()
+}
+
+/// The same wrapping, as byte offsets into `text` rather than copies of it.
+///
+/// What lets a run inside a paragraph be found on the page: a link is a range
+/// of the paragraph's own bytes, and turning it into a rectangle means knowing
+/// which line it landed on and how much of that line comes before it. Answering
+/// from the strings alone is not possible -- wrapping drops the whitespace at
+/// each break, so the lines put back together are not the paragraph.
+///
+/// Empty for text that wraps to nothing, which [`wrap_text_in`] turns back into
+/// the single empty line every caller downstream expects.
+fn wrap_ranges(text: &str, max_width: i32, size: FontSize, face: Face) -> Vec<(usize, usize)> {
+    if text.is_empty() || max_width <= 0 {
+        return Vec::new();
     }
     let opportunities = TYPESETTER
         .get()
@@ -7192,7 +7296,7 @@ pub fn wrap_text_in(text: &str, max_width: i32, size: FontSize, face: Face) -> V
         },
         |face| face.grapheme_boundaries(text),
     );
-    let mut lines = Vec::new();
+    let mut lines: Vec<(usize, usize)> = Vec::new();
     let mut start = 0;
     while start < text.len() {
         start = skip_soft_whitespace(text, start);
@@ -7200,7 +7304,7 @@ pub fn wrap_text_in(text: &str, max_width: i32, size: FontSize, face: Face) -> V
             break;
         }
 
-        let mut best = None;
+        let mut best: Option<(usize, usize)> = None;
         let mut emitted = false;
         for &(end, opportunity) in opportunities.iter().filter(|entry| entry.0 > start) {
             let visible_end = if opportunity == BreakOpportunity::Mandatory {
@@ -7209,10 +7313,11 @@ pub fn wrap_text_in(text: &str, max_width: i32, size: FontSize, face: Face) -> V
                 end
             };
             let candidate = text[start..visible_end].trim_end_matches(char::is_whitespace);
+            let candidate_end = start + candidate.len();
             if measure_text_in(candidate, size, face).0 <= max_width {
-                best = Some((end, candidate.to_owned()));
+                best = Some((end, candidate_end));
                 if opportunity == BreakOpportunity::Mandatory {
-                    lines.push(candidate.to_owned());
+                    lines.push((start, candidate_end));
                     start = end;
                     emitted = true;
                     break;
@@ -7220,13 +7325,13 @@ pub fn wrap_text_in(text: &str, max_width: i32, size: FontSize, face: Face) -> V
                 continue;
             }
 
-            if let Some((best_end, line)) = best.take() {
-                lines.push(line);
+            if let Some((best_end, line_end)) = best.take() {
+                lines.push((start, line_end));
                 start = best_end;
             } else {
                 let forced_end =
                     force_grapheme_break(text, start, visible_end, max_width, size, &graphemes);
-                lines.push(text[start..forced_end].trim_end().to_owned());
+                lines.push((start, start + text[start..forced_end].trim_end().len()));
                 start = forced_end;
             }
             emitted = true;
@@ -7236,12 +7341,9 @@ pub fn wrap_text_in(text: &str, max_width: i32, size: FontSize, face: Face) -> V
         if !emitted {
             let forced_end =
                 force_grapheme_break(text, start, text.len(), max_width, size, &graphemes);
-            lines.push(text[start..forced_end].trim_end().to_owned());
+            lines.push((start, start + text[start..forced_end].trim_end().len()));
             start = forced_end;
         }
-    }
-    if lines.is_empty() {
-        lines.push(String::new());
     }
     lines
 }
@@ -8469,6 +8571,14 @@ fn validate_layout_nodes(layout: &Layout, metrics: &DisplayMetrics, issues: &mut
     }
 }
 
+/// Which kinds are held to the minimum a finger can reliably hit.
+///
+/// Controls, in other words: something a designer chose the size of, and could
+/// have made larger. [`LayoutKind::InlineLink`] is deliberately absent. Its size
+/// is the size of the words the author wrote, which nobody here chose and
+/// nothing here can change, and reporting every footnote marker in an annotated
+/// edition as a layout error would say only that books have short words in
+/// them.
 const fn is_tappable(kind: LayoutKind) -> bool {
     matches!(
         kind,
@@ -9384,6 +9494,30 @@ pub fn render_all(
                         clip,
                     );
                 }
+            }
+            // The words are already on the panel: the paragraph drew them.
+            // What a link adds is the one mark that has meant "this goes
+            // somewhere" since long before anybody put it on a screen. Set
+            // clear of the descenders rather than through them, and a rule
+            // thick, because a single pixel at this density is not there.
+            LayoutKind::InlineLink(_) => {
+                let thickness = metrics.rule_thickness();
+                let baseline = node
+                    .rect
+                    .y
+                    .saturating_add(FontSize::Body.line_height_in(prose))
+                    .saturating_sub(thickness.saturating_mul(2));
+                fill_clipped(
+                    surface,
+                    Rect {
+                        x: node.rect.x,
+                        y: baseline,
+                        width: node.rect.width,
+                        height: thickness,
+                    },
+                    tone::INK,
+                    clip,
+                );
             }
             LayoutKind::Text | LayoutKind::PagedList => draw_lines_in(
                 surface,
@@ -10758,6 +10892,7 @@ mod tests {
             .map(|index| Node::Text {
                 id: NodeId(index + 1),
                 text: "A paragraph that occupies a real line.".into(),
+                links: Vec::new(),
             })
             .collect();
         let issues = Screen::new(1, nodes).validate(&CLARA_BW_METRICS);
@@ -11300,6 +11435,7 @@ mod page_turn_tests {
             vec![Node::Text {
                 id: NodeId(2),
                 text: "A page of a book.".to_owned(),
+                links: Vec::new(),
             }],
         )
         .with_top_bar(TopBar::new(NodeId(3), "Reading"))
@@ -11602,6 +11738,7 @@ mod chrome_tests {
             .map(|index| Node::Text {
                 id: NodeId(index),
                 text: "A line of body copy that occupies a row".into(),
+                links: Vec::new(),
             })
             .collect();
         let screen =
@@ -12320,6 +12457,7 @@ mod loading_tests {
             Node::Text {
                 id: NodeId(2),
                 text: "Some body text that is long enough to wrap onto a second line.".into(),
+                links: Vec::new(),
             },
             Node::Button {
                 id: NodeId(3),
@@ -12333,6 +12471,7 @@ mod loading_tests {
                 children: vec![Node::Text {
                     id: NodeId(5),
                     text: "Inside a card".into(),
+                    links: Vec::new(),
                 }],
             },
             Node::Divider { id: NodeId(6) },
@@ -12567,6 +12706,7 @@ mod prose_tests {
             .map(|(index, paragraph)| Node::Text {
                 id: NodeId(index as u32 + 1),
                 text: paragraph.clone(),
+                links: Vec::new(),
             })
             .collect();
         let screen = Screen::new(1, nodes)
@@ -12903,6 +13043,7 @@ mod prose_tests {
             vec![Node::Text {
                 id: NodeId(1),
                 text: "A paragraph the reader is meant to be able to read.".to_owned(),
+                links: Vec::new(),
             }],
         )
         .with_top_bar(TopBar::new(NodeId(0), "Feeds"));
@@ -13207,6 +13348,7 @@ mod prose_tests {
                 Node::Text {
                     id: NodeId(1),
                     text: "Twenty Thousand Leagues Under the Sea".to_owned(),
+                    links: Vec::new(),
                 },
                 Node::Secondary {
                     id: NodeId(2),
@@ -13491,6 +13633,7 @@ mod prose_tests {
                 nodes.push(Node::Text {
                     id: NodeId(1),
                     text: before.to_string(),
+                    links: Vec::new(),
                 });
             }
             nodes.push(Node::Button {
@@ -13504,6 +13647,7 @@ mod prose_tests {
                 nodes.push(Node::Text {
                     id: NodeId(3),
                     text: after.to_string(),
+                    links: Vec::new(),
                 });
             }
             Screen::new(1, nodes)
@@ -14469,6 +14613,7 @@ mod prose_tests {
                 vec![Node::Text {
                     id: NodeId(41),
                     text: "Something".to_owned(),
+                    links: Vec::new(),
                 }],
             ));
         let layout = screen.layout_with(&CLARA_BW_METRICS, &Chrome::default());
@@ -14498,6 +14643,7 @@ mod prose_tests {
             vec![Node::Text {
                 id: NodeId(1),
                 text: "A page of a book.".to_owned(),
+                links: Vec::new(),
             }],
         )
         .with_page_turns(ActionId(2), ActionId(3))
@@ -14531,6 +14677,7 @@ mod prose_tests {
                     nodes: vec![Node::Text {
                         id: NodeId(3),
                         text: "This cannot be undone.".into(),
+                        links: Vec::new(),
                     }],
                 });
                 let layout = screen.layout_with(&metrics, &Chrome::with_back(false));
@@ -14583,6 +14730,7 @@ mod prose_tests {
                 nodes: vec![Node::Text {
                     id: NodeId(3),
                     text: "Standard".into(),
+                    links: Vec::new(),
                 }],
             });
         let layout = screen.layout_with(&CLARA_BW_METRICS, &Chrome::with_back(false));
@@ -14714,6 +14862,7 @@ mod prose_tests {
                 Node::Text {
                     id: NodeId(1),
                     text: "A page of a book.".to_owned(),
+                    links: Vec::new(),
                 },
                 Node::Button {
                     id: NodeId(2),
@@ -14760,6 +14909,7 @@ mod prose_tests {
             vec![Node::Text {
                 id: NodeId(1),
                 text: "A page of a book.".to_owned(),
+                links: Vec::new(),
             }],
         )
         .with_hold(ActionId(9))
@@ -14769,6 +14919,7 @@ mod prose_tests {
             vec![Node::Text {
                 id: NodeId(41),
                 text: "Type size".to_owned(),
+                links: Vec::new(),
             }],
         ));
         let layout = screen.layout_with(&CLARA_BW_METRICS, &Chrome::default());
@@ -14848,6 +14999,7 @@ mod prose_tests {
                 Node::Text {
                     id: NodeId(1),
                     text: "Nothing to do.".into(),
+                    links: Vec::new(),
                 },
                 Node::Button {
                     id: NodeId(2),
@@ -14879,6 +15031,7 @@ mod prose_tests {
                 vec![Node::Text {
                     id: NodeId(1),
                     text: "A page of prose.".into(),
+                    links: Vec::new(),
                 }],
             )
             .with_page_turns(ActionId(1), ActionId(2));
@@ -14922,6 +15075,7 @@ mod prose_tests {
                 vec![Node::Text {
                     id: NodeId(1),
                     text: "A page of prose.".into(),
+                    links: Vec::new(),
                 }],
             )
             .with_page_turns(ActionId(7), ActionId(9));
@@ -15725,10 +15879,12 @@ mod prose_tests {
                     BandSlot::fill(vec![Node::Text {
                         id: NodeId(2),
                         text: "Left".to_owned(),
+                        links: Vec::new(),
                     }]),
                     BandSlot::fill(vec![Node::Text {
                         id: NodeId(3),
                         text: "Right".to_owned(),
+                        links: Vec::new(),
                     }]),
                 ],
             }],
@@ -15764,10 +15920,12 @@ mod prose_tests {
                     BandSlot::fill(vec![Node::Text {
                         id: NodeId(2),
                         text: "Left".to_owned(),
+                        links: Vec::new(),
                     }]),
                     BandSlot::fill(vec![Node::Text {
                         id: NodeId(3),
                         text: "Right".to_owned(),
+                        links: Vec::new(),
                     }]),
                 ],
             }],
@@ -15848,6 +16006,7 @@ mod prose_tests {
                     BandSlot::fill(vec![Node::Text {
                         id: NodeId(2),
                         text: "A title that wants the whole line to itself".to_owned(),
+                        links: Vec::new(),
                     }]),
                     BandSlot::natural(vec![Node::Secondary {
                         id: NodeId(3),
@@ -16005,6 +16164,7 @@ mod press_feedback_tests {
             vec![Node::Text {
                 id: NodeId(1),
                 text: "Once upon a time".into(),
+                links: Vec::new(),
             }],
         );
         let layout = screen.layout_with(&CLARA_BW_METRICS, &Chrome::default());
@@ -16542,6 +16702,7 @@ mod press_feedback_tests {
                 Node::Text {
                     id: NodeId(2),
                     text: "Published in 1851.".to_owned(),
+                    links: Vec::new(),
                 },
             ],
         );
@@ -16600,6 +16761,7 @@ mod press_feedback_tests {
                     children: vec![Node::Text {
                         id: NodeId(5),
                         text: "A card is the surface tone.".to_owned(),
+                        links: Vec::new(),
                     }],
                 },
                 Node::Button {
@@ -16899,6 +17061,7 @@ mod figure_tests {
                 vec![Node::Text {
                     id: NodeId(1),
                     text: "body".into(),
+                    links: Vec::new(),
                 }],
             );
             screen

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -2939,6 +2939,7 @@ mod tests {
             vec![kobo_ui::Node::Text {
                 id: kobo_ui::NodeId(1),
                 text: "A page of a book.".to_owned(),
+                links: Vec::new(),
             }],
         )
         .with_page_turns(ActionId(11), ActionId(12))

--- a/examples/gutenbird/src/main.rs
+++ b/examples/gutenbird/src/main.rs
@@ -219,15 +219,6 @@ const MAX_RECENT: usize = 6;
 /// How many steps back the application remembers.
 const MAX_TRAIL: usize = 8;
 
-/// How long one pass at the queued plates may spend before giving the runtime
-/// its thread back.
-///
-/// Comfortably inside the two hundred and fifty millisecond callback deadline,
-/// with room for the redraw that may follow. A single plate can take a hundred
-/// milliseconds on this processor, so this is one or two of them per pass, and
-/// the rest come round again immediately behind a zero-length sleep.
-const PLATE_BUDGET: std::time::Duration = std::time::Duration::from_millis(120);
-
 /// The store key the added-catalog registry is written under.
 const REGISTRY_KEY: &str = "catalogs";
 /// The store key naming which catalog was open when the reader last left.
@@ -641,6 +632,12 @@ struct Gutenbird {
     /// moment it has been decoded, so what an illustrated book costs while it
     /// opens falls as it goes rather than being both copies at once.
     plates: VecDeque<(String, Vec<u8>)>,
+    /// A plate read from the book but not yet reduced to the panel's greys.
+    ///
+    /// The two halves of preparing a plate happen in separate callbacks
+    /// because together they are longer than one is allowed to be, so the
+    /// half-finished picture has to live somewhere in between.
+    dithering: Option<(String, kobo_image::Picture)>,
     /// The sleep that will bring the next pass at the queue.
     plating: Option<TaskId>,
     place: Option<Memory>,
@@ -690,6 +687,7 @@ impl Default for Gutenbird {
             reader: None,
             book_pictures: Vec::new(),
             plates: VecDeque::new(),
+            dithering: None,
             plating: None,
             place: None,
             keeping: None,
@@ -1108,6 +1106,13 @@ impl Gutenbird {
 
     fn open_publication(&mut self, context: &mut Context, publication: Publication) {
         self.open = Some(publication);
+        // Given back, not merely forgotten. Every book's cover is held against
+        // the same handle, and the frame this page reserves names that handle
+        // before any bytes have arrived for it -- so the runtime, still
+        // holding the last book's pixels, drew them. On the panel, opening The
+        // Tale of Peter Rabbit showed Pride and Prejudice's peacock in the
+        // space Beatrix Potter's cover was about to take.
+        context.drop_picture(OPEN_COVER_HANDLE);
         self.open_cover = None;
         self.open_cover_task = None;
         self.detail_page = 0;
@@ -1621,6 +1626,24 @@ impl Gutenbird {
                     continue;
                 }
             }
+            // A list of categories is cut between two of them, on the same
+            // reasoning as a summary. Pride and Prejudice carries eleven, and
+            // as one block they were placed whole whatever the room: on the
+            // panel the last of them was drawn through the "3 of 4" beneath it.
+            if let DetailBlock::Categories(categories) = &block {
+                if let Some((head, tail)) = self.split_categories(
+                    context,
+                    publication,
+                    pages.is_empty(),
+                    &current,
+                    categories,
+                ) {
+                    current.push(DetailBlock::Categories(head));
+                    pages.push(std::mem::take(&mut current));
+                    queue.push_front(DetailBlock::Categories(tail));
+                    continue;
+                }
+            }
             if current.is_empty() {
                 current = candidate;
                 continue;
@@ -1674,6 +1697,43 @@ impl Gutenbird {
             }
         }
         Some((words[..low].join(" "), words[low..].join(" ")))
+    }
+
+    /// How many categories fit here, and the ones that do not.
+    ///
+    /// The same binary search [`Self::split_summary`] runs over words, run
+    /// over rows instead. `None` when there is nothing to cut -- one category,
+    /// or a page with no room for even one -- and the caller then does what it
+    /// does for any block that will not fit: starts a page with it.
+    fn split_categories(
+        &self,
+        context: &Context,
+        publication: &Publication,
+        first_page: bool,
+        current: &[DetailBlock],
+        categories: &[Category],
+    ) -> Option<(Vec<Category>, Vec<Category>)> {
+        if categories.len() < 2 {
+            return None;
+        }
+        let fits = |count: usize| {
+            let mut blocks = current.to_vec();
+            blocks.push(DetailBlock::Categories(categories[..count].to_vec()));
+            self.detail_fits(context, publication, first_page, &blocks)
+        };
+        if !fits(1) {
+            return None;
+        }
+        let (mut low, mut high) = (1usize, categories.len() - 1);
+        while low < high {
+            let middle = low + (high - low).div_ceil(2);
+            if fits(middle) {
+                low = middle;
+            } else {
+                high = middle - 1;
+            }
+        }
+        Some((categories[..low].to_vec(), categories[low..].to_vec()))
     }
 
     fn detail_fits(
@@ -2341,7 +2401,7 @@ impl Gutenbird {
         // is here for the case where the runtime had no room for the sleep
         // that would have carried it, and the plates would otherwise stop
         // arriving with no way to start again.
-        if self.plating.is_none() && !self.plates.is_empty() {
+        if self.plating.is_none() && (!self.plates.is_empty() || self.dithering.is_some()) {
             self.decode_more_plates(context);
         }
         self.show(context);
@@ -2458,7 +2518,12 @@ impl Gutenbird {
                 ),
             );
             self.reader = Some(reader);
-            self.decode_more_plates(context);
+            // Handed to the runtime rather than started here. This callback
+            // has already spent its parse and its pagination; a plate on top
+            // of that is what put it over the deadline.
+            if !self.plates.is_empty() {
+                self.plating = context.spawn(Task::Sleep { seconds: 0 });
+            }
         } else {
             self.problem = Some("This book could not be read.".to_owned());
             if self.complete {
@@ -2493,6 +2558,7 @@ impl Gutenbird {
         // reading any more. The sleep already in flight is left to land and be
         // ignored: cancelling it would cost a message to save nothing.
         self.plates.clear();
+        self.dithering = None;
         self.reader = None;
         self.download = None;
         self.fetched = 0;
@@ -2565,16 +2631,24 @@ impl Gutenbird {
         reserved
     }
 
-    /// Turns some of the queued plates into pixels, and asks to be called again
-    /// if any are left.
+    /// Carries one plate one step further towards the panel, and asks to be
+    /// called again while any step is left.
     ///
-    /// Bounded by a clock rather than by a count, because a plate takes as long
-    /// as it takes: a hundred milliseconds for a Potter watercolour and rather
-    /// more for a full-page engraving, and a budget of "three of them" is a
-    /// budget that means something different in every book. `PLATE_BUDGET` is
-    /// well inside the callback deadline, and what is left goes round again
-    /// behind a zero-length sleep, which is this runtime's way of saying
-    /// "later, but as soon as possible".
+    /// One step, not as many as fit in a time budget. Nothing here can be
+    /// interrupted half way, so a budget can only be checked before starting
+    /// something, and the pass then runs for the budget plus however long that
+    /// something takes: on the panel a hundred and twenty millisecond budget
+    /// produced callbacks of 272, 293 and 311 milliseconds against a deadline
+    /// of 250. One whole plate per pass was no better -- 250 to 311 -- because
+    /// one whole plate is itself over the deadline on this processor.
+    ///
+    /// So a plate is taken in its two natural halves. Reading the file and
+    /// fitting it is one; reducing a million pixels to the sixteen greys the
+    /// panel can hold is the other, and on a development machine the two are
+    /// two milliseconds and three, which on the reader is about a hundred and
+    /// about a hundred and seventy. Either alone is comfortably inside the
+    /// deadline. There is no third half, and the honest fix is a runtime that
+    /// can decode off this thread at all; until then this is where the seam is.
     ///
     /// The page being looked at is decoded first. Everything else can arrive
     /// while it is being read.
@@ -2582,6 +2656,7 @@ impl Gutenbird {
         let metrics = context.metrics();
         let Some((width, height)) = plate_box(&metrics) else {
             self.plates.clear();
+            self.dithering = None;
             return;
         };
         let showing: Vec<String> = self.reader.as_ref().map_or_else(Vec::new, |reader| {
@@ -2591,30 +2666,38 @@ impl Gutenbird {
                 .map(str::to_owned)
                 .collect()
         });
-        self.plates_first(&showing);
-        let started = std::time::Instant::now();
         let mut on_this_page = false;
-        while started.elapsed() < PLATE_BUDGET {
-            let Some((name, bytes)) = self.plates.pop_front() else {
-                break;
-            };
-            let Some(reserved) = self.handed_plate(&name) else {
-                continue;
-            };
-            let Ok(picture) = kobo_image::decode(&bytes) else {
-                continue;
-            };
-            let Ok(mut picture) = picture.fit(width, height) else {
-                continue;
-            };
+        if let Some((name, mut picture)) = self.dithering.take() {
+            // The second half: the greys.
             picture.dither(kobo_image::PANEL_GREYS);
             let (drawn_width, drawn_height) = (picture.width(), picture.height());
-            if context
-                .put_picture(reserved, drawn_width, drawn_height, picture.into_grey())
-                .is_some()
-                && showing.contains(&name)
-            {
-                on_this_page = true;
+            if let Some(reserved) = self.handed_plate(&name) {
+                if context
+                    .put_picture(reserved, drawn_width, drawn_height, picture.into_grey())
+                    .is_some()
+                    && showing.contains(&name)
+                {
+                    on_this_page = true;
+                }
+            }
+        } else {
+            self.plates_first(&showing);
+            // The first half: the file. A plate that will not read costs
+            // nothing, so this goes past it rather than spending a whole round
+            // trip discovering there was nothing to draw, and stops on the
+            // first one that works.
+            while let Some((name, bytes)) = self.plates.pop_front() {
+                if self.handed_plate(&name).is_none() {
+                    continue;
+                }
+                let Ok(picture) = kobo_image::decode(&bytes) else {
+                    continue;
+                };
+                let Ok(picture) = picture.fit(width, height) else {
+                    continue;
+                };
+                self.dithering = Some((name, picture));
+                break;
             }
         }
         // Only when the page in front of somebody actually changed. A plate
@@ -2623,7 +2706,7 @@ impl Gutenbird {
         if on_this_page {
             self.show(context);
         }
-        if self.plates.is_empty() {
+        if self.plates.is_empty() && self.dithering.is_none() {
             self.plating = None;
             return;
         }
@@ -3593,7 +3676,7 @@ mod tests {
         book_keys, catalog_display_name, decode_registry, download_kind, encode_registry,
         plate_box, read_offer, readable, Awaiting, BTreeMap, Catalog, DetailBlock, Download,
         DownloadKind, FeedPurpose, FillStage, Gutenbird, Memory, ReadOffer, Reader, SearchState,
-        SearchWay, StackEntry, View, COVER_TRIES,
+        SearchWay, StackEntry, View, COVER_TRIES, OPEN_COVER_HANDLE,
     };
     use kobo_opds::{
         Acquisition, AcquisitionKind, Category, Feed, Image, ImageSource, Link, Navigation,
@@ -5031,8 +5114,37 @@ Please read this before you distribute or use this work.\n";
         app.plating = Some(TaskId(1));
 
         let mut runner = AppRunner::new(app);
-        let commands = runner.task_outcome(TaskId(1), TaskOutcome::Completed(Vec::new()));
-        let handed: Vec<(PictureHandle, u32, u32)> = commands
+        // The first pass reads the plate and asks for another; the second
+        // reduces it to the panel's greys and hands it over. Neither half is
+        // allowed to take as long as both would.
+        let first = runner.task_outcome(TaskId(1), TaskOutcome::Completed(Vec::new()));
+        assert!(
+            handed_pictures(&first).is_empty(),
+            "a plate was decoded and dithered in one callback"
+        );
+        assert!(
+            runner.app().plates.is_empty() && runner.app().dithering.is_some(),
+            "the plate was not read out of the book"
+        );
+        let plating = runner
+            .app()
+            .plating
+            .expect("another pass was not asked for");
+
+        let second = runner.task_outcome(plating, TaskOutcome::Completed(Vec::new()));
+        assert_eq!(
+            handed_pictures(&second),
+            vec![(claimed.handle, claimed.source.0, claimed.source.1)],
+            "the plate did not fill the frame that was standing in for it"
+        );
+        assert!(
+            runner.app().dithering.is_none(),
+            "the decoded plate was kept after it was drawn"
+        );
+    }
+
+    fn handed_pictures(commands: &[kobo_sdk::Command]) -> Vec<(PictureHandle, u32, u32)> {
+        commands
             .iter()
             .filter_map(|command| match command {
                 kobo_sdk::Command::PutPicture {
@@ -5043,16 +5155,7 @@ Please read this before you distribute or use this work.\n";
                 } => Some((*handle, *width, *height)),
                 _ => None,
             })
-            .collect();
-        assert_eq!(
-            handed,
-            vec![(claimed.handle, claimed.source.0, claimed.source.1)],
-            "the plate did not fill the frame that was standing in for it"
-        );
-        assert!(
-            runner.app().plates.is_empty(),
-            "the source bytes were kept after the plate was drawn"
-        );
+            .collect()
     }
 
     #[test]
@@ -5156,6 +5259,30 @@ Please read this before you distribute or use this work.\n";
             runner.app().view,
             View::Shelf,
             "leaving the list should return to the shelf the globe was pressed on"
+        );
+    }
+
+    /// One book's cover must not be drawn in the frame the next book reserved.
+    ///
+    /// Every book's cover is held against a single handle. The detail page
+    /// claims the room for a cover before the bytes arrive, and names that
+    /// handle to do it -- so with the last book's pixels still against it, the
+    /// runtime drew them. On the panel, The Tale of Peter Rabbit opened with
+    /// Pride and Prejudice's peacock where Beatrix Potter's cover belonged.
+    #[test]
+    fn arriving_at_a_book_gives_back_the_cover_the_last_one_left_behind() {
+        let mut app = Gutenbird::default();
+        let mut context = kobo_sdk::Context::default();
+        app.open_publication(
+            &mut context,
+            publication("The Tale of Peter Rabbit", Vec::new()),
+        );
+        assert!(
+            context.commands().iter().any(|command| matches!(
+                command,
+                kobo_sdk::Command::DropPicture(handle) if *handle == OPEN_COVER_HANDLE
+            )),
+            "the runtime was left holding the cover of whatever was open before"
         );
     }
 
@@ -5562,6 +5689,78 @@ Please read this before you distribute or use this work.\n";
             .flat_map(str::split_whitespace)
             .map(str::to_owned)
             .collect()
+    }
+
+    /// A long list of categories is cut between two of them.
+    ///
+    /// Drawn as rows they take a finger-height band each, and Pride and
+    /// Prejudice carries eleven. Placed whole -- which is what a block that
+    /// fits nowhere used to get -- the last of them was drawn on the panel
+    /// through the "3 of 4" beneath it.
+    #[test]
+    fn a_long_list_of_categories_is_divided_rather_than_drawn_over_the_page_position() {
+        let mut book = publication(
+            "Pride and Prejudice",
+            vec![text_acquisition("https://x/pp")],
+        );
+        book.categories = [
+            "England -- Fiction",
+            "Young women -- Fiction",
+            "Love stories",
+            "Sisters -- Fiction",
+            "Domestic fiction",
+            "Courtship -- Fiction",
+            "Social classes -- Fiction",
+            "Language and Literatures: English literature",
+            "Regency fiction",
+            "Married people -- Fiction",
+            "Class differences -- Fiction",
+        ]
+        .into_iter()
+        .map(|label| Category {
+            term: label.to_owned(),
+            label: Some(label.to_owned()),
+            scheme: None,
+        })
+        .collect();
+        let mut app = Gutenbird {
+            view: View::Details,
+            open: Some(book),
+            complete: true,
+            ..Gutenbird::default()
+        };
+        let context = kobo_sdk::Context::default();
+        let publication = app.open.clone().unwrap();
+        let blocks = Gutenbird::detail_blocks(&publication);
+        let pages = app.detail_pagination(&context, &publication, &blocks);
+
+        let listed: Vec<String> = pages
+            .iter()
+            .flatten()
+            .filter_map(|block| match block {
+                DetailBlock::Categories(categories) => Some(categories.clone()),
+                _ => None,
+            })
+            .flatten()
+            .map(|category| category.term)
+            .collect();
+        assert_eq!(
+            listed.len(),
+            publication.categories.len(),
+            "dividing the list lost categories"
+        );
+
+        for page in 0..pages.len() {
+            app.detail_page = page;
+            let errors: Vec<_> = app
+                .details_screen(&context)
+                .diagnostics(&context.metrics(), &Chrome::with_back(true))
+                .issues
+                .into_iter()
+                .filter(|issue| issue.severity == DiagnosticSeverity::Error)
+                .collect();
+            assert!(errors.is_empty(), "page {page} does not fit: {errors:?}");
+        }
     }
 
     #[test]

--- a/examples/gutenbird/src/main.rs
+++ b/examples/gutenbird/src/main.rs
@@ -40,10 +40,10 @@ use kobo_opds::{AcquisitionKind, Category, Feed, ImageSource, Link, Publication,
 use kobo_read::{Memory, Outcome, Reader};
 use kobo_sdk::keyboard::{Keyboard, Pressed};
 use kobo_sdk::{
-    action_id, ActionId, BannerLevel, Chrome, Context, DiagnosticSeverity, Failure, Glyph, Header,
-    KoboApp, LogLevel, PictureHandle, RowLead, ScreenBuilder, ShelfDownload, ShelfProgress,
-    ShelfUpload, StoreResult, Task, TaskId, TaskOutcome, Tile, TilePicture, TileShape, TileState,
-    MAX_STORE_VALUE,
+    action_id, ActionId, BannerLevel, Chrome, Context, DiagnosticSeverity, DisplayMetrics, Failure,
+    Glyph, Header, KoboApp, LogLevel, PictureHandle, RowLead, ScreenBuilder, ShelfDownload,
+    ShelfProgress, ShelfUpload, StoreResult, Task, TaskId, TaskOutcome, Tile, TilePicture,
+    TileShape, TileState, MAX_STORE_VALUE,
 };
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::process::ExitCode;
@@ -192,12 +192,41 @@ const FILL_LANES: usize = 2;
 /// How wide the cover in a book's hero is drawn.
 const DETAILS_COVER_MM: u16 = 30;
 
+/// The box a book's own cover is always given, in pixels.
+///
+/// Always: the room is claimed before the bytes arrive and every cover is
+/// padded out to exactly this, so the shape of what turns up cannot change
+/// what is around it. A detail page drew with no cover, then redrew with one
+/// above the title block, and everything under it -- Read included -- moved
+/// about two hundred pixels down the panel. An owner reaching for Read as the
+/// page appeared pressed the About text instead and turned the page. On a slow
+/// catalog the gap between the two layouts is seconds rather than an instant.
+///
+/// Three by two, which is the shape of nearly every book cover ever printed, so
+/// the padding is usually a few pixels of the paper it sits on.
+const OPEN_COVER_PX: (u32, u32) = (DETAILS_COVER_MM as u32 * 8, DETAILS_COVER_MM as u32 * 12);
+
+/// The handle the open book's cover is always held against.
+const OPEN_COVER_HANDLE: PictureHandle = PictureHandle(u32::MAX);
+
 /// How close to the end of what has been downloaded the reader may get before
 /// the next piece of a plain-text fallback book is requested.
 const TOP_UP_PAGES: usize = 2;
 
 /// How many recent searches one catalog's search screen keeps.
 const MAX_RECENT: usize = 6;
+
+/// How many steps back the application remembers.
+const MAX_TRAIL: usize = 8;
+
+/// How long one pass at the queued plates may spend before giving the runtime
+/// its thread back.
+///
+/// Comfortably inside the two hundred and fifty millisecond callback deadline,
+/// with room for the redraw that may follow. A single plate can take a hundred
+/// milliseconds on this processor, so this is one or two of them per pass, and
+/// the rest come round again immediately behind a zero-length sleep.
+const PLATE_BUDGET: std::time::Duration = std::time::Duration::from_millis(120);
 
 /// The store key the added-catalog registry is written under.
 const REGISTRY_KEY: &str = "catalogs";
@@ -429,13 +458,32 @@ impl DetailBlock {
         match self {
             Self::Section(title) => screen.section(*title),
             Self::Text(text) => screen.text(text.clone()),
+            // Rows rather than chips, because a category is a phrase rather
+            // than a word. "Fiction -- England -- 19th century" in a chip is a
+            // square box holding one line of small type with air above and
+            // below it, and a screen of them showed four; the same phrases as
+            // rows read as the list they are, several to a screen, with room
+            // for the scheme they came from underneath.
             Self::Categories(categories) => {
-                screen.chips(categories.iter().enumerate().map(|(index, category)| {
+                screen.rows(categories.iter().enumerate().map(|(index, category)| {
                     let label = category
                         .label
                         .clone()
                         .unwrap_or_else(|| category.term.clone());
-                    (format!("category-{index}"), label, false)
+                    // The term only when it says something the label does not.
+                    // Most catalogs set both to the same string, and a row that
+                    // repeats its own title underneath itself is noise.
+                    let summary = if category.term == label {
+                        String::new()
+                    } else {
+                        category.term.clone()
+                    };
+                    (
+                        format!("category-{index}"),
+                        label,
+                        summary,
+                        RowLead::Icon(Glyph::Search),
+                    )
                 }))
             }
             Self::Facts(facts) => screen.facts(facts.clone()),
@@ -513,6 +561,24 @@ struct Download {
 #[allow(clippy::struct_excessive_bools)]
 struct Gutenbird {
     view: View,
+    /// The screens stepped through to reach the one showing, oldest first.
+    ///
+    /// Back used to name a fixed destination per screen, and every screen but
+    /// one named the shelf. That left the catalog list reachable only through
+    /// the globe, which does not look like navigation, and leaving it put the
+    /// owner back on the catalog they had pressed the globe to get away from --
+    /// a loop with no way out of the catalog they were already in. The root of
+    /// a catalog had no Back control at all, because it was the one screen with
+    /// nowhere fixed to go.
+    ///
+    /// Recording the step instead answers both: the catalog list is a screen
+    /// above the shelf and Back reaches it, and Back from anywhere undoes the
+    /// step that was taken rather than returning to a screen chosen in advance.
+    ///
+    /// Pages followed inside one catalog are deliberately absent: they are in
+    /// [`Gutenbird::stack`], which Back unwinds first, because they are that
+    /// catalog's own history rather than the application's.
+    trail: Vec<View>,
     keyboard: Keyboard,
 
     catalogs: Vec<Catalog>,
@@ -568,6 +634,15 @@ struct Gutenbird {
     /// costing the device several megabytes of decoded greyscale while its
     /// owner was back on the shelf looking at covers.
     book_pictures: Vec<PictureHandle>,
+    /// The open book's plates still to be turned into pixels, in the order the
+    /// text refers to them, each with the bytes it was stored as.
+    ///
+    /// Drained rather than iterated: a plate's source bytes are dropped the
+    /// moment it has been decoded, so what an illustrated book costs while it
+    /// opens falls as it goes rather than being both copies at once.
+    plates: VecDeque<(String, Vec<u8>)>,
+    /// The sleep that will bring the next pass at the queue.
+    plating: Option<TaskId>,
     place: Option<Memory>,
     keeping: Option<ShelfUpload>,
     loading: Option<ShelfDownload>,
@@ -582,7 +657,11 @@ impl Default for Gutenbird {
     fn default() -> Self {
         Self {
             nav_cover_handle: 0,
-            view: View::Shelf,
+            // The catalog list, not a shelf. Starting up opens the catalog
+            // that was last open, which is a step taken from here, and that is
+            // what puts a way back to the list under the first shelf drawn.
+            view: View::Catalogs,
+            trail: Vec::new(),
             keyboard: Keyboard::new(),
             catalogs: CATALOGS
                 .iter()
@@ -610,6 +689,8 @@ impl Default for Gutenbird {
             complete: false,
             reader: None,
             book_pictures: Vec::new(),
+            plates: VecDeque::new(),
+            plating: None,
             place: None,
             keeping: None,
             loading: None,
@@ -651,13 +732,71 @@ impl Gutenbird {
             View::Details => self.details_screen(context),
             View::Reading => self.reading_screen(context),
         };
-        // Only the catalog root, with no stack pushed above it and no other
-        // screen over it, is where Back leaves the application. Every other
-        // screen -- including a page pushed by following a link -- unwinds
-        // one step first, the way the reading screen and the book page
-        // always have.
-        let at_root = self.view == View::Shelf && self.stack.len() <= 1;
-        context.set_screen(screen.with_own_back(!at_root));
+        // The application draws its own Back wherever it has somewhere to go,
+        // which is every screen except the catalog list with nothing open over
+        // it. Only there does Back mean leaving.
+        context.set_screen(screen.with_own_back(self.can_go_back()));
+    }
+
+    /// Takes a step to another screen, remembering the one being left.
+    ///
+    /// For a step forward only. A screen returned to unwinds the trail through
+    /// [`Self::back_to`] instead, or the trail grows by one every time an
+    /// owner walks the same two screens.
+    fn go(&mut self, view: View) {
+        if self.view == view {
+            return;
+        }
+        self.trail.push(self.view);
+        // Bounded, because a reader who paces between a shelf and its search
+        // for an hour is still only ever going to press Back a few times, and
+        // an unbounded list of where they have been is a leak with a nice name.
+        if self.trail.len() > MAX_TRAIL {
+            self.trail.remove(0);
+        }
+        self.view = view;
+    }
+
+    /// Returns to a screen, undoing the step that left it.
+    ///
+    /// The step is only undone when it is the one on top: a screen that
+    /// finished for its own reasons -- a download that failed back to the
+    /// book page -- is arriving somewhere rather than retracing.
+    fn back_to(&mut self, view: View) {
+        if self.trail.last() == Some(&view) {
+            self.trail.pop();
+        }
+        self.view = view;
+    }
+
+    /// The screen Back would return to, without taking the step.
+    fn way_back(&self) -> Option<View> {
+        self.trail
+            .iter()
+            .rev()
+            .copied()
+            .find(|previous| *previous != self.view)
+    }
+
+    /// Whether Back is the application's to answer rather than the runtime's.
+    fn can_go_back(&self) -> bool {
+        self.way_back().is_some() || (self.view == View::Shelf && self.stack.len() > 1)
+    }
+
+    /// Takes the step [`Self::way_back`] describes.
+    ///
+    /// Entries matching the screen already showing are dropped on the way
+    /// past. A search answer replaces the shelf without being a step from it,
+    /// so the shelf can be both where the trail points and where the owner
+    /// already is, and Back that appears to do nothing is worse than Back that
+    /// goes too far.
+    fn step_back(&mut self) -> Option<View> {
+        while let Some(previous) = self.trail.pop() {
+            if previous != self.view {
+                return Some(previous);
+            }
+        }
+        None
     }
 
     // ---------------------------------------------------------------
@@ -740,7 +879,7 @@ impl Gutenbird {
     fn open_catalog(&mut self, context: &mut Context) {
         self.stop_federating();
         self.stack.clear();
-        self.view = View::Shelf;
+        self.go(View::Shelf);
         let root = self.current_catalog().root.clone();
         self.save_last_open(context);
         self.spawn_feed(
@@ -972,7 +1111,7 @@ impl Gutenbird {
         self.open_cover = None;
         self.open_cover_task = None;
         self.detail_page = 0;
-        self.view = View::Details;
+        self.go(View::Details);
         self.download = None;
         self.fetched = 0;
         self.complete = false;
@@ -1989,11 +2128,23 @@ impl Gutenbird {
 
     fn ask_open_cover(&mut self, context: &mut Context) {
         let Some(image) = self.open.as_ref().and_then(Publication::cover).cloned() else {
+            // Nothing is coming, so nothing is reserved. An empty frame that
+            // will never be filled is not a placeholder, it is a hole.
             return;
         };
+        // Claimed now, drawn as an outlined box until the bytes land. A
+        // publication that says it has a cover is going to have one, and the
+        // room it takes is decided here rather than by what turns up.
+        self.open_cover = Some(TilePicture::new(
+            OPEN_COVER_HANDLE,
+            OPEN_COVER_PX.0,
+            OPEN_COVER_PX.1,
+        ));
         match image.href {
             ImageSource::Inline { bytes, .. } => {
-                self.took_open_cover(context, &bytes);
+                if !self.took_open_cover(context, &bytes) {
+                    self.letter_open_cover(context);
+                }
             }
             ImageSource::Url(url) => {
                 if let Some(task) = context.spawn_retrying(Task::Fetch {
@@ -2010,8 +2161,7 @@ impl Gutenbird {
     }
 
     fn took_open_cover(&mut self, context: &mut Context, bytes: &[u8]) -> bool {
-        let width = u32::from(DETAILS_COVER_MM) * 8;
-        let height = width * 3 / 2;
+        let (width, height) = OPEN_COVER_PX;
         let Ok(picture) = kobo_image::decode(bytes) else {
             return false;
         };
@@ -2022,15 +2172,49 @@ impl Gutenbird {
             return false;
         };
         picture.dither(kobo_image::PANEL_GREYS);
-        let handle = PictureHandle(u32::MAX);
-        let (picture_width, picture_height) = (picture.width(), picture.height());
-        let Some(reference) =
-            context.put_picture(handle, picture_width, picture_height, picture.into_grey())
-        else {
+        // Padded out to the reserved box rather than handed over at whatever
+        // size it came back. A cover an eighth taller than three by two would
+        // otherwise be an eighth taller on the page than the frame that was
+        // standing in for it, and the block underneath would move by that much
+        // at the moment it arrived -- which is the whole thing being fixed.
+        let padded = on_paper(&picture, width, height);
+        let Some(reference) = context.put_picture(OPEN_COVER_HANDLE, width, height, padded) else {
             return false;
         };
         self.open_cover = Some(reference);
         true
+    }
+
+    /// Sets the book's own title in the room its cover was going to take.
+    ///
+    /// For a cover that was promised and did not arrive, or arrived and would
+    /// not decode. Emptying the frame instead would move everything under it
+    /// back up the panel, which is the reflow this reservation exists to stop,
+    /// and leaving it empty says only that something is missing. The shelf
+    /// already letters a tile whose cover will not decode; this is the same
+    /// answer one page in.
+    fn letter_open_cover(&mut self, context: &mut Context) {
+        // Nothing was reserved, so nothing was promised: this book has no
+        // cover at all and its metadata already has the whole width.
+        if self.open_cover.is_none() {
+            return;
+        }
+        let Some(publication) = self.open.as_ref() else {
+            return;
+        };
+        let (width, height) = OPEN_COVER_PX;
+        let grey = kobo_sdk::typographic_cover(
+            &publication.title,
+            publication.authors.first().map(String::as_str),
+            width,
+            height,
+        );
+        if grey.is_empty() {
+            return;
+        }
+        if let Some(reference) = context.put_picture(OPEN_COVER_HANDLE, width, height, grey) {
+            self.open_cover = Some(reference);
+        }
     }
 
     // ---------------------------------------------------------------
@@ -2141,7 +2325,7 @@ impl Gutenbird {
         };
         match reader.act_on(action, &metrics) {
             Outcome::Elsewhere => return false,
-            Outcome::Close => self.view = View::Details,
+            Outcome::Close => self.back_to(View::Details),
             Outcome::Light(level) => {
                 context.device().set_frontlight(level);
                 self.save_place(context);
@@ -2151,6 +2335,14 @@ impl Gutenbird {
                 self.top_up(context);
             }
             Outcome::Repaint => {}
+        }
+        // A page turn is also the moment a plate on the page turned to is
+        // wanted. Nothing to do while the queue is already going round; this
+        // is here for the case where the runtime had no room for the sleep
+        // that would have carried it, and the plates would otherwise stop
+        // arriving with no way to start again.
+        if self.plating.is_none() && !self.plates.is_empty() {
+            self.decode_more_plates(context);
         }
         self.show(context);
         true
@@ -2229,6 +2421,7 @@ impl Gutenbird {
             DownloadKind::Epub => ("book.epub", kobo_doc::read("book.epub", &download.bytes)),
         };
         let read_ms = started.elapsed().as_millis();
+        let downloaded = download.bytes.len();
         let _ = name;
         if let Ok(mut document) = result {
             let blocks = document.blocks.len();
@@ -2240,32 +2433,32 @@ impl Gutenbird {
             for handle in self.book_pictures.drain(..) {
                 context.drop_picture(handle);
             }
-            let pictures = Self::hand_over_pictures(context, &document);
-            self.book_pictures = pictures.values().map(|picture| picture.handle).collect();
-            // The scanned bytes have done their work. Holding them as well as
-            // the decoded greyscale meant every plate was paid for twice, and
-            // for an illustrated Pride and Prejudice the copy nobody reads is
-            // the larger of the two at four and a half megabytes.
-            document.images = BTreeMap::new();
+            // Taken off the document rather than left on it: the reader owns
+            // the document from here, and holding the scanned bytes as well as
+            // the decoded greyscale meant every plate was paid for twice.
+            let images = std::mem::take(&mut document.images);
             let pictures_ms = started.elapsed().as_millis();
             let started = std::time::Instant::now();
             let mut reader = Reader::open(document, memory, &context.metrics());
-            // Before the count is read, because handing the pictures over
-            // measures the book again around them -- and it is that second
-            // count, the one an illustrated book is actually read at, that the
-            // timing line is worth having.
-            reader.set_pictures(pictures, &context.metrics());
+            // Before the count is read, because the sizes are what an
+            // illustrated book is measured at, and it is that count -- the one
+            // it will actually be read at -- that the timing line is worth
+            // having.
+            let reserved = self.reserve_plates(&reader, &images, &context.metrics());
+            reader.set_pictures(reserved, &context.metrics());
             let paginate_ms = started.elapsed().as_millis();
             context.log(
                 LogLevel::Info,
                 format!(
                     "opened {} bytes in {read_ms} ms read, {pictures_ms} ms pictures, \
-                     {paginate_ms} ms paginate ({blocks} blocks, {} pages)",
-                    download.bytes.len(),
-                    reader.page_count()
+                     {paginate_ms} ms paginate ({blocks} blocks, {} pages, {} plates queued)",
+                    downloaded,
+                    reader.page_count(),
+                    self.plates.len()
                 ),
             );
             self.reader = Some(reader);
+            self.decode_more_plates(context);
         } else {
             self.problem = Some("This book could not be read.".to_owned());
             if self.complete {
@@ -2296,56 +2489,165 @@ impl Gutenbird {
         for handle in self.book_pictures.drain(..) {
             context.drop_picture(handle);
         }
+        // Whatever is still queued is source bytes for a book nobody is
+        // reading any more. The sleep already in flight is left to land and be
+        // ignored: cancelling it would cost a message to save nothing.
+        self.plates.clear();
         self.reader = None;
         self.download = None;
         self.fetched = 0;
         self.complete = false;
     }
 
-    /// Decodes the book's pictures and hands them to the runtime.
+    /// Claims the room every plate in the book will take, decoding none of it.
     ///
-    /// Handles are the runtime's to give and a `Context` is needed to ask, so
-    /// this is the application's work rather than the reader's -- `kobo-read`
-    /// draws what it is given and each picture's description where it was
-    /// given nothing.
+    /// Opening a book used to decode, fit and dither every image the container
+    /// held before it returned, inside a lifecycle callback with a two hundred
+    /// and fifty millisecond deadline. The Tale of Peter Rabbit is twenty-eight
+    /// plates, and on a Clara BW that was two thousand seven hundred and
+    /// eighty-four milliseconds: parsing the book took ten and paginating it
+    /// thirty-two, so the images were ninety-nine per cent of a stall during
+    /// which nothing drew, no control answered, and three watchdogs counted.
     ///
-    /// Bounded twice over, because a book of plates would otherwise decode
-    /// four hundred images at the moment it opened: at most `MAX_BOOK_PICTURES`
-    /// are decoded, and each is fitted to the panel before it is handed over
-    /// so what the runtime holds is the size it will be drawn rather than the
-    /// size it was scanned. A picture that will not decode is simply left out,
-    /// and the page then reads its description, which is what a book with a
-    /// broken plate should look like.
-    fn hand_over_pictures(
-        context: &mut Context,
-        document: &kobo_doc::Document,
+    /// A picture's header states its size in its first few dozen bytes, and
+    /// size is the only thing pagination needs. Reading the headers costs
+    /// microseconds and gives the reader the same page count it would have got
+    /// from the pixels, so the book opens measured and correct and the plates
+    /// are drawn into the room already reserved for them as they decode. Until
+    /// each one does the panel draws an empty frame at exactly the right size,
+    /// which is what stops a page from resizing under somebody reading it.
+    ///
+    /// Only the pictures the text actually refers to, in the order it refers to
+    /// them, and at most `MAX_BOOK_PICTURES` of those: a container's spare
+    /// artwork is not something to spend a decode on, and the order is what
+    /// lets the plates arrive roughly as fast as they are read past.
+    fn reserve_plates(
+        &mut self,
+        reader: &Reader,
+        images: &BTreeMap<String, Vec<u8>>,
+        metrics: &DisplayMetrics,
     ) -> BTreeMap<String, TilePicture> {
-        let mut handed = BTreeMap::new();
-        let metrics = context.metrics();
-        let width = metrics.tenth_mm(i32::from(PICTURE_WIDTH_MM) * 10);
-        let height = metrics.tenth_mm(i32::from(PICTURE_HEIGHT_MM) * 10);
-        let (Ok(width), Ok(height)) = (u32::try_from(width), u32::try_from(height)) else {
-            return handed;
+        self.plates.clear();
+        self.book_pictures.clear();
+        let mut reserved = BTreeMap::new();
+        let Some((width, height)) = plate_box(metrics) else {
+            return reserved;
         };
-        for (index, (name, bytes)) in document.images.iter().take(MAX_BOOK_PICTURES).enumerate() {
-            let Ok(picture) = kobo_image::decode(bytes) else {
+        for (index, name) in reader
+            .pictures_wanted()
+            .into_iter()
+            .take(MAX_BOOK_PICTURES)
+            .enumerate()
+        {
+            let Some(bytes) = images.get(name) else {
+                continue;
+            };
+            // A header that will not parse is a plate that will not decode, so
+            // it is left out here and the page reads its description instead --
+            // which is what a book with a broken plate should look like.
+            let Ok(source) = kobo_image::size(bytes) else {
+                continue;
+            };
+            let (drawn_width, drawn_height) = kobo_image::fitted_size(source, width, height);
+            if drawn_width == 0 || drawn_height == 0 {
+                continue;
+            }
+            // Numbered from a base that cannot collide with the cover handles
+            // the shelf is holding at the same time.
+            let handle = PictureHandle(PICTURE_HANDLE_BASE + u32::try_from(index).unwrap_or(0));
+            reserved.insert(
+                name.to_owned(),
+                TilePicture::new(handle, drawn_width, drawn_height),
+            );
+            self.book_pictures.push(handle);
+            self.plates.push_back((name.to_owned(), bytes.clone()));
+        }
+        reserved
+    }
+
+    /// Turns some of the queued plates into pixels, and asks to be called again
+    /// if any are left.
+    ///
+    /// Bounded by a clock rather than by a count, because a plate takes as long
+    /// as it takes: a hundred milliseconds for a Potter watercolour and rather
+    /// more for a full-page engraving, and a budget of "three of them" is a
+    /// budget that means something different in every book. `PLATE_BUDGET` is
+    /// well inside the callback deadline, and what is left goes round again
+    /// behind a zero-length sleep, which is this runtime's way of saying
+    /// "later, but as soon as possible".
+    ///
+    /// The page being looked at is decoded first. Everything else can arrive
+    /// while it is being read.
+    fn decode_more_plates(&mut self, context: &mut Context) {
+        let metrics = context.metrics();
+        let Some((width, height)) = plate_box(&metrics) else {
+            self.plates.clear();
+            return;
+        };
+        let showing: Vec<String> = self.reader.as_ref().map_or_else(Vec::new, |reader| {
+            reader
+                .pictures_on_page()
+                .into_iter()
+                .map(str::to_owned)
+                .collect()
+        });
+        self.plates_first(&showing);
+        let started = std::time::Instant::now();
+        let mut on_this_page = false;
+        while started.elapsed() < PLATE_BUDGET {
+            let Some((name, bytes)) = self.plates.pop_front() else {
+                break;
+            };
+            let Some(reserved) = self.handed_plate(&name) else {
+                continue;
+            };
+            let Ok(picture) = kobo_image::decode(&bytes) else {
                 continue;
             };
             let Ok(mut picture) = picture.fit(width, height) else {
                 continue;
             };
             picture.dither(kobo_image::PANEL_GREYS);
-            // Numbered from a base that cannot collide with the cover handles
-            // the shelf is holding at the same time.
-            let handle = PictureHandle(PICTURE_HANDLE_BASE + u32::try_from(index).unwrap_or(0));
             let (drawn_width, drawn_height) = (picture.width(), picture.height());
-            if let Some(reference) =
-                context.put_picture(handle, drawn_width, drawn_height, picture.into_grey())
+            if context
+                .put_picture(reserved, drawn_width, drawn_height, picture.into_grey())
+                .is_some()
+                && showing.contains(&name)
             {
-                handed.insert(name.clone(), reference);
+                on_this_page = true;
             }
         }
-        handed
+        // Only when the page in front of somebody actually changed. A plate
+        // twenty pages ahead landing is not a reason to flash an E Ink panel,
+        // and there are two dozen of them in an illustrated book.
+        if on_this_page {
+            self.show(context);
+        }
+        if self.plates.is_empty() {
+            self.plating = None;
+            return;
+        }
+        self.plating = context.spawn(Task::Sleep { seconds: 0 });
+    }
+
+    /// Moves the named plates to the front of the queue, keeping their order.
+    fn plates_first(&mut self, names: &[String]) {
+        if names.is_empty() {
+            return;
+        }
+        let (wanted, rest): (VecDeque<_>, VecDeque<_>) = self
+            .plates
+            .drain(..)
+            .partition(|(name, _)| names.contains(name));
+        self.plates = wanted.into_iter().chain(rest).collect();
+    }
+
+    /// The handle a plate was reserved against, if it was.
+    fn handed_plate(&self, name: &str) -> Option<PictureHandle> {
+        self.reader
+            .as_ref()
+            .and_then(|reader| reader.picture_named(name))
+            .map(|picture| picture.handle)
     }
 
     /// A blob that arrived and will not parse is forgotten rather than kept,
@@ -2390,7 +2692,7 @@ impl Gutenbird {
             );
             self.failed = Some("This book did not arrive.".to_owned());
             self.retryable = false;
-            self.view = View::Details;
+            self.back_to(View::Details);
             return;
         }
         // The ceiling applied to the bytes rather than to what the catalog
@@ -2420,7 +2722,7 @@ impl Gutenbird {
             self.keep_book(context);
         }
         if self.reader.is_some() {
-            self.view = View::Reading;
+            self.go(View::Reading);
         }
         // A chunk that lands is what asks for the one after it. Nothing else
         // can: the reader drives the plain text path by turning pages, and an
@@ -2505,6 +2807,56 @@ fn book_keys(publication: &Publication) -> Option<(String, String)> {
 
 fn cover_key(url: &str) -> String {
     kobo_sdk::cache_key(format!("cover.{:08x}", stamp(url)))
+}
+
+/// The box an illustration inside a book is fitted into, in pixels.
+///
+/// `None` on a panel so small the box has no area, which is not a device this
+/// runs on but is a shape the arithmetic can produce.
+fn plate_box(metrics: &DisplayMetrics) -> Option<(u32, u32)> {
+    let width = metrics.tenth_mm(i32::from(PICTURE_WIDTH_MM) * 10);
+    let height = metrics.tenth_mm(i32::from(PICTURE_HEIGHT_MM) * 10);
+    match (u32::try_from(width), u32::try_from(height)) {
+        (Ok(width), Ok(height)) if width > 0 && height > 0 => Some((width, height)),
+        _ => None,
+    }
+}
+
+/// Centres a picture on a sheet of exactly `width` by `height`.
+///
+/// The renderer draws a picture at the shape it was handed, so a cover handed
+/// over at its own shape has a height decided by its publisher -- and a page
+/// cannot reserve room for a number it does not know yet. Padding moves that
+/// variation into a margin of white, which on white paper is nothing to look
+/// at, and leaves everything below the cover exactly where it was first drawn.
+///
+/// A picture larger than the sheet in either direction is cropped rather than
+/// scaled: callers fit before they get here, and silently resampling would
+/// disagree with what was measured.
+fn on_paper(picture: &kobo_image::Picture, width: u32, height: u32) -> Vec<u8> {
+    let sheet_width = usize::try_from(width).unwrap_or(0);
+    let sheet_height = usize::try_from(height).unwrap_or(0);
+    let mut sheet = vec![u8::MAX; sheet_width * sheet_height];
+    let source_width = usize::try_from(picture.width()).unwrap_or(0);
+    let copied_width = source_width.min(sheet_width);
+    let copied_height = usize::try_from(picture.height())
+        .unwrap_or(0)
+        .min(sheet_height);
+    let left = (sheet_width - copied_width) / 2;
+    let top = (sheet_height - copied_height) / 2;
+    let grey = picture.grey();
+    for row in 0..copied_height {
+        let from = row * source_width;
+        let to = (top + row) * sheet_width + left;
+        let (Some(source), Some(target)) = (
+            grey.get(from..from + copied_width),
+            sheet.get_mut(to..to + copied_width),
+        ) else {
+            break;
+        };
+        target.copy_from_slice(source);
+    }
+    sheet
 }
 
 fn stamp(url: &str) -> u32 {
@@ -2784,7 +3136,7 @@ impl KoboApp for Gutenbird {
                     });
                     self.reopen(context);
                     if self.reader.is_some() {
-                        self.view = View::Reading;
+                        self.go(View::Reading);
                     }
                     self.show(context);
                     return;
@@ -2879,23 +3231,25 @@ impl KoboApp for Gutenbird {
                     }
                 }
             }
-            match self.view {
-                View::Reading if self.open.is_some() => {
+            // A shelf deeper than its own root unwinds itself first. The pages
+            // followed inside one catalog belong to that catalog rather than
+            // to the application, and leaving the catalog while standing three
+            // pages inside it is not what Back was asked for.
+            if self.view == View::Shelf && self.stack.len() > 1 {
+                self.stop_federating();
+                self.stack.pop();
+                self.want_covers(context);
+                self.hydrate_visible(context);
+            } else {
+                if self.view == View::Reading && self.open.is_some() {
                     self.close_book(context);
-                    self.view = View::Details;
                 }
-                View::Details | View::Search | View::AddCatalog | View::Catalogs => {
+                if let Some(previous) = self.step_back() {
                     self.stop_federating();
-                    self.view = View::Shelf;
+                    self.view = previous;
                 }
-                View::Shelf | View::Reading => {
-                    if self.stack.len() > 1 {
-                        self.stop_federating();
-                        self.stack.pop();
-                        self.want_covers(context);
-                        self.hydrate_visible(context);
-                    }
-                }
+                // Nothing to step back to means the runtime was told this
+                // screen has no Back of its own, so this call did not happen.
             }
             self.problem = None;
             self.trouble = None;
@@ -2941,20 +3295,20 @@ impl KoboApp for Gutenbird {
 
         if action == action_id("catalogs") {
             self.stop_federating();
-            self.view = View::Catalogs;
+            self.go(View::Catalogs);
             self.show(context);
             return;
         }
         if action == action_id("add-catalog") {
             self.keyboard.clear();
             self.add_catalog_problem = None;
-            self.view = View::AddCatalog;
+            self.go(View::AddCatalog);
             self.show(context);
             return;
         }
         if action == action_id("search") {
             self.problem = None;
-            self.view = View::Search;
+            self.go(View::Search);
             self.show(context);
             return;
         }
@@ -2987,7 +3341,7 @@ impl KoboApp for Gutenbird {
             .enumerate()
         {
             if action == action_id(&format!("recent-{index}")) {
-                self.view = View::Search;
+                self.go(View::Search);
                 self.begin_search(context, self.current, term, false);
                 self.show(context);
                 return;
@@ -3003,7 +3357,7 @@ impl KoboApp for Gutenbird {
         }
 
         if let Some(category) = self.category_for(action) {
-            self.view = View::Search;
+            self.go(View::Search);
             self.begin_search(context, self.current, category, false);
             self.show(context);
             return;
@@ -3094,11 +3448,22 @@ impl KoboApp for Gutenbird {
             self.next_cover(context);
             return;
         }
+        if self.plating == Some(task) {
+            self.plating = None;
+            // Only while a book is open. Leaving one empties the queue, and a
+            // sleep that was already in flight when it did lands here.
+            if self.reader.is_some() {
+                self.decode_more_plates(context);
+            }
+            return;
+        }
         if self.open_cover_task.is_some_and(|(id, _)| id == task) {
             let (_, tries) = self.open_cover_task.take().expect("just checked");
             match outcome {
                 TaskOutcome::Completed(bytes) => {
-                    self.took_open_cover(context, &bytes);
+                    if !self.took_open_cover(context, &bytes) {
+                        self.letter_open_cover(context);
+                    }
                     self.show(context);
                 }
                 TaskOutcome::Failed(_) if tries + 1 < COVER_TRIES => {
@@ -3116,7 +3481,14 @@ impl KoboApp for Gutenbird {
                         }
                     }
                 }
-                TaskOutcome::Failed(_) | TaskOutcome::Cancelled => {}
+                // Out of attempts. The frame stays where it is and takes the
+                // book's own title, rather than emptying and letting the page
+                // move under whoever is looking at it.
+                TaskOutcome::Failed(_) => {
+                    self.letter_open_cover(context);
+                    self.show(context);
+                }
+                TaskOutcome::Cancelled => {}
             }
             return;
         }
@@ -3181,7 +3553,7 @@ impl KoboApp for Gutenbird {
                         let failure = Failure::of(error);
                         self.failed = Some(failure.advice.to_owned());
                         self.retryable = failure.retryable;
-                        self.view = View::Details;
+                        self.back_to(View::Details);
                     } else if let Some(reader) = &mut self.reader {
                         reader.expect_more(false);
                     }
@@ -3219,9 +3591,9 @@ impl KoboApp for Gutenbird {
 mod tests {
     use super::{
         book_keys, catalog_display_name, decode_registry, download_kind, encode_registry,
-        read_offer, readable, Awaiting, Catalog, DetailBlock, Download, DownloadKind, FeedPurpose,
-        FillStage, Gutenbird, Memory, ReadOffer, Reader, SearchState, SearchWay, StackEntry, View,
-        COVER_TRIES,
+        plate_box, read_offer, readable, Awaiting, BTreeMap, Catalog, DetailBlock, Download,
+        DownloadKind, FeedPurpose, FillStage, Gutenbird, Memory, ReadOffer, Reader, SearchState,
+        SearchWay, StackEntry, View, COVER_TRIES,
     };
     use kobo_opds::{
         Acquisition, AcquisitionKind, Category, Feed, Image, ImageSource, Link, Navigation,
@@ -4354,6 +4726,7 @@ Please read this before you distribute or use this work.\n";
         app.stack = vec![StackEntry::fresh(Feed::default(), BASE.to_owned())];
         app.search_all = true;
         app.view = View::Search;
+        app.trail = vec![View::Catalogs, View::Shelf];
         let mut runner = AppRunner::new(app);
         runner.action(action_id("search"));
         for key in ["kb.r0c9", "kb.r1c0", "kb.r0c1"] {
@@ -4567,6 +4940,121 @@ Please read this before you distribute or use this work.\n";
         )
     }
 
+    /// A plate is measured from its header and decoded later.
+    ///
+    /// Opening The Tale of Peter Rabbit on the panel decoded twenty-eight
+    /// images inside a lifecycle callback and took 2,784 milliseconds doing
+    /// it, against a deadline of 250. Reading the headers costs microseconds
+    /// and answers the only question pagination has, so the book opens at the
+    /// page count it will be read at and the pixels arrive afterwards.
+    #[test]
+    fn a_book_of_plates_is_measured_from_its_headers_and_decoded_afterwards() {
+        let plate = kobo_image::encode_png_grey(1200, 2000, &vec![128; 1200 * 2000])
+            .expect("a png of a plate");
+        let images: BTreeMap<String, Vec<u8>> = [("plate.png".to_owned(), plate.clone())]
+            .into_iter()
+            .collect();
+        // Enough prose to fill the page it opens on, so that the room the
+        // plate takes is the difference between one page and two.
+        let mut blocks: Vec<kobo_doc::Block> = (0..12)
+            .map(|_| {
+                kobo_doc::Block::Paragraph(
+                    "Once upon a time there were four little rabbits, and their names were \
+                     Flopsy, Mopsy, Cotton-tail and Peter."
+                        .to_owned(),
+                )
+            })
+            .collect();
+        blocks.push(kobo_doc::Block::Picture {
+            name: "plate.png".to_owned(),
+            alt: "Four rabbits".to_owned(),
+        });
+        let document = kobo_doc::Document {
+            blocks,
+            ..kobo_doc::Document::default()
+        };
+        let mut reader = Reader::open(document, Memory::default(), &CLARA_BW_METRICS);
+        let without = reader.page_count();
+
+        let mut app = Gutenbird::default();
+        let reserved = app.reserve_plates(&reader, &images, &CLARA_BW_METRICS);
+
+        // The room, from the header alone, and the same room decoding would
+        // have asked for.
+        let (width, height) = plate_box(&CLARA_BW_METRICS).expect("a panel with room on it");
+        let decoded = kobo_image::decode(&plate)
+            .expect("decode")
+            .fit(width, height)
+            .expect("fit");
+        assert_eq!(
+            reserved.get("plate.png").map(|picture| picture.source),
+            Some((decoded.width(), decoded.height())),
+            "the size claimed from the header is not the size the decoder produces"
+        );
+        assert_eq!(
+            app.plates.len(),
+            1,
+            "the plate should be queued rather than decoded"
+        );
+
+        reader.set_pictures(reserved, &CLARA_BW_METRICS);
+        assert!(
+            reader.page_count() > without,
+            "the book was not measured around the room the plate takes"
+        );
+    }
+
+    /// And the pixels, when they come, go into the room already reserved.
+    #[test]
+    fn a_queued_plate_is_handed_over_against_the_handle_it_was_measured_at() {
+        let plate = kobo_image::encode_png_grey(1200, 2000, &vec![128; 1200 * 2000])
+            .expect("a png of a plate");
+        let images: BTreeMap<String, Vec<u8>> =
+            [("plate.png".to_owned(), plate)].into_iter().collect();
+        let document = kobo_doc::Document {
+            blocks: vec![kobo_doc::Block::Picture {
+                name: "plate.png".to_owned(),
+                alt: "Four rabbits".to_owned(),
+            }],
+            ..kobo_doc::Document::default()
+        };
+        let mut reader = Reader::open(document, Memory::default(), &CLARA_BW_METRICS);
+        let mut app = Gutenbird::default();
+        let reserved = app.reserve_plates(&reader, &images, &CLARA_BW_METRICS);
+        let claimed = reserved
+            .get("plate.png")
+            .copied()
+            .expect("the plate was reserved");
+        reader.set_pictures(reserved, &CLARA_BW_METRICS);
+        app.reader = Some(reader);
+        // The sleep that carries the queue round, answered.
+        app.plating = Some(TaskId(1));
+
+        let mut runner = AppRunner::new(app);
+        let commands = runner.task_outcome(TaskId(1), TaskOutcome::Completed(Vec::new()));
+        let handed: Vec<(PictureHandle, u32, u32)> = commands
+            .iter()
+            .filter_map(|command| match command {
+                kobo_sdk::Command::PutPicture {
+                    handle,
+                    width,
+                    height,
+                    ..
+                } => Some((*handle, *width, *height)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            handed,
+            vec![(claimed.handle, claimed.source.0, claimed.source.1)],
+            "the plate did not fill the frame that was standing in for it"
+        );
+        assert!(
+            runner.app().plates.is_empty(),
+            "the source bytes were kept after the plate was drawn"
+        );
+    }
+
     #[test]
     fn leaving_a_book_gives_back_everything_it_was_costing() {
         // The device this was found on had been reading an illustrated book,
@@ -4579,6 +5067,9 @@ Please read this before you distribute or use this work.\n";
         let mut runner = AppRunner::new(Gutenbird {
             open: Some(book),
             view: View::Reading,
+            // The way an owner actually arrives at a page of a book: a
+            // catalog, a shelf, the book's own page, and then reading it.
+            trail: vec![View::Catalogs, View::Shelf, View::Details],
             complete: true,
             reader: Some(opened("A book with plates in it.")),
             download: Some(Download {
@@ -4611,6 +5102,63 @@ Please read this before you distribute or use this work.\n";
         assert_eq!(runner.app().view, View::Details);
     }
 
+    /// The root of a catalog is not the end of the road.
+    ///
+    /// On the device, Project Gutenberg's own first screen drew no Back at
+    /// all, so the only way to the catalog list was the globe -- which does
+    /// not look like navigation -- and the list's Back went straight back to
+    /// Project Gutenberg. There was no way out of the catalog you were in.
+    #[test]
+    fn the_first_screen_of_a_catalog_leads_back_to_the_list_of_catalogs() {
+        let mut runner = AppRunner::new(Gutenbird::default());
+        runner.start();
+        assert_eq!(
+            runner.app().view,
+            View::Shelf,
+            "starting up should open the catalog that was last open"
+        );
+        assert!(
+            runner.app().can_go_back(),
+            "the root of a catalog drew no way back to the catalog list"
+        );
+
+        runner.action(kobo_sdk::ActionId::BACK);
+        assert_eq!(runner.app().view, View::Catalogs);
+        assert!(
+            !runner.app().can_go_back(),
+            "the catalog list is the root, and Back there means leaving"
+        );
+    }
+
+    /// Back undoes the step that was taken, rather than naming a screen.
+    ///
+    /// Pressing the globe from a shelf and then Back used to land on the
+    /// shelf by coincidence -- Back on the catalog list was hard-coded to the
+    /// shelf whatever had come before it. From the Add screen, which is only
+    /// ever reached from the list, the same rule threw the owner two screens.
+    #[test]
+    fn back_returns_to_the_screen_the_step_was_taken_from() {
+        let mut runner = AppRunner::new(Gutenbird::default());
+        runner.start();
+        runner.action(action_id("catalogs"));
+        assert_eq!(runner.app().view, View::Catalogs);
+        runner.action(action_id("add-catalog"));
+        assert_eq!(runner.app().view, View::AddCatalog);
+
+        runner.action(kobo_sdk::ActionId::BACK);
+        assert_eq!(
+            runner.app().view,
+            View::Catalogs,
+            "leaving the Add screen should return to the list it was opened from"
+        );
+        runner.action(kobo_sdk::ActionId::BACK);
+        assert_eq!(
+            runner.app().view,
+            View::Shelf,
+            "leaving the list should return to the shelf the globe was pressed on"
+        );
+    }
+
     #[test]
     fn a_book_still_arriving_is_not_released_out_from_under_the_chunk_that_is_coming() {
         // The guard the release needs: a text book is readable while the rest
@@ -4620,6 +5168,7 @@ Please read this before you distribute or use this work.\n";
         let mut runner = AppRunner::new(Gutenbird {
             open: Some(book),
             view: View::Reading,
+            trail: vec![View::Catalogs, View::Shelf, View::Details],
             complete: false,
             reader: Some(opened("The first chunk of a longer book.")),
             download: Some(Download {


### PR DESCRIPTION
Closes #9, #10, #11, #12, #13, #14.

Six defects an owner meets within a minute of opening a book, plus three
more found while verifying the first six on a Clara BW.

## What changed

**#9 — a name with a breve draws as tofu.** A letter the interface face has
no glyph for is borrowed from the compiled-in grid face rather than drawn as
an empty box. Atkinson Hyperlegible carries 84 of the 128 letters of Latin
Extended-A and none of the 256 in Cyrillic. There is no near equivalent of a
letter to substitute — an unaccented `i` is a different name — so the answer
is a face that has it. Measuring and drawing both consult the fallback, so a
line still ends where wrapping said it would.

**#10 — a link inside prose cannot be tapped.** `Node::Text` carries the byte
ranges that go somewhere; layout turns each into a rectangle on the line it
landed on, and the hit test finds it ahead of the page turn underneath. A run
that wraps becomes two rectangles naming one action. The list under "Links on
this page" stays — a finger is a poor instrument for a superscript, and this
gives it the width of the words instead.

**#11 — a category tile is mostly empty space.** Categories are rows now. A
long list is cut between two of them rather than placed whole.

**#12 — Read moves out from under the finger.** The cover takes a fixed box,
claimed before the bytes arrive and padded out to when they land. A cover
that never arrives gets the book's own title lettered into the same frame.

**#13 — the root of a catalogue has no way back.** Back undoes the step that
was taken. Pages followed inside one catalogue still unwind first: they are
that catalogue's history rather than the application's.

**#14 — opening a book blocks the runtime for seconds.** A picture states its
size in its header, and size is all pagination needs, so a book is measured
from the headers and opens at the page count it will be read at. Plates decode
afterwards in reading order, the page in front of somebody first, into frames
already the right size — and in two callbacks each, because one whole plate is
itself over the deadline on this processor.

## Verified on a Kobo Clara BW (N365, 4.45.23697)

| | evidence |
|---|---|
| #9 | "Note: Translation of: Мы" draws as letters; Atkinson has 0/256 Cyrillic |
| #10 | Crime and Punishment's contents underlined; tapping CHAPTER IV went to page 91 of 1129 |
| #11 | eight rows a screen instead of four tiles, list cut across pages, nothing over the page position |
| #12 | screenshots before and after the cover landed differ only in rows 186–522; Read did not move a pixel |
| #13 | Back on Project Gutenberg's root reaches the catalogue list, which has no Back of its own |
| #14 | `opened 1510370 bytes in 10 ms read, 0 ms pictures, 44 ms paginate (75 blocks, 24 pages, 28 plates queued)` and zero callbacks over the deadline, against `2831 ms` in one callback before |

Three defects were found by that verification and fixed here: the category
list overflowing its own footer, one book's cover drawn in the frame the next
book reserved, and plates still crossing the deadline one at a time.

## Known, not fixed here

Opening a *long* book is still slow, for an unrelated reason: Crime and
Punishment paginates in 7,376 ms for 4,060 blocks. That is pagination rather
than pictures, it predates this branch, and it wants its own issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789039348&installation_model_id=20525&pr_number=15&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F15&signature=550a8db0ab0ee5715e055c6b67a9f2c8a184c1773fb2dead59a9bb54b2d50ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->