### PR TITLE
Cobalt 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "icon-import"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "image"
@@ -187,14 +187,14 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kobo-abi"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "kobo-app-store"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-arxiv"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-html",
  "kobo-sdk",
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-audiobook"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-doc",
  "kobo-json",
@@ -222,7 +222,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-brief"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-chat"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-app-store",
  "kobo-image",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-html",
  "miniz_oxide 0.9.1",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doctor"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -267,14 +267,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-gallery"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-guard"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -282,7 +282,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gutenbird"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-hal"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-abi",
  "kobo-doc",
@@ -305,21 +305,21 @@ dependencies = [
 
 [[package]]
 name = "kobo-handoff"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-hello"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-hn"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -329,22 +329,22 @@ dependencies = [
 
 [[package]]
 name = "kobo-html"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "kobo-image"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "image",
 ]
 
 [[package]]
 name = "kobo-json"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "kobo-launcher"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-magnet"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-morse"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-net"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "http",
  "httparse",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-opds"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-json",
  "kobo-xml",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-policy"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-abi",
  "kobo-protocol",
@@ -396,18 +396,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-profile"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "kobo-protocol"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-ui",
 ]
 
 [[package]]
 name = "kobo-read"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-doc",
  "kobo-sdk",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-rss"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sdk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-policy",
  "kobo-protocol",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-settings"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -445,7 +445,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-shell"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-abi",
  "kobo-policy",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekick"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekickd"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sim"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-net",
  "kobo-policy",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-smoke"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-store"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sudoku"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tap"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-term"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-ui",
  "vt100",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-terminal"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-policy",
  "kobo-sdk",
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-text"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "fontdue",
  "kobo-ui",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tictactoe"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -555,7 +555,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-todo"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -563,15 +563,15 @@ dependencies = [
 
 [[package]]
 name = "kobo-ui"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "kobo-xml"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "kobod"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kobo-abi",
  "kobo-app-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.85"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Bumps the workspace version so the platform build carrying Morse and arXiv has a number of its own.

Store applications publish independently of the platform, so this is not what puts the two new apps in the Store — it is what a reader reports when asked which Cobalt it is running, and what `minimum_cobalt_version` is measured against.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789052566&installation_model_id=20525&pr_number=18&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F18&signature=849676ef2beda1601125ae7eb32e88c185690d9b50baec22facd28931b4e389d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->