### PR TITLE
Fix two things Morse only got wrong on the panel

### DIFF
--- a/apps/catalog.json
+++ b/apps/catalog.json
@@ -95,7 +95,7 @@
       "display_name": "Morse",
       "short_label": "Morse",
       "summary": "Sends a typed message in Morse on the front light, a letter at a time.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "light",
       "capabilities": ["frontlight-control", "keep-awake"]

--- a/apps/morse/README.md
+++ b/apps/morse/README.md
@@ -14,9 +14,9 @@ which counts whole seconds, and there is no way to run work off the callback
 thread. So the unit here is one second and cannot currently be anything else.
 
 That makes the beacon slow. `SOS` takes twenty-seven seconds; a short sentence
-takes minutes. The estimate is on the screen before you press Send, because a
-beacon that quietly committed you to four minutes would be worse than a slow
-one that said so.
+takes minutes. The estimate sits beside the Send key, updating as you type,
+because Send starts the beacon there and then and a beacon that quietly
+committed you to four minutes would be worse than a slow one that said so.
 
 Slow is also the safe speed. The SDK's own guidance is that flashing the front
 light is a photosensitivity hazard, and the hazard band starts around three

--- a/apps/morse/src/main.rs
+++ b/apps/morse/src/main.rs
@@ -65,13 +65,6 @@ const LETTER: PictureHandle = PictureHandle(1);
 /// Stop off the bottom edge would be a beacon with no way to end it.
 const LETTER_SENDING_TENTHS_MM: i32 = 940;
 
-/// How tall it is while nothing is going out.
-///
-/// Smaller, because the resting screen also carries the code about to be sent
-/// and how long it will take, and those are what somebody is reading before
-/// they press Send.
-const LETTER_RESTING_TENTHS_MM: i32 = 700;
-
 /// What the light does on a lit beat.
 ///
 /// Full rather than a step up from wherever the reader had it: the beacon is
@@ -242,6 +235,18 @@ fn beats(signals: &[Signal]) -> Vec<Beat> {
     beats
 }
 
+/// A number of beats said the way somebody deciding whether to wait would say
+/// it, since a beat is a second and the figure is only there to be weighed
+/// against the reader's patience.
+fn spoken(seconds: usize) -> String {
+    match seconds {
+        0 => "nothing to send".to_owned(),
+        1 => "1 second".to_owned(),
+        seconds if seconds < 60 => format!("{seconds} seconds"),
+        seconds => format!("{} min {} sec", seconds / 60, seconds % 60),
+    }
+}
+
 /// A five by seven block alphabet, one `u8` a row, the fifth bit leftmost.
 ///
 /// Only the characters [`CODE`] can send, plus the space between words, because
@@ -402,13 +407,7 @@ impl Morse {
 
     /// How long the whole message takes, in words rather than a bare number.
     fn duration(&self) -> String {
-        let seconds = self.beats.len();
-        match seconds {
-            0 => "nothing to send".to_owned(),
-            1 => "1 second".to_owned(),
-            seconds if seconds < 60 => format!("{seconds} seconds"),
-            seconds => format!("{} min {} sec", seconds / 60, seconds % 60),
-        }
+        spoken(self.beats.len())
     }
 
     fn writing(&self) -> Screen {
@@ -416,8 +415,17 @@ impl Morse {
         if let Some(trouble) = &self.trouble {
             screen = screen.banner(BannerLevel::Attention, trouble.clone());
         }
+        // The estimate belongs here, beside the Send key, rather than on the
+        // screen that follows it. Send starts the beacon there and then, so
+        // anywhere later is somewhere the reader is already committed, and a
+        // beacon that quietly commits somebody to four minutes is the thing
+        // the estimate exists to prevent. It is measured from what is in the
+        // box rather than from the composed message, because at this point
+        // nothing has been composed.
+        let (signals, _) = encode(self.keyboard.text());
         screen
             .typed(&self.keyboard, "A message to send in light")
+            .secondary(format!("{} to send.", spoken(beats(&signals).len())))
             .keyboard(&self.keyboard, "Send")
             .build()
     }
@@ -441,24 +449,23 @@ impl Morse {
             screen = screen.banner(BannerLevel::Attention, trouble.clone());
         }
         // Sending, the letter is the only thing on the screen and takes the
-        // whole of it. Resting, it gives back the few lines the code and the
-        // estimate need, because at that point the thing worth reading is what
-        // is about to go out rather than what is going out now.
-        let tenths = if self.running {
-            LETTER_SENDING_TENTHS_MM
-        } else {
-            LETTER_RESTING_TENTHS_MM
-        };
-        let room = context.metrics().tenth_mm(tenths);
-        let character = self
+        // whole of it. Resting, there is no letter -- nothing is going out --
+        // and drawing one anyway meant painting the space glyph, which on the
+        // panel is an empty frame the size of the screen sitting where a letter
+        // had just been. So the picture belongs to the run, and the resting
+        // screen carries the code and the estimate in its place.
+        if let Some(character) = self
             .showing
             .and_then(|index| self.signals.get(index))
-            .map_or(' ', |signal| signal.character);
-        if let Some(picture) = paint(character, room)
-            .and_then(|(width, height, grey)| context.put_picture(LETTER, width, height, grey))
+            .map(|signal| signal.character)
         {
-            let millimetres = u16::try_from(tenths / 10).unwrap_or(u16::MAX);
-            screen = screen.picture(picture, millimetres);
+            let room = context.metrics().tenth_mm(LETTER_SENDING_TENTHS_MM);
+            if let Some(picture) = paint(character, room)
+                .and_then(|(width, height, grey)| context.put_picture(LETTER, width, height, grey))
+            {
+                let millimetres = u16::try_from(LETTER_SENDING_TENTHS_MM / 10).unwrap_or(u16::MAX);
+                screen = screen.picture(picture, millimetres);
+            }
         }
         if !self.running {
             screen = screen
@@ -883,6 +890,57 @@ mod tests {
         assert!(
             drawn.contains("27 seconds"),
             "the estimate is not shown: {drawn}"
+        );
+    }
+
+    /// Resting, nothing is going out, and the space glyph the beacon used to
+    /// fall back on paints as an empty frame filling the panel. On the device
+    /// that read as a bug -- a blank box sitting where a letter had been -- so
+    /// the picture is drawn only while a letter is actually being sent.
+    #[test]
+    fn a_resting_beacon_draws_no_letter_at_all() {
+        let mut runner = AppRunner::new(Morse::default());
+        runner.start();
+        runner.action(action_id(AGAIN));
+        let commands = runner.action(action_id(STOP));
+        let screen = commands
+            .iter()
+            .rev()
+            .find_map(|command| match command {
+                Command::SetScreen(screen) => Some(screen.clone()),
+                _ => None,
+            })
+            .expect("a screen");
+        let drawn = format!("{screen:?}");
+        assert!(
+            !drawn.contains("Picture"),
+            "the resting beacon still draws a letter: {drawn}"
+        );
+    }
+
+    /// Send starts the beacon there and then, so the screen the Send key is on
+    /// is the last one where the estimate can still change anybody's mind.
+    #[test]
+    fn the_estimate_is_on_the_screen_the_send_key_is_on() {
+        let mut runner = AppRunner::new(Morse::default());
+        let commands = runner.start();
+        let screen = commands
+            .iter()
+            .rev()
+            .find_map(|command| match command {
+                Command::SetScreen(screen) => Some(screen.clone()),
+                _ => None,
+            })
+            .expect("a writing screen");
+        let drawn = format!("{screen:?}");
+        assert!(
+            drawn.contains("27 seconds"),
+            "the estimate is not on the writing screen: {drawn}"
+        );
+        let issues = screen.diagnostics(&CLARA_BW_METRICS, &Chrome::measuring(true));
+        assert!(
+            !issues.has_errors(),
+            "the writing screen does not fit: {issues:?}"
         );
     }
 


### PR DESCRIPTION
Both found while driving Morse through the Store on a Clara BW, and neither was visible in the simulator.

## An empty box the size of the screen

Resting, nothing is going out, so `showing` is `None` and the letter fell back to the space glyph. That paints as a blank picture — framed, filling the panel, sitting exactly where a letter had been a second earlier. It reads as a bug because it looks like one.

The picture now belongs to the run. `LETTER_RESTING_TENTHS_MM` goes with it: the resting screen never had a character to size, so the constant was sizing nothing.

## An estimate that arrived too late to be one

Send starts the beacon immediately, so "27 seconds to send" only appeared once the twenty-seven seconds were already running — the exact commitment it exists to warn about. It now sits beside the Send key and updates as you type.

## Store version

1.0.1 rather than 1.0.0. `has_update` compares the catalog version against the installed one, so a fix shipped under the same number reaches nobody who already has the app.

## Checks

`cargo +1.85.0 test --workspace --all-targets --all-features` exits 0, 50 suites. Clippy and fmt clean on the same toolchain. Two new tests: one asserts the resting beacon emits no picture (verified non-vacuous — the sending beacon does emit one), the other that the estimate is on the screen the Send key is on.

Not yet re-run on hardware: that needs this merged and republished, since the fixes reach the device through the Store.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789055188&installation_model_id=20525&pr_number=19&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F19&signature=d7d3294a74a5841dff639d6b695c63b871cd51350ca8b7b30c495ab066f6d3b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->