### PR TITLE
Build a faithful EPUB/HTML reader with offline lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,10 @@ dependencies = [
 name = "kobo-arxiv"
 version = "0.2.3"
 dependencies = [
+ "kobo-bookview",
+ "kobo-doc",
  "kobo-html",
+ "kobo-read",
  "kobo-sdk",
  "kobo-xml",
 ]
@@ -218,6 +221,17 @@ dependencies = [
  "kobo-doc",
  "kobo-json",
  "kobo-sdk",
+]
+
+[[package]]
+name = "kobo-bookview"
+version = "0.2.3"
+dependencies = [
+ "kobo-doc",
+ "kobo-image",
+ "kobo-read",
+ "kobo-sdk",
+ "kobo-ui",
 ]
 
 [[package]]
@@ -291,6 +305,7 @@ dependencies = [
 name = "kobo-gutenbird"
 version = "0.2.3"
 dependencies = [
+ "kobo-bookview",
  "kobo-doc",
  "kobo-image",
  "kobo-opds",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,6 +249,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "kobo-dict"
+version = "0.2.2"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
 name = "kobo-doc"
 version = "0.2.2"
 dependencies = [
@@ -391,6 +398,7 @@ name = "kobo-policy"
 version = "0.2.2"
 dependencies = [
  "kobo-abi",
+ "kobo-dict",
  "kobo-protocol",
 ]
 
@@ -831,6 +839,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "ttf-parser"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +876,15 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,7 @@ dependencies = [
  "kobo-doc",
  "kobo-sdk",
  "kobo-ui",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -564,6 +565,9 @@ dependencies = [
 [[package]]
 name = "kobo-ui"
 version = "0.2.2"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "kobo-xml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "icon-import"
-version = "0.2.3"
+version = "0.2.4"
 
 [[package]]
 name = "image"
@@ -187,14 +187,14 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "kobo-abi"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "kobo-app-store"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-arxiv"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-audiobook"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-doc",
  "kobo-json",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-bookview"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-brief"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-chat"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-app-store",
  "kobo-image",
@@ -264,14 +264,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-dict"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "unicode-normalization",
 ]
 
 [[package]]
 name = "kobo-doc"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-html",
  "miniz_oxide 0.9.1",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doctor"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -288,14 +288,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-gallery"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-guard"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gutenbird"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-hal"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-abi",
  "kobo-doc",
@@ -327,21 +327,21 @@ dependencies = [
 
 [[package]]
 name = "kobo-handoff"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-hello"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-hn"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -351,22 +351,22 @@ dependencies = [
 
 [[package]]
 name = "kobo-html"
-version = "0.2.3"
+version = "0.2.4"
 
 [[package]]
 name = "kobo-image"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "image",
 ]
 
 [[package]]
 name = "kobo-json"
-version = "0.2.3"
+version = "0.2.4"
 
 [[package]]
 name = "kobo-launcher"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-magnet"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-morse"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-net"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "http",
  "httparse",
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-opds"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-json",
  "kobo-xml",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-policy"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-abi",
  "kobo-dict",
@@ -419,18 +419,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-profile"
-version = "0.2.3"
+version = "0.2.4"
 
 [[package]]
 name = "kobo-protocol"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-ui",
 ]
 
 [[package]]
 name = "kobo-read"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-doc",
  "kobo-sdk",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-rss"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sdk"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-policy",
  "kobo-protocol",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-settings"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-shell"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-abi",
  "kobo-policy",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekick"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekickd"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sim"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-net",
  "kobo-policy",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-smoke"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-store"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sudoku"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tap"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -542,7 +542,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-term"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-ui",
  "vt100",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-terminal"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-policy",
  "kobo-sdk",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-text"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "fontdue",
  "kobo-ui",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tictactoe"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-todo"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -587,18 +587,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-ui"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "kobo-xml"
-version = "0.2.3"
+version = "0.2.4"
 
 [[package]]
 name = "kobod"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kobo-abi",
  "kobo-app-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "crates/kobo-abi",
     "crates/kobo-app-store",
+    "crates/kobo-bookview",
     "crates/kobo-cli",
     "crates/kobo-doc",
     "crates/kobo-doctor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 rust-version = "1.85"
 license = "AGPL-3.0-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/kobo-cli",
     "crates/kobo-doc",
     "crates/kobo-doctor",
+    "crates/kobo-dict",
     "crates/kobo-hal",
     "crates/kobo-html",
     "crates/kobo-image",

--- a/apps/arxiv/Cargo.toml
+++ b/apps/arxiv/Cargo.toml
@@ -7,7 +7,10 @@ license.workspace = true
 publish = false
 
 [dependencies]
+kobo-bookview = { path = "../../crates/kobo-bookview" }
+kobo-doc = { path = "../../crates/kobo-doc" }
 kobo-html = { path = "../../crates/kobo-html" }
+kobo-read = { path = "../../crates/kobo-read" }
 kobo-sdk = { path = "../../crates/kobo-sdk" }
 kobo-xml = { path = "../../crates/kobo-xml" }
 

--- a/apps/arxiv/src/main.rs
+++ b/apps/arxiv/src/main.rs
@@ -26,11 +26,14 @@
 mod atom;
 
 use atom::{Paper, Results};
+use kobo_bookview::{BookView, Step};
+use kobo_read::{Memory, Outcome};
 use kobo_sdk::keyboard::{Keyboard, Pressed};
 use kobo_sdk::{
     action_id, ActionId, BannerLevel, Context, Glyph, KoboApp, RowLead, Screen, ScreenBuilder,
     Task, TaskError, TaskId, TaskOutcome,
 };
+use std::collections::VecDeque;
 use std::fmt::Write as _;
 use std::process::ExitCode;
 
@@ -51,6 +54,21 @@ const LISTING_BYTES: u32 = 512 * 1024;
 /// page rather than hidden, because a paper that simply stops is otherwise
 /// indistinguishable from one that ended.
 const FULL_TEXT_BYTES: u32 = 768 * 1024;
+
+/// The most figures fetched for one paper.
+///
+/// A rendered paper's figures are separate files, so each one is a fetch of
+/// its own over a connection that is somebody's home wifi at best. A typical
+/// paper has half a dozen; a survey with every experiment plotted has thirty,
+/// and the reader is past the ones that matter long before the last arrives.
+const MAX_FIGURES: usize = 24;
+
+/// The ceiling on one figure.
+///
+/// A plot is tens of kilobytes. The ones that overrun this are photographs at
+/// print resolution, which the panel cannot show anyway: it is sixteen greys
+/// on a screen narrower than the figure's own caption.
+const FIGURE_BYTES: u32 = 512 * 1024;
 
 /// The subjects offered on the way in.
 ///
@@ -162,9 +180,34 @@ struct Arxiv {
     listing_page: usize,
     /// Which paper is open, as an index into `papers`.
     open: Option<usize>,
-    /// The abstract or the full text, already broken into panel pages.
+    /// The abstract, already broken into panel pages.
+    ///
+    /// A summary and its metadata, which is a card rather than a document. The
+    /// paper itself is read through `book`.
     pages: Vec<Vec<String>>,
     page: usize,
+    /// The paper's full text, open in the reader every other application on
+    /// this device reads through.
+    ///
+    /// arXiv used to flatten the rendering to one long string and hand it to a
+    /// line wrapper, which is why a paper had no headings, no emphasis, no
+    /// figures, no captions, no equations set apart from the prose, and none
+    /// of the marking, searching or dictionary a reader has everywhere else.
+    /// The markup arXiv sends says all of that; nothing was reading it.
+    book: BookView,
+    /// Figures named by the rendering and not yet fetched, in the order the
+    /// paper refers to them.
+    ///
+    /// A web page carries no pictures, only the addresses of some. An EPUB
+    /// hands its plates over with the text and `kobo-doc` will not touch the
+    /// network, so fetching these is this application's job and nobody
+    /// else's.
+    figures: VecDeque<String>,
+    /// The figure fetch in flight, and the name it will fill.
+    ///
+    /// Its own slot rather than the one every other fetch shares: a figure
+    /// arriving must never be the reason a listing or a paper is lost.
+    figure: Option<(TaskId, String)>,
     /// Whether the full text arrived cut off at the byte ceiling.
     truncated: bool,
     task: Option<(TaskId, Awaiting)>,
@@ -357,15 +400,25 @@ impl Arxiv {
         for line in self.pages.get(page).map(Vec::as_slice).unwrap_or_default() {
             screen = screen.text(line.clone());
         }
-        screen = screen.fill();
-        screen = match self.view {
-            View::FullText => screen.bottom_action_marked(ABSTRACT, "Abstract", Glyph::Note),
-            _ => screen.bottom_action_marked(FULL_TEXT, "Full text", Glyph::Book),
-        };
         screen
+            .fill()
+            .bottom_action_marked(FULL_TEXT, "Full text", Glyph::Book)
             .page_turns(READ_BACK, READ_NEXT)
             .page_position(page_number(page), page_total(self.pages.len()))
             .build()
+    }
+
+    /// The paper itself, set by the reader the whole device shares.
+    ///
+    /// Its type size, its front light, its table of contents, its highlights
+    /// and its dictionary are the ones somebody already learned in every other
+    /// reading application here, and its Back closes the paper and returns to
+    /// the abstract it was opened from.
+    fn full_text(&self) -> Screen {
+        let title = self
+            .paper()
+            .map_or_else(|| "arXiv".to_owned(), |paper| paper.id.clone());
+        self.book.screen(&title).unwrap_or_else(|| self.reading())
     }
 
     fn waiting_for(&self, what: Awaiting) -> bool {
@@ -377,7 +430,8 @@ impl Arxiv {
             View::Subjects => self.subjects(context),
             View::Search => self.search(),
             View::Listing => self.listing(context),
-            View::Paper | View::FullText => self.reading(),
+            View::Paper => self.reading(),
+            View::FullText => self.full_text(),
         };
         // Every view but the subject list was reached from another one, so
         // Back has somewhere to go from all of them and nowhere to go from it.
@@ -390,8 +444,10 @@ impl Arxiv {
         let page = match self.view {
             View::Subjects => &mut self.subject_page,
             View::Listing => &mut self.listing_page,
-            View::Paper | View::FullText => &mut self.page,
-            View::Search => return,
+            View::Paper => &mut self.page,
+            // The reader turns its own pages, and the taps that ask it to are
+            // its own actions rather than this application's.
+            View::FullText | View::Search => return,
         };
         if forward {
             *page += 1;
@@ -418,31 +474,154 @@ impl Arxiv {
         self.listing_page = 0;
     }
 
-    fn took_full_text(&mut self, context: &Context, bytes: &[u8]) {
+    fn took_full_text(&mut self, context: &mut Context, bytes: &[u8]) {
         let Ok(html) = std::str::from_utf8(bytes) else {
             self.trouble = Some("That rendering was not text.".to_owned());
             return;
         };
-        // Converted against the ceiling this application was already willing to
-        // hold rather than the one meant for a field in a feed. A paper is tens
-        // of thousands of characters and the field ceiling is eight thousand,
-        // so every paper used to arrive as its opening pages and an ellipsis --
-        // about a tenth of the document, with a page count that made the tenth
-        // look like the whole of it.
-        let text = kobo_html::to_text_within(paper_body(html), FULL_TEXT_BYTES as usize);
-        if text.trim().is_empty() {
+        let body = paper_body(html);
+        // Parsed rather than flattened. What comes back is the paper's own
+        // structure -- its sections, its emphasis, its figures and their
+        // captions -- which is what the reader needs in order to set it as a
+        // document rather than as one long paragraph.
+        let mut document = kobo_doc::html::parse(body);
+        if document.blocks.is_empty() {
             self.trouble =
                 Some("arXiv has no readable rendering of this paper, only a PDF.".to_owned());
             return;
         }
-        // What was cut is the text, which is the thing the reader is turning
-        // pages through. The fetched bytes are markup and a paper can be at the
-        // transport limit with every word of it converted.
-        self.truncated = text.ends_with('\u{2026}');
-        self.pages = context.paginate_reading(&text, false);
+        // A rendering cut off at the byte ceiling has no closing tag, which is
+        // the honest signal: the fetched bytes are markup, and a paper can sit
+        // at the transport limit with every word of it delivered.
+        //
+        // Told to the document rather than kept here, because the reader
+        // already says this on the last page and says it better: a paper that
+        // simply stops is otherwise indistinguishable from one that ended.
+        self.truncated = !body.contains("</article>");
+        document.truncated |= self.truncated;
+        self.book.open(context, document, Memory::default());
         self.page = 0;
         self.view = View::FullText;
+        // The addresses of the figures, which arrived as addresses and not as
+        // pictures. The paper is readable now; these fill in behind it.
+        self.figures = self
+            .book
+            .missing_pictures()
+            .into_iter()
+            .take(MAX_FIGURES)
+            .collect();
+        self.next_figure(context);
     }
+
+    /// Asks for the next figure the paper named.
+    ///
+    /// One at a time. A paper with thirty plots is thirty fetches, and asking
+    /// for all of them at once is how an application uses up every lane the
+    /// runtime has and leaves nothing for the next listing.
+    fn next_figure(&mut self, context: &mut Context) {
+        if self.figure.is_some() {
+            return;
+        }
+        let Some(paper) = self.paper() else {
+            return;
+        };
+        let base = format!("https://arxiv.org/html/{}/", escape_path(&paper.id));
+        while let Some(name) = self.figures.pop_front() {
+            let Some(url) = figure_url(&base, &name) else {
+                continue;
+            };
+            // Not retrying: a figure is worth one attempt. The paper is
+            // already readable without it, and a plot that will not come is
+            // not a reason to spend the connection on it three times.
+            if let Some(task) = context.spawn(Task::Fetch {
+                url,
+                offset: 0,
+                max_bytes: FIGURE_BYTES,
+                credential: None,
+                headers: Vec::new(),
+            }) {
+                self.figure = Some((task, name));
+                return;
+            }
+            // No lane free. What is left stays queued, and the next page turn
+            // asks again.
+            self.figures.push_front(name);
+            return;
+        }
+        // Nothing left to ask for, so whatever did arrive is measured in.
+        self.settle_figures(context);
+    }
+
+    /// Measures every figure that arrived, once.
+    ///
+    /// Once rather than on each arrival: measuring is what decides where the
+    /// pages break, and doing it twelve times as twelve plots land would move
+    /// the text under somebody who is reading it. They keep their place across
+    /// it either way -- the reader remembers a paragraph, not a page number --
+    /// but the paragraph should not walk up the screen twelve times.
+    fn settle_figures(&mut self, context: &mut Context) {
+        if self.book.settle_pictures(context) {
+            self.show(context);
+        }
+    }
+
+    fn took_figure(&mut self, context: &mut Context, name: &str, bytes: Vec<u8>) {
+        self.book.provide_picture(name, bytes);
+        self.next_figure(context);
+    }
+
+    /// Gives back everything the open paper was costing.
+    fn close_paper(&mut self, context: &mut Context) {
+        self.book.close(context);
+        self.figures.clear();
+        // The fetch in flight is left to land and be ignored: cancelling it
+        // would cost a message to save nothing, and `provide_picture` refuses
+        // a name no open document mentions.
+        self.figure = None;
+        self.truncated = false;
+    }
+}
+
+/// Resolves a figure's address against the paper it was named in.
+///
+/// `LaTeXML` writes figures as `x1.png`, relative to the rendering's own
+/// address. A rendering is a web page before it is a paper, and its author
+/// wrote it: a figure that names another host would have the device announce
+/// itself to whoever the author chose, or knock on whatever else answers on
+/// the reader's own network. So an absolute address is taken only when it is
+/// arXiv's own, and everything else has to be a name inside the paper.
+fn figure_url(base: &str, name: &str) -> Option<String> {
+    if name.is_empty() || name.len() > 512 {
+        return None;
+    }
+    if let Some(rest) = name.strip_prefix("https://") {
+        let host = rest.split(['/', '?', '#']).next().unwrap_or_default();
+        // A port or credentials before the host are ways of writing an
+        // address that reads as arXiv's and is not, so neither is allowed.
+        let arxiv = host == "arxiv.org" || host.ends_with(".arxiv.org");
+        return if arxiv { Some(name.to_owned()) } else { None };
+    }
+    // Not http, not a data URI, not a protocol-relative address: this
+    // application fetches over TLS and nothing else, and a figure is not worth
+    // making an exception for.
+    if name.contains("://") || name.starts_with("//") || name.starts_with("data:") {
+        return None;
+    }
+    // A rooted path leaves the paper's own directory, which no `LaTeXML`
+    // rendering does, and a walk upwards out of it is a thing only a hostile
+    // page tries. The walk is also refused when it is spelled in percent
+    // escapes or with a backslash, because the address is joined as text here
+    // and resolved as a path somewhere else.
+    let escaped = name.to_ascii_lowercase();
+    if name.starts_with('/')
+        || name.contains('\\')
+        || escaped.contains("%2e")
+        || escaped.contains("%2f")
+        || name.split('/').any(|part| part == "..")
+    {
+        return None;
+    }
+    Some(format!("{base}{name}"))
 }
 
 /// Narrows a rendered paper to the paper.
@@ -591,14 +770,43 @@ impl KoboApp for Arxiv {
                     self.open = None;
                 }
                 // The full text was reached from the abstract, so Back is the
-                // abstract rather than the list two steps behind it.
+                // abstract rather than the list two steps behind it. Leaving
+                // is also the moment the paper stops costing anything: the
+                // document, the picture handles the runtime is holding
+                // against it and the figures still queued for it all go now,
+                // rather than lingering for a paper nobody is reading.
                 View::FullText => {
+                    self.close_paper(context);
                     self.view = View::Paper;
                     self.open_abstract(context);
                 }
             }
             self.show(context);
             return;
+        }
+
+        // The reader first, while a paper is open in it: its page turns, its
+        // type panel, its light, its contents, its marks and its dictionary
+        // are all actions of its own, and none of them is this application's
+        // to recognise.
+        if self.view == View::FullText {
+            if let Some(outcome) = self.book.act(context, action) {
+                match outcome {
+                    Outcome::Close => {
+                        self.close_paper(context);
+                        self.view = View::Paper;
+                        self.open_abstract(context);
+                    }
+                    Outcome::Light(level) => context.device().set_frontlight(level),
+                    Outcome::Elsewhere | Outcome::Repaint | Outcome::Save => {}
+                }
+                // A page turn is also the moment the figures on the page
+                // turned to are wanted, and a lane may have come free since
+                // the last one was asked for.
+                self.next_figure(context);
+                self.show(context);
+                return;
+            }
         }
 
         if action == action_id(SEARCH) {
@@ -642,6 +850,7 @@ impl KoboApp for Arxiv {
         }
 
         if action == action_id(ABSTRACT) {
+            self.close_paper(context);
             self.view = View::Paper;
             self.open_abstract(context);
             self.show(context);
@@ -667,6 +876,9 @@ impl KoboApp for Arxiv {
 
         for index in 0..self.papers.len() {
             if action == action_id(&format!("{PAPER}{index}")) {
+                // Whatever the last paper was costing goes back before another
+                // one starts costing anything.
+                self.close_paper(context);
                 self.open = Some(index);
                 self.view = View::Paper;
                 self.open_abstract(context);
@@ -677,6 +889,30 @@ impl KoboApp for Arxiv {
     }
 
     fn on_task(&mut self, context: &mut Context, task: TaskId, outcome: TaskOutcome) {
+        // The reader's own sleep, which is what carries a figure from bytes to
+        // pixels a half-step at a time.
+        match self.book.woke(context, task) {
+            Step::Elsewhere => {}
+            Step::Quiet => return,
+            Step::Repaint => {
+                self.show(context);
+                return;
+            }
+        }
+
+        if self.figure.as_ref().is_some_and(|(id, _)| *id == task) {
+            let (_, name) = self.figure.take().expect("just checked");
+            match outcome {
+                TaskOutcome::Completed(bytes) => self.took_figure(context, &name, bytes),
+                // A figure that will not come is a figure the paper reads
+                // without: the reader draws what the caption said it shows,
+                // which is what a document with a missing plate should look
+                // like. Nothing is said on screen about it.
+                TaskOutcome::Failed(_) | TaskOutcome::Cancelled => self.next_figure(context),
+            }
+            return;
+        }
+
         let Some((waiting, awaiting)) = self.task else {
             return;
         };
@@ -727,10 +963,11 @@ fn main() -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::{
-        abstract_text, escape, escape_path, paper_body, row_summary, Arxiv, Query, View, SUBJECTS,
+        abstract_text, escape, escape_path, figure_url, paper_body, row_summary, Arxiv, Query,
+        View, ABSTRACT, FULL_TEXT, SUBJECTS,
     };
     use crate::atom::Paper;
-    use kobo_sdk::{action_id, AppRunner, Command, Task};
+    use kobo_sdk::{action_id, ActionId, AppRunner, Command, Task, TaskOutcome};
 
     fn paper() -> Paper {
         Paper {
@@ -863,7 +1100,7 @@ mod tests {
     #[test]
     fn a_rendered_paper_is_narrowed_to_the_paper() {
         let body = paper_body(RENDERED);
-        let text = kobo_html::to_text(body);
+        let text = document_text(&kobo_doc::html::parse(body));
         assert!(text.contains("The first sentence."), "{text}");
         for furniture in [
             "independent nonprofit",
@@ -880,9 +1117,28 @@ mod tests {
     #[test]
     fn a_rendering_cut_off_before_its_closing_tag_is_still_the_paper() {
         let cut = &RENDERED[..RENDERED.find("The first sentence.").unwrap() + 10];
-        let text = kobo_html::to_text(paper_body(cut));
+        let text = document_text(&kobo_doc::html::parse(paper_body(cut)));
         assert!(text.contains("A Paper"), "{text}");
         assert!(!text.contains("Submit without GitHub"), "{text}");
+    }
+
+    /// Everything a parsed document would put on the panel, run together.
+    fn document_text(document: &kobo_doc::Document) -> String {
+        document
+            .blocks
+            .iter()
+            .map(|block| match block {
+                kobo_doc::Block::Heading { text, .. }
+                | kobo_doc::Block::Item { text, .. }
+                | kobo_doc::Block::Paragraph(text)
+                | kobo_doc::Block::Quote(text)
+                | kobo_doc::Block::Preformatted(text)
+                | kobo_doc::Block::Caption(text) => text.clone(),
+                kobo_doc::Block::Picture { alt, .. } => alt.clone(),
+                _ => String::new(),
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
     }
 
     /// Furniture is worse than the paper; nothing is worse than both.
@@ -923,5 +1179,148 @@ mod tests {
         runner.start();
         runner.action(kobo_sdk::ActionId::BACK);
         assert_eq!(runner.app_mut().view, View::Paper);
+    }
+
+    /// A paper opened for reading and the fetch that puts it there.
+    fn opened_on(runner: &mut AppRunner<Arxiv>, rendering: &str) -> Vec<Command> {
+        runner.app_mut().papers = vec![paper()];
+        runner.app_mut().open = Some(0);
+        runner.start();
+        runner.action(action_id(FULL_TEXT));
+        let task = runner
+            .app()
+            .task
+            .expect("the full text was not asked for")
+            .0;
+        runner.task_outcome(task, TaskOutcome::Completed(rendering.as_bytes().to_vec()))
+    }
+
+    /// The point of all of this: a paper is a document, not a wall of text.
+    ///
+    /// It used to be flattened to one string and handed to a line wrapper, so
+    /// a section heading, an emphasised term and a figure's caption all came
+    /// out as the same undifferentiated prose -- and the figure itself did not
+    /// come out at all.
+    #[test]
+    fn a_paper_is_read_as_a_document_rather_than_as_flattened_text() {
+        let mut runner = AppRunner::new(Arxiv::default());
+        let _ = opened_on(
+            &mut runner,
+            "<article><h2>1 Introduction</h2><p>The <em>first</em> sentence.</p>             <figure><img src=\"x1.png\" alt=\"A plot\"><figcaption>Figure 1.</figcaption>             </figure></article>",
+        );
+
+        assert_eq!(runner.app().view, View::FullText);
+        let reader = runner.app().book.reader().expect("the paper is not open");
+        let kinds: Vec<_> = reader
+            .document()
+            .blocks
+            .iter()
+            .map(std::mem::discriminant)
+            .collect();
+        assert!(
+            kinds.contains(&std::mem::discriminant(&kobo_doc::Block::Heading {
+                level: 2,
+                text: String::new()
+            })),
+            "the section heading was flattened into the prose"
+        );
+        assert!(
+            reader.pictures_wanted().contains(&"x1.png"),
+            "the figure was dropped rather than drawn"
+        );
+    }
+
+    /// And its figures, which live at addresses rather than in the file, are
+    /// fetched against the address the paper itself was fetched from.
+    #[test]
+    fn a_figure_is_fetched_from_beside_the_paper_that_names_it() {
+        let mut runner = AppRunner::new(Arxiv::default());
+        let commands = opened_on(
+            &mut runner,
+            "<article><p>A paper.</p><img src=\"x1.png\" alt=\"A plot\"></article>",
+        );
+
+        let (_, name) = runner
+            .app()
+            .figure
+            .clone()
+            .expect("the figure was never asked for");
+        assert_eq!(name, "x1.png");
+        let asked: Vec<String> = commands
+            .iter()
+            .filter_map(|command| match command {
+                Command::Spawn {
+                    work: Task::Fetch { url, .. },
+                    ..
+                } => Some(url.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            asked
+                .iter()
+                .any(|url| url == "https://arxiv.org/html/2401.00001v2/x1.png"),
+            "the figure was not asked for beside its paper: {asked:?}"
+        );
+    }
+
+    /// A rendering can name anything at all, and most of it is not a figure
+    /// this application is willing to go and get.
+    #[test]
+    fn a_figure_address_that_leaves_the_paper_is_refused() {
+        let base = "https://arxiv.org/html/2401.00001v2/";
+        assert_eq!(
+            figure_url(base, "x1.png").as_deref(),
+            Some("https://arxiv.org/html/2401.00001v2/x1.png")
+        );
+        assert_eq!(
+            figure_url(base, "https://arxiv.org/html/2401.00001v2/x1.png").as_deref(),
+            Some("https://arxiv.org/html/2401.00001v2/x1.png")
+        );
+        for hostile in [
+            "",
+            "/etc/passwd",
+            "../../../secrets.png",
+            "..%2f..%2fsecrets.png",
+            "%2e%2e/secrets.png",
+            "..\\secrets.png",
+            "http://example.org/x1.png",
+            "//example.org/x1.png",
+            "data:image/png;base64,AAAA",
+            // Another host is another host however it is spelled, and a
+            // rendering is written by whoever wrote the paper.
+            "https://example.org/x1.png",
+            "https://arxiv.org.example.org/x1.png",
+            "https://evil.org/?a=arxiv.org",
+        ] {
+            assert!(
+                figure_url(base, hostile).is_none(),
+                "{hostile:?} was allowed"
+            );
+        }
+    }
+
+    /// Leaving a paper gives back what it was costing the device, by whichever
+    /// of the two ways out of the reader the reader took.
+    #[test]
+    fn leaving_a_paper_gives_back_the_figures_it_was_holding() {
+        for way_out in [ActionId::BACK, action_id(ABSTRACT)] {
+            let mut runner = AppRunner::new(Arxiv::default());
+            let _ = opened_on(
+                &mut runner,
+                "<article><p>A paper.</p><img src=\"x1.png\" alt=\"A plot\"></article>",
+            );
+            runner.action(way_out);
+
+            assert_eq!(runner.app().view, View::Paper);
+            assert!(
+                !runner.app().book.is_open(),
+                "the parsed paper was kept after leaving it"
+            );
+            assert!(
+                runner.app().figures.is_empty() && runner.app().figure.is_none(),
+                "figures were still being fetched for a paper nobody is reading"
+            );
+        }
     }
 }

--- a/apps/arxiv/src/main.rs
+++ b/apps/arxiv/src/main.rs
@@ -888,6 +888,24 @@ impl KoboApp for Arxiv {
         }
     }
 
+    /// The front light level the device is actually holding.
+    ///
+    /// Asked for by the reading surface itself when a paper is opened, so the
+    /// panel's number and the lamp agree from the first tap rather than after
+    /// it.
+    fn on_device_result(
+        &mut self,
+        context: &mut Context,
+        _request: kobo_sdk::DeviceRequest,
+        result: kobo_sdk::DeviceResult,
+    ) {
+        if let kobo_sdk::DeviceResult::Frontlight { percent } = result {
+            if self.book.took_light(percent) {
+                self.show(context);
+            }
+        }
+    }
+
     fn on_task(&mut self, context: &mut Context, task: TaskId, outcome: TaskOutcome) {
         // The reader's own sleep, which is what carries a figure from bytes to
         // pixels a half-step at a time.

--- a/apps/arxiv/src/main.rs
+++ b/apps/arxiv/src/main.rs
@@ -33,7 +33,6 @@ use kobo_sdk::{
     action_id, ActionId, BannerLevel, Context, Glyph, KoboApp, RowLead, Screen, ScreenBuilder,
     Task, TaskError, TaskId, TaskOutcome,
 };
-use std::collections::VecDeque;
 use std::fmt::Write as _;
 use std::process::ExitCode;
 
@@ -54,21 +53,6 @@ const LISTING_BYTES: u32 = 512 * 1024;
 /// page rather than hidden, because a paper that simply stops is otherwise
 /// indistinguishable from one that ended.
 const FULL_TEXT_BYTES: u32 = 768 * 1024;
-
-/// The most figures fetched for one paper.
-///
-/// A rendered paper's figures are separate files, so each one is a fetch of
-/// its own over a connection that is somebody's home wifi at best. A typical
-/// paper has half a dozen; a survey with every experiment plotted has thirty,
-/// and the reader is past the ones that matter long before the last arrives.
-const MAX_FIGURES: usize = 24;
-
-/// The ceiling on one figure.
-///
-/// A plot is tens of kilobytes. The ones that overrun this are photographs at
-/// print resolution, which the panel cannot show anyway: it is sixteen greys
-/// on a screen narrower than the figure's own caption.
-const FIGURE_BYTES: u32 = 512 * 1024;
 
 /// The subjects offered on the way in.
 ///
@@ -195,19 +179,6 @@ struct Arxiv {
     /// of the marking, searching or dictionary a reader has everywhere else.
     /// The markup arXiv sends says all of that; nothing was reading it.
     book: BookView,
-    /// Figures named by the rendering and not yet fetched, in the order the
-    /// paper refers to them.
-    ///
-    /// A web page carries no pictures, only the addresses of some. An EPUB
-    /// hands its plates over with the text and `kobo-doc` will not touch the
-    /// network, so fetching these is this application's job and nobody
-    /// else's.
-    figures: VecDeque<String>,
-    /// The figure fetch in flight, and the name it will fill.
-    ///
-    /// Its own slot rather than the one every other fetch shares: a figure
-    /// arriving must never be the reason a listing or a paper is lost.
-    figure: Option<(TaskId, String)>,
     /// Whether the full text arrived cut off at the byte ceiling.
     truncated: bool,
     task: Option<(TaskId, Awaiting)>,
@@ -479,13 +450,21 @@ impl Arxiv {
             self.trouble = Some("That rendering was not text.".to_owned());
             return;
         };
+        let Some(paper) = self.paper().cloned() else {
+            return;
+        };
         let body = paper_body(html);
-        // Parsed rather than flattened. What comes back is the paper's own
-        // structure -- its sections, its emphasis, its figures and their
-        // captions -- which is what the reader needs in order to set it as a
-        // document rather than as one long paragraph.
-        let mut document = kobo_doc::html::parse(body);
-        if document.blocks.is_empty() {
+        // Handed to the reader whole. It parses the markup into the paper's
+        // own structure -- its sections, its emphasis, its figures and their
+        // captions -- and fetches the figures itself, one at a time, against
+        // the address the rendering came from. None of that is arXiv's to
+        // know: it is what reading a web page on this device means, and every
+        // application that shows one gets the same answer.
+        let origin = format!("https://arxiv.org/html/{}/", escape_path(&paper.id));
+        if !self
+            .book
+            .open_html(context, body, &origin, Memory::default())
+        {
             self.trouble =
                 Some("arXiv has no readable rendering of this paper, only a PDF.".to_owned());
             return;
@@ -493,135 +472,17 @@ impl Arxiv {
         // A rendering cut off at the byte ceiling has no closing tag, which is
         // the honest signal: the fetched bytes are markup, and a paper can sit
         // at the transport limit with every word of it delivered.
-        //
-        // Told to the document rather than kept here, because the reader
-        // already says this on the last page and says it better: a paper that
-        // simply stops is otherwise indistinguishable from one that ended.
         self.truncated = !body.contains("</article>");
-        document.truncated |= self.truncated;
-        self.book.open(context, document, Memory::default());
+        self.book.mark_truncated(self.truncated);
         self.page = 0;
         self.view = View::FullText;
-        // The addresses of the figures, which arrived as addresses and not as
-        // pictures. The paper is readable now; these fill in behind it.
-        self.figures = self
-            .book
-            .missing_pictures()
-            .into_iter()
-            .take(MAX_FIGURES)
-            .collect();
-        self.next_figure(context);
-    }
-
-    /// Asks for the next figure the paper named.
-    ///
-    /// One at a time. A paper with thirty plots is thirty fetches, and asking
-    /// for all of them at once is how an application uses up every lane the
-    /// runtime has and leaves nothing for the next listing.
-    fn next_figure(&mut self, context: &mut Context) {
-        if self.figure.is_some() {
-            return;
-        }
-        let Some(paper) = self.paper() else {
-            return;
-        };
-        let base = format!("https://arxiv.org/html/{}/", escape_path(&paper.id));
-        while let Some(name) = self.figures.pop_front() {
-            let Some(url) = figure_url(&base, &name) else {
-                continue;
-            };
-            // Not retrying: a figure is worth one attempt. The paper is
-            // already readable without it, and a plot that will not come is
-            // not a reason to spend the connection on it three times.
-            if let Some(task) = context.spawn(Task::Fetch {
-                url,
-                offset: 0,
-                max_bytes: FIGURE_BYTES,
-                credential: None,
-                headers: Vec::new(),
-            }) {
-                self.figure = Some((task, name));
-                return;
-            }
-            // No lane free. What is left stays queued, and the next page turn
-            // asks again.
-            self.figures.push_front(name);
-            return;
-        }
-        // Nothing left to ask for, so whatever did arrive is measured in.
-        self.settle_figures(context);
-    }
-
-    /// Measures every figure that arrived, once.
-    ///
-    /// Once rather than on each arrival: measuring is what decides where the
-    /// pages break, and doing it twelve times as twelve plots land would move
-    /// the text under somebody who is reading it. They keep their place across
-    /// it either way -- the reader remembers a paragraph, not a page number --
-    /// but the paragraph should not walk up the screen twelve times.
-    fn settle_figures(&mut self, context: &mut Context) {
-        if self.book.settle_pictures(context) {
-            self.show(context);
-        }
-    }
-
-    fn took_figure(&mut self, context: &mut Context, name: &str, bytes: Vec<u8>) {
-        self.book.provide_picture(name, bytes);
-        self.next_figure(context);
     }
 
     /// Gives back everything the open paper was costing.
     fn close_paper(&mut self, context: &mut Context) {
         self.book.close(context);
-        self.figures.clear();
-        // The fetch in flight is left to land and be ignored: cancelling it
-        // would cost a message to save nothing, and `provide_picture` refuses
-        // a name no open document mentions.
-        self.figure = None;
         self.truncated = false;
     }
-}
-
-/// Resolves a figure's address against the paper it was named in.
-///
-/// `LaTeXML` writes figures as `x1.png`, relative to the rendering's own
-/// address. A rendering is a web page before it is a paper, and its author
-/// wrote it: a figure that names another host would have the device announce
-/// itself to whoever the author chose, or knock on whatever else answers on
-/// the reader's own network. So an absolute address is taken only when it is
-/// arXiv's own, and everything else has to be a name inside the paper.
-fn figure_url(base: &str, name: &str) -> Option<String> {
-    if name.is_empty() || name.len() > 512 {
-        return None;
-    }
-    if let Some(rest) = name.strip_prefix("https://") {
-        let host = rest.split(['/', '?', '#']).next().unwrap_or_default();
-        // A port or credentials before the host are ways of writing an
-        // address that reads as arXiv's and is not, so neither is allowed.
-        let arxiv = host == "arxiv.org" || host.ends_with(".arxiv.org");
-        return if arxiv { Some(name.to_owned()) } else { None };
-    }
-    // Not http, not a data URI, not a protocol-relative address: this
-    // application fetches over TLS and nothing else, and a figure is not worth
-    // making an exception for.
-    if name.contains("://") || name.starts_with("//") || name.starts_with("data:") {
-        return None;
-    }
-    // A rooted path leaves the paper's own directory, which no `LaTeXML`
-    // rendering does, and a walk upwards out of it is a thing only a hostile
-    // page tries. The walk is also refused when it is spelled in percent
-    // escapes or with a backslash, because the address is joined as text here
-    // and resolved as a path somewhere else.
-    let escaped = name.to_ascii_lowercase();
-    if name.starts_with('/')
-        || name.contains('\\')
-        || escaped.contains("%2e")
-        || escaped.contains("%2f")
-        || name.split('/').any(|part| part == "..")
-    {
-        return None;
-    }
-    Some(format!("{base}{name}"))
 }
 
 /// Narrows a rendered paper to the paper.
@@ -800,10 +661,6 @@ impl KoboApp for Arxiv {
                     Outcome::Light(level) => context.device().set_frontlight(level),
                     Outcome::Elsewhere | Outcome::Repaint | Outcome::Save => {}
                 }
-                // A page turn is also the moment the figures on the page
-                // turned to are wanted, and a lane may have come free since
-                // the last one was asked for.
-                self.next_figure(context);
                 self.show(context);
                 return;
             }
@@ -909,26 +766,13 @@ impl KoboApp for Arxiv {
     fn on_task(&mut self, context: &mut Context, task: TaskId, outcome: TaskOutcome) {
         // The reader's own sleep, which is what carries a figure from bytes to
         // pixels a half-step at a time.
-        match self.book.woke(context, task) {
+        match self.book.woke(context, task, &outcome) {
             Step::Elsewhere => {}
             Step::Quiet => return,
             Step::Repaint => {
                 self.show(context);
                 return;
             }
-        }
-
-        if self.figure.as_ref().is_some_and(|(id, _)| *id == task) {
-            let (_, name) = self.figure.take().expect("just checked");
-            match outcome {
-                TaskOutcome::Completed(bytes) => self.took_figure(context, &name, bytes),
-                // A figure that will not come is a figure the paper reads
-                // without: the reader draws what the caption said it shows,
-                // which is what a document with a missing plate should look
-                // like. Nothing is said on screen about it.
-                TaskOutcome::Failed(_) | TaskOutcome::Cancelled => self.next_figure(context),
-            }
-            return;
         }
 
         let Some((waiting, awaiting)) = self.task else {
@@ -981,8 +825,8 @@ fn main() -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::{
-        abstract_text, escape, escape_path, figure_url, paper_body, row_summary, Arxiv, Query,
-        View, ABSTRACT, FULL_TEXT, SUBJECTS,
+        abstract_text, escape, escape_path, paper_body, row_summary, Arxiv, Query, View, ABSTRACT,
+        FULL_TEXT, SUBJECTS,
     };
     use crate::atom::Paper;
     use kobo_sdk::{action_id, ActionId, AppRunner, Command, Task, TaskOutcome};
@@ -1258,12 +1102,6 @@ mod tests {
             "<article><p>A paper.</p><img src=\"x1.png\" alt=\"A plot\"></article>",
         );
 
-        let (_, name) = runner
-            .app()
-            .figure
-            .clone()
-            .expect("the figure was never asked for");
-        assert_eq!(name, "x1.png");
         let asked: Vec<String> = commands
             .iter()
             .filter_map(|command| match command {
@@ -1280,42 +1118,6 @@ mod tests {
                 .any(|url| url == "https://arxiv.org/html/2401.00001v2/x1.png"),
             "the figure was not asked for beside its paper: {asked:?}"
         );
-    }
-
-    /// A rendering can name anything at all, and most of it is not a figure
-    /// this application is willing to go and get.
-    #[test]
-    fn a_figure_address_that_leaves_the_paper_is_refused() {
-        let base = "https://arxiv.org/html/2401.00001v2/";
-        assert_eq!(
-            figure_url(base, "x1.png").as_deref(),
-            Some("https://arxiv.org/html/2401.00001v2/x1.png")
-        );
-        assert_eq!(
-            figure_url(base, "https://arxiv.org/html/2401.00001v2/x1.png").as_deref(),
-            Some("https://arxiv.org/html/2401.00001v2/x1.png")
-        );
-        for hostile in [
-            "",
-            "/etc/passwd",
-            "../../../secrets.png",
-            "..%2f..%2fsecrets.png",
-            "%2e%2e/secrets.png",
-            "..\\secrets.png",
-            "http://example.org/x1.png",
-            "//example.org/x1.png",
-            "data:image/png;base64,AAAA",
-            // Another host is another host however it is spelled, and a
-            // rendering is written by whoever wrote the paper.
-            "https://example.org/x1.png",
-            "https://arxiv.org.example.org/x1.png",
-            "https://evil.org/?a=arxiv.org",
-        ] {
-            assert!(
-                figure_url(base, hostile).is_none(),
-                "{hostile:?} was allowed"
-            );
-        }
     }
 
     /// Leaving a paper gives back what it was costing the device, by whichever
@@ -1336,7 +1138,7 @@ mod tests {
                 "the parsed paper was kept after leaving it"
             );
             assert!(
-                runner.app().figures.is_empty() && runner.app().figure.is_none(),
+                runner.app().book.missing_pictures().is_empty(),
                 "figures were still being fetched for a paper nobody is reading"
             );
         }

--- a/apps/catalog.json
+++ b/apps/catalog.json
@@ -7,7 +7,7 @@
       "display_name": "arXiv",
       "short_label": "arXiv",
       "summary": "Browse and search preprints, and read the ones with a rendering.",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "note",
       "capabilities": ["network"]

--- a/crates/kobo-bookview/Cargo.toml
+++ b/crates/kobo-bookview/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "kobo-bookview"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+kobo-doc = { path = "../kobo-doc" }
+kobo-image = { path = "../kobo-image" }
+kobo-read = { path = "../kobo-read" }
+kobo-sdk = { path = "../kobo-sdk" }
+kobo-ui = { path = "../kobo-ui" }
+
+[lints]
+workspace = true

--- a/crates/kobo-bookview/src/lib.rs
+++ b/crates/kobo-bookview/src/lib.rs
@@ -1,0 +1,871 @@
+//! One reading surface, shared by every application that puts a document on
+//! the panel.
+//!
+//! [`kobo_doc`] turns a file into a [`Document`], and [`kobo_read`] turns a
+//! `Document` into pages, a place that survives the book being closed, a table
+//! of contents, highlights and a dictionary. Between the two sits a stretch of
+//! work that is neither parsing nor reading, and that every application was
+//! expected to write for itself: reserving room for the illustrations before
+//! any of them have been decoded, decoding them slowly enough that the panel's
+//! watchdog stays asleep, handing the pixels to the runtime under the handle
+//! the page reserved, and giving all of it back when the book is closed.
+//!
+//! That stretch is about two hundred and fifty lines, and the first
+//! application to need it wrote them. The second application to need it --
+//! arXiv, whose papers are HTML with figures in them -- would have written
+//! them again, slightly differently, and the device would have had two
+//! readers that behaved almost alike. This crate is the seam that stops that:
+//! applications hold a [`BookView`], hand it bytes, and get the reader
+//! everything else on the device already has.
+//!
+//! # What it opens
+//!
+//! Whatever [`kobo_doc::read`] opens, which today is EPUB, HTML, Markdown and
+//! plain text, sniffed from the name and the leading bytes. A format added
+//! there arrives here without this crate changing; PDF is the one people ask
+//! for and the one that has no backend yet, so [`BookView::open_bytes`] on a
+//! PDF fails the same way an unreadable EPUB does rather than pretending.
+//!
+//! # Pictures that are not in the file
+//!
+//! An EPUB carries its illustrations inside the container, so a book opens
+//! with every plate already in hand. A web page does not: `<img src="x1.png">`
+//! is a promise to fetch something, and [`kobo_doc::html`] leaves
+//! [`Document::images`] empty because a parser is not allowed to touch the
+//! network. Such a document opens immediately with its figures standing in as
+//! their own descriptions, and the application fetches the names
+//! [`BookView::missing_pictures`] gives it, hands each one back through
+//! [`BookView::provide_picture`], and calls [`BookView::settle_pictures`] when
+//! the batch is done. The book is measured once more at that point, and the
+//! reader stays on the block they were reading rather than the page number
+//! that block used to be on.
+
+use std::collections::{BTreeMap, VecDeque};
+
+use kobo_doc::{Block, Document};
+use kobo_read::{Memory, Outcome, Reader};
+use kobo_sdk::{Context, DisplayMetrics, PictureHandle, Screen, Task, TaskId, TilePicture};
+
+/// The most pictures one document may have room reserved for.
+///
+/// Every one costs a handle in the runtime and a decode on a processor that
+/// takes about a quarter of a second over each. An illustrated children's book
+/// is a few dozen; a paper is a dozen. A container that names four hundred is
+/// either a gallery or a mistake, and either way the sixty-fifth plate is not
+/// the thing standing between somebody and the page they wanted.
+pub const MAX_PICTURES: usize = 64;
+
+/// The handle illustrations are numbered from.
+///
+/// An application draws other things through the same runtime -- a shelf of
+/// covers, an icon strip -- and those hold handles of their own. Book plates
+/// start high enough to leave room underneath, and an application that already
+/// numbers its own pictures past this can move them with
+/// [`BookView::numbered_from`].
+pub const PICTURE_HANDLE_BASE: u32 = 1_000;
+
+/// The width a plate is fitted into, in millimetres.
+const PLATE_WIDTH_MM: u16 = 80;
+
+/// The height a plate is fitted into, in millimetres.
+///
+/// The ceiling `kobo-read` draws pictures at. Fitted before the pixels are
+/// handed over rather than after, because a plate scanned at print resolution
+/// is several megabytes the panel has no way to show.
+const PLATE_HEIGHT_MM: u16 = 90;
+
+/// What a step of the picture pipeline left behind.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Step {
+    /// The step was not this view's to take.
+    Elsewhere,
+    /// Work happened, and nothing on the page in front of anybody changed.
+    ///
+    /// A plate twenty pages ahead is not a reason to flash an E Ink panel, and
+    /// an illustrated book has two dozen of them.
+    Quiet,
+    /// A picture on the page being read arrived. Draw it.
+    Repaint,
+}
+
+/// A document, open, with everything it costs the device accounted for.
+///
+/// Created with [`BookView::new`], filled with [`BookView::open`] or
+/// [`BookView::open_bytes`], drawn with [`BookView::screen`], driven with
+/// [`BookView::act`] and [`BookView::woke`], and emptied with
+/// [`BookView::close`]. A view with no document in it is not an error state:
+/// it is what an application holds while somebody is browsing, and every
+/// method says so rather than panicking.
+#[derive(Debug, Default)]
+pub struct BookView {
+    reader: Option<Reader>,
+    /// The room claimed for each picture, by name.
+    ///
+    /// Kept rather than handed straight to the reader because a picture that
+    /// arrives late has to be merged into what was reserved at open, and the
+    /// reader takes the whole map or none of it.
+    reserved: BTreeMap<String, TilePicture>,
+    /// Source bytes for pictures with room reserved and no pixels yet, in the
+    /// order the text refers to them.
+    plates: VecDeque<(String, Vec<u8>)>,
+    /// A plate read and fitted, waiting for its greys.
+    dithering: Option<(String, kobo_image::Picture)>,
+    /// The task carrying the pipeline forward, if one is in flight.
+    plating: Option<TaskId>,
+    /// Bytes handed over for pictures the document could not supply itself,
+    /// waiting for [`BookView::settle_pictures`] to measure them.
+    offered: BTreeMap<String, Vec<u8>>,
+    /// Every handle the runtime is holding pixels against for this document.
+    handles: Vec<PictureHandle>,
+    /// The next handle to reserve against.
+    next_handle: u32,
+    /// The handle plates are numbered from.
+    base: u32,
+}
+
+impl BookView {
+    /// An empty view, numbering its plates from [`PICTURE_HANDLE_BASE`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::numbered_from(PICTURE_HANDLE_BASE)
+    }
+
+    /// An empty view, numbering its plates from `base`.
+    ///
+    /// For an application whose own pictures would otherwise collide with the
+    /// book's.
+    #[must_use]
+    pub fn numbered_from(base: u32) -> Self {
+        Self {
+            base,
+            next_handle: base,
+            ..Self::default()
+        }
+    }
+
+    /// A view holding a document somebody else opened.
+    ///
+    /// For an application that already has a [`Reader`] in hand. Nothing is
+    /// reserved and nothing is queued: a document arriving this way draws its
+    /// figures as their own descriptions until pictures are offered through
+    /// [`BookView::provide_picture`].
+    #[must_use]
+    pub fn holding(reader: Reader) -> Self {
+        Self {
+            reader: Some(reader),
+            ..Self::new()
+        }
+    }
+
+    /// Opens whatever `bytes` turn out to be.
+    ///
+    /// The name is what decides the format when the bytes are ambiguous, so it
+    /// is worth passing the real one; `kobo_doc` sniffs the leading bytes
+    /// either way. An error here is a file this device cannot read, and the
+    /// view is left holding nothing.
+    ///
+    /// # Errors
+    ///
+    /// Returns the parse fault when the bytes are not a document this device
+    /// knows how to open.
+    pub fn open_bytes(
+        &mut self,
+        context: &mut Context,
+        name: &str,
+        bytes: &[u8],
+        memory: Memory,
+    ) -> Result<(), kobo_doc::epub::Fault> {
+        let document = kobo_doc::read(name, bytes)?;
+        self.open(context, document, memory);
+        Ok(())
+    }
+
+    /// Opens a document that has already been parsed.
+    ///
+    /// The pictures the container carried are taken off the document rather
+    /// than left on it: the reader owns the document from here, and holding
+    /// the scanned bytes as well as the decoded greyscale meant every plate
+    /// was paid for twice.
+    pub fn open(&mut self, context: &mut Context, mut document: Document, memory: Memory) {
+        // Whatever the last document handed over is about to be replaced, so
+        // it goes back first. Without this, a book reopened from the shelf
+        // left its first set decoded in the runtime with nothing left that
+        // could name it.
+        self.release(context);
+        let images = std::mem::take(&mut document.images);
+        let metrics = context.metrics();
+        let mut reader = Reader::open(document, memory, &metrics);
+        // Before the page count is read, because the sizes are what an
+        // illustrated document is measured at.
+        for name in reader
+            .pictures_wanted()
+            .into_iter()
+            .take(MAX_PICTURES)
+            .map(str::to_owned)
+            .collect::<Vec<_>>()
+        {
+            if let Some(bytes) = images.get(&name) {
+                self.reserve(&name, bytes, &metrics);
+            }
+        }
+        reader.set_pictures(self.reserved.clone(), &metrics);
+        self.reader = Some(reader);
+        // Handed to the runtime rather than started here. Opening has already
+        // spent its parse and its pagination, and a plate on top of that is
+        // what puts a lifecycle callback past the watchdog's deadline.
+        self.kick(context);
+    }
+
+    /// Gives back everything the open document was costing.
+    ///
+    /// Leaving a book used to release nothing, so an owner who read one
+    /// illustrated book and went back to browsing carried the whole of it --
+    /// parsed document, source bytes and every decoded plate -- for the rest
+    /// of the session.
+    pub fn close(&mut self, context: &mut Context) {
+        self.release(context);
+        self.reader = None;
+    }
+
+    /// Whether there is a document open.
+    #[must_use]
+    pub const fn is_open(&self) -> bool {
+        self.reader.is_some()
+    }
+
+    /// The reader, for the parts of it this view does not wrap.
+    #[must_use]
+    pub const fn reader(&self) -> Option<&Reader> {
+        self.reader.as_ref()
+    }
+
+    /// The reader, mutably, for the parts of it this view does not wrap.
+    pub fn reader_mut(&mut self) -> Option<&mut Reader> {
+        self.reader.as_mut()
+    }
+
+    /// Where the reader had got to, for saving.
+    #[must_use]
+    pub fn memory(&self) -> Option<&Memory> {
+        self.reader.as_ref().map(Reader::memory)
+    }
+
+    /// How many plates are still waiting to become pixels.
+    ///
+    /// For an application that logs what opening a document cost.
+    #[must_use]
+    pub fn queued(&self) -> usize {
+        self.plates.len() + usize::from(self.dithering.is_some())
+    }
+
+    /// The page to draw, titled.
+    #[must_use]
+    pub fn screen(&self, title: &str) -> Option<Screen> {
+        self.reader.as_ref().map(|reader| reader.screen(title))
+    }
+
+    /// Offers an action to the open document.
+    ///
+    /// `None` when nothing is open or the reader does not answer that action,
+    /// which is the application's cue to handle it itself. Carrying the
+    /// picture pipeline forward is part of this: a page turn is also the
+    /// moment a plate on the page turned to is wanted, and an application that
+    /// only ever decoded on a timer would stop decoding the moment the runtime
+    /// had no room for one.
+    pub fn act(&mut self, context: &mut Context, action: kobo_ui::ActionId) -> Option<Outcome> {
+        let metrics = context.metrics();
+        let outcome = match self.reader.as_mut()?.act_on(action, &metrics) {
+            Outcome::Elsewhere => return None,
+            handled => handled,
+        };
+        if self.plating.is_none() && (!self.plates.is_empty() || self.dithering.is_some()) {
+            self.decode_more(context);
+        }
+        Some(outcome)
+    }
+
+    /// Carries the picture pipeline forward when its task lands.
+    ///
+    /// An application passes every finished task here; a task that was not
+    /// this view's comes back as [`Step::Elsewhere`] and costs a comparison.
+    pub fn woke(&mut self, context: &mut Context, task: TaskId) -> Step {
+        if self.plating != Some(task) {
+            return Step::Elsewhere;
+        }
+        self.plating = None;
+        self.decode_more(context)
+    }
+
+    /// Every picture the document refers to and could not supply.
+    ///
+    /// Empty for a container that carries its own illustrations. For a web
+    /// page these are the `src` attributes, exactly as they were written, so
+    /// an application resolves them against wherever it fetched the page from.
+    #[must_use]
+    pub fn missing_pictures(&self) -> Vec<String> {
+        let Some(reader) = &self.reader else {
+            return Vec::new();
+        };
+        reader
+            .pictures_wanted()
+            .into_iter()
+            .take(MAX_PICTURES)
+            .filter(|name| !self.reserved.contains_key(*name))
+            .map(str::to_owned)
+            .collect()
+    }
+
+    /// Hands over the bytes for a picture the document could not supply.
+    ///
+    /// Held, not measured: measuring is what changes where the page breaks
+    /// fall, and doing that once per figure as a dozen of them arrive would
+    /// move the text under somebody who is reading it. The whole batch is
+    /// taken in by [`BookView::settle_pictures`].
+    ///
+    /// Returns whether the picture was wanted; bytes for a name the document
+    /// never mentioned are dropped rather than held.
+    pub fn provide_picture(&mut self, name: &str, bytes: Vec<u8>) -> bool {
+        if bytes.is_empty() || self.reserved.contains_key(name) {
+            return false;
+        }
+        if self.reserved.len() + self.offered.len() >= MAX_PICTURES {
+            return false;
+        }
+        let wanted = self
+            .reader
+            .as_ref()
+            .is_some_and(|reader| reader.pictures_wanted().contains(&name));
+        if !wanted {
+            return false;
+        }
+        self.offered.insert(name.to_owned(), bytes);
+        true
+    }
+
+    /// Measures everything handed over since the document opened.
+    ///
+    /// One repagination for the batch. The reader keeps its place across it:
+    /// where somebody is is remembered as a block, not a page number, so the
+    /// words they were looking at are still the words in front of them even
+    /// though there are now figures above them.
+    ///
+    /// Returns whether anything changed, which is whether to repaint.
+    pub fn settle_pictures(&mut self, context: &mut Context) -> bool {
+        if self.offered.is_empty() {
+            return false;
+        }
+        let metrics = context.metrics();
+        let offered = std::mem::take(&mut self.offered);
+        // In the order the text refers to them rather than the order they
+        // happened to arrive, so the queue decodes down the document.
+        let order: Vec<String> = self.reader.as_ref().map_or_else(Vec::new, |reader| {
+            reader
+                .pictures_wanted()
+                .into_iter()
+                .map(str::to_owned)
+                .collect()
+        });
+        let mut settled = false;
+        for name in order {
+            if let Some(bytes) = offered.get(&name) {
+                settled |= self.reserve(&name, bytes, &metrics);
+            }
+        }
+        if !settled {
+            return false;
+        }
+        let reserved = self.reserved.clone();
+        if let Some(reader) = &mut self.reader {
+            reader.set_pictures(reserved, &metrics);
+        }
+        self.kick(context);
+        true
+    }
+
+    /// Claims the room one picture will take, decoding none of it.
+    ///
+    /// A picture's header states its size in its first few dozen bytes, and
+    /// that is all pagination needs. Opening a book used to decode, fit and
+    /// dither every illustration before it returned, inside a callback with a
+    /// two hundred and fifty millisecond deadline: twenty-eight plates came to
+    /// two thousand seven hundred milliseconds, during which nothing drew, no
+    /// control answered, and three watchdogs counted.
+    ///
+    /// A header that will not parse is a picture that will not decode, so it
+    /// is left out here and the page reads its description instead -- which is
+    /// what a document with a broken figure should look like.
+    fn reserve(&mut self, name: &str, bytes: &[u8], metrics: &DisplayMetrics) -> bool {
+        if self.reserved.len() >= MAX_PICTURES {
+            return false;
+        }
+        let Some((width, height)) = plate_box(metrics) else {
+            return false;
+        };
+        let Ok(source) = kobo_image::size(bytes) else {
+            return false;
+        };
+        let (drawn_width, drawn_height) = kobo_image::fitted_size(source, width, height);
+        if drawn_width == 0 || drawn_height == 0 {
+            return false;
+        }
+        let handle = PictureHandle(self.next_handle);
+        self.next_handle = self.next_handle.saturating_add(1);
+        self.reserved.insert(
+            name.to_owned(),
+            TilePicture::new(handle, drawn_width, drawn_height),
+        );
+        self.handles.push(handle);
+        self.plates.push_back((name.to_owned(), bytes.to_vec()));
+        true
+    }
+
+    /// Asks the runtime to carry the pipeline forward, if there is anything
+    /// left to carry and nothing already carrying it.
+    fn kick(&mut self, context: &mut Context) {
+        if self.plating.is_some() || (self.plates.is_empty() && self.dithering.is_none()) {
+            return;
+        }
+        self.plating = context.spawn(Task::Sleep { seconds: 0 });
+    }
+
+    /// Carries one plate one step further towards the panel, and asks to be
+    /// called again while any step is left.
+    ///
+    /// One step, not as many as fit in a time budget. Nothing here can be
+    /// interrupted half way, so a budget can only be checked before starting
+    /// something, and the pass then runs for the budget plus however long that
+    /// something takes: on the panel a hundred and twenty millisecond budget
+    /// produced callbacks of 272, 293 and 311 milliseconds against a deadline
+    /// of 250. One whole plate per pass was no better -- 250 to 311 -- because
+    /// one whole plate is itself over the deadline on this processor.
+    ///
+    /// So a plate is taken in its two natural halves. Reading the file and
+    /// fitting it is one; reducing a million pixels to the sixteen greys the
+    /// panel can hold is the other, and on a development machine the two are
+    /// two milliseconds and three, which on the reader is about a hundred and
+    /// about a hundred and seventy. Either alone is comfortably inside the
+    /// deadline.
+    ///
+    /// The page being looked at is decoded first. Everything else can arrive
+    /// while it is being read.
+    fn decode_more(&mut self, context: &mut Context) -> Step {
+        let metrics = context.metrics();
+        let Some((width, height)) = plate_box(&metrics) else {
+            self.plates.clear();
+            self.dithering = None;
+            return Step::Quiet;
+        };
+        let showing: Vec<String> = self.reader.as_ref().map_or_else(Vec::new, |reader| {
+            reader
+                .pictures_on_page()
+                .into_iter()
+                .map(str::to_owned)
+                .collect()
+        });
+        let mut on_this_page = false;
+        if let Some((name, mut picture)) = self.dithering.take() {
+            // The second half: the greys.
+            picture.dither(kobo_image::PANEL_GREYS);
+            let (drawn_width, drawn_height) = (picture.width(), picture.height());
+            if let Some(reserved) = self.handed(&name) {
+                if context
+                    .put_picture(reserved, drawn_width, drawn_height, picture.into_grey())
+                    .is_some()
+                    && showing.contains(&name)
+                {
+                    on_this_page = true;
+                }
+            }
+        } else {
+            self.wanted_first(&showing);
+            // The first half: the file. A plate that will not read costs
+            // nothing, so this goes past it rather than spending a whole round
+            // trip discovering there was nothing to draw, and stops on the
+            // first one that works.
+            while let Some((name, bytes)) = self.plates.pop_front() {
+                if self.handed(&name).is_none() {
+                    continue;
+                }
+                let Ok(picture) = kobo_image::decode(&bytes) else {
+                    continue;
+                };
+                let Ok(picture) = picture.fit(width, height) else {
+                    continue;
+                };
+                self.dithering = Some((name, picture));
+                break;
+            }
+        }
+        self.kick(context);
+        if on_this_page {
+            Step::Repaint
+        } else {
+            Step::Quiet
+        }
+    }
+
+    /// Moves the named plates to the front of the queue, keeping their order.
+    fn wanted_first(&mut self, names: &[String]) {
+        if names.is_empty() {
+            return;
+        }
+        let (wanted, rest): (VecDeque<_>, VecDeque<_>) = self
+            .plates
+            .drain(..)
+            .partition(|(name, _)| names.contains(name));
+        self.plates = wanted.into_iter().chain(rest).collect();
+    }
+
+    /// The handle a plate was reserved against, if it was.
+    fn handed(&self, name: &str) -> Option<PictureHandle> {
+        self.reserved.get(name).map(|picture| picture.handle)
+    }
+
+    /// Hands back every handle and forgets every plate, leaving the reader.
+    ///
+    /// Whatever is still queued is source bytes for a document nobody is
+    /// reading any more. A sleep already in flight is left to land and be
+    /// ignored: cancelling it would cost a message to save nothing.
+    fn release(&mut self, context: &mut Context) {
+        for handle in self.handles.drain(..) {
+            context.drop_picture(handle);
+        }
+        self.plates.clear();
+        self.offered.clear();
+        self.reserved.clear();
+        self.dithering = None;
+        self.plating = None;
+        self.next_handle = self.base;
+    }
+}
+
+/// The box an illustration is fitted into, in pixels.
+///
+/// `None` on a panel so small the box has no area, which is not a device this
+/// runs on but is a shape the arithmetic can produce.
+fn plate_box(metrics: &DisplayMetrics) -> Option<(u32, u32)> {
+    let width = metrics.tenth_mm(i32::from(PLATE_WIDTH_MM) * 10);
+    let height = metrics.tenth_mm(i32::from(PLATE_HEIGHT_MM) * 10);
+    match (u32::try_from(width), u32::try_from(height)) {
+        (Ok(width), Ok(height)) if width > 0 && height > 0 => Some((width, height)),
+        _ => None,
+    }
+}
+
+/// Every picture a document refers to, before it is opened.
+///
+/// What an application asks in order to know what to fetch when the document
+/// is a web page whose figures live somewhere else. The same order
+/// [`BookView::missing_pictures`] uses, and available without a reader.
+#[must_use]
+pub fn pictures_in(document: &Document) -> Vec<&str> {
+    let mut wanted = Vec::new();
+    for block in &document.blocks {
+        if let Block::Picture { name, .. } = block {
+            if !wanted.contains(&name.as_str()) && wanted.len() < MAX_PICTURES {
+                wanted.push(name.as_str());
+            }
+        }
+    }
+    wanted
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{pictures_in, BookView, Step};
+    use kobo_doc::{Block, Document};
+    use kobo_read::{Memory, Reader};
+    use kobo_sdk::{Command, Context, PictureHandle, TaskId};
+
+    /// A page of prose, so that the room a plate takes is the difference
+    /// between one page and two.
+    fn prose(blocks: usize) -> Vec<Block> {
+        (0..blocks)
+            .map(|_| {
+                Block::Paragraph(
+                    "Once upon a time there were four little rabbits, and their names were \
+                     Flopsy, Mopsy, Cotton-tail and Peter."
+                        .to_owned(),
+                )
+            })
+            .collect()
+    }
+
+    fn plate_bytes() -> Vec<u8> {
+        kobo_image::encode_png_grey(1200, 2000, &vec![128; 1200 * 2000]).expect("a png of a plate")
+    }
+
+    fn illustrated(plate: &[u8]) -> Document {
+        let mut blocks = prose(12);
+        blocks.push(Block::Picture {
+            name: "plate.png".to_owned(),
+            alt: "Four rabbits".to_owned(),
+        });
+        Document {
+            blocks,
+            images: [("plate.png".to_owned(), plate.to_vec())]
+                .into_iter()
+                .collect(),
+            ..Document::default()
+        }
+    }
+
+    fn handed(commands: &[Command]) -> Vec<(PictureHandle, u32, u32)> {
+        commands
+            .iter()
+            .filter_map(|command| match command {
+                Command::PutPicture {
+                    handle,
+                    width,
+                    height,
+                    ..
+                } => Some((*handle, *width, *height)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn dropped(commands: &[Command]) -> Vec<PictureHandle> {
+        commands
+            .iter()
+            .filter_map(|command| match command {
+                Command::DropPicture(handle) => Some(*handle),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// A plate is measured from its header and decoded later.
+    ///
+    /// Opening The Tale of Peter Rabbit on the panel decoded twenty-eight
+    /// images inside a lifecycle callback and took 2,784 milliseconds doing
+    /// it, against a deadline of 250. Reading the headers costs microseconds
+    /// and answers the only question pagination has, so the book opens at the
+    /// page count it will be read at and the pixels arrive afterwards.
+    #[test]
+    fn a_book_of_plates_is_measured_from_its_headers_and_decoded_afterwards() {
+        let plate = plate_bytes();
+        let mut context = Context::default();
+        let metrics = context.metrics();
+
+        let bare = Document {
+            blocks: prose(12),
+            ..Document::default()
+        };
+        let without = Reader::open(bare, Memory::default(), &metrics).page_count();
+
+        let mut view = BookView::new();
+        view.open(&mut context, illustrated(&plate), Memory::default());
+
+        assert_eq!(
+            view.queued(),
+            1,
+            "the plate should be queued rather than decoded"
+        );
+        assert!(
+            handed(&context.take_commands()).is_empty(),
+            "a plate was decoded while the book was opening"
+        );
+        assert!(
+            view.reader().expect("a book").page_count() > without,
+            "the book was not measured around the room the plate takes"
+        );
+    }
+
+    /// The room claimed from the header is the room the decoder asks for.
+    #[test]
+    fn the_room_claimed_from_a_header_is_the_room_the_decoder_wants() {
+        let plate = plate_bytes();
+        let mut context = Context::default();
+        let metrics = context.metrics();
+        let (width, height) = super::plate_box(&metrics).expect("a panel with room on it");
+
+        let mut view = BookView::new();
+        view.open(&mut context, illustrated(&plate), Memory::default());
+
+        let decoded = kobo_image::decode(&plate)
+            .expect("decode")
+            .fit(width, height)
+            .expect("fit");
+        assert_eq!(
+            view.reader()
+                .and_then(|reader| reader.picture_named("plate.png"))
+                .map(|picture| picture.source),
+            Some((decoded.width(), decoded.height())),
+            "the size claimed from the header is not the size the decoder produces"
+        );
+    }
+
+    /// And the pixels, when they come, go into the room already reserved.
+    #[test]
+    fn a_queued_plate_is_handed_over_against_the_handle_it_was_measured_at() {
+        let plate = plate_bytes();
+        let mut context = Context::default();
+        let mut view = BookView::new();
+        let document = Document {
+            blocks: vec![Block::Picture {
+                name: "plate.png".to_owned(),
+                alt: "Four rabbits".to_owned(),
+            }],
+            images: [("plate.png".to_owned(), plate)].into_iter().collect(),
+            ..Document::default()
+        };
+        view.open(&mut context, document, Memory::default());
+        let claimed = view
+            .reader()
+            .and_then(|reader| reader.picture_named("plate.png"))
+            .expect("the plate was reserved");
+        let first_task = view.plating.expect("the queue was not started");
+        let _ = context.take_commands();
+
+        // The first pass reads the plate and asks for another; the second
+        // reduces it to the panel's greys and hands it over. Neither half is
+        // allowed to take as long as both would.
+        let step = view.woke(&mut context, first_task);
+        assert!(
+            handed(&context.take_commands()).is_empty(),
+            "a plate was decoded and dithered in one callback"
+        );
+        assert_eq!(step, Step::Quiet, "a plate off screen asked for a repaint");
+        assert!(
+            view.plates.is_empty() && view.dithering.is_some(),
+            "the plate was not read out of the book"
+        );
+        let next = view.plating.expect("another pass was not asked for");
+
+        let step = view.woke(&mut context, next);
+        assert_eq!(
+            handed(&context.take_commands()),
+            vec![(claimed.handle, claimed.source.0, claimed.source.1)],
+            "the plate did not fill the frame that was standing in for it"
+        );
+        assert_eq!(
+            step,
+            Step::Repaint,
+            "the plate on the page arrived without asking to be drawn"
+        );
+        assert!(
+            view.dithering.is_none(),
+            "the decoded plate was kept after it was drawn"
+        );
+    }
+
+    /// A sleep belonging to somebody else is not this view's to answer.
+    #[test]
+    fn a_task_that_was_not_the_pipelines_is_left_alone() {
+        let mut context = Context::default();
+        let mut view = BookView::new();
+        assert_eq!(
+            view.woke(&mut context, TaskId(7)),
+            Step::Elsewhere,
+            "an unrelated task was taken for a plate"
+        );
+    }
+
+    /// Leaving a document gives back every handle the runtime was holding.
+    ///
+    /// The runtime frees pictures when an application exits, which is no help
+    /// at all to one that stays open: a book of plates was costing the device
+    /// several megabytes of decoded greyscale while its owner was back on the
+    /// shelf looking at covers.
+    #[test]
+    fn leaving_a_document_gives_back_every_handle_the_runtime_was_holding() {
+        let plate = plate_bytes();
+        let mut context = Context::default();
+        let mut view = BookView::new();
+        view.open(&mut context, illustrated(&plate), Memory::default());
+        let handle = view
+            .reader()
+            .and_then(|reader| reader.picture_named("plate.png"))
+            .expect("the plate was reserved")
+            .handle;
+        let _ = context.take_commands();
+
+        view.close(&mut context);
+
+        assert_eq!(
+            dropped(&context.take_commands()),
+            vec![handle],
+            "the runtime was left holding the plates"
+        );
+        assert!(!view.is_open(), "the parsed document was kept");
+        assert_eq!(view.queued(), 0, "the queue outlived the document");
+    }
+
+    /// A web page names its figures and carries none of them.
+    #[test]
+    fn a_page_whose_figures_live_elsewhere_says_which_ones_it_wants() {
+        let mut context = Context::default();
+        let mut view = BookView::new();
+        let document = kobo_doc::html::parse(
+            "<article><p>A paper.</p><img src=\"x1.png\" alt=\"A figure\"></article>",
+        );
+        assert_eq!(pictures_in(&document), vec!["x1.png"]);
+
+        view.open(&mut context, document, Memory::default());
+
+        assert_eq!(
+            view.missing_pictures(),
+            vec!["x1.png".to_owned()],
+            "a figure with no bytes was not asked for"
+        );
+        assert_eq!(view.queued(), 0, "a figure with no bytes was queued anyway");
+    }
+
+    /// And when they arrive, the page is measured around them.
+    #[test]
+    fn a_figure_fetched_afterwards_is_measured_in_and_keeps_the_readers_place() {
+        let plate = plate_bytes();
+        let mut context = Context::default();
+        let mut view = BookView::new();
+        let mut html = String::from("<article>");
+        for _ in 0..12 {
+            html.push_str("<p>Once upon a time there were four little rabbits.</p>");
+        }
+        html.push_str("<img src=\"x1.png\" alt=\"A figure\"></article>");
+        view.open(
+            &mut context,
+            kobo_doc::html::parse(&html),
+            Memory::default(),
+        );
+        let without = view.reader().expect("a paper").page_count();
+
+        assert!(
+            view.provide_picture("x1.png", plate),
+            "the figure the page asked for was refused"
+        );
+        assert_eq!(
+            view.queued(),
+            0,
+            "an offered figure was queued before it was measured"
+        );
+        assert!(
+            view.settle_pictures(&mut context),
+            "measuring the offered figure changed nothing"
+        );
+
+        assert_eq!(view.queued(), 1, "the settled figure was not queued");
+        assert!(
+            view.missing_pictures().is_empty(),
+            "the figure is still wanted"
+        );
+        assert!(
+            view.reader().expect("a paper").page_count() > without,
+            "the paper was not measured around the room the figure takes"
+        );
+    }
+
+    /// Bytes for something the page never mentioned are not held.
+    #[test]
+    fn a_picture_the_page_never_asked_for_is_refused() {
+        let mut context = Context::default();
+        let mut view = BookView::new();
+        view.open(
+            &mut context,
+            kobo_doc::html::parse("<p>A paper with no figures.</p>"),
+            Memory::default(),
+        );
+        assert!(!view.provide_picture("x1.png", plate_bytes()));
+        assert!(!view.settle_pictures(&mut context));
+    }
+}

--- a/crates/kobo-bookview/src/lib.rs
+++ b/crates/kobo-bookview/src/lib.rs
@@ -44,7 +44,9 @@ use std::collections::{BTreeMap, VecDeque};
 
 use kobo_doc::{Block, Document};
 use kobo_read::{Memory, Outcome, Reader};
-use kobo_sdk::{Context, DisplayMetrics, PictureHandle, Screen, Task, TaskId, TilePicture};
+use kobo_sdk::{
+    Context, DisplayMetrics, PictureHandle, Screen, Task, TaskId, TaskOutcome, TilePicture,
+};
 
 /// The most pictures one document may have room reserved for.
 ///
@@ -63,6 +65,16 @@ pub const MAX_PICTURES: usize = 64;
 /// numbers its own pictures past this can move them with
 /// [`BookView::numbered_from`].
 pub const PICTURE_HANDLE_BASE: u32 = 1_000;
+
+/// The ceiling on one fetched picture.
+///
+/// A plot is tens of kilobytes. The ones that overrun this are photographs at
+/// print resolution, which the panel cannot show anyway: it is sixteen greys
+/// on a screen narrower than the figure's own caption.
+pub const MAX_PICTURE_BYTES: u32 = 512 * 1024;
+
+/// The longest a picture's address may be.
+const MAX_PICTURE_NAME: usize = 512;
 
 /// The width a plate is fitted into, in millimetres.
 const PLATE_WIDTH_MM: u16 = 80;
@@ -117,10 +129,21 @@ pub struct BookView {
     offered: BTreeMap<String, Vec<u8>>,
     /// Every handle the runtime is holding pixels against for this document.
     handles: Vec<PictureHandle>,
+    /// Whether the last settle changed what is on the page.
+    settled: bool,
     /// The next handle to reserve against.
     next_handle: u32,
     /// The handle plates are numbered from.
     base: u32,
+    /// Where the open document was fetched from, when it came off the web.
+    ///
+    /// Every picture it names is resolved against this, and only pictures that
+    /// resolve to the same host are asked for.
+    origin: Option<String>,
+    /// Pictures named by the document that have still to be asked for.
+    wanted: VecDeque<String>,
+    /// The fetch in flight, and what it is for.
+    fetching: Option<(TaskId, String)>,
 }
 
 impl BookView {
@@ -247,6 +270,97 @@ impl BookView {
             .is_some_and(|reader| reader.seed_light(percent))
     }
 
+    /// Opens a web page, and fetches the pictures it names.
+    ///
+    /// This is the whole of what an application has to do to put a page on the
+    /// panel: hand over the markup and the address it came from. The markup is
+    /// parsed into the page's own structure -- its headings, its emphasis, its
+    /// figures and their captions -- rather than flattened into a wall of
+    /// text, and the pictures, which arrived as addresses and not as pixels,
+    /// are asked for one at a time behind the words. The reader is legible
+    /// from the first paint and fills in as they land.
+    ///
+    /// It used to be the application's job, and the application it was written
+    /// in got it subtly wrong in ways nothing else could see: a paper left
+    /// without going back through the door it came in leaked every figure it
+    /// was holding, and the pipeline it left running never started again.
+    /// There is one copy of it now, here, where the document already is.
+    ///
+    /// `origin` is the address the markup was fetched from. Pictures are
+    /// resolved against it, and a picture that resolves anywhere else is not
+    /// asked for -- see [`picture_url`] for exactly what that admits and why.
+    ///
+    /// Returns whether anything readable came out of the markup. `false` is a
+    /// page with no prose in it at all, and the view is left holding nothing.
+    pub fn open_html(
+        &mut self,
+        context: &mut Context,
+        html: &str,
+        origin: &str,
+        memory: Memory,
+    ) -> bool {
+        let document = kobo_doc::html::parse(html);
+        if document.blocks.is_empty() {
+            return false;
+        }
+        self.open(context, document, memory);
+        self.origin = Some(origin.to_owned());
+        self.wanted = self.missing_pictures().into_iter().collect();
+        self.fetch_next(context);
+        true
+    }
+
+    /// Says the document stopped short of its own end.
+    ///
+    /// For a page fetched under a byte ceiling. The reader says so on the last
+    /// page, which is the only place it matters and the only place somebody is
+    /// looking when it does.
+    pub fn mark_truncated(&mut self, truncated: bool) {
+        if let Some(reader) = &mut self.reader {
+            reader.mark_truncated(truncated);
+        }
+    }
+
+    /// Asks for the next picture the document named.
+    ///
+    /// One at a time. A page with thirty plots is thirty fetches, and asking
+    /// for all of them at once is how an application uses up every lane the
+    /// runtime has and leaves nothing for whatever the reader does next.
+    fn fetch_next(&mut self, context: &mut Context) {
+        if self.fetching.is_some() {
+            return;
+        }
+        let Some(origin) = self.origin.clone() else {
+            return;
+        };
+        while let Some(name) = self.wanted.pop_front() {
+            let Some(url) = picture_url(&origin, &name) else {
+                continue;
+            };
+            // Not retried: a picture is worth one attempt. The page is already
+            // readable without it, and a plot that will not come is not a
+            // reason to spend the connection on it three times.
+            if let Some(task) = context.spawn(Task::Fetch {
+                url,
+                offset: 0,
+                max_bytes: MAX_PICTURE_BYTES,
+                credential: None,
+                headers: Vec::new(),
+            }) {
+                self.fetching = Some((task, name));
+                return;
+            }
+            // No lane free. What is left stays queued, and the next page turn
+            // asks again.
+            self.wanted.push_front(name);
+            return;
+        }
+        // Nothing left to ask for, so whatever did arrive is measured in.
+        if self.settle_pictures(context) {
+            self.settled = true;
+        }
+    }
+
     /// Gives back everything the open document was costing.
     ///
     /// Leaving a book used to release nothing, so an owner who read one
@@ -312,14 +426,38 @@ impl BookView {
         if self.plating.is_none() && (!self.plates.is_empty() || self.dithering.is_some()) {
             self.decode_more(context);
         }
+        // A page turn is also the moment the pictures on the page turned to
+        // are wanted, and a lane may have come free since the last one was
+        // asked for.
+        self.fetch_next(context);
         Some(outcome)
     }
 
-    /// Carries the picture pipeline forward when its task lands.
+    /// Carries the picture pipeline forward when one of its tasks lands.
     ///
     /// An application passes every finished task here; a task that was not
-    /// this view's comes back as [`Step::Elsewhere`] and costs a comparison.
-    pub fn woke(&mut self, context: &mut Context, task: TaskId) -> Step {
+    /// this view's comes back as [`Step::Elsewhere`] and costs two
+    /// comparisons. Two kinds of task are this view's: the sleep that carries
+    /// a plate from bytes to pixels a half-step at a time, and the fetch of a
+    /// picture a web page named but did not carry.
+    pub fn woke(&mut self, context: &mut Context, task: TaskId, outcome: &TaskOutcome) -> Step {
+        if let Some((_, name)) = self.fetching.take_if(|(id, _)| *id == task) {
+            // A picture that will not come is a picture the page reads
+            // without: the reader draws what the caption said it shows, which
+            // is what a document with a missing plate should look like.
+            // Nothing is said on screen about it.
+            if let TaskOutcome::Completed(bytes) = outcome {
+                self.provide_picture(&name, bytes.clone());
+            }
+            self.settled = false;
+            self.fetch_next(context);
+            return if self.settled {
+                self.settled = false;
+                Step::Repaint
+            } else {
+                Step::Quiet
+            };
+        }
         if self.plating != Some(task) {
             return Step::Elsewhere;
         }
@@ -567,7 +705,72 @@ impl BookView {
         self.dithering = None;
         self.plating = None;
         self.next_handle = self.base;
+        self.origin = None;
+        self.wanted.clear();
+        self.settled = false;
+        // The fetch in flight is left to land and be ignored rather than
+        // cancelled: cancelling costs a message to save nothing, and
+        // `provide_picture` refuses a name no open document mentions anyway.
+        self.fetching = None;
     }
+}
+
+/// Resolves a picture's address against the page that named it.
+///
+/// A web page is a web page before it is a document, and somebody else wrote
+/// it. A picture that named another host would have the device announce itself
+/// to whoever the author chose -- a read receipt saying this reader opened
+/// this page at this moment -- or knock on whatever else answers at that
+/// address on the reader's own network. So an absolute address is taken only
+/// when it is the page's own host or a sub-domain of it, and everything else
+/// has to be a name inside the page.
+///
+/// A port or credentials written before the host are ways of spelling an
+/// address that reads as the page's and is not, so neither is allowed. A
+/// rooted path leaves the page's own directory and a walk upwards climbs out
+/// of it; both are refused, including when they are spelled in percent escapes
+/// or with a backslash, because the address is joined as text here and
+/// resolved as a path somewhere else.
+#[must_use]
+pub fn picture_url(origin: &str, name: &str) -> Option<String> {
+    if name.is_empty() || name.len() > MAX_PICTURE_NAME {
+        return None;
+    }
+    let base = origin.rsplit_once('/').map_or(origin, |(head, _)| head);
+    if let Some(rest) = name.strip_prefix("https://") {
+        let host = rest.split(['/', '?', '#']).next().unwrap_or_default();
+        let home = host_of(origin)?;
+        let same = host == home || host.ends_with(&format!(".{home}"));
+        return same.then(|| name.to_owned());
+    }
+    // Not http, not a data URI, not a protocol-relative address: a document is
+    // fetched over TLS and nothing else, and a picture is not worth making an
+    // exception for.
+    if name.contains("://") || name.starts_with("//") || name.starts_with("data:") {
+        return None;
+    }
+    let escaped = name.to_ascii_lowercase();
+    if name.starts_with('/')
+        || name.contains('\\')
+        || escaped.contains("%2e")
+        || escaped.contains("%2f")
+        || name.split('/').any(|part| part == "..")
+    {
+        return None;
+    }
+    Some(format!("{base}/{name}"))
+}
+
+/// The host an address is at, if it is one this device would fetch.
+fn host_of(url: &str) -> Option<&str> {
+    let rest = url.strip_prefix("https://")?;
+    let host = rest.split(['/', '?', '#']).next().unwrap_or_default();
+    // Credentials or a port make the host something other than what it reads
+    // as, and neither belongs in an address a document was fetched from.
+    if host.is_empty() || host.contains('@') || host.contains(':') {
+        return None;
+    }
+    Some(host)
 }
 
 /// The box an illustration is fitted into, in pixels.
@@ -603,10 +806,63 @@ pub fn pictures_in(document: &Document) -> Vec<&str> {
 
 #[cfg(test)]
 mod tests {
-    use super::{pictures_in, BookView, Step};
+
+    use super::{picture_url, pictures_in, BookView, Step};
     use kobo_doc::{Block, Document};
     use kobo_read::{Memory, Reader};
-    use kobo_sdk::{Command, Context, PictureHandle, TaskId};
+    use kobo_sdk::{Command, Context, PictureHandle, Task, TaskError, TaskId, TaskOutcome};
+
+    /// A page can name anything at all, and most of it is not a picture this
+    /// device is willing to go and get. The rule is the page's own host: what
+    /// a document refers to is fetched from where the document came from.
+    #[test]
+    fn a_picture_address_that_leaves_the_page_is_refused() {
+        let origin = "https://arxiv.org/html/2401.00001v2/";
+        assert_eq!(
+            picture_url(origin, "x1.png").as_deref(),
+            Some("https://arxiv.org/html/2401.00001v2/x1.png")
+        );
+        // A name beside a page whose address does not end in a slash resolves
+        // against the directory it is in, which is what every browser does.
+        assert_eq!(
+            picture_url("https://example.org/a/page.html", "x1.png").as_deref(),
+            Some("https://example.org/a/x1.png")
+        );
+        // The page's own host, and a sub-domain of it, are the page.
+        assert_eq!(
+            picture_url(origin, "https://arxiv.org/x1.png").as_deref(),
+            Some("https://arxiv.org/x1.png")
+        );
+        assert_eq!(
+            picture_url(origin, "https://static.arxiv.org/x1.png").as_deref(),
+            Some("https://static.arxiv.org/x1.png")
+        );
+        for hostile in [
+            "",
+            "/etc/passwd",
+            "../../../secrets.png",
+            "..%2f..%2fsecrets.png",
+            "%2e%2e/secrets.png",
+            "..\\secrets.png",
+            "http://example.org/x1.png",
+            "//example.org/x1.png",
+            "data:image/png;base64,AAAA",
+            // Another host is another host however it is spelled, and the page
+            // is written by whoever wrote the page.
+            "https://example.org/x1.png",
+            "https://arxiv.org.example.org/x1.png",
+            "https://evil.org/?a=arxiv.org",
+        ] {
+            assert!(
+                picture_url(origin, hostile).is_none(),
+                "{hostile:?} was allowed"
+            );
+        }
+        // A page fetched from somewhere this device would not fetch from can
+        // vouch for nothing, so nothing absolute resolves against it.
+        assert!(picture_url("http://example.org/a/", "https://example.org/x.png").is_none());
+        assert!(picture_url("https://user@arxiv.org/a/", "https://arxiv.org/x.png").is_none());
+    }
 
     /// A page of prose, so that the room a plate takes is the difference
     /// between one page and two.
@@ -656,6 +912,19 @@ mod tests {
             .collect()
     }
 
+    fn fetched(commands: &[Command]) -> Vec<String> {
+        commands
+            .iter()
+            .filter_map(|command| match command {
+                Command::Spawn {
+                    work: Task::Fetch { url, .. },
+                    ..
+                } => Some(url.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
     fn dropped(commands: &[Command]) -> Vec<PictureHandle> {
         commands
             .iter()
@@ -664,6 +933,91 @@ mod tests {
                 _ => None,
             })
             .collect()
+    }
+
+    /// A page of markup opens the same reader a book does.
+    ///
+    /// This is the whole point of the shared surface: an application that has
+    /// some HTML hands it over and is done, rather than flattening it to a
+    /// string of its own and losing every heading, link and figure the page
+    /// had. The pictures a page names live at addresses instead of inside a
+    /// file, so opening one also starts going and getting them.
+    #[test]
+    fn a_page_of_markup_opens_the_reader_and_goes_after_what_it_names() {
+        let mut context = Context::default();
+        let mut view = BookView::new();
+
+        assert!(view.open_html(
+            &mut context,
+            "<h1>A paper</h1><p>A body.</p><img src=\"x1.png\" alt=\"A plot\">",
+            "https://arxiv.org/html/2401.00001v2/",
+            Memory::default(),
+        ));
+        assert!(view.is_open(), "the page did not open the reader");
+
+        let asked = fetched(&context.take_commands());
+        assert_eq!(
+            asked,
+            vec!["https://arxiv.org/html/2401.00001v2/x1.png".to_owned()],
+            "the figure was not asked for beside the page that names it"
+        );
+    }
+
+    /// Markup with nothing in it is not a document, and opening the reader on
+    /// it would leave somebody staring at a blank page with no way to tell
+    /// that the fetch, rather than the paper, was the thing that was empty.
+    #[test]
+    fn a_page_with_nothing_in_it_does_not_open() {
+        let mut context = Context::default();
+        let mut view = BookView::new();
+
+        assert!(!view.open_html(
+            &mut context,
+            "<html><head><style>p { color: red }</style></head><body></body></html>",
+            "https://example.org/a/",
+            Memory::default(),
+        ));
+        assert!(!view.is_open(), "an empty page opened the reader");
+        assert!(fetched(&context.take_commands()).is_empty());
+    }
+
+    /// Pictures are fetched one at a time, and a picture that will not come is
+    /// not allowed to stop the ones behind it.
+    #[test]
+    fn pictures_are_asked_for_one_at_a_time_and_a_failure_does_not_stall_the_rest() {
+        let mut context = Context::default();
+        let mut view = BookView::new();
+
+        assert!(view.open_html(
+            &mut context,
+            "<p>A body.</p><img src=\"x1.png\"><img src=\"https://evil.example/x2.png\">\
+             <img src=\"x3.png\">",
+            "https://arxiv.org/html/2401.00001v2/",
+            Memory::default(),
+        ));
+        assert_eq!(
+            fetched(&context.take_commands()),
+            vec!["https://arxiv.org/html/2401.00001v2/x1.png".to_owned()],
+            "more than one picture was asked for at once"
+        );
+
+        let first = view
+            .fetching
+            .as_ref()
+            .expect("the first fetch was not remembered")
+            .0;
+        let _ = view.woke(
+            &mut context,
+            first,
+            &TaskOutcome::Failed(TaskError::Unreachable),
+        );
+        // The second is another host's, so it is skipped without being asked
+        // for at all and the third is what comes next.
+        assert_eq!(
+            fetched(&context.take_commands()),
+            vec!["https://arxiv.org/html/2401.00001v2/x3.png".to_owned()],
+            "a refused address stopped the pictures behind it"
+        );
     }
 
     /// A plate is measured from its header and decoded later.
@@ -752,7 +1106,7 @@ mod tests {
         // The first pass reads the plate and asks for another; the second
         // reduces it to the panel's greys and hands it over. Neither half is
         // allowed to take as long as both would.
-        let step = view.woke(&mut context, first_task);
+        let step = view.woke(&mut context, first_task, &TaskOutcome::Cancelled);
         assert!(
             handed(&context.take_commands()).is_empty(),
             "a plate was decoded and dithered in one callback"
@@ -764,7 +1118,7 @@ mod tests {
         );
         let next = view.plating.expect("another pass was not asked for");
 
-        let step = view.woke(&mut context, next);
+        let step = view.woke(&mut context, next, &TaskOutcome::Cancelled);
         assert_eq!(
             handed(&context.take_commands()),
             vec![(claimed.handle, claimed.source.0, claimed.source.1)],
@@ -787,7 +1141,7 @@ mod tests {
         let mut context = Context::default();
         let mut view = BookView::new();
         assert_eq!(
-            view.woke(&mut context, TaskId(7)),
+            view.woke(&mut context, TaskId(7), &TaskOutcome::Cancelled),
             Step::Elsewhere,
             "an unrelated task was taken for a plate"
         );

--- a/crates/kobo-bookview/src/lib.rs
+++ b/crates/kobo-bookview/src/lib.rs
@@ -214,6 +214,37 @@ impl BookView {
         // spent its parse and its pagination, and a plate on top of that is
         // what puts a lifecycle callback past the watchdog's deadline.
         self.kick(context);
+        self.match_light(context);
+    }
+
+    /// Puts the light panel and the hardware into agreement, both ways round.
+    ///
+    /// The panel used to be seeded from the device only when the book had no
+    /// remembered level, which left the other case wrong in a way nobody could
+    /// see until they were in the dark: a book last read at eighty percent
+    /// opened saying eighty while the lamp was still at ten from the book
+    /// before it, and the first tap on "dimmer" jumped the room to seventy.
+    ///
+    /// So a book that has a level of its own now asserts it, and a book that
+    /// has none takes whatever the lamp is already at. Either way the number
+    /// under the reader's thumb is the number the hardware is holding.
+    fn match_light(&mut self, context: &mut Context) {
+        match self.reader.as_ref().and_then(Reader::light) {
+            Some(level) => context.device().set_frontlight(level),
+            None => context.device().read_frontlight(),
+        }
+    }
+
+    /// Takes a front light reading back from the device.
+    ///
+    /// Returns whether the panel changed and is worth redrawing. Applications
+    /// pass every [`kobo_sdk::DeviceResult::Frontlight`] here rather than
+    /// filtering first: a reading that arrives for a document already closed,
+    /// or that says what the panel already said, is quietly ignored.
+    pub fn took_light(&mut self, percent: u8) -> bool {
+        self.reader
+            .as_mut()
+            .is_some_and(|reader| reader.seed_light(percent))
     }
 
     /// Gives back everything the open document was costing.

--- a/crates/kobo-dict/Cargo.toml
+++ b/crates/kobo-dict/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kobo-dict"
+version.workspace = true
+edition.workspace = true
+publish = false
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Bounded offline dictionary indexes and lookup for Cobalt"
+
+[dependencies]
+unicode-normalization = "0.1.24"
+
+[lints]
+workspace = true

--- a/crates/kobo-dict/src/lib.rs
+++ b/crates/kobo-dict/src/lib.rs
@@ -1,0 +1,309 @@
+#![forbid(unsafe_code)]
+
+//! Offline dictionaries owned by the platform.
+//!
+//! Dictionaries are UTF-8 TSV files. Comment metadata may precede entries:
+//! `# name=Oxford`, `# language=en`, `# priority=10`. Every remaining line is
+//! `headword<TAB>definition`. A malformed line costs that line, never the
+//! other dictionaries or the reading session.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use unicode_normalization::UnicodeNormalization;
+
+pub const MAX_DICTIONARIES: usize = 32;
+pub const MAX_DICTIONARY_BYTES: usize = 8 * 1024 * 1024;
+pub const MAX_TOTAL_BYTES: usize = 64 * 1024 * 1024;
+pub const MAX_ENTRIES_PER_LOOKUP: usize = 8;
+pub const MAX_HEADWORD_BYTES: usize = 128;
+pub const MAX_DEFINITION_BYTES: usize = 4_096;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Entry {
+    pub dictionary: String,
+    pub language: String,
+    pub headword: String,
+    pub definition: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct StoredEntry {
+    headword: String,
+    definition: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Dictionary {
+    pub name: String,
+    pub language: String,
+    pub priority: i16,
+    entries: BTreeMap<String, Vec<StoredEntry>>,
+    pub rejected_lines: usize,
+}
+
+impl Dictionary {
+    #[must_use]
+    pub fn from_tsv(fallback_name: &str, source: &str) -> Self {
+        let mut dictionary = Self {
+            name: bounded_label(fallback_name, "Dictionary"),
+            language: "und".to_owned(),
+            priority: 0,
+            entries: BTreeMap::new(),
+            rejected_lines: 0,
+        };
+        for line in source.lines() {
+            let line = line.trim_end_matches('\r');
+            if let Some(metadata) = line.strip_prefix('#') {
+                dictionary.apply_metadata(metadata.trim());
+                continue;
+            }
+            if line.trim().is_empty() {
+                continue;
+            }
+            let Some((headword, definition)) = line.split_once('\t') else {
+                dictionary.rejected_lines += 1;
+                continue;
+            };
+            let headword = headword.trim();
+            let definition = definition.trim();
+            if headword.is_empty()
+                || definition.is_empty()
+                || headword.len() > MAX_HEADWORD_BYTES
+                || definition.len() > MAX_DEFINITION_BYTES
+            {
+                dictionary.rejected_lines += 1;
+                continue;
+            }
+            let key = normalize(headword);
+            if key.is_empty() {
+                dictionary.rejected_lines += 1;
+                continue;
+            }
+            dictionary
+                .entries
+                .entry(key)
+                .or_default()
+                .push(StoredEntry {
+                    headword: headword.to_owned(),
+                    definition: definition.to_owned(),
+                });
+        }
+        dictionary
+    }
+
+    fn apply_metadata(&mut self, metadata: &str) {
+        let Some((key, value)) = metadata.split_once('=') else {
+            return;
+        };
+        match key.trim() {
+            "name" => self.name = bounded_label(value.trim(), &self.name),
+            "language" if valid_language(value.trim()) => {
+                value.trim().clone_into(&mut self.language);
+            }
+            "priority" => {
+                if let Ok(priority) = value.trim().parse() {
+                    self.priority = priority;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct Index {
+    dictionaries: Vec<Dictionary>,
+}
+
+impl Index {
+    pub fn install(&mut self, dictionary: Dictionary) -> bool {
+        if self.dictionaries.len() >= MAX_DICTIONARIES || dictionary.entries.is_empty() {
+            return false;
+        }
+        self.dictionaries.push(dictionary);
+        self.dictionaries.sort_by(|left, right| {
+            right
+                .priority
+                .cmp(&left.priority)
+                .then_with(|| left.name.cmp(&right.name))
+                .then_with(|| left.language.cmp(&right.language))
+        });
+        true
+    }
+
+    #[must_use]
+    pub fn load_directory(path: &Path) -> Self {
+        let mut index = Self::default();
+        let Ok(entries) = fs::read_dir(path) else {
+            return index;
+        };
+        let mut paths = entries
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().is_some_and(|extension| extension == "tsv"))
+            .collect::<Vec<_>>();
+        paths.sort();
+        let mut total = 0usize;
+        for path in paths.into_iter().take(MAX_DICTIONARIES) {
+            let Ok(metadata) = fs::symlink_metadata(&path) else {
+                continue;
+            };
+            if !metadata.file_type().is_file() {
+                continue;
+            }
+            let Ok(length) = usize::try_from(metadata.len()) else {
+                continue;
+            };
+            if length > MAX_DICTIONARY_BYTES || total.saturating_add(length) > MAX_TOTAL_BYTES {
+                continue;
+            }
+            let Ok(source) = fs::read_to_string(&path) else {
+                continue;
+            };
+            total += length;
+            let name = path
+                .file_stem()
+                .and_then(|name| name.to_str())
+                .unwrap_or("Dictionary");
+            let _ = index.install(Dictionary::from_tsv(name, &source));
+        }
+        index
+    }
+
+    #[must_use]
+    pub fn lookup(&self, word: &str, language: Option<&str>) -> Vec<Entry> {
+        let keys = lookup_keys(word);
+        let mut found = Vec::new();
+        for dictionary in &self.dictionaries {
+            if language.is_some_and(|wanted| {
+                dictionary.language != "und"
+                    && !dictionary.language.eq_ignore_ascii_case(wanted)
+                    && !dictionary.language.starts_with(&format!("{wanted}-"))
+            }) {
+                continue;
+            }
+            for key in &keys {
+                let Some(entries) = dictionary.entries.get(key) else {
+                    continue;
+                };
+                for entry in entries {
+                    found.push(Entry {
+                        dictionary: dictionary.name.clone(),
+                        language: dictionary.language.clone(),
+                        headword: entry.headword.clone(),
+                        definition: entry.definition.clone(),
+                    });
+                    if found.len() >= MAX_ENTRIES_PER_LOOKUP {
+                        return found;
+                    }
+                }
+                break;
+            }
+        }
+        found
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.dictionaries.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.dictionaries.is_empty()
+    }
+}
+
+#[must_use]
+pub fn normalize(value: &str) -> String {
+    value
+        .trim_matches(|character: char| !character.is_alphanumeric())
+        .nfkc()
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn lookup_keys(word: &str) -> Vec<String> {
+    let exact = normalize(word);
+    let mut keys = vec![exact.clone()];
+    let mut add = |candidate: String| {
+        if !candidate.is_empty() && !keys.contains(&candidate) {
+            keys.push(candidate);
+        }
+    };
+    if let Some(stem) = exact.strip_suffix("'s") {
+        add(stem.to_owned());
+    }
+    if let Some(stem) = exact.strip_suffix("ies") {
+        add(format!("{stem}y"));
+    }
+    for suffix in ["ing", "ed", "es", "s"] {
+        if let Some(stem) = exact
+            .strip_suffix(suffix)
+            .filter(|stem| stem.chars().count() >= 3)
+        {
+            add(stem.to_owned());
+            if matches!(suffix, "ing" | "ed") {
+                add(format!("{stem}e"));
+            }
+        }
+    }
+    keys
+}
+
+fn bounded_label(value: &str, fallback: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() || value.len() > 96 {
+        fallback.to_owned()
+    } else {
+        value.to_owned()
+    }
+}
+
+fn valid_language(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 16
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact_normalized_and_inflected_words_are_found_without_a_network() {
+        let source = "# name=Pocket English\n# language=en\nCafé\tA small coffee house.\nstory\tAn account of events.\nmake\tTo create.\n";
+        let mut index = Index::default();
+        assert!(index.install(Dictionary::from_tsv("fallback", source)));
+        assert_eq!(index.lookup("CAFÉ!", Some("en"))[0].headword, "Café");
+        assert_eq!(index.lookup("stories", Some("en"))[0].headword, "story");
+        assert_eq!(index.lookup("making", Some("en"))[0].headword, "make");
+    }
+
+    #[test]
+    fn dictionary_order_is_priority_then_name_and_results_are_bounded() {
+        let mut index = Index::default();
+        for number in 0..12 {
+            let source =
+                format!("# name=D{number:02}\n# priority={number}\nword\tDefinition {number}\n");
+            assert!(index.install(Dictionary::from_tsv("fallback", &source)));
+        }
+        let found = index.lookup("word", None);
+        assert_eq!(found.len(), MAX_ENTRIES_PER_LOOKUP);
+        assert_eq!(found[0].dictionary, "D11");
+    }
+
+    #[test]
+    fn malformed_and_oversized_lines_are_isolated() {
+        let long = "x".repeat(MAX_DEFINITION_BYTES + 1);
+        let dictionary =
+            Dictionary::from_tsv("Safe", &format!("broken\ngood\tUseful.\nlarge\t{long}\n"));
+        assert_eq!(dictionary.rejected_lines, 2);
+        let mut index = Index::default();
+        assert!(index.install(dictionary));
+        assert_eq!(index.lookup("good", None)[0].definition, "Useful.");
+    }
+}

--- a/crates/kobo-doc/src/epub.rs
+++ b/crates/kobo-doc/src/epub.rs
@@ -910,13 +910,19 @@ fn unescape(path: &str) -> String {
     let mut at = 0;
     while at < bytes.len() {
         // A `%` that is not followed by two hex digits is a literal `%`, which
-        // is a character a filename is allowed to contain.
+        // is a character a filename is allowed to contain. The two digits are
+        // read as bytes rather than sliced out of the string: `%` followed by
+        // one ASCII byte and a multibyte character would otherwise cut that
+        // character in half, and publisher CSS supplies these names.
         if bytes[at] == b'%' && at + 2 < bytes.len() {
-            let hex = &path[at + 1..at + 3];
-            if let Ok(byte) = u8::from_str_radix(hex, 16) {
-                out.push(byte);
-                at += 3;
-                continue;
+            let high = char::from(bytes[at + 1]).to_digit(16);
+            let low = char::from(bytes[at + 2]).to_digit(16);
+            if let (Some(high), Some(low)) = (high, low) {
+                if let Ok(byte) = u8::try_from(high * 16 + low) {
+                    out.push(byte);
+                    at += 3;
+                    continue;
+                }
             }
         }
         out.push(bytes[at]);
@@ -1854,6 +1860,12 @@ mod tests {
         assert_eq!(unescape("100%"), "100%");
         assert_eq!(unescape("a%zzb"), "a%zzb");
         assert_eq!(unescape("a%20b"), "a b");
+        // A `%` followed by one ASCII byte and a multibyte character. The two
+        // digits are read as bytes, so this cannot cut the character in half.
+        // Publisher `@font-face` URLs reach this, so a book must not be able
+        // to choose the panic.
+        assert_eq!(unescape("a%bé.otf"), "a%bé.otf");
+        assert_eq!(unescape("%é"), "%é");
     }
 
     #[test]

--- a/crates/kobo-doc/src/epub.rs
+++ b/crates/kobo-doc/src/epub.rs
@@ -34,7 +34,7 @@ use kobo_html::{attribute, decode_entities, element_name, skip_element};
 
 use crate::html::skip_bracketed;
 use crate::zip::{self, Archive};
-use crate::{collapse, Block, Builder, Contents, Document};
+use crate::{collapse, Block, Builder, Contents, Document, EmbeddedFont};
 
 /// Where the container always is. The one path in an EPUB that is fixed.
 const CONTAINER: &str = "META-INF/container.xml";
@@ -81,6 +81,7 @@ pub fn parse(bytes: &[u8]) -> Result<Document, Fault> {
     let package_at = find_package(&archive).ok_or(Fault::NotABook)?;
     let package = read_package(&text_of(&archive.read(&package_at)?));
     let base = directory_of(&package_at);
+    let publisher_styles = stylesheets_of(&archive, &package, &base);
 
     let mut builder = Builder::new();
     // The package's own metadata outranks anything found inside a chapter: the
@@ -118,7 +119,7 @@ pub fn parse(bytes: &[u8]) -> Result<Document, Fault> {
         let Ok(bytes) = archive.read(&name) else {
             continue;
         };
-        let part = crate::html::parse(&strip_toc(&text_of(&bytes)));
+        let part = crate::html::parse_with_css(&strip_toc(&text_of(&bytes)), &publisher_styles.css);
         truncated |= part.truncated;
         if part.blocks.is_empty() {
             // An empty file (a cover page holding only an image) should not
@@ -162,8 +163,13 @@ pub fn parse(bytes: &[u8]) -> Result<Document, Fault> {
             links.push(link);
         }
         starts.push((name, start));
-        for block in part.blocks {
-            builder.push(block);
+        let mut rich = part.rich;
+        for (part_index, block) in part.blocks.into_iter().enumerate() {
+            if let Some(styled) = rich.remove(&part_index) {
+                builder.push_rich(block, styled);
+            } else {
+                builder.push(block);
+            }
         }
         parts += 1;
     }
@@ -175,9 +181,174 @@ pub fn parse(bytes: &[u8]) -> Result<Document, Fault> {
     builder.set_anchors(anchors);
     builder.set_links(links);
     builder.set_images(images_of(&archive, &builder));
+    builder.set_fonts(fonts_of(
+        &archive,
+        &package,
+        &base,
+        &publisher_styles.font_families,
+    ));
     let mut document = builder.finish();
     document.truncated |= truncated;
     Ok(document)
+}
+
+const MAX_STYLESHEET_BYTES: usize = 256 * 1024;
+
+#[derive(Default)]
+struct PublisherStyles {
+    css: String,
+    font_families: BTreeMap<String, String>,
+}
+
+fn stylesheets_of(archive: &Archive<'_>, package: &Package, base: &str) -> PublisherStyles {
+    let mut styles = PublisherStyles::default();
+    let mut css = String::new();
+    for item in package.manifest.values() {
+        let is_css_name = std::path::Path::new(&item.href)
+            .extension()
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("css"));
+        if !item.media_type.eq_ignore_ascii_case("text/css") && !is_css_name {
+            continue;
+        }
+        let stylesheet_name = resolve(base, &item.href);
+        let Ok(bytes) = archive.read(&stylesheet_name) else {
+            continue;
+        };
+        let text = text_of(&bytes);
+        read_font_faces(
+            &text,
+            &directory_of(&stylesheet_name),
+            &mut styles.font_families,
+        );
+        let left = MAX_STYLESHEET_BYTES.saturating_sub(css.len());
+        if left == 0 {
+            break;
+        }
+        let mut take = text.len().min(left);
+        while !text.is_char_boundary(take) {
+            take -= 1;
+        }
+        css.push_str(&text[..take]);
+        css.push('\n');
+    }
+    styles.css = css;
+    styles
+}
+
+/// Reads the small part of `@font-face` needed to connect a CSS family name
+/// to its archive asset. Unknown descriptors and remote/data URLs are ignored.
+fn read_font_faces(css: &str, base: &str, families: &mut BTreeMap<String, String>) {
+    let lower = css.to_ascii_lowercase();
+    let mut at = 0usize;
+    while let Some(found) = lower[at..].find("@font-face") {
+        let found = at + found;
+        let Some(open) = lower[found..].find('{').map(|offset| found + offset) else {
+            break;
+        };
+        let Some(close) = lower[open + 1..].find('}').map(|offset| open + 1 + offset) else {
+            break;
+        };
+        let body = &css[open + 1..close];
+        let mut family = None;
+        let mut source = None;
+        for declaration in body.split(';') {
+            let Some((name, value)) = declaration.split_once(':') else {
+                continue;
+            };
+            match name.trim().to_ascii_lowercase().as_str() {
+                "font-family" => {
+                    let value = value.trim().trim_matches(['\'', '"']);
+                    if !value.is_empty() && value.len() <= 128 {
+                        family = Some(value.to_owned());
+                    }
+                }
+                "src" => {
+                    let value_lower = value.to_ascii_lowercase();
+                    if let Some(start) = value_lower.find("url(") {
+                        let inside = &value[start + 4..];
+                        if let Some(end) = inside.find(')') {
+                            let url = inside[..end].trim().trim_matches(['\'', '"']);
+                            if !url.starts_with("data:") && !url.contains("://") {
+                                source = Some(resolve(base, url));
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        if let (Some(source), Some(family)) = (source, family) {
+            families.entry(source).or_insert(family);
+        }
+        at = close + 1;
+    }
+}
+
+/// The most publisher-font data retained from one book.
+///
+/// Two regular/italic faces in a typical EPUB are comfortably below this.
+/// The cap prevents a package manifest from turning the document model into
+/// an unbounded copy of arbitrary archive members.
+const MAX_FONT_BYTES: usize = 4 * 1024 * 1024;
+
+/// The largest single outline face accepted from a book.
+const MAX_ONE_FONT_BYTES: usize = 2 * 1024 * 1024;
+
+/// Reads bounded font resources named by the package manifest.
+fn fonts_of(
+    archive: &Archive<'_>,
+    package: &Package,
+    base: &str,
+    families: &BTreeMap<String, String>,
+) -> BTreeMap<String, EmbeddedFont> {
+    let mut fonts = BTreeMap::new();
+    let mut total = 0usize;
+    for item in package.manifest.values() {
+        if !is_font(&item.media_type, &item.href) {
+            continue;
+        }
+        let name = resolve(base, &item.href);
+        if fonts.contains_key(&name) {
+            continue;
+        }
+        let Ok(bytes) = archive.read(&name) else {
+            continue;
+        };
+        if bytes.len() > MAX_ONE_FONT_BYTES || total.saturating_add(bytes.len()) > MAX_FONT_BYTES {
+            continue;
+        }
+        total += bytes.len();
+        let family = families.get(&name).cloned();
+        fonts.insert(
+            name,
+            EmbeddedFont {
+                media_type: item.media_type.clone(),
+                family,
+                bytes,
+            },
+        );
+    }
+    fonts
+}
+
+fn is_font(media_type: &str, href: &str) -> bool {
+    let media_type = media_type.to_ascii_lowercase();
+    if matches!(
+        media_type.as_str(),
+        "font/ttf"
+            | "font/otf"
+            | "font/woff"
+            | "font/woff2"
+            | "application/font-sfnt"
+            | "application/font-woff"
+            | "application/vnd.ms-opentype"
+    ) {
+        return true;
+    }
+    let href = href.to_ascii_lowercase();
+    [".ttf", ".otf", ".woff", ".woff2"]
+        .iter()
+        .any(|suffix| href.ends_with(suffix))
 }
 
 /// The most contents entries kept from one book.
@@ -1064,6 +1235,78 @@ mod tests {
                 "It got worse."
             ]
         );
+    }
+
+    #[test]
+    fn publisher_fonts_are_carried_as_bounded_document_assets() {
+        let package = opf(
+            r#"<itemref idref="one"/>"#,
+            r#"<item id="one" href="one.xhtml" media-type="application/xhtml+xml"/>
+               <item id="css" href="styles/book.css" media-type="text/css"/>
+               <item id="serif" href="fonts/Book.otf" media-type="font/otf"/>"#,
+        );
+        let bytes = b"OTTOindependently-authored-font-fixture";
+        let book = archive(&[
+            ("mimetype", b"application/epub+zip"),
+            ("META-INF/container.xml", CONTAINER_XML.as_bytes()),
+            ("OEBPS/book.opf", package.as_bytes()),
+            ("OEBPS/one.xhtml", b"<p>The words.</p>"),
+            (
+                "OEBPS/styles/book.css",
+                b"@font-face { font-family: 'Publisher Serif'; src: url('../fonts/Book.otf'); }",
+            ),
+            ("OEBPS/fonts/Book.otf", bytes),
+        ]);
+
+        let document = parse(&book).expect("a readable book");
+        let font = document
+            .fonts
+            .get("OEBPS/fonts/Book.otf")
+            .expect("publisher font");
+        assert_eq!(font.media_type, "font/otf");
+        assert_eq!(font.family.as_deref(), Some("Publisher Serif"));
+        assert_eq!(font.bytes, bytes);
+    }
+
+    #[test]
+    fn package_stylesheets_are_applied_to_spine_xhtml() {
+        let package = opf(
+            r#"<itemref idref="one"/>"#,
+            r#"<item id="one" href="one.xhtml" media-type="application/xhtml+xml"/>
+               <item id="css" href="book.css" media-type="text/css"/>"#,
+        );
+        let book = archive(&[
+            ("META-INF/container.xml", CONTAINER_XML.as_bytes()),
+            ("OEBPS/book.opf", package.as_bytes()),
+            (
+                "OEBPS/book.css",
+                b".opening { text-align: center; line-height: 150%; }",
+            ),
+            ("OEBPS/one.xhtml", b"<p class=\"opening\">Styled words.</p>"),
+        ]);
+        let document = parse(&book).expect("a readable book");
+        let rich = document.rich.get(&0).expect("publisher style");
+        assert_eq!(rich.style.alignment, crate::TextAlignment::Center);
+        assert_eq!(rich.style.line_height_percent, 150);
+    }
+
+    #[test]
+    fn an_oversized_publisher_font_is_not_retained() {
+        let package = opf(
+            r#"<itemref idref="one"/>"#,
+            r#"<item id="one" href="one.xhtml" media-type="application/xhtml+xml"/>
+               <item id="serif" href="huge.ttf" media-type="font/ttf"/>"#,
+        );
+        let huge = vec![0; MAX_ONE_FONT_BYTES + 1];
+        let book = archive(&[
+            ("META-INF/container.xml", CONTAINER_XML.as_bytes()),
+            ("OEBPS/book.opf", package.as_bytes()),
+            ("OEBPS/one.xhtml", b"<p>The words.</p>"),
+            ("OEBPS/huge.ttf", &huge),
+        ]);
+
+        let document = parse(&book).expect("the prose remains readable");
+        assert!(document.fonts.is_empty());
     }
 
     #[test]

--- a/crates/kobo-doc/src/html.rs
+++ b/crates/kobo-doc/src/html.rs
@@ -211,6 +211,18 @@ impl State {
         }
     }
 
+    /// Writes text the document did not literally contain.
+    ///
+    /// A line break's space, a table cell's separator, a picture's bracketed
+    /// description: each has to reach the styled runs as well as the block
+    /// text. If only one of the two receives it the runs stop matching the
+    /// block, and `bound_rich_spans` answers that by throwing away every
+    /// emphasis the block had.
+    fn synthetic(&mut self, text: &str) {
+        self.text.push_str(text);
+        self.push_span(text);
+    }
+
     #[allow(clippy::too_many_lines)]
     fn open(&mut self, name: &str, inside: &str) {
         // Inside a `<pre>`, nothing but its own end tag changes anything. A
@@ -218,7 +230,7 @@ impl State {
         // would lose the shape that is the whole point of the element.
         if self.pre > 0 {
             if name == "br" {
-                self.text.push('\n');
+                self.synthetic("\n");
             }
             return;
         }
@@ -276,16 +288,17 @@ impl State {
             // A `<br>` is a soft break. One column, and the paginator wraps:
             // honouring it would give a ragged short line in the middle of a
             // paragraph.
-            "br" => self.text.push(' '),
+            "br" => self.synthetic(" "),
             // A picture cannot be drawn inside a run of text, so what it was
             // described as is the only part that can survive. An `<img>` with
             // no description says nothing, and brackets around nothing would
             // be worse than silence.
             "img" | "image" => {
                 if let Some(alt) = attribute(inside, "alt").filter(|alt| !alt.trim().is_empty()) {
-                    self.text.push_str(" [");
-                    self.text.push_str(&decode_entities(alt));
-                    self.text.push_str("] ");
+                    let alt = decode_entities(alt);
+                    self.synthetic(" [");
+                    self.synthetic(&alt);
+                    self.synthetic("] ");
                 }
             }
             "hr" => {
@@ -329,10 +342,12 @@ impl State {
             }
             // A cell is not a paragraph of its own; a row is. Running the
             // cells together with a mark that does not occur inside one keeps
-            // the row readable in a single column.
+            // the row readable in a single column. The mark goes into the
+            // styled runs too, or the runs stop matching the block text and
+            // the row loses every emphasis it had.
             "td" | "th" => {
                 if !self.text.trim_end().is_empty() {
-                    self.text.push_str(" \u{2014} ");
+                    self.synthetic(" \u{2014} ");
                 }
             }
             _ => {
@@ -516,42 +531,67 @@ fn embedded_styles(source: &str) -> String {
     out
 }
 
+/// At-rules whose body holds further rules rather than declarations.
+///
+/// Their contents have to be read, not skipped: a publisher that wraps its
+/// whole stylesheet in `@media screen` is still styling the book.
+const NESTED_AT_RULES: [&str; 5] = ["media", "supports", "document", "layer", "container"];
+
+/// How deeply conditional groups are followed before the rest is ignored.
+const MAX_AT_RULE_DEPTH: usize = 4;
+
+/// Removes `/* ... */` comments.
+///
+/// A brace inside a comment is not a block, and leaving one in desynchronises
+/// every rule after it. An unterminated comment runs to the end of the sheet,
+/// which is what a browser does with one.
+fn strip_css_comments(css: &str) -> String {
+    let mut out = String::with_capacity(css.len());
+    let mut rest = css;
+    while let Some(open) = rest.find("/*") {
+        out.push_str(&rest[..open]);
+        let after = &rest[open + 2..];
+        let Some(close) = after.find("*/") else {
+            return out;
+        };
+        rest = &after[close + 2..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// The byte index of the `}` closing the block that opens at `open`.
+fn matching_brace(css: &str, open: usize) -> Option<usize> {
+    let mut depth = 0usize;
+    for (at, character) in css[open..].char_indices() {
+        match character {
+            '{' => depth += 1,
+            '}' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(open + at);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// The at-rule keyword `@media screen and (...)` begins with, lowercased.
+fn at_rule_keyword(selectors: &str) -> String {
+    selectors
+        .trim_start_matches('@')
+        .chars()
+        .take_while(char::is_ascii_alphabetic)
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
 impl StyleSheet {
     fn parse(css: &str) -> Self {
         let mut rules = Vec::new();
-        let mut rest = css;
-        while rules.len() < MAX_CSS_RULES {
-            let Some(open) = rest.find('{') else { break };
-            let selectors = rest[..open].trim();
-            let tail = &rest[open + 1..];
-            let Some(close) = tail.find('}') else { break };
-            let body = tail[..close].trim();
-            rest = &tail[close + 1..];
-            if selectors.starts_with('@') || body.is_empty() {
-                continue;
-            }
-            for selector in selectors.split(',') {
-                let selector = selector.trim().to_ascii_lowercase();
-                if selector.is_empty()
-                    || selector.contains([' ', '>', '+', '~', '[', ':', '*'])
-                    || rules.len() >= MAX_CSS_RULES
-                {
-                    continue;
-                }
-                let specificity = u8::from(selector.contains('#')) * 100
-                    + u8::try_from(selector.matches('.').count())
-                        .unwrap_or(9)
-                        .min(9)
-                        * 10
-                    + u8::from(!selector.starts_with(['.', '#']));
-                rules.push(CssRule {
-                    selector,
-                    declarations: body.to_owned(),
-                    specificity,
-                    order: rules.len(),
-                });
-            }
-        }
+        collect_rules(&strip_css_comments(css), 0, &mut rules);
         Self { rules }
     }
 
@@ -573,6 +613,62 @@ impl StyleSheet {
             result.push_str(inline);
         }
         result
+    }
+}
+
+/// Reads rules from one stylesheet level, following conditional groups.
+///
+/// Block extents are found by matching braces rather than by the first `}`,
+/// so a nested `@media` body cannot leave the scanner pointing into the
+/// middle of the sheet and silently discard every rule after it.
+fn collect_rules(css: &str, depth: usize, rules: &mut Vec<CssRule>) {
+    let mut rest = css;
+    while rules.len() < MAX_CSS_RULES {
+        let Some(open) = rest.find('{') else { break };
+        let selectors = rest[..open].trim();
+        let Some(close) = matching_brace(rest, open) else {
+            break;
+        };
+        let body = rest[open + 1..close].trim();
+        let tail = &rest[close + 1..];
+        if selectors.starts_with('@') {
+            // A conditional group wraps ordinary rules, so its body is read at
+            // the next level. A flat at-rule such as `@font-face` or `@page`
+            // carries declarations this parser has no selector for, and is
+            // skipped whole.
+            if depth < MAX_AT_RULE_DEPTH
+                && NESTED_AT_RULES.contains(&at_rule_keyword(selectors).as_str())
+            {
+                collect_rules(body, depth + 1, rules);
+            }
+            rest = tail;
+            continue;
+        }
+        rest = tail;
+        if body.is_empty() {
+            continue;
+        }
+        for selector in selectors.split(',') {
+            let selector = selector.trim().to_ascii_lowercase();
+            if selector.is_empty()
+                || selector.contains([' ', '>', '+', '~', '[', ':', '*'])
+                || rules.len() >= MAX_CSS_RULES
+            {
+                continue;
+            }
+            let specificity = u8::from(selector.contains('#')) * 100
+                + u8::try_from(selector.matches('.').count())
+                    .unwrap_or(9)
+                    .min(9)
+                    * 10
+                + u8::from(!selector.starts_with(['.', '#']));
+            rules.push(CssRule {
+                selector,
+                declarations: body.to_owned(),
+                specificity,
+                order: rules.len(),
+            });
+        }
     }
 }
 
@@ -804,6 +900,105 @@ fn breaks_a_block(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rules_after_a_conditional_group_are_still_read() {
+        // A publisher that opens with `@media` was previously losing every
+        // rule that followed, because the scanner resumed inside the group.
+        let document = parse_with_css(
+            "<p class=\"opening\">Styled words.</p>",
+            "@media screen { p { text-align: right } }\n.opening { text-align: center; }",
+        );
+        let rich = document.rich.get(&0).expect("publisher style");
+        assert_eq!(rich.style.alignment, TextAlignment::Center);
+    }
+
+    #[test]
+    fn rules_inside_a_conditional_group_apply() {
+        let document = parse_with_css(
+            "<p class=\"opening\">Styled words.</p>",
+            "@media screen and (min-width: 100px) { .opening { text-align: center } }",
+        );
+        let rich = document.rich.get(&0).expect("publisher style");
+        assert_eq!(rich.style.alignment, TextAlignment::Center);
+    }
+
+    #[test]
+    fn a_flat_at_rule_does_not_consume_the_rules_after_it() {
+        let document = parse_with_css(
+            "<p class=\"opening\">Styled words.</p>",
+            "@font-face { font-family: 'X'; src: url(x.otf) }\n.opening { text-align: center; }",
+        );
+        let rich = document.rich.get(&0).expect("publisher style");
+        assert_eq!(rich.style.alignment, TextAlignment::Center);
+    }
+
+    #[test]
+    fn a_comment_holding_a_brace_does_not_swallow_the_stylesheet() {
+        let document = parse_with_css(
+            "<p class=\"opening\">Styled words.</p>",
+            "/* the opening { rule */ .opening { text-align: center; }",
+        );
+        let rich = document.rich.get(&0).expect("publisher style");
+        assert_eq!(rich.style.alignment, TextAlignment::Center);
+    }
+
+    #[test]
+    fn an_unterminated_comment_ends_the_stylesheet_rather_than_the_reader() {
+        let document = parse_with_css(
+            "<p class=\"opening\">Styled words.</p>",
+            ".opening { text-align: center; } /* and then nothing closes",
+        );
+        let rich = document.rich.get(&0).expect("publisher style");
+        assert_eq!(rich.style.alignment, TextAlignment::Center);
+    }
+
+    #[test]
+    fn deeply_nested_conditional_groups_stay_bounded() {
+        let mut css = String::new();
+        for _ in 0..64 {
+            css.push_str("@media screen {");
+        }
+        css.push_str(".opening { text-align: center }");
+        for _ in 0..64 {
+            css.push('}');
+        }
+        // The point is that this returns at all, and without the rule, rather
+        // than recursing once per group.
+        let document = parse_with_css("<p class=\"opening\">Styled words.</p>", &css);
+        let rich = document.rich.get(&0).expect("a block is still produced");
+        assert_eq!(rich.style.alignment, TextAlignment::Start);
+    }
+
+    #[test]
+    fn emphasis_survives_a_line_break_inside_a_paragraph() {
+        // `<br>` writes a space the source never held. When it reached only
+        // the block text, the runs stopped matching it and every emphasis in
+        // the paragraph was thrown away -- which is most EPUB verse.
+        let document = parse("<p><b>One line</b><br>and its <i>continuation</i>.</p>");
+        assert_eq!(
+            document.blocks[0].text(),
+            Some("One line and its continuation.")
+        );
+        let rich = document.rich.get(&0).expect("retained emphasis");
+        assert!(rich.spans.iter().any(|span| span.style.strong));
+        assert!(rich.spans.iter().any(|span| span.style.emphasis));
+    }
+
+    #[test]
+    fn emphasis_survives_a_table_row() {
+        let document = parse("<table><tr><td>Plain</td><td><b>Bold</b></td></tr></table>");
+        assert_eq!(document.blocks[0].text(), Some("Plain \u{2014} Bold"));
+        let rich = document.rich.get(&0).expect("retained emphasis");
+        assert!(rich.spans.iter().any(|span| span.style.strong));
+    }
+
+    #[test]
+    fn emphasis_survives_a_described_picture_in_a_run_of_text() {
+        let document = parse("<p>Before <img alt=\"a lantern\"> and <b>after</b>.</p>");
+        let rich = document.rich.get(&0).expect("retained emphasis");
+        assert!(rich.spans.iter().any(|span| span.style.strong));
+    }
 
     #[test]
     fn a_heading_survives_as_a_heading() {

--- a/crates/kobo-doc/src/html.rs
+++ b/crates/kobo-doc/src/html.rs
@@ -31,7 +31,21 @@ use crate::{
 };
 
 /// Elements whose contents are instructions rather than words.
-const OPAQUE: [&str; 4] = ["script", "style", "svg", "iframe"];
+const OPAQUE: [&str; 3] = ["script", "style", "iframe"];
+
+/// Elements that carry their own reading in an attribute.
+///
+/// `MathML` is the case that matters. Every renderer that turns a paper into a
+/// web page -- `LaTeXML`, which is what arXiv uses, above all -- writes an
+/// equation as a tree of `<mi>`, `<mo>` and `<mrow>` whose text nodes are the
+/// individual symbols. Read as prose those come out as a run of unspaced
+/// letters and operators in the middle of a sentence: "where italic-x
+/// plus-or-minus 1" for something that was one formula.
+///
+/// The same renderers put the source of the equation in `alttext`, which is
+/// the line the author actually wrote. It is not typeset, but it is a
+/// mathematician's notation rather than a machine's, and it reads.
+const ALT_TEXT: [&str; 2] = ["math", "svg"];
 
 /// Reads an HTML document.
 #[must_use]
@@ -80,6 +94,28 @@ pub fn parse_with_css(source: &str, external_css: &str) -> Document {
 
         let name = element_name(inside);
         let closing = inside.starts_with('/');
+        if !closing && ALT_TEXT.contains(&name.as_str()) {
+            // Read from the attribute, never from the children: the point is
+            // that the children are notation and the attribute is the reading
+            // of it. An element with neither is skipped in silence, which is
+            // what a picture with no caption gets too.
+            for spelling in ["alttext", "aria-label", "title"] {
+                let Some(text) = attribute(inside, spelling).map(str::trim) else {
+                    continue;
+                };
+                if !text.is_empty() {
+                    // Spaced on both sides because an equation sits inside a
+                    // sentence, and the tags either side of it carry no
+                    // whitespace of their own.
+                    state.words(" ");
+                    state.words(text);
+                    state.words(" ");
+                    break;
+                }
+            }
+            rest = skip_element(rest, &name);
+            continue;
+        }
         if !closing && OPAQUE.contains(&name.as_str()) {
             rest = skip_element(rest, &name);
             continue;
@@ -900,6 +936,34 @@ fn breaks_a_block(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An equation is read from its `alttext`, not from its symbols.
+    ///
+    /// This is the shape `LaTeXML` gives every formula on arXiv. Reading the
+    /// element's children puts each symbol on the page as a separate word;
+    /// reading the attribute puts the line the author wrote.
+    #[test]
+    fn an_equation_is_read_from_the_line_the_author_wrote() {
+        let document = parse(
+            "<p>We take <math alttext=\"x \\pm 1\" display=\"inline\">\
+             <mi>x</mi><mo>&#xB1;</mo><mn>1</mn></math> as given.</p>",
+        );
+        let Block::Paragraph(text) = &document.blocks[0] else {
+            panic!("not a paragraph: {:?}", document.blocks[0]);
+        };
+        assert_eq!(text, "We take x \\pm 1 as given.");
+    }
+
+    /// A formula with no reading of its own says nothing rather than saying
+    /// its own markup.
+    #[test]
+    fn an_equation_with_no_reading_is_left_out() {
+        let document = parse("<p>We take <math><mi>x</mi><mn>1</mn></math> as given.</p>");
+        let Block::Paragraph(text) = &document.blocks[0] else {
+            panic!("not a paragraph: {:?}", document.blocks[0]);
+        };
+        assert_eq!(text, "We take as given.");
+    }
 
     #[test]
     fn rules_after_a_conditional_group_are_still_read() {

--- a/crates/kobo-doc/src/html.rs
+++ b/crates/kobo-doc/src/html.rs
@@ -177,6 +177,25 @@ struct State {
     /// Whether the words being collected are the document's title rather than
     /// something to draw.
     titling: bool,
+    /// The table row being read, once `<tr>` has opened one.
+    ///
+    /// A cell's words are collected by the same machinery as a paragraph's
+    /// and taken out again when the cell closes, so everything that already
+    /// worked inside prose -- entities, inline tags, links -- works inside a
+    /// cell without a second implementation of any of it.
+    row: Option<Row>,
+}
+
+/// A table row part way through being read.
+#[derive(Default)]
+struct Row {
+    cells: Vec<String>,
+    /// Set by the first `th` in the row. A row of headings names the columns
+    /// and is drawn differently from one that fills them.
+    header: bool,
+    /// Whether a cell is open, so that the words collected since belong to it
+    /// rather than to the row's stray text.
+    open: bool,
 }
 
 impl State {
@@ -198,6 +217,7 @@ impl State {
             item: false,
             caption: false,
             titling: false,
+            row: None,
         }
     }
 
@@ -376,14 +396,27 @@ impl State {
                 apply_inline_style(&mut self.inline, Some(&declarations));
                 self.caption = true;
             }
-            // A cell is not a paragraph of its own; a row is. Running the
-            // cells together with a mark that does not occur inside one keeps
-            // the row readable in a single column. The mark goes into the
-            // styled runs too, or the runs stop matching the block text and
-            // the row loses every emphasis it had.
+            // A row is one block and a cell is one column of it. Both are
+            // needed: a cell alone cannot be laid out, because how wide it is
+            // depends on every other cell in its column, and a row alone
+            // cannot say where one value ends and the next begins.
+            "tr" => {
+                self.end_row();
+                self.flush();
+                self.row = Some(Row::default());
+            }
             "td" | "th" => {
-                if !self.text.trim_end().is_empty() {
-                    self.synthetic(" \u{2014} ");
+                // A cell outside any row is a cell in a table written without
+                // one, which is common enough in hand-written HTML. It opens
+                // a row so that the cells still line up with each other.
+                if self.row.is_none() {
+                    self.flush();
+                    self.row = Some(Row::default());
+                }
+                self.end_cell();
+                if let Some(row) = &mut self.row {
+                    row.open = true;
+                    row.header |= name == "th";
                 }
             }
             _ => {
@@ -448,6 +481,14 @@ impl State {
                 self.lists.pop();
             }
             "title" => self.flush(),
+            "td" | "th" => self.end_cell(),
+            "tr" => self.end_row(),
+            // A table that ends with a row still open is a table whose last
+            // `</tr>` was never written, which is a page, not a corner.
+            "table" | "thead" | "tbody" | "tfoot" => {
+                self.end_row();
+                self.flush();
+            }
             _ => {
                 if heading_level(name).is_some() || breaks_a_block(name) {
                     self.flush();
@@ -477,7 +518,60 @@ impl State {
         }
     }
 
+    /// Takes the words collected since the cell opened and makes them a cell.
+    ///
+    /// A no-op outside a table, and outside a cell inside one: text loose in
+    /// a row is markup nobody meant, and it stays where it is so that the
+    /// ordinary flush treats it as the stray prose it is.
+    fn end_cell(&mut self) {
+        let Some(row) = &self.row else {
+            return;
+        };
+        if !row.open {
+            return;
+        }
+        let cell = std::mem::take(&mut self.text);
+        self.spans.clear();
+        if let Some(row) = &mut self.row {
+            row.open = false;
+            if row.cells.len() < crate::MAX_ROW_CELLS {
+                row.cells.push(cell);
+            }
+        }
+    }
+
+    /// Closes the row being read and pushes it, if there is one worth pushing.
+    fn end_row(&mut self) {
+        self.end_cell();
+        let Some(row) = self.row.take() else {
+            return;
+        };
+        if row.cells.is_empty() {
+            return;
+        }
+        self.builder.push(Block::Row {
+            header: row.header,
+            cells: row.cells,
+        });
+    }
+
     fn flush(&mut self) {
+        // Inside a cell there is nowhere for a block to go. A cell holding a
+        // paragraph, or three, is one cell of a row and not three blocks of
+        // prose, so the words are kept where they are and the boundary
+        // becomes a space. Without this a `<td><p>...</p></td>` table --
+        // which is most of the tables LaTeX generators emit -- would spill
+        // one paragraph per cell into the body and lose its columns.
+        if self.row.as_ref().is_some_and(|row| row.open) {
+            self.heading = None;
+            self.item = false;
+            self.caption = false;
+            self.titling = false;
+            if !self.text.is_empty() && !self.text.ends_with(char::is_whitespace) {
+                self.text.push(' ');
+            }
+            return;
+        }
         let text = std::mem::take(&mut self.text);
         let spans = normalise_spans(std::mem::take(&mut self.spans));
         let style = self.block_style.clone();
@@ -521,6 +615,7 @@ impl State {
     }
 
     fn finish(mut self) -> Document {
+        self.end_row();
         self.flush();
         self.builder.finish()
     }
@@ -1049,12 +1144,19 @@ mod tests {
         assert!(rich.spans.iter().any(|span| span.style.emphasis));
     }
 
+    // A cell keeps its words but not their weight: the row is a list of
+    // strings, because lining columns up is already as much as the panel can
+    // do with a table, and bold inside a squeezed column buys nothing.
     #[test]
-    fn emphasis_survives_a_table_row() {
+    fn a_table_cell_keeps_its_words_when_they_were_emphasised() {
         let document = parse("<table><tr><td>Plain</td><td><b>Bold</b></td></tr></table>");
-        assert_eq!(document.blocks[0].text(), Some("Plain \u{2014} Bold"));
-        let rich = document.rich.get(&0).expect("retained emphasis");
-        assert!(rich.spans.iter().any(|span| span.style.strong));
+        assert_eq!(
+            document.blocks,
+            vec![Block::Row {
+                header: false,
+                cells: vec!["Plain".to_owned(), "Bold".to_owned()],
+            }]
+        );
     }
 
     #[test]
@@ -1406,14 +1508,69 @@ mod tests {
     }
 
     #[test]
-    fn a_table_row_becomes_one_readable_line() {
+    fn a_table_keeps_one_block_per_row_with_its_cells_apart() {
         let document = parse("<table><tr><td>a</td><td>b</td></tr><tr><td>1</td><td>2</td></tr>");
         assert_eq!(
             document.blocks,
             vec![
-                Block::Paragraph("a \u{2014} b".to_owned()),
-                Block::Paragraph("1 \u{2014} 2".to_owned()),
+                Block::Row {
+                    header: false,
+                    cells: vec!["a".to_owned(), "b".to_owned()],
+                },
+                Block::Row {
+                    header: false,
+                    cells: vec!["1".to_owned(), "2".to_owned()],
+                },
             ]
+        );
+    }
+
+    #[test]
+    fn a_head_row_is_marked_so_the_panel_can_rule_under_it() {
+        let document = parse(
+            "<table><thead><tr><th>Model</th><th>Top-1</th></tr></thead>\
+             <tbody><tr><td>Small</td><td>71.2</td></tr></tbody></table><p>After.</p>",
+        );
+        assert_eq!(
+            document.blocks,
+            vec![
+                Block::Row {
+                    header: true,
+                    cells: vec!["Model".to_owned(), "Top-1".to_owned()],
+                },
+                Block::Row {
+                    header: false,
+                    cells: vec!["Small".to_owned(), "71.2".to_owned()],
+                },
+                Block::Paragraph("After.".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn two_paragraphs_in_one_cell_are_read_as_one_cell() {
+        let document = parse("<table><tr><td><p>First.</p><p>Second.</p></td></tr></table>");
+        assert_eq!(
+            document.blocks,
+            vec![Block::Row {
+                header: false,
+                cells: vec!["First. Second.".to_owned()],
+            }]
+        );
+    }
+
+    // A cell holding a whole paragraph is the shape that used to run the two
+    // cells together; it must still come out as two.
+    #[test]
+    fn a_cell_that_wraps_its_words_in_a_paragraph_stays_one_cell() {
+        let document =
+            parse("<table><tr><td><p>Left words</p></td><td><p>Right words</p></td></tr></table>");
+        assert_eq!(
+            document.blocks,
+            vec![Block::Row {
+                header: false,
+                cells: vec!["Left words".to_owned(), "Right words".to_owned()],
+            }]
         );
     }
 

--- a/crates/kobo-doc/src/html.rs
+++ b/crates/kobo-doc/src/html.rs
@@ -25,7 +25,10 @@
 
 use kobo_html::{attribute, decode_entities, element_name, skip_element};
 
-use crate::{Block, Builder, Document, MAX_BLOCK_TEXT};
+use crate::{
+    Block, BlockStyle, Builder, Document, InlineSpan, InlineStyle, RichBlock, TextAlignment,
+    MAX_BLOCK_TEXT,
+};
 
 /// Elements whose contents are instructions rather than words.
 const OPAQUE: [&str; 4] = ["script", "style", "svg", "iframe"];
@@ -33,7 +36,19 @@ const OPAQUE: [&str; 4] = ["script", "style", "svg", "iframe"];
 /// Reads an HTML document.
 #[must_use]
 pub fn parse(source: &str) -> Document {
-    let mut state = State::new();
+    parse_with_css(source, "")
+}
+
+/// Reads HTML with a bounded safe subset of publisher CSS.
+#[must_use]
+pub fn parse_with_css(source: &str, external_css: &str) -> Document {
+    let mut take = external_css.len().min(MAX_CSS_BYTES);
+    while !external_css.is_char_boundary(take) {
+        take -= 1;
+    }
+    let mut css = external_css[..take].to_owned();
+    css.push_str(&embedded_styles(source));
+    let mut state = State::new(StyleSheet::parse(&css));
     let mut rest = source;
     while let Some(at) = rest.find('<') {
         state.words(&rest[..at]);
@@ -74,6 +89,9 @@ pub fn parse(source: &str) -> Document {
     state.finish()
 }
 
+const MAX_CSS_BYTES: usize = 256 * 1024;
+const MAX_CSS_RULES: usize = 4_096;
+
 /// Skips a comment, a doctype or a CDATA section, if `tail` begins with one.
 pub(crate) fn skip_bracketed(tail: &str) -> Option<&str> {
     for (opens, closes) in [("<!--", "-->"), ("<![CDATA[", "]]>")] {
@@ -93,6 +111,12 @@ pub(crate) fn skip_bracketed(tail: &str) -> Option<&str> {
 struct State {
     builder: Builder,
     text: String,
+    spans: Vec<InlineSpan>,
+    inline: InlineStyle,
+    inline_stack: Vec<(String, InlineStyle)>,
+    block_style: BlockStyle,
+    block_stack: Vec<(String, BlockStyle)>,
+    stylesheet: StyleSheet,
     /// The link being read: where it points, and how much text had been
     /// collected when it opened, so its own words can be taken back out.
     link: Option<(String, usize)>,
@@ -114,11 +138,17 @@ struct State {
 }
 
 impl State {
-    fn new() -> Self {
+    fn new(stylesheet: StyleSheet) -> Self {
         Self {
             builder: Builder::new(),
             link: None,
             text: String::new(),
+            spans: Vec::new(),
+            inline: InlineStyle::default(),
+            inline_stack: Vec::new(),
+            block_style: BlockStyle::default(),
+            block_stack: Vec::new(),
+            stylesheet,
             quoted: 0,
             pre: 0,
             lists: Vec::new(),
@@ -141,6 +171,7 @@ impl State {
             return;
         }
         let decoded = decode_entities(text);
+        self.push_span(&decoded);
         if self.pre > 0 {
             // Control characters have no drawing, and the preformatted path
             // does not collapse them away. Tabs and newlines stay: both are
@@ -155,6 +186,25 @@ impl State {
         }
     }
 
+    fn push_span(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        if let Some(last) = self
+            .spans
+            .last_mut()
+            .filter(|last| last.style == self.inline)
+        {
+            last.text.push_str(text);
+        } else {
+            self.spans.push(InlineSpan {
+                text: text.to_owned(),
+                style: self.inline,
+            });
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
     fn open(&mut self, name: &str, inside: &str) {
         // Inside a `<pre>`, nothing but its own end tag changes anything. A
         // listing full of `<` is a listing, and re-flowing it on a stray tag
@@ -196,6 +246,23 @@ impl State {
             if let Some(href) = attribute(inside, "href") {
                 self.link = Some((decode_entities(href), self.text.len()));
             }
+            return;
+        }
+        if matches!(
+            name,
+            "strong" | "b" | "em" | "i" | "u" | "sup" | "sub" | "span" | "small" | "mark"
+        ) {
+            self.inline_stack.push((name.to_owned(), self.inline));
+            match name {
+                "strong" | "b" => self.inline.strong = true,
+                "em" | "i" => self.inline.emphasis = true,
+                "u" => self.inline.underline = true,
+                "sup" => self.inline.superscript = true,
+                "sub" => self.inline.subscript = true,
+                _ => {}
+            }
+            let declarations = self.stylesheet.declarations_for(name, inside);
+            apply_inline_style(&mut self.inline, Some(&declarations));
             return;
         }
         match name {
@@ -254,9 +321,21 @@ impl State {
             _ => {
                 if let Some(level) = heading_level(name) {
                     self.flush();
+                    let declarations = self.stylesheet.declarations_for(name, inside);
+                    let parent = self.block_style.clone();
+                    self.block_stack.push((name.to_owned(), parent.clone()));
+                    self.block_style = block_style_inheriting(&parent, &declarations);
+                    self.inline_stack.push((name.to_owned(), self.inline));
+                    apply_inline_style(&mut self.inline, Some(&declarations));
                     self.heading = Some(level);
                 } else if breaks_a_block(name) {
                     self.flush();
+                    let declarations = self.stylesheet.declarations_for(name, inside);
+                    let parent = self.block_style.clone();
+                    self.block_stack.push((name.to_owned(), parent.clone()));
+                    self.block_style = block_style_inheriting(&parent, &declarations);
+                    self.inline_stack.push((name.to_owned(), self.inline));
+                    apply_inline_style(&mut self.inline, Some(&declarations));
                 }
             }
         }
@@ -270,6 +349,18 @@ impl State {
             if let Some((target, from)) = self.link.take() {
                 let words = self.text.get(from..).unwrap_or_default().to_owned();
                 self.builder.record_link(&words, &target);
+            }
+            return;
+        }
+        if let Some(at) = self.inline_stack.iter().rposition(|(open, _)| open == name) {
+            if heading_level(name).is_some() || breaks_a_block(name) {
+                self.flush();
+            }
+            let (_, style) = self.inline_stack.remove(at);
+            self.inline = style;
+            if let Some(at) = self.block_stack.iter().rposition(|(open, _)| open == name) {
+                let (_, style) = self.block_stack.remove(at);
+                self.block_style = style;
             }
             return;
         }
@@ -320,6 +411,8 @@ impl State {
 
     fn flush(&mut self) {
         let text = std::mem::take(&mut self.text);
+        let spans = normalise_spans(std::mem::take(&mut self.spans));
+        let style = self.block_style.clone();
         let heading = self.heading.take();
         let item = std::mem::replace(&mut self.item, false);
         if std::mem::replace(&mut self.titling, false) {
@@ -327,7 +420,8 @@ impl State {
             return;
         }
         if self.pre > 0 {
-            self.builder.push(Block::Preformatted(text));
+            self.builder
+                .push_rich(Block::Preformatted(text), RichBlock { spans, style });
             return;
         }
         if text.trim().is_empty() {
@@ -339,14 +433,18 @@ impl State {
             if level == 1 {
                 self.builder.set_title(&text);
             }
-            self.builder.push(Block::Heading { level, text });
+            self.builder
+                .push_rich(Block::Heading { level, text }, RichBlock { spans, style });
         } else if item {
             let ordered = self.lists.last().copied().unwrap_or(false);
-            self.builder.push(Block::Item { ordered, text });
+            self.builder
+                .push_rich(Block::Item { ordered, text }, RichBlock { spans, style });
         } else if self.quoted > 0 {
-            self.builder.push(Block::Quote(text));
+            self.builder
+                .push_rich(Block::Quote(text), RichBlock { spans, style });
         } else {
-            self.builder.push(Block::Paragraph(text));
+            self.builder
+                .push_rich(Block::Paragraph(text), RichBlock { spans, style });
         }
     }
 
@@ -354,6 +452,280 @@ impl State {
         self.flush();
         self.builder.finish()
     }
+}
+
+#[derive(Clone, Debug, Default)]
+struct StyleSheet {
+    rules: Vec<CssRule>,
+}
+
+#[derive(Clone, Debug)]
+struct CssRule {
+    selector: String,
+    declarations: String,
+    specificity: u8,
+    order: usize,
+}
+
+fn embedded_styles(source: &str) -> String {
+    let lower = source.to_ascii_lowercase();
+    let mut out = String::new();
+    let mut at = 0usize;
+    while out.len() < MAX_CSS_BYTES {
+        let Some(open) = lower[at..].find("<style") else {
+            break;
+        };
+        let open = at + open;
+        let Some(tag_end) = lower[open..].find('>') else {
+            break;
+        };
+        let body = open + tag_end + 1;
+        let Some(close) = lower[body..].find("</style") else {
+            break;
+        };
+        let close = body + close;
+        let content = &source[body..close];
+        let mut take = content.len().min(MAX_CSS_BYTES.saturating_sub(out.len()));
+        while !content.is_char_boundary(take) {
+            take -= 1;
+        }
+        out.push_str(&content[..take]);
+        at = close + "</style".len();
+    }
+    out
+}
+
+impl StyleSheet {
+    fn parse(css: &str) -> Self {
+        let mut rules = Vec::new();
+        let mut rest = css;
+        while rules.len() < MAX_CSS_RULES {
+            let Some(open) = rest.find('{') else { break };
+            let selectors = rest[..open].trim();
+            let tail = &rest[open + 1..];
+            let Some(close) = tail.find('}') else { break };
+            let body = tail[..close].trim();
+            rest = &tail[close + 1..];
+            if selectors.starts_with('@') || body.is_empty() {
+                continue;
+            }
+            for selector in selectors.split(',') {
+                let selector = selector.trim().to_ascii_lowercase();
+                if selector.is_empty()
+                    || selector.contains([' ', '>', '+', '~', '[', ':', '*'])
+                    || rules.len() >= MAX_CSS_RULES
+                {
+                    continue;
+                }
+                let specificity = u8::from(selector.contains('#')) * 100
+                    + u8::try_from(selector.matches('.').count())
+                        .unwrap_or(9)
+                        .min(9)
+                        * 10
+                    + u8::from(!selector.starts_with(['.', '#']));
+                rules.push(CssRule {
+                    selector,
+                    declarations: body.to_owned(),
+                    specificity,
+                    order: rules.len(),
+                });
+            }
+        }
+        Self { rules }
+    }
+
+    fn declarations_for(&self, name: &str, inside: &str) -> String {
+        let classes = attribute(inside, "class").unwrap_or_default();
+        let id = attribute(inside, "id").unwrap_or_default();
+        let mut matched: Vec<&CssRule> = self
+            .rules
+            .iter()
+            .filter(|rule| selector_matches(&rule.selector, name, id, classes))
+            .collect();
+        matched.sort_by_key(|rule| (rule.specificity, rule.order));
+        let mut result = String::new();
+        for rule in matched {
+            result.push_str(&rule.declarations);
+            result.push(';');
+        }
+        if let Some(inline) = attribute(inside, "style") {
+            result.push_str(inline);
+        }
+        result
+    }
+}
+
+fn selector_matches(selector: &str, name: &str, id: &str, classes: &str) -> bool {
+    let tag_end = selector.find(['.', '#']).unwrap_or(selector.len());
+    let tag = &selector[..tag_end];
+    if !tag.is_empty() && !tag.eq_ignore_ascii_case(name) {
+        return false;
+    }
+    let class_words: Vec<&str> = classes.split_whitespace().collect();
+    let mut rest = &selector[tag_end..];
+    while !rest.is_empty() {
+        let marker = rest.as_bytes()[0];
+        rest = &rest[1..];
+        let end = rest.find(['.', '#']).unwrap_or(rest.len());
+        let value = &rest[..end];
+        let matches = match marker {
+            b'.' => class_words
+                .iter()
+                .any(|class| class.eq_ignore_ascii_case(value)),
+            b'#' => id.eq_ignore_ascii_case(value),
+            _ => false,
+        };
+        if !matches {
+            return false;
+        }
+        rest = &rest[end..];
+    }
+    true
+}
+
+fn normalise_spans(spans: Vec<InlineSpan>) -> Vec<InlineSpan> {
+    let mut out: Vec<InlineSpan> = Vec::new();
+    let mut pending_space = false;
+    for span in spans {
+        let mut text = String::new();
+        for character in span.text.chars() {
+            if character.is_whitespace() {
+                pending_space = !out.is_empty() || !text.is_empty();
+                continue;
+            }
+            if pending_space {
+                text.push(' ');
+                pending_space = false;
+            }
+            if !character.is_control() {
+                text.push(character);
+            }
+        }
+        if text.is_empty() {
+            continue;
+        }
+        if let Some(last) = out.last_mut().filter(|last| last.style == span.style) {
+            last.text.push_str(&text);
+        } else {
+            out.push(InlineSpan {
+                text,
+                style: span.style,
+            });
+        }
+    }
+    out
+}
+
+fn declarations(style: Option<&str>) -> impl Iterator<Item = (&str, &str)> {
+    style.into_iter().flat_map(|style| {
+        style.split(';').filter_map(|declaration| {
+            let (name, value) = declaration.split_once(':')?;
+            Some((name.trim(), value.trim()))
+        })
+    })
+}
+
+fn apply_inline_style(style: &mut InlineStyle, source: Option<&str>) {
+    for (name, value) in declarations(source) {
+        match name.to_ascii_lowercase().as_str() {
+            "font-weight"
+                if value.eq_ignore_ascii_case("bold")
+                    || value.parse::<u16>().is_ok_and(|weight| weight >= 600) =>
+            {
+                style.strong = true;
+            }
+            "font-style"
+                if value.eq_ignore_ascii_case("italic")
+                    || value.eq_ignore_ascii_case("oblique") =>
+            {
+                style.emphasis = true;
+            }
+            "text-decoration"
+                if value
+                    .split_whitespace()
+                    .any(|word| word.eq_ignore_ascii_case("underline")) =>
+            {
+                style.underline = true;
+            }
+            "vertical-align" if value.eq_ignore_ascii_case("super") => style.superscript = true,
+            "vertical-align" if value.eq_ignore_ascii_case("sub") => style.subscript = true,
+            _ => {}
+        }
+    }
+}
+
+fn block_style_inheriting(parent: &BlockStyle, source: &str) -> BlockStyle {
+    let mut style = BlockStyle {
+        alignment: parent.alignment,
+        line_height_percent: parent.line_height_percent,
+        font_family: parent.font_family.clone(),
+        ..BlockStyle::default()
+    };
+    for (name, value) in declarations(Some(source)) {
+        match name.to_ascii_lowercase().as_str() {
+            "text-align" => {
+                style.alignment = match value.to_ascii_lowercase().as_str() {
+                    "center" => TextAlignment::Center,
+                    "right" | "end" => TextAlignment::End,
+                    "justify" => TextAlignment::Justify,
+                    _ => TextAlignment::Start,
+                };
+            }
+            "line-height" => {
+                if let Some(percent) = percent(value) {
+                    style.line_height_percent = percent.clamp(80, 250);
+                }
+            }
+            "margin-top" => style.margin_before_em = em_hundredths(value).unwrap_or(0),
+            "margin-bottom" => style.margin_after_em = em_hundredths(value).unwrap_or(0),
+            "text-indent" => {
+                style.first_line_indent_em = em_hundredths(value)
+                    .and_then(|value| i16::try_from(value).ok())
+                    .unwrap_or(0);
+            }
+            "font-family" => {
+                let family = value
+                    .split(',')
+                    .next()
+                    .unwrap_or_default()
+                    .trim_matches([' ', '\'', '"']);
+                if !family.is_empty() && family.len() <= 128 {
+                    style.font_family = Some(family.to_owned());
+                }
+            }
+            "page-break-before" | "break-before"
+                if value.eq_ignore_ascii_case("always") || value.eq_ignore_ascii_case("page") =>
+            {
+                style.page_break_before = true;
+            }
+            "page-break-after" | "break-after"
+                if value.eq_ignore_ascii_case("always") || value.eq_ignore_ascii_case("page") =>
+            {
+                style.page_break_after = true;
+            }
+            _ => {}
+        }
+    }
+    style
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn percent(value: &str) -> Option<u16> {
+    if let Some(value) = value.strip_suffix('%') {
+        return value.trim().parse().ok();
+    }
+    let ratio = value.parse::<f32>().ok()?;
+    u16::try_from((ratio * 100.0).round() as i32).ok()
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn em_hundredths(value: &str) -> Option<u16> {
+    let value = value.trim().strip_suffix("em")?.trim();
+    let em = value.parse::<f32>().ok()?;
+    if !(0.0..=20.0).contains(&em) {
+        return None;
+    }
+    u16::try_from((em * 100.0).round() as i32).ok()
 }
 
 fn heading_level(name: &str) -> Option<u8> {
@@ -427,6 +799,89 @@ mod tests {
                 Block::Paragraph("It began badly.".to_owned()),
             ]
         );
+    }
+
+    #[test]
+    fn inline_structure_and_safe_publisher_css_survive_parsing() {
+        let document = parse(
+            r#"<style>
+                p.lead { text-align: center; line-height: 140%; margin-bottom: 0.5em; }
+                .accent { font-style: italic; text-decoration: underline; }
+               </style>
+               <p class="lead">Before <strong>bold <span class="accent">both</span></strong>.</p>"#,
+        );
+        assert_eq!(document.blocks[0].text(), Some("Before bold both."));
+        let rich = document.rich.get(&0).expect("rich paragraph");
+        assert_eq!(rich.style.alignment, TextAlignment::Center);
+        assert_eq!(rich.style.line_height_percent, 140);
+        assert_eq!(rich.style.margin_after_em, 50);
+        assert_eq!(
+            rich.spans
+                .iter()
+                .map(|span| span.text.as_str())
+                .collect::<String>(),
+            "Before bold both."
+        );
+        let both = rich
+            .spans
+            .iter()
+            .find(|span| span.text.contains("both"))
+            .expect("styled run");
+        assert!(both.style.strong);
+        assert!(both.style.emphasis);
+        assert!(both.style.underline);
+    }
+
+    #[test]
+    fn unsupported_css_cannot_escape_the_bounded_flow() {
+        let document = parse_with_css(
+            r#"<p class="moved">Words stay readable.</p>"#,
+            ".moved { position: fixed; left: -999999px; color: transparent; text-align: right; }",
+        );
+        assert_eq!(document.blocks[0].text(), Some("Words stay readable."));
+        assert_eq!(
+            document
+                .rich
+                .get(&0)
+                .expect("supported style")
+                .style
+                .alignment,
+            TextAlignment::End
+        );
+    }
+
+    #[test]
+    fn tag_per_character_styling_is_bounded_without_losing_words() {
+        let mut source = String::from("<p>");
+        for index in 0..400 {
+            if index % 2 == 0 {
+                source.push_str("<b>x</b>");
+            } else {
+                source.push_str("<i>y</i>");
+            }
+        }
+        source.push_str("</p>");
+        let document = parse(&source);
+        let text = document.blocks[0].text().expect("paragraph");
+        let rich = document.rich.get(&0).expect("rich paragraph");
+        assert_eq!(text.len(), 400);
+        assert_eq!(
+            rich.spans.iter().map(|span| span.text.len()).sum::<usize>(),
+            400
+        );
+        assert!(rich.spans.len() <= crate::MAX_RICH_SPANS);
+    }
+
+    #[test]
+    fn inherited_body_typography_reaches_ordinary_paragraphs() {
+        let document = parse_with_css(
+            "<body><p>Inherited prose.</p></body>",
+            "body { font-family: Publisher Serif; line-height: 135%; text-align: justify; }",
+        );
+        let style = &document.rich.get(&0).expect("publisher style").style;
+        assert_eq!(style.font_family.as_deref(), Some("Publisher Serif"));
+        assert_eq!(style.line_height_percent, 135);
+        assert_eq!(style.alignment, TextAlignment::Justify);
     }
 
     #[test]

--- a/crates/kobo-doc/src/html.rs
+++ b/crates/kobo-doc/src/html.rs
@@ -47,7 +47,12 @@ pub fn parse_with_css(source: &str, external_css: &str) -> Document {
         take -= 1;
     }
     let mut css = external_css[..take].to_owned();
-    css.push_str(&embedded_styles(source));
+    let embedded = embedded_styles(source);
+    let mut remaining = embedded.len().min(MAX_CSS_BYTES.saturating_sub(css.len()));
+    while !embedded.is_char_boundary(remaining) {
+        remaining -= 1;
+    }
+    css.push_str(&embedded[..remaining]);
     let mut state = State::new(StyleSheet::parse(&css));
     let mut rest = source;
     while let Some(at) = rest.find('<') {
@@ -132,6 +137,7 @@ struct State {
     lists: Vec<bool>,
     heading: Option<u8>,
     item: bool,
+    caption: bool,
     /// Whether the words being collected are the document's title rather than
     /// something to draw.
     titling: bool,
@@ -154,6 +160,7 @@ impl State {
             lists: Vec::new(),
             heading: None,
             item: false,
+            caption: false,
             titling: false,
         }
     }
@@ -310,6 +317,16 @@ impl State {
                 self.flush();
                 self.item = true;
             }
+            "figcaption" => {
+                self.flush();
+                let declarations = self.stylesheet.declarations_for(name, inside);
+                let parent = self.block_style.clone();
+                self.block_stack.push((name.to_owned(), parent.clone()));
+                self.block_style = block_style_inheriting(&parent, &declarations);
+                self.inline_stack.push((name.to_owned(), self.inline));
+                apply_inline_style(&mut self.inline, Some(&declarations));
+                self.caption = true;
+            }
             // A cell is not a paragraph of its own; a row is. Running the
             // cells together with a mark that does not occur inside one keeps
             // the row readable in a single column.
@@ -415,6 +432,7 @@ impl State {
         let style = self.block_style.clone();
         let heading = self.heading.take();
         let item = std::mem::replace(&mut self.item, false);
+        let caption = std::mem::replace(&mut self.caption, false);
         if std::mem::replace(&mut self.titling, false) {
             self.builder.set_title(&text);
             return;
@@ -435,6 +453,9 @@ impl State {
             }
             self.builder
                 .push_rich(Block::Heading { level, text }, RichBlock { spans, style });
+        } else if caption {
+            self.builder
+                .push_rich(Block::Caption(text), RichBlock { spans, style });
         } else if item {
             let ordered = self.lists.last().copied().unwrap_or(false);
             self.builder
@@ -851,6 +872,30 @@ mod tests {
     }
 
     #[test]
+    fn external_and_embedded_css_share_one_total_byte_budget() {
+        let mut external = String::from("p { text-align: center; }");
+        external.extend(std::iter::repeat_n(
+            ' ',
+            MAX_CSS_BYTES.saturating_sub(external.len()),
+        ));
+        let document = parse_with_css(
+            "<style>p { text-align: right; }</style><p>Bounded prose.</p>",
+            &external,
+        );
+
+        assert_eq!(
+            document
+                .rich
+                .get(&0)
+                .expect("external style")
+                .style
+                .alignment,
+            TextAlignment::Center,
+            "embedded CSS must not extend the combined stylesheet past its limit"
+        );
+    }
+
+    #[test]
     fn tag_per_character_styling_is_bounded_without_losing_words() {
         let mut source = String::from("<p>");
         for index in 0..400 {
@@ -1061,6 +1106,33 @@ mod tests {
             document.blocks,
             vec![Block::Paragraph("Before after.".to_owned())]
         );
+    }
+
+    #[test]
+    fn a_figure_keeps_its_picture_caption_and_following_heading_in_order() {
+        let document = parse(
+            r#"<p>Before.</p><figure><img src="plate.png" alt="A plate"><figcaption><em>Figure 1.</em> A caption.</figcaption></figure><h2>After</h2>"#,
+        );
+        assert_eq!(
+            document.blocks,
+            vec![
+                Block::Paragraph("Before.".to_owned()),
+                Block::Picture {
+                    name: "plate.png".to_owned(),
+                    alt: "A plate".to_owned(),
+                },
+                Block::Caption("Figure 1. A caption.".to_owned()),
+                Block::Heading {
+                    level: 2,
+                    text: "After".to_owned(),
+                },
+            ]
+        );
+        let caption = document.rich.get(&2).expect("rich caption");
+        assert!(caption
+            .spans
+            .iter()
+            .any(|span| span.text.contains("Figure 1.") && span.style.emphasis));
     }
 
     #[test]

--- a/crates/kobo-doc/src/lib.rs
+++ b/crates/kobo-doc/src/lib.rs
@@ -149,6 +149,9 @@ pub const MAX_LINKS: usize = 20_000;
 /// file with no line breaks in it, and cutting it is better than handing the
 /// layout engine a single block it will spend a second wrapping.
 pub const MAX_BLOCK_TEXT: usize = 64 * 1024;
+/// Styled runs retained for one block. Pathological tag-per-character XHTML
+/// degrades into one final run rather than growing the render protocol.
+const MAX_RICH_SPANS: usize = 256;
 
 /// The deepest heading level that means anything.
 ///
@@ -199,6 +202,70 @@ pub enum Block {
     /// asks for the next chapter means the next file, even when the author
     /// never wrote a heading at the top of it.
     Break,
+}
+
+/// Inline emphasis retained from HTML/XHTML instead of flattened away.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct InlineStyle {
+    pub strong: bool,
+    pub emphasis: bool,
+    pub underline: bool,
+    pub superscript: bool,
+    pub subscript: bool,
+}
+
+/// One styled run inside a block of prose.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct InlineSpan {
+    pub text: String,
+    pub style: InlineStyle,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum TextAlignment {
+    #[default]
+    Start,
+    Center,
+    End,
+    Justify,
+}
+
+/// Safe publisher styling that affects one reflowable block.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BlockStyle {
+    pub alignment: TextAlignment,
+    /// Percent of the selected face's natural line height.
+    pub line_height_percent: u16,
+    /// Before/after spacing in hundredths of an em.
+    pub margin_before_em: u16,
+    pub margin_after_em: u16,
+    pub first_line_indent_em: i16,
+    pub font_family: Option<String>,
+    pub page_break_before: bool,
+    pub page_break_after: bool,
+}
+
+impl Default for BlockStyle {
+    fn default() -> Self {
+        Self {
+            alignment: TextAlignment::Start,
+            line_height_percent: 100,
+            margin_before_em: 0,
+            margin_after_em: 0,
+            first_line_indent_em: 0,
+            font_family: None,
+            page_break_before: false,
+            page_break_after: false,
+        }
+    }
+}
+
+/// Structure and publisher styling retained for a text block.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RichBlock {
+    pub spans: Vec<InlineSpan>,
+    pub style: BlockStyle,
 }
 
 impl Block {
@@ -272,12 +339,37 @@ pub struct Document {
     /// drawing them rather than to the parser. A book of four hundred
     /// engravings should not cost four hundred decodes to open.
     pub images: BTreeMap<String, Vec<u8>>,
+    /// Outline fonts embedded by the publisher, keyed by their resolved
+    /// archive name.
+    ///
+    /// Kept as bounded, undecoded bytes for the same reason pictures are: the
+    /// document parser has no panel and no glyph cache, while the reader can
+    /// choose one face and hand it to the runtime only when publisher styling
+    /// is enabled. WOFF/WOFF2 assets are retained for diagnostics but only
+    /// OpenType/TrueType faces are currently usable by the rasterizer.
+    pub fonts: BTreeMap<String, EmbeddedFont>,
+    /// Rich XHTML representation for blocks that carried inline/CSS styling.
+    /// Blocks absent from the map use their ordinary semantic presentation.
+    pub rich: BTreeMap<usize, RichBlock>,
     /// The links the book makes from one part of itself to another.
     ///
     /// A footnote marker, an endnote's way back, a cross-reference: all of
     /// them were flattened to plain text, so the words stayed and the going
     /// there did not. Kept in reading order.
     pub links: Vec<Link>,
+}
+
+/// One font declared by an EPUB package.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct EmbeddedFont {
+    /// MIME type from the package manifest, when it supplied one.
+    pub media_type: String,
+    /// Family named by the publisher's `@font-face`, when one refers to this
+    /// asset. This lets the reader choose the face the book actually asks for
+    /// instead of whichever font filename sorts first.
+    pub family: Option<String>,
+    /// The bounded font bytes exactly as stored in the EPUB.
+    pub bytes: Vec<u8>,
 }
 
 /// Somewhere the book points, and the words it points from.
@@ -446,6 +538,11 @@ impl Builder {
         self.document.images = images;
     }
 
+    /// Records publisher fonts that passed the EPUB resource bounds.
+    pub(crate) fn set_fonts(&mut self, fonts: BTreeMap<String, EmbeddedFont>) {
+        self.document.fonts = fonts;
+    }
+
     /// Replaces the anchors, once a caller has re-keyed them.
     pub(crate) fn set_anchors(&mut self, anchors: BTreeMap<String, usize>) {
         self.document.anchors = anchors;
@@ -528,6 +625,17 @@ impl Builder {
         self.document.blocks.push(block);
     }
 
+    /// Adds a block while retaining its independently bounded XHTML styling.
+    pub(crate) fn push_rich(&mut self, block: Block, mut rich: RichBlock) {
+        let at = self.document.blocks.len();
+        self.push(block);
+        if self.document.blocks.len() == at + 1 && !rich.spans.is_empty() {
+            let canonical = self.document.blocks[at].text().unwrap_or_default();
+            bound_rich_spans(&mut rich.spans, canonical);
+            self.document.rich.insert(at, rich);
+        }
+    }
+
     /// Cuts `text` to what is left of the ceilings.
     fn fit(&mut self, mut text: String) -> String {
         if text.len() > MAX_BLOCK_TEXT {
@@ -599,6 +707,13 @@ impl Builder {
             link.block = block;
             block < kept
         });
+        self.document.rich = std::mem::take(&mut self.document.rich)
+            .into_iter()
+            .filter_map(|(at, rich)| {
+                let at = at.checked_sub(removed_from_front)?;
+                (at < kept).then_some((at, rich))
+            })
+            .collect();
         self.document
     }
 }
@@ -654,6 +769,38 @@ fn strip_boilerplate(blocks: &mut Vec<Block>) -> usize {
 }
 
 /// Cuts a string to at most `limit` bytes without splitting a character.
+fn bound_rich_spans(spans: &mut Vec<InlineSpan>, canonical: &str) {
+    let joined = spans
+        .iter()
+        .map(|span| span.text.as_str())
+        .collect::<String>();
+    if !joined.starts_with(canonical) {
+        *spans = vec![InlineSpan {
+            text: canonical.to_owned(),
+            style: InlineStyle::default(),
+        }];
+        return;
+    }
+    let mut left = canonical.len();
+    for span in spans.iter_mut() {
+        if span.text.len() > left {
+            truncate_to(&mut span.text, left);
+        }
+        left = left.saturating_sub(span.text.len());
+    }
+    spans.retain(|span| !span.text.is_empty());
+    if spans.len() > MAX_RICH_SPANS {
+        let tail = spans
+            .drain(MAX_RICH_SPANS - 1..)
+            .map(|span| span.text)
+            .collect::<String>();
+        spans.push(InlineSpan {
+            text: tail,
+            style: InlineStyle::default(),
+        });
+    }
+}
+
 pub(crate) fn truncate_to(text: &mut String, limit: usize) {
     if text.len() <= limit {
         return;

--- a/crates/kobo-doc/src/lib.rs
+++ b/crates/kobo-doc/src/lib.rs
@@ -149,6 +149,15 @@ pub const MAX_LINKS: usize = 20_000;
 /// file with no line breaks in it, and cutting it is better than handing the
 /// layout engine a single block it will spend a second wrapping.
 pub const MAX_BLOCK_TEXT: usize = 64 * 1024;
+
+/// The most columns one table row is kept at.
+///
+/// A panel seven centimetres across cannot show a dozen columns of prose and
+/// nothing is gained by carrying them: past this the row is not a table any
+/// more, it is a spreadsheet somebody published as a web page. Cells past the
+/// limit are dropped rather than merged, because merging them silently
+/// changes which value sits under which heading.
+pub const MAX_ROW_CELLS: usize = 12;
 /// Styled runs retained for one block. Pathological tag-per-character XHTML
 /// degrades into one final run rather than growing the render protocol.
 const MAX_RICH_SPANS: usize = 256;
@@ -195,6 +204,26 @@ pub enum Block {
         /// the image will not decode, and on a panel that cannot show colour
         /// a caption is often the more useful of the two.
         alt: String,
+    },
+    /// One row of a table.
+    ///
+    /// A table is a run of these, and the run is the table: there is no
+    /// enclosing block, because a document is a flat list and a nested one
+    /// would have to be paginated, searched and highlighted through a second
+    /// shape. Consecutive rows are laid out together, so the columns of a
+    /// table line up without any block having to own the whole of it.
+    ///
+    /// Cells were previously joined into one paragraph with an em dash
+    /// between them, which reads as a sentence made of fragments and loses
+    /// the one thing a table is for: knowing which value belongs to which
+    /// column.
+    Row {
+        /// Whether the row was written with `th` rather than `td`, and so
+        /// names the columns rather than filling them.
+        header: bool,
+        /// Left to right, as written. Empty cells are kept: a gap in a table
+        /// is where the alignment of everything after it comes from.
+        cells: Vec<String>,
     },
     /// A break between parts with no words on it.
     Rule,
@@ -284,8 +313,33 @@ impl Block {
             // A picture's description is not the words of the book: returning
             // it here would put a caption into a search, a highlight and the
             // count of what a page holds, all of which are about prose.
-            Self::Picture { .. } | Self::Rule | Self::Break => None,
+            //
+            // A row has words but no single string of them: joining the cells
+            // to answer this is exactly the flattening this block exists to
+            // stop. What a row reads as is [`Block::row_text`], which the
+            // things that genuinely want prose ask for by name.
+            Self::Picture { .. } | Self::Rule | Self::Break | Self::Row { .. } => None,
         }
+    }
+
+    /// A row read out as one line, for the things that can only take one.
+    ///
+    /// Search and the word count want the words; they do not want the
+    /// columns. The cells are joined with a space rather than with a mark, so
+    /// that a phrase which happens to straddle two cells is still found.
+    #[must_use]
+    pub fn row_text(&self) -> Option<String> {
+        let Self::Row { cells, .. } = self else {
+            return None;
+        };
+        Some(
+            cells
+                .iter()
+                .filter(|cell| !cell.trim().is_empty())
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(" "),
+        )
     }
 
     /// Whether this block is where a reader would say a chapter starts.
@@ -586,6 +640,27 @@ impl Builder {
                 }
                 block
             }
+            // A row is normalised cell by cell, because the thing that has
+            // to be bounded is the row's width in columns as well as its
+            // length in characters. A row of nothing but blanks is a spacer
+            // somebody drew with a table and is not kept.
+            Block::Row { header, cells } => {
+                let mut kept: Vec<String> = cells
+                    .into_iter()
+                    .take(MAX_ROW_CELLS)
+                    .map(|cell| self.fit(collapse(&cell)))
+                    .collect();
+                while matches!(kept.last(), Some(cell) if cell.is_empty()) {
+                    kept.pop();
+                }
+                if kept.iter().all(String::is_empty) {
+                    return;
+                }
+                Block::Row {
+                    header,
+                    cells: kept,
+                }
+            }
             Block::Rule | Block::Break => {
                 // Two rules in a row, or a break with nothing between it and
                 // the last one, is a seam in the source rather than something
@@ -616,9 +691,11 @@ impl Builder {
                     Block::Quote(_) => Block::Quote(text),
                     Block::Item { ordered, .. } => Block::Item { ordered, text },
                     Block::Caption(_) => Block::Caption(text),
-                    Block::Preformatted(_) | Block::Picture { .. } | Block::Rule | Block::Break => {
-                        return
-                    }
+                    Block::Preformatted(_)
+                    | Block::Picture { .. }
+                    | Block::Rule
+                    | Block::Break
+                    | Block::Row { .. } => return,
                 }
             }
         };

--- a/crates/kobo-doc/src/lib.rs
+++ b/crates/kobo-doc/src/lib.rs
@@ -178,6 +178,8 @@ pub enum Block {
     /// is drawn, so that inserting an item cannot leave the list numbered
     /// wrongly.
     Item { ordered: bool, text: String },
+    /// Text belonging to the illustration immediately before it.
+    Caption(String),
     /// A picture the book set into its text.
     ///
     /// Carried as the name it was stored under rather than as pixels, because
@@ -277,7 +279,8 @@ impl Block {
             | Self::Paragraph(text)
             | Self::Quote(text)
             | Self::Preformatted(text)
-            | Self::Item { text, .. } => Some(text),
+            | Self::Item { text, .. }
+            | Self::Caption(text) => Some(text),
             // A picture's description is not the words of the book: returning
             // it here would put a caption into a search, a highlight and the
             // count of what a page holds, all of which are about prose.
@@ -612,6 +615,7 @@ impl Builder {
                     Block::Paragraph(_) => Block::Paragraph(text),
                     Block::Quote(_) => Block::Quote(text),
                     Block::Item { ordered, .. } => Block::Item { ordered, text },
+                    Block::Caption(_) => Block::Caption(text),
                     Block::Preformatted(_) | Block::Picture { .. } | Block::Rule | Block::Break => {
                         return
                     }

--- a/crates/kobo-policy/Cargo.toml
+++ b/crates/kobo-policy/Cargo.toml
@@ -10,6 +10,7 @@ description = "Capability, task, storage, and credential policy for Kobo applica
 
 [dependencies]
 kobo-abi = { version = "0.2.0", path = "../kobo-abi" }
+kobo-dict = { version = "0.2.2", path = "../kobo-dict" }
 kobo-protocol = { version = "0.2.0", path = "../kobo-protocol" }
 
 [lints]

--- a/crates/kobo-policy/src/services.rs
+++ b/crates/kobo-policy/src/services.rs
@@ -10,7 +10,9 @@
 //!   is willing to pay for.
 
 use crate::{Capability, Declared, Grant, Grants, PowerPolicy};
-use kobo_protocol::{AudioPlaybackState, DenyReason, DeviceError, DeviceRequest, DeviceResult};
+use kobo_protocol::{
+    AudioPlaybackState, DenyReason, DeviceError, DeviceRequest, DeviceResult, DictionaryEntry,
+};
 use std::collections::BTreeSet;
 use std::time::Duration;
 
@@ -91,6 +93,7 @@ pub struct DeviceServices {
     audio_position_ms: u32,
     audio_duration_ms: u32,
     audio_volume: u8,
+    dictionaries: kobo_dict::Index,
 }
 
 impl DeviceServices {
@@ -129,7 +132,21 @@ impl DeviceServices {
             audio_position_ms: 0,
             audio_duration_ms: 0,
             audio_volume: 70,
+            dictionaries: kobo_dict::Index::default(),
         }
+    }
+
+    /// Loads owner-installed offline dictionaries from bounded UTF-8 TSV
+    /// files. Missing or malformed files yield fewer dictionaries rather than
+    /// making the reading service unavailable.
+    pub fn load_dictionaries(&mut self, directory: &std::path::Path) -> usize {
+        self.dictionaries = kobo_dict::Index::load_directory(directory);
+        self.dictionaries.len()
+    }
+
+    #[cfg(test)]
+    pub fn install_dictionary(&mut self, dictionary: kobo_dict::Dictionary) -> bool {
+        self.dictionaries.install(dictionary)
     }
 
     /// Updates the battery state used for both reads and policy decisions.
@@ -290,7 +307,25 @@ impl DeviceServices {
             DeviceRequest::InstallApp { .. } | DeviceRequest::UninstallApp { .. } => {
                 DeviceResult::Done
             }
+            DeviceRequest::LookupWord { word, language } => {
+                self.lookup_word(word, language.as_deref())
+            }
         }
+    }
+
+    fn lookup_word(&self, word: String, language: Option<&str>) -> DeviceResult {
+        let entries = self
+            .dictionaries
+            .lookup(&word, language)
+            .into_iter()
+            .map(|entry| DictionaryEntry {
+                dictionary: entry.dictionary,
+                language: entry.language,
+                headword: entry.headword,
+                definition: entry.definition,
+            })
+            .collect();
+        DeviceResult::Dictionary { word, entries }
     }
 
     /// Returns the policy refusal for a request that a real hardware backend
@@ -553,7 +588,8 @@ pub fn request_capability(request: &DeviceRequest) -> Option<Capability> {
         | DeviceRequest::ReadAppCatalog
         | DeviceRequest::RefreshAppCatalog
         | DeviceRequest::InstallApp { .. }
-        | DeviceRequest::UninstallApp { .. } => return None,
+        | DeviceRequest::UninstallApp { .. }
+        | DeviceRequest::LookupWord { .. } => return None,
     })
 }
 
@@ -569,6 +605,33 @@ mod tests {
 
     fn seconds_of(duration: std::time::Duration) -> u32 {
         u32::try_from(duration.as_secs()).expect("policy fits in u32")
+    }
+
+    #[test]
+    fn dictionary_lookup_is_local_normalized_and_explicit_when_missing() {
+        let mut services = DeviceServices::simulated();
+        assert!(services.install_dictionary(kobo_dict::Dictionary::from_tsv(
+            "Pocket",
+            "# language=en\nstory\tAn account of events.\n",
+        )));
+        assert!(matches!(
+            services.handle(DeviceRequest::LookupWord {
+                word: "stories".into(),
+                language: Some("en".into()),
+            }),
+            DeviceResult::Dictionary { entries, .. }
+                if entries.len() == 1 && entries[0].headword == "story"
+        ));
+        assert_eq!(
+            services.handle(DeviceRequest::LookupWord {
+                word: "absent".into(),
+                language: Some("en".into()),
+            }),
+            DeviceResult::Dictionary {
+                word: "absent".into(),
+                entries: Vec::new(),
+            }
+        );
     }
 
     fn declared(names: &[&str]) -> Declared {

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -552,6 +552,13 @@ pub enum Message {
     Action {
         action: ActionId,
     },
+    /// A held word in application-defined logical text coordinates.
+    TextHold {
+        action: ActionId,
+        context: u64,
+        start: u32,
+        end: u32,
+    },
     Log {
         level: LogLevel,
         message: String,
@@ -1465,6 +1472,17 @@ pub fn encode(frame: &Frame) -> Result<Vec<u8>, ProtocolError> {
         Message::Action { action } => {
             push_u32(&mut payload, action.0);
         }
+        Message::TextHold {
+            action,
+            context,
+            start,
+            end,
+        } => {
+            push_u32(&mut payload, action.0);
+            push_u64(&mut payload, *context);
+            push_u32(&mut payload, *start);
+            push_u32(&mut payload, *end);
+        }
         Message::Log { level, message } => {
             payload.push(*level as u8);
             push_string(&mut payload, message)?;
@@ -1999,6 +2017,12 @@ fn encoded_message_layout(message: &Message) -> Result<(u8, usize), ProtocolErro
             Ok((3, encoded_screen_len(screen, 0, &mut count)?))
         }
         Message::Action { .. } => Ok((4, 4)),
+        Message::TextHold { start, end, .. } => {
+            if start >= end {
+                return Err(ProtocolError::InvalidValue("text hold range"));
+            }
+            Ok((26, 20))
+        }
         Message::Log { message, .. } => {
             let mut length = 1;
             add_encoded_len(&mut length, encoded_string_len(message)?)?;
@@ -2949,15 +2973,22 @@ fn encoded_node_len(node: &Node, depth: usize, count: &mut usize) -> Result<usiz
             length
         }
         Node::RichText {
-            text, spans, links, ..
+            text,
+            spans,
+            links,
+            selection,
+            ..
         } => {
             if spans.len() > kobo_ui::MAX_RICH_TEXT_SPANS {
                 return Err(ProtocolError::TooManyNodes);
             }
             let mut length = 5;
             add_encoded_len(&mut length, encoded_string_len(text)?)?;
-            add_encoded_len(&mut length, 2 + spans.len() * 9 + 9 + 1)?;
+            add_encoded_len(&mut length, 2 + spans.len() * 9 + 9 + 1 + 1)?;
             for _ in links.iter().take(kobo_ui::MAX_TEXT_LINKS) {
+                add_encoded_len(&mut length, 12)?;
+            }
+            if selection.is_some() {
                 add_encoded_len(&mut length, 12)?;
             }
             length
@@ -3284,6 +3315,21 @@ pub fn decode(bytes: &[u8]) -> Result<Frame, ProtocolError> {
         4 => Message::Action {
             action: ActionId(reader.u32()?),
         },
+        26 => {
+            let action = ActionId(reader.u32()?);
+            let context = reader.u64()?;
+            let start = reader.u32()?;
+            let end = reader.u32()?;
+            if start >= end {
+                return Err(ProtocolError::InvalidValue("text hold range"));
+            }
+            Message::TextHold {
+                action,
+                context,
+                start,
+                end,
+            }
+        }
         5 => Message::Log {
             level: LogLevel::try_from(reader.u8()?)?,
             message: reader.string()?,
@@ -3879,10 +3925,11 @@ fn text_presentation_byte(style: kobo_ui::TextPresentation) -> u8 {
         | (u8::from(style.underline) << 2)
         | (u8::from(style.superscript) << 3)
         | (u8::from(style.subscript) << 4)
+        | (u8::from(style.highlighted) << 5)
 }
 
 fn text_presentation_from_byte(value: u8) -> Result<kobo_ui::TextPresentation, ProtocolError> {
-    if value & !0x1f != 0 {
+    if value & !0x3f != 0 {
         return Err(ProtocolError::InvalidValue("rich text style"));
     }
     Ok(kobo_ui::TextPresentation {
@@ -3891,6 +3938,7 @@ fn text_presentation_from_byte(value: u8) -> Result<kobo_ui::TextPresentation, P
         underline: value & 4 != 0,
         superscript: value & 8 != 0,
         subscript: value & 16 != 0,
+        highlighted: value & 32 != 0,
     })
 }
 
@@ -3932,6 +3980,7 @@ fn encode_node(
             spans,
             links,
             presentation,
+            selection,
         } => {
             if spans.len() > kobo_ui::MAX_RICH_TEXT_SPANS {
                 return Err(ProtocolError::TooManyNodes);
@@ -3980,6 +4029,14 @@ fn encode_node(
                 push_u32(output, link.action.0);
                 push_u32(output, u32::try_from(link.start).unwrap_or(u32::MAX));
                 push_u32(output, u32::try_from(link.end).unwrap_or(u32::MAX));
+            }
+            match selection {
+                Some(selection) => {
+                    output.push(1);
+                    push_u64(output, selection.context);
+                    push_u32(output, selection.offset);
+                }
+                None => output.push(0),
             }
         }
         Node::Secondary { id, text } => {
@@ -4884,12 +4941,21 @@ fn decode_node(
                     links.push(kobo_ui::TextLink { action, start, end });
                 }
             }
+            let selection = match reader.u8()? {
+                0 => None,
+                1 => Some(kobo_ui::TextSelection {
+                    context: reader.u64()?,
+                    offset: reader.u32()?,
+                }),
+                _ => return Err(ProtocolError::InvalidValue("text selection flag")),
+            };
             Ok(Node::RichText {
                 id,
                 text,
                 spans,
                 links,
                 presentation,
+                selection,
             })
         }
         18 => {
@@ -6217,6 +6283,10 @@ mod node_coverage_tests {
                     line_height_percent: 130,
                     ..kobo_ui::ParagraphPresentation::default()
                 },
+                selection: Some(kobo_ui::TextSelection {
+                    context: 3,
+                    offset: 11,
+                }),
             },
             Node::Quote {
                 id: NodeId(30),
@@ -6914,6 +6984,17 @@ mod store_tests {
         };
         let bytes = encode(&frame).expect("encode");
         decode(&bytes).expect("decode").message
+    }
+
+    #[test]
+    fn a_text_hold_survives_the_wire_without_losing_its_range() {
+        let message = Message::TextHold {
+            action: ActionId(9),
+            context: u64::MAX - 1,
+            start: 41,
+            end: 48,
+        };
+        assert_eq!(message_round_trip(message.clone()), message);
     }
 
     #[test]

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -3259,6 +3259,15 @@ fn encoded_node_len(node: &Node, depth: usize, count: &mut usize) -> Result<usiz
             length
         }
         Node::Picture { .. } => 19,
+        Node::Stepper {
+            label, less, more, ..
+        } => {
+            let mut length = 8;
+            add_encoded_len(&mut length, encoded_string_len(label)?)?;
+            add_encoded_len(&mut length, encoded_bar_action_len(less)?)?;
+            add_encoded_len(&mut length, encoded_bar_action_len(more)?)?;
+            length
+        }
         Node::Choice {
             prompt,
             options,
@@ -4429,6 +4438,33 @@ fn encode_node(
             push_u32(output, source.1);
             push_u16(output, *max_height_tenths_mm);
         }
+        Node::Stepper {
+            id,
+            label,
+            less,
+            more,
+            less_state,
+            more_state,
+            fill,
+        } => {
+            output.push(29);
+            push_u32(output, id.0);
+            push_string(output, label)?;
+            encode_bar_action(output, less)?;
+            encode_bar_action(output, more)?;
+            for state in [less_state, more_state] {
+                output.push(match state {
+                    ControlState::Enabled => 0,
+                    ControlState::Disabled => 1,
+                });
+            }
+            // Sent as one past the reading so that "no track" is zero, which is
+            // what a peer that never asks for one produces.
+            output.push(match fill {
+                None => 0,
+                Some(fill) => fill.min(&100).saturating_add(1),
+            });
+        }
         Node::Choice {
             id,
             prompt,
@@ -4721,6 +4757,7 @@ const fn encode_glyph(glyph: Glyph) -> u8 {
         Glyph::Next => 41,
         Glyph::Plus => 42,
         Glyph::Headphones => 43,
+        Glyph::Minus => 44,
     }
 }
 
@@ -4770,6 +4807,7 @@ const fn decode_glyph(tag: u8) -> Option<Glyph> {
         41 => Glyph::Next,
         42 => Glyph::Plus,
         43 => Glyph::Headphones,
+        44 => Glyph::Minus,
 
         _ => return None,
     })
@@ -5367,6 +5405,34 @@ fn decode_node(
                 options,
                 selected,
                 freeform,
+            })
+        }
+        29 => {
+            let label = reader.string()?;
+            let less = decode_bar_action(reader)?;
+            let more = decode_bar_action(reader)?;
+            let mut states = [ControlState::Enabled; 2];
+            for state in &mut states {
+                *state = match reader.u8()? {
+                    0 => ControlState::Enabled,
+                    1 => ControlState::Disabled,
+                    _ => return Err(ProtocolError::InvalidValue("stepper control state")),
+                };
+            }
+            let [less_state, more_state] = states;
+            let fill = match reader.u8()? {
+                0 => None,
+                marked if marked <= 101 => Some(marked - 1),
+                _ => return Err(ProtocolError::InvalidValue("stepper fill")),
+            };
+            Ok(Node::Stepper {
+                id,
+                label,
+                less,
+                more,
+                less_state,
+                more_state,
+                fill,
             })
         }
         11 => {
@@ -6534,6 +6600,15 @@ mod node_coverage_tests {
             Node::Progress {
                 id: NodeId(8),
                 value: Percent::new(40),
+            },
+            Node::Stepper {
+                id: NodeId(96),
+                label: "120%".into(),
+                less: BarAction::new(ActionId(30), String::new()).with_glyph(Glyph::Minus),
+                more: BarAction::new(ActionId(31), String::new()).with_glyph(Glyph::Plus),
+                less_state: ControlState::Enabled,
+                more_state: ControlState::Disabled,
+                fill: Some(75),
             },
             Node::PagedList {
                 id: NodeId(9),

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -43,7 +43,9 @@ pub const MAGIC: [u8; 4] = *b"KOBO";
 /// credential sits ahead of the header count, so a frame it did not expect
 /// would have been misread from that point on rather than refused. Version 9
 /// adds bounded rich EPUB text and runtime-held publisher-font handles.
-pub const VERSION: u8 = 9;
+/// Version 10 adds exact text-hold coordinates and typed offline dictionary
+/// requests/results.
+pub const VERSION: u8 = 10;
 pub const HEADER_LEN: usize = 14;
 /// The largest single frame either side will read.
 ///
@@ -172,6 +174,9 @@ pub const MAX_SHELF_BYTES: u64 = 256 * 1024 * 1024;
 
 /// The most blobs one application may keep.
 pub const MAX_SHELF_BLOBS: usize = 4_096;
+pub const MAX_LOOKUP_WORD_BYTES: usize = 128;
+pub const MAX_DICTIONARY_ENTRIES: usize = 8;
+pub const MAX_DICTIONARY_DEFINITION_BYTES: usize = 4_096;
 
 /// How much of the card must stay free whatever an application asks for.
 ///
@@ -1013,6 +1018,19 @@ pub enum DeviceRequest {
     InstallApp { id: String },
     /// Remove one app-store application by stable identity.
     UninstallApp { id: String },
+    /// Look up one selected word using only runtime-installed dictionaries.
+    LookupWord {
+        word: String,
+        language: Option<String>,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DictionaryEntry {
+    pub dictionary: String,
+    pub language: String,
+    pub headword: String,
+    pub definition: String,
 }
 
 /// Everything the gauge publishes that is worth putting in front of a reader.
@@ -1145,6 +1163,12 @@ pub enum DeviceResult {
     },
     /// A bounded app-store or installed-app listing.
     Apps { entries: Vec<AppInfo> },
+    /// Bounded offline definitions in installed dictionary order. An empty
+    /// list is an explicit no-result answer, not a transport failure.
+    Dictionary {
+        word: String,
+        entries: Vec<DictionaryEntry>,
+    },
     /// The backend exists, but the requested operation failed.
     Failed(DeviceError),
     /// The request was refused, with the exact reason.
@@ -1447,6 +1471,7 @@ impl From<io::Error> for StreamError {
 /// # Errors
 ///
 /// Returns an error when a message exceeds protocol limits.
+#[allow(clippy::too_many_lines)]
 pub fn encode(frame: &Frame) -> Result<Vec<u8>, ProtocolError> {
     let (kind, payload_len) = encoded_message_layout(&frame.message)?;
     let mut payload = Vec::with_capacity(payload_len);
@@ -2234,6 +2259,12 @@ fn encode_device_request(
         DeviceRequest::InstallApp { .. } | DeviceRequest::UninstallApp { .. } => {
             return Err(ProtocolError::InvalidValue("application id"));
         }
+        DeviceRequest::LookupWord { word, language } => {
+            validate_lookup(word, language.as_deref())?;
+            output.push(37);
+            push_string(output, word)?;
+            push_optional_string(output, language.as_deref())?;
+        }
     }
     Ok(())
 }
@@ -2478,6 +2509,12 @@ fn decode_device_request(reader: &mut Reader<'_>) -> Result<DeviceRequest, Proto
         34 => Ok(DeviceRequest::RefreshAppCatalog),
         35 => decode_app_request(reader, true),
         36 => decode_app_request(reader, false),
+        37 => {
+            let word = reader.string()?;
+            let language = reader.optional_string()?;
+            validate_lookup(&word, language.as_deref())?;
+            Ok(DeviceRequest::LookupWord { word, language })
+        }
         _ => Err(ProtocolError::InvalidValue("device request")),
     }
 }
@@ -2631,6 +2668,22 @@ fn encode_device_result(output: &mut Vec<u8>, result: &DeviceResult) -> Result<(
             );
             for entry in entries {
                 encode_app_info(output, entry)?;
+            }
+        }
+        DeviceResult::Dictionary { word, entries } => {
+            validate_lookup(word, None)?;
+            if entries.len() > MAX_DICTIONARY_ENTRIES {
+                return Err(ProtocolError::InvalidValue("too many dictionary entries"));
+            }
+            output.push(13);
+            push_string(output, word)?;
+            output.push(u8::try_from(entries.len()).map_err(|_| ProtocolError::FrameTooLarge)?);
+            for entry in entries {
+                validate_dictionary_entry(entry)?;
+                push_string(output, &entry.dictionary)?;
+                push_string(output, &entry.language)?;
+                push_string(output, &entry.headword)?;
+                push_string(output, &entry.definition)?;
             }
         }
     }
@@ -2791,8 +2844,61 @@ fn decode_device_result(reader: &mut Reader<'_>) -> Result<DeviceResult, Protoco
         8 => Ok(DeviceResult::Failed(DeviceError::try_from(reader.u8()?)?)),
         9 => decode_audio_result(reader),
         12 => decode_apps_result(reader),
+        13 => decode_dictionary_result(reader),
         _ => Err(ProtocolError::InvalidValue("device result")),
     }
+}
+
+fn validate_lookup(word: &str, language: Option<&str>) -> Result<(), ProtocolError> {
+    if word.trim().is_empty()
+        || word.len() > MAX_LOOKUP_WORD_BYTES
+        || language.is_some_and(|language| {
+            language.is_empty()
+                || language.len() > 16
+                || !language
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+        })
+    {
+        return Err(ProtocolError::InvalidValue("dictionary lookup"));
+    }
+    Ok(())
+}
+
+fn validate_dictionary_entry(entry: &DictionaryEntry) -> Result<(), ProtocolError> {
+    if entry.dictionary.is_empty()
+        || entry.dictionary.len() > 96
+        || entry.language.is_empty()
+        || entry.language.len() > 16
+        || entry.headword.is_empty()
+        || entry.headword.len() > MAX_LOOKUP_WORD_BYTES
+        || entry.definition.is_empty()
+        || entry.definition.len() > MAX_DICTIONARY_DEFINITION_BYTES
+    {
+        return Err(ProtocolError::InvalidValue("dictionary entry"));
+    }
+    Ok(())
+}
+
+fn decode_dictionary_result(reader: &mut Reader<'_>) -> Result<DeviceResult, ProtocolError> {
+    let word = reader.string()?;
+    validate_lookup(&word, None)?;
+    let count = usize::from(reader.u8()?);
+    if count > MAX_DICTIONARY_ENTRIES {
+        return Err(ProtocolError::InvalidValue("too many dictionary entries"));
+    }
+    let mut entries = Vec::with_capacity(count);
+    for _ in 0..count {
+        let entry = DictionaryEntry {
+            dictionary: reader.string()?,
+            language: reader.string()?,
+            headword: reader.string()?,
+            definition: reader.string()?,
+        };
+        validate_dictionary_entry(&entry)?;
+        entries.push(entry);
+    }
+    Ok(DeviceResult::Dictionary { word, entries })
 }
 
 fn decode_apps_result(reader: &mut Reader<'_>) -> Result<DeviceResult, ProtocolError> {
@@ -6995,6 +7101,26 @@ mod store_tests {
             end: 48,
         };
         assert_eq!(message_round_trip(message.clone()), message);
+    }
+
+    #[test]
+    fn offline_dictionary_requests_and_entries_are_bounded_and_typed() {
+        let request = Message::DeviceRequest(DeviceRequest::LookupWord {
+            word: "café".into(),
+            language: Some("fr".into()),
+        });
+        assert_eq!(message_round_trip(request.clone()), request);
+
+        let result = Message::DeviceResult(DeviceResult::Dictionary {
+            word: "café".into(),
+            entries: vec![DictionaryEntry {
+                dictionary: "Pocket French".into(),
+                language: "fr".into(),
+                headword: "café".into(),
+                definition: "Établissement où l'on sert des boissons.".into(),
+            }],
+        });
+        assert_eq!(message_round_trip(result.clone()), result);
     }
 
     #[test]

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -3259,6 +3259,23 @@ fn encoded_node_len(node: &Node, depth: usize, count: &mut usize) -> Result<usiz
             length
         }
         Node::Picture { .. } => 19,
+        Node::Table { rows, weights, .. } => {
+            if rows.len() > u8::MAX as usize || weights.len() > u8::MAX as usize {
+                return Err(ProtocolError::TooManyNodes);
+            }
+            let mut length = 7;
+            add_encoded_len(&mut length, weights.len().saturating_mul(2))?;
+            for row in rows {
+                if row.cells.len() > u8::MAX as usize {
+                    return Err(ProtocolError::TooManyNodes);
+                }
+                add_encoded_len(&mut length, 2)?;
+                for cell in &row.cells {
+                    add_encoded_len(&mut length, encoded_string_len(cell)?)?;
+                }
+            }
+            length
+        }
         Node::Stepper {
             label, less, more, ..
         } => {
@@ -4438,6 +4455,23 @@ fn encode_node(
             push_u32(output, source.1);
             push_u16(output, *max_height_tenths_mm);
         }
+        Node::Table { id, rows, weights } => {
+            output.push(30);
+            push_u32(output, id.0);
+            output.push(u8::try_from(weights.len()).map_err(|_| ProtocolError::TooManyNodes)?);
+            for weight in weights {
+                push_u16(output, *weight);
+            }
+            output.push(u8::try_from(rows.len()).map_err(|_| ProtocolError::TooManyNodes)?);
+            for row in rows {
+                output.push(u8::from(row.header));
+                output
+                    .push(u8::try_from(row.cells.len()).map_err(|_| ProtocolError::TooManyNodes)?);
+                for cell in &row.cells {
+                    push_string(output, cell)?;
+                }
+            }
+        }
         Node::Stepper {
             id,
             label,
@@ -5406,6 +5440,29 @@ fn decode_node(
                 selected,
                 freeform,
             })
+        }
+        30 => {
+            let count = reader.u8()? as usize;
+            let mut weights = Vec::with_capacity(count.min(MAX_NODES));
+            for _ in 0..count {
+                weights.push(reader.u16()?);
+            }
+            let count = reader.u8()? as usize;
+            let mut rows = Vec::with_capacity(count.min(MAX_NODES));
+            for _ in 0..count {
+                let header = match reader.u8()? {
+                    0 => false,
+                    1 => true,
+                    _ => return Err(ProtocolError::InvalidValue("table heading flag")),
+                };
+                let cells = reader.u8()? as usize;
+                let mut row = Vec::with_capacity(cells.min(MAX_NODES));
+                for _ in 0..cells {
+                    row.push(reader.string()?);
+                }
+                rows.push(kobo_ui::TableRow { header, cells: row });
+            }
+            Ok(Node::Table { id, rows, weights })
         }
         29 => {
             let label = reader.string()?;
@@ -6429,6 +6486,20 @@ mod node_coverage_tests {
     #[allow(clippy::too_many_lines, reason = "one literal per node variant")]
     fn one_of_every_node() -> Vec<Node> {
         vec![
+            Node::Table {
+                id: NodeId(70),
+                rows: vec![
+                    kobo_ui::TableRow {
+                        header: true,
+                        cells: vec!["Model".into(), "Top-1".into()],
+                    },
+                    kobo_ui::TableRow {
+                        header: false,
+                        cells: vec!["ResNet-50".into(), "76.1".into()],
+                    },
+                ],
+                weights: vec![240, 90],
+            },
             Node::Heading {
                 id: NodeId(1),
                 text: "Heading".into(),

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -6,10 +6,11 @@ use std::fmt;
 use std::io::{self, Read, Write};
 
 use kobo_ui::{
-    ActionId, BannerLevel, BarAction, BarStyle, BottomAction, Caret, Cell, ControlState, Freeform,
-    Glyph, NavBar, Node, NodeId, PageTurns, Percent, PictureHandle, Row, RowLead, RowState, Screen,
-    Space, TextScale, Tile, TilePicture, TileShape, TileState, TopBar, TransferFailure,
-    MAX_BAR_ACTIONS, MAX_TERMINAL_COLUMNS, MAX_TERMINAL_ROWS, MIN_NAV_DESTINATIONS,
+    ActionId, BannerLevel, BarAction, BarStyle, BottomAction, Caret, Cell, ControlState,
+    FontHandle, Freeform, Glyph, NavBar, Node, NodeId, PageTurns, Percent, PictureHandle, Row,
+    RowLead, RowState, Screen, Space, TextScale, Tile, TilePicture, TileShape, TileState, TopBar,
+    TransferFailure, MAX_BAR_ACTIONS, MAX_TERMINAL_COLUMNS, MAX_TERMINAL_ROWS,
+    MIN_NAV_DESTINATIONS,
 };
 use std::cmp::min;
 
@@ -40,8 +41,9 @@ pub const MAGIC: [u8; 4] = *b"KOBO";
 /// authenticate became an answer of its own rather than being reported as a
 /// missing page. Both are tags an older runtime has no reading for, and the
 /// credential sits ahead of the header count, so a frame it did not expect
-/// would have been misread from that point on rather than refused.
-pub const VERSION: u8 = 8;
+/// would have been misread from that point on rather than refused. Version 9
+/// adds bounded rich EPUB text and runtime-held publisher-font handles.
+pub const VERSION: u8 = 9;
 pub const HEADER_LEN: usize = 14;
 /// The largest single frame either side will read.
 ///
@@ -61,6 +63,8 @@ pub const MAX_INLINE_PICTURE_BYTES: usize = 768 * 1024;
 /// Largest piece of a chunked upload. Small enough to bound transient copies
 /// while still moving a full panel in a handful of local-socket writes.
 pub const MAX_PICTURE_CHUNK_BYTES: usize = 256 * 1024;
+/// Largest embedded outline font one application may hand to the runtime.
+pub const MAX_FONT_BYTES: usize = 2 * 1024 * 1024;
 pub const MAX_STRING_LEN: usize = 16_384;
 pub const MAX_NODES: usize = 512;
 /// The byte a nav bar sends when no destination is the current one.
@@ -641,6 +645,16 @@ pub enum Message {
     /// pictures rather than a requirement.
     DropPicture {
         handle: PictureHandle,
+    },
+    /// Hands one bounded TrueType/OpenType publisher face to the runtime.
+    PutFont {
+        handle: FontHandle,
+        name: String,
+        bytes: Vec<u8>,
+    },
+    /// Releases a publisher face and its glyph cache.
+    DropFont {
+        handle: FontHandle,
     },
 }
 
@@ -1498,6 +1512,16 @@ pub fn encode(frame: &Frame) -> Result<Vec<u8>, ProtocolError> {
         Message::CommitPicture { handle } | Message::DropPicture { handle } => {
             push_u32(&mut payload, handle.0);
         }
+        Message::PutFont {
+            handle,
+            name,
+            bytes,
+        } => {
+            push_u32(&mut payload, handle.0);
+            push_string(&mut payload, name)?;
+            payload.extend_from_slice(bytes);
+        }
+        Message::DropFont { handle } => push_u32(&mut payload, handle.0),
         Message::Lifecycle(state) => payload.push(match state {
             Lifecycle::Foreground => 0,
             Lifecycle::Background => 1,
@@ -2050,6 +2074,16 @@ fn encoded_message_layout(message: &Message) -> Result<(u8, usize), ProtocolErro
         }
         Message::CommitPicture { .. } => Ok((22, 4)),
         Message::CoverChanged { .. } => Ok((23, 1)),
+        Message::PutFont { name, bytes, .. } => {
+            if bytes.is_empty() || bytes.len() > MAX_FONT_BYTES {
+                return Err(ProtocolError::FrameTooLarge);
+            }
+            let mut length = 4;
+            add_encoded_len(&mut length, encoded_string_len(name)?)?;
+            add_encoded_len(&mut length, bytes.len())?;
+            Ok((24, length))
+        }
+        Message::DropFont { .. } => Ok((25, 4)),
     }
 }
 
@@ -2841,8 +2875,12 @@ fn encoded_screen_len(
     }
     // One flag byte for first refusal on the runtime's Back control, one for a
     // text size this screen asks for in place of the reader's own, and one for
-    // whether its text is a book rather than an interface.
-    add_encoded_len(&mut length, 3)?;
+    // whether its text is a book rather than an interface, and one for an
+    // optional runtime-held publisher font.
+    add_encoded_len(&mut length, 4)?;
+    if screen.reading_font.is_some() {
+        add_encoded_len(&mut length, 4)?;
+    }
     if let Some(nav_bar) = &screen.nav_bar {
         if nav_bar.destinations.len() > u8::MAX as usize {
             return Err(ProtocolError::TooManyNodes);
@@ -2905,6 +2943,20 @@ fn encoded_node_len(node: &Node, depth: usize, count: &mut usize) -> Result<usiz
             // id, the text, the count, then an action and two offsets each.
             let mut length = 6;
             add_encoded_len(&mut length, encoded_string_len(text)?)?;
+            for _ in links.iter().take(kobo_ui::MAX_TEXT_LINKS) {
+                add_encoded_len(&mut length, 12)?;
+            }
+            length
+        }
+        Node::RichText {
+            text, spans, links, ..
+        } => {
+            if spans.len() > kobo_ui::MAX_RICH_TEXT_SPANS {
+                return Err(ProtocolError::TooManyNodes);
+            }
+            let mut length = 5;
+            add_encoded_len(&mut length, encoded_string_len(text)?)?;
+            add_encoded_len(&mut length, 2 + spans.len() * 9 + 9 + 1)?;
             for _ in links.iter().take(kobo_ui::MAX_TEXT_LINKS) {
                 add_encoded_len(&mut length, 12)?;
             }
@@ -3541,6 +3593,22 @@ pub fn decode(bytes: &[u8]) -> Result<Frame, ProtocolError> {
         23 => Message::CoverChanged {
             magnet_present: read_boolean(&mut reader, "cover magnet present")?,
         },
+        24 => {
+            let handle = FontHandle(reader.u32()?);
+            let name = reader.string()?;
+            let length = reader.remaining();
+            if length == 0 || length > MAX_FONT_BYTES {
+                return Err(ProtocolError::FrameTooLarge);
+            }
+            Message::PutFont {
+                handle,
+                name,
+                bytes: reader.take(length)?.to_vec(),
+            }
+        }
+        25 => Message::DropFont {
+            handle: FontHandle(reader.u32()?),
+        },
         value => return Err(ProtocolError::UnknownMessageType(value)),
     };
     if !reader.is_finished() {
@@ -3611,6 +3679,7 @@ fn encode_top_bar(output: &mut Vec<u8>, top_bar: Option<&TopBar>) -> Result<(), 
     Ok(())
 }
 
+#[allow(clippy::too_many_lines)]
 fn encode_screen(
     output: &mut Vec<u8>,
     screen: &Screen,
@@ -3710,6 +3779,13 @@ fn encode_screen(
     // setting and the byte costs nothing to leave alone.
     output.push(screen.text_scale.map_or(0, |scale| scale.wire_value() + 1));
     output.push(u8::from(screen.reading));
+    match screen.reading_font {
+        None => output.push(0),
+        Some(handle) => {
+            output.push(1);
+            push_u32(output, handle.0);
+        }
+    }
     push_u16(
         output,
         u16::try_from(screen.nodes.len()).map_err(|_| ProtocolError::TooManyNodes)?,
@@ -3797,6 +3873,27 @@ fn decode_bar_action(reader: &mut Reader<'_>) -> Result<BarAction, ProtocolError
 // One exhaustive match over every node kind. Splitting it would only move
 // arms out of reach of the compiler's exhaustiveness check, which is the one
 // thing making it impossible to add a node and forget the wire format.
+fn text_presentation_byte(style: kobo_ui::TextPresentation) -> u8 {
+    u8::from(style.strong)
+        | (u8::from(style.emphasis) << 1)
+        | (u8::from(style.underline) << 2)
+        | (u8::from(style.superscript) << 3)
+        | (u8::from(style.subscript) << 4)
+}
+
+fn text_presentation_from_byte(value: u8) -> Result<kobo_ui::TextPresentation, ProtocolError> {
+    if value & !0x1f != 0 {
+        return Err(ProtocolError::InvalidValue("rich text style"));
+    }
+    Ok(kobo_ui::TextPresentation {
+        strong: value & 1 != 0,
+        emphasis: value & 2 != 0,
+        underline: value & 4 != 0,
+        superscript: value & 8 != 0,
+        subscript: value & 16 != 0,
+    })
+}
+
 #[allow(clippy::too_many_lines)]
 fn encode_node(
     output: &mut Vec<u8>,
@@ -3822,6 +3919,62 @@ fn encode_node(
             output.push(2);
             push_u32(output, id.0);
             push_string(output, text)?;
+            output.push(u8::try_from(links.len()).map_err(|_| ProtocolError::TooManyNodes)?);
+            for link in links {
+                push_u32(output, link.action.0);
+                push_u32(output, u32::try_from(link.start).unwrap_or(u32::MAX));
+                push_u32(output, u32::try_from(link.end).unwrap_or(u32::MAX));
+            }
+        }
+        Node::RichText {
+            id,
+            text,
+            spans,
+            links,
+            presentation,
+        } => {
+            if spans.len() > kobo_ui::MAX_RICH_TEXT_SPANS {
+                return Err(ProtocolError::TooManyNodes);
+            }
+            output.push(28);
+            push_u32(output, id.0);
+            push_string(output, text)?;
+            push_u16(
+                output,
+                u16::try_from(spans.len()).map_err(|_| ProtocolError::TooManyNodes)?,
+            );
+            for span in spans {
+                if span.start >= span.end
+                    || span.end > text.len()
+                    || !text.is_char_boundary(span.start)
+                    || !text.is_char_boundary(span.end)
+                {
+                    return Err(ProtocolError::InvalidValue("rich text span"));
+                }
+                push_u32(
+                    output,
+                    u32::try_from(span.start).map_err(|_| ProtocolError::FrameTooLarge)?,
+                );
+                push_u32(
+                    output,
+                    u32::try_from(span.end).map_err(|_| ProtocolError::FrameTooLarge)?,
+                );
+                output.push(text_presentation_byte(span.presentation));
+            }
+            output.push(match presentation.alignment {
+                kobo_ui::ParagraphAlignment::Start => 0,
+                kobo_ui::ParagraphAlignment::Center => 1,
+                kobo_ui::ParagraphAlignment::End => 2,
+                kobo_ui::ParagraphAlignment::Justify => 3,
+            });
+            push_u16(output, presentation.line_height_percent);
+            push_u16(output, presentation.margin_before_em);
+            push_u16(output, presentation.margin_after_em);
+            push_u16(
+                output,
+                u16::from_ne_bytes(presentation.first_line_indent_em.to_ne_bytes()),
+            );
+            let links = &links[..links.len().min(kobo_ui::MAX_TEXT_LINKS)];
             output.push(u8::try_from(links.len()).map_err(|_| ProtocolError::TooManyNodes)?);
             for link in links {
                 push_u32(output, link.action.0);
@@ -4572,6 +4725,11 @@ fn decode_screen(
         1 => true,
         _ => return Err(ProtocolError::InvalidValue("reading flag")),
     };
+    let reading_font = match reader.u8()? {
+        0 => None,
+        1 => Some(FontHandle(reader.u32()?)),
+        _ => return Err(ProtocolError::InvalidValue("reading font flag")),
+    };
     let count_nodes = usize::from(reader.u16()?);
     if count_nodes > MAX_NODES {
         return Err(ProtocolError::TooManyNodes);
@@ -4624,6 +4782,7 @@ fn decode_screen(
     screen.owns_back = owns_back;
     screen.text_scale = text_scale;
     screen.reading = reading;
+    screen.reading_font = reading_font;
     Ok(screen)
 }
 
@@ -4670,6 +4829,68 @@ fn decode_node(
                 }
             }
             Ok(Node::Text { id, text, links })
+        }
+        28 => {
+            let text = reader.string()?;
+            let span_count = usize::from(reader.u16()?);
+            if span_count > kobo_ui::MAX_RICH_TEXT_SPANS {
+                return Err(ProtocolError::TooManyNodes);
+            }
+            let mut spans = Vec::with_capacity(span_count);
+            for _ in 0..span_count {
+                let start = reader.u32()? as usize;
+                let end = reader.u32()? as usize;
+                let style = text_presentation_from_byte(reader.u8()?)?;
+                if start >= end
+                    || end > text.len()
+                    || !text.is_char_boundary(start)
+                    || !text.is_char_boundary(end)
+                {
+                    return Err(ProtocolError::InvalidValue("rich text span"));
+                }
+                spans.push(kobo_ui::RichTextSpan {
+                    start,
+                    end,
+                    presentation: style,
+                });
+            }
+            let alignment = match reader.u8()? {
+                0 => kobo_ui::ParagraphAlignment::Start,
+                1 => kobo_ui::ParagraphAlignment::Center,
+                2 => kobo_ui::ParagraphAlignment::End,
+                3 => kobo_ui::ParagraphAlignment::Justify,
+                _ => return Err(ProtocolError::InvalidValue("paragraph alignment")),
+            };
+            let presentation = kobo_ui::ParagraphPresentation {
+                alignment,
+                line_height_percent: reader.u16()?.clamp(80, 250),
+                margin_before_em: reader.u16()?.min(2_000),
+                margin_after_em: reader.u16()?.min(2_000),
+                first_line_indent_em: i16::from_ne_bytes(reader.u16()?.to_ne_bytes())
+                    .clamp(-2_000, 2_000),
+            };
+            let link_count = usize::from(reader.u8()?);
+            let mut links = Vec::with_capacity(link_count.min(kobo_ui::MAX_TEXT_LINKS));
+            for _ in 0..link_count {
+                let action = ActionId(reader.u32()?);
+                let start = reader.u32()? as usize;
+                let end = reader.u32()? as usize;
+                if start < end
+                    && end <= text.len()
+                    && text.is_char_boundary(start)
+                    && text.is_char_boundary(end)
+                    && links.len() < kobo_ui::MAX_TEXT_LINKS
+                {
+                    links.push(kobo_ui::TextLink { action, start, end });
+                }
+            }
+            Ok(Node::RichText {
+                id,
+                text,
+                spans,
+                links,
+                presentation,
+            })
         }
         18 => {
             let depth = reader.u8()?;
@@ -5979,6 +6200,24 @@ mod node_coverage_tests {
                 text: "Body".into(),
                 links: Vec::new(),
             },
+            Node::RichText {
+                id: NodeId(52),
+                text: "Styled body".into(),
+                spans: vec![kobo_ui::RichTextSpan {
+                    start: 0,
+                    end: 6,
+                    presentation: kobo_ui::TextPresentation {
+                        strong: true,
+                        ..kobo_ui::TextPresentation::default()
+                    },
+                }],
+                links: Vec::new(),
+                presentation: kobo_ui::ParagraphPresentation {
+                    alignment: kobo_ui::ParagraphAlignment::Center,
+                    line_height_percent: 130,
+                    ..kobo_ui::ParagraphPresentation::default()
+                },
+            },
             Node::Quote {
                 id: NodeId(30),
                 depth: 2,
@@ -6280,6 +6519,21 @@ mod node_coverage_tests {
             Some(Node::Grid { cells: back, .. }) => assert_eq!(back, &cells),
             other => panic!("expected a grid, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn a_reading_screen_keeps_its_publisher_font_handle() {
+        let screen = Screen::new(
+            1,
+            vec![Node::Text {
+                id: NodeId(1),
+                text: "Publisher prose".into(),
+                links: Vec::new(),
+            }],
+        )
+        .with_reading(true)
+        .with_reading_font(Some(FontHandle(42)));
+        assert_eq!(round_trip(screen.clone()), screen);
     }
 
     #[test]
@@ -7367,6 +7621,34 @@ mod picture_tests {
         };
         let bytes = encode(&frame).expect("encode");
         assert_eq!(decode(&bytes).expect("decode"), frame);
+    }
+
+    #[test]
+    fn a_publisher_font_travels_once_and_is_bounded() {
+        let message = Message::PutFont {
+            handle: FontHandle(7),
+            name: "Book.otf".into(),
+            bytes: b"OTTOfixture".to_vec(),
+        };
+        let frame = Frame {
+            request_id: 1,
+            message: message.clone(),
+        };
+        let bytes = encode(&frame).expect("encode font");
+        assert_eq!(decode(&bytes).expect("decode font").message, message);
+
+        let oversized = Frame {
+            request_id: 1,
+            message: Message::PutFont {
+                handle: FontHandle(8),
+                name: "huge.ttf".into(),
+                bytes: vec![0; MAX_FONT_BYTES + 1],
+            },
+        };
+        assert!(matches!(
+            encode(&oversized),
+            Err(ProtocolError::FrameTooLarge)
+        ));
     }
 
     #[test]

--- a/crates/kobo-read/Cargo.toml
+++ b/crates/kobo-read/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 kobo-doc = { path = "../kobo-doc" }
 kobo-sdk = { path = "../kobo-sdk" }
 kobo-ui = { path = "../kobo-ui" }
+unicode-segmentation = "1.13.3"
 
 [lints]
 workspace = true

--- a/crates/kobo-read/src/lib.rs
+++ b/crates/kobo-read/src/lib.rs
@@ -41,6 +41,7 @@ use kobo_doc::{Block, Document};
 use kobo_sdk::{BannerLevel, Screen, ScreenBuilder};
 use kobo_ui::TextScale;
 use kobo_ui::{quote_offsets, wrap_text_in, DisplayMetrics, Face, FontSize, ProseArea};
+use unicode_segmentation::UnicodeSegmentation;
 
 /// Where something is in a book, independent of how the book is set.
 ///
@@ -48,6 +49,45 @@ use kobo_ui::{quote_offsets, wrap_text_in, DisplayMetrics, Face, FontSize, Prose
 /// character offset into a rendering, and not a percentage: those all move
 /// when the type size does, and a bookmark that moves is not a bookmark.
 pub type Locator = u32;
+
+/// A stable position inside the logical text of one document block.
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+pub struct TextPosition {
+    pub block: Locator,
+    /// UTF-8 byte offset in the canonical block text, always on a grapheme
+    /// boundary. It is independent of pages, fonts, margins and orientation.
+    pub offset: u32,
+}
+
+/// A non-empty logical text range used by highlights, notes and lookups.
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+pub struct TextRange {
+    pub start: TextPosition,
+    pub end: TextPosition,
+}
+
+pub type AnnotationId = u64;
+
+/// Owner-authored marginalia attached to an immutable logical text range.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Annotation {
+    pub id: AnnotationId,
+    pub range: TextRange,
+    pub note: Option<String>,
+}
+
+pub const MAX_ANNOTATIONS: usize = 2_048;
+pub const MAX_NOTE_BYTES: usize = 4_096;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AnnotationFault {
+    MissingText,
+    Reversed,
+    NotGraphemeBoundary,
+    TooMany,
+    NoteTooLarge,
+    NotFound,
+}
 
 /// The depth a highlight's rule is set in. One, because a highlight is not a
 /// reply to anything, it just needs a margin to put the mark in.
@@ -131,6 +171,7 @@ pub struct Piece {
     kind: Kind,
     spans: Vec<kobo_ui::RichTextSpan>,
     presentation: kobo_ui::ParagraphPresentation,
+    source_offset: Option<u32>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -180,16 +221,35 @@ impl Kind {
 /// Small enough for the ordinary key-value store: a position, a type size, a
 /// light level, and two sorted sets of block indices. A book with a thousand
 /// marks in it is still only a few kilobytes.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Memory {
     /// The block that was at the top of the page.
     pub at: Locator,
     pub bookmarks: BTreeSet<Locator>,
     pub highlights: BTreeSet<Locator>,
+    /// Version-1 range annotations. The legacy paragraph set above remains a
+    /// migration input and is written until the platform annotation service
+    /// has shipped to every supported installation.
+    pub annotations: BTreeMap<AnnotationId, Annotation>,
+    pub next_annotation_id: AnnotationId,
     pub scale: TextScale,
     /// `None` means the reader has never set one here, so the device's own
     /// level is left alone. Zero is a real setting and is not the same thing.
     pub light: Option<u8>,
+}
+
+impl Default for Memory {
+    fn default() -> Self {
+        Self {
+            at: 0,
+            bookmarks: BTreeSet::new(),
+            highlights: BTreeSet::new(),
+            annotations: BTreeMap::new(),
+            next_annotation_id: 1,
+            scale: TextScale::default(),
+            light: None,
+        }
+    }
 }
 
 impl Memory {
@@ -215,6 +275,20 @@ impl Memory {
         for highlight in &self.highlights {
             let _ = writeln!(text, "high {highlight}");
         }
+        for annotation in self.annotations.values().take(MAX_ANNOTATIONS) {
+            let note = annotation.note.as_deref().unwrap_or_default();
+            let _ = writeln!(
+                text,
+                "ann {} {} {} {} {} {}",
+                annotation.id,
+                annotation.range.start.block,
+                annotation.range.start.offset,
+                annotation.range.end.block,
+                annotation.range.end.offset,
+                hex_encode(note.as_bytes()),
+            );
+        }
+        let _ = writeln!(text, "next-ann {}", self.next_annotation_id.max(1));
         text.into_bytes()
     }
 
@@ -247,11 +321,90 @@ impl Memory {
                         memory.highlights.insert(at);
                     }
                 }
+                "ann" if memory.annotations.len() < MAX_ANNOTATIONS => {
+                    if let Some(annotation) = decode_annotation(value) {
+                        memory.next_annotation_id = memory
+                            .next_annotation_id
+                            .max(annotation.id.saturating_add(1));
+                        memory
+                            .annotations
+                            .entry(annotation.id)
+                            .or_insert(annotation);
+                    }
+                }
+                "next-ann" => {
+                    memory.next_annotation_id = value.parse().unwrap_or(1).max(1);
+                }
                 _ => {}
             }
         }
         memory
     }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len().saturating_mul(2));
+    for byte in bytes.iter().take(MAX_NOTE_BYTES) {
+        out.push(char::from(DIGITS[usize::from(byte >> 4)]));
+        out.push(char::from(DIGITS[usize::from(byte & 0x0f)]));
+    }
+    out
+}
+
+fn hex_decode(value: &str) -> Option<Vec<u8>> {
+    if value.len() > MAX_NOTE_BYTES * 2 || value.len() % 2 != 0 {
+        return None;
+    }
+    value
+        .as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            let high = char::from(pair[0]).to_digit(16)?;
+            let low = char::from(pair[1]).to_digit(16)?;
+            u8::try_from((high << 4) | low).ok()
+        })
+        .collect()
+}
+
+fn decode_annotation(value: &str) -> Option<Annotation> {
+    let mut fields = value.splitn(6, ' ');
+    let id = fields.next()?.parse().ok()?;
+    let start_block = fields.next()?.parse().ok()?;
+    let start_offset = fields.next()?.parse().ok()?;
+    let end_block = fields.next()?.parse().ok()?;
+    let end_offset = fields.next()?.parse().ok()?;
+    let note = String::from_utf8(hex_decode(fields.next().unwrap_or_default())?).ok()?;
+    Some(Annotation {
+        id,
+        range: TextRange {
+            start: TextPosition {
+                block: start_block,
+                offset: start_offset,
+            },
+            end: TextPosition {
+                block: end_block,
+                offset: end_offset,
+            },
+        },
+        note: (!note.is_empty()).then_some(note),
+    })
+}
+
+fn bounded_note(note: Option<&str>) -> Result<Option<String>, AnnotationFault> {
+    let note = note.map(str::trim).filter(|note| !note.is_empty());
+    if note.is_some_and(|note| note.len() > MAX_NOTE_BYTES) {
+        return Err(AnnotationFault::NoteTooLarge);
+    }
+    Ok(note.map(str::to_owned))
+}
+
+fn is_grapheme_boundary(text: &str, offset: usize) -> bool {
+    offset <= text.len()
+        && (offset == text.len()
+            || text
+                .grapheme_indices(true)
+                .any(|(boundary, _)| boundary == offset))
 }
 
 /// The names a reader answers to.
@@ -434,9 +587,147 @@ impl Reader {
                 capped = cut;
             }
         }
+        decorate_annotation_ranges(&self.document, &self.memory.annotations, &mut pages);
         self.pages = pages;
         self.cut = capped || self.document.truncated;
         self.page = self.page_holding(self.memory.at);
+    }
+
+    /// Creates a range highlight or marginal note exactly once for an
+    /// operation identifier supplied by the caller.
+    pub fn create_annotation(
+        &mut self,
+        operation: AnnotationId,
+        range: TextRange,
+        note: Option<&str>,
+        panel: &DisplayMetrics,
+    ) -> Result<&Annotation, AnnotationFault> {
+        if self.memory.annotations.contains_key(&operation) {
+            return Ok(&self.memory.annotations[&operation]);
+        }
+        if self.memory.annotations.len() >= MAX_ANNOTATIONS {
+            return Err(AnnotationFault::TooMany);
+        }
+        self.validate_range(range)?;
+        let note = bounded_note(note)?;
+        self.memory.next_annotation_id = self
+            .memory
+            .next_annotation_id
+            .max(operation.saturating_add(1));
+        self.memory.annotations.insert(
+            operation,
+            Annotation {
+                id: operation,
+                range,
+                note,
+            },
+        );
+        self.repaginate(panel);
+        Ok(&self.memory.annotations[&operation])
+    }
+
+    /// Allocates a local operation identity and creates one annotation.
+    pub fn annotate(
+        &mut self,
+        range: TextRange,
+        note: Option<&str>,
+        panel: &DisplayMetrics,
+    ) -> Result<AnnotationId, AnnotationFault> {
+        let id = self.memory.next_annotation_id.max(1);
+        self.create_annotation(id, range, note, panel)?;
+        Ok(id)
+    }
+
+    /// Changes only an annotation's marginal note, never its selected words.
+    pub fn edit_annotation_note(
+        &mut self,
+        id: AnnotationId,
+        note: Option<&str>,
+    ) -> Result<(), AnnotationFault> {
+        let note = bounded_note(note)?;
+        let annotation = self
+            .memory
+            .annotations
+            .get_mut(&id)
+            .ok_or(AnnotationFault::NotFound)?;
+        annotation.note = note;
+        Ok(())
+    }
+
+    pub fn remove_annotation(
+        &mut self,
+        id: AnnotationId,
+        panel: &DisplayMetrics,
+    ) -> Result<Annotation, AnnotationFault> {
+        let annotation = self
+            .memory
+            .annotations
+            .remove(&id)
+            .ok_or(AnnotationFault::NotFound)?;
+        self.repaginate(panel);
+        Ok(annotation)
+    }
+
+    /// Range annotations sorted by logical location and then stable identity.
+    #[must_use]
+    pub fn annotations(&self) -> Vec<&Annotation> {
+        let mut annotations = self.memory.annotations.values().collect::<Vec<_>>();
+        annotations.sort_by_key(|annotation| (annotation.range, annotation.id));
+        annotations
+    }
+
+    /// Exact selected words, independent of their current page layout.
+    #[must_use]
+    pub fn text_in(&self, range: TextRange) -> Option<String> {
+        self.validate_range(range).ok()?;
+        let mut out = String::new();
+        for block in range.start.block..=range.end.block {
+            let text = self
+                .document
+                .blocks
+                .get(usize::try_from(block).ok()?)?
+                .text()?;
+            let from = if block == range.start.block {
+                usize::try_from(range.start.offset).ok()?
+            } else {
+                0
+            };
+            let to = if block == range.end.block {
+                usize::try_from(range.end.offset).ok()?
+            } else {
+                text.len()
+            };
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(text.get(from..to)?);
+        }
+        Some(out)
+    }
+
+    fn validate_range(&self, range: TextRange) -> Result<(), AnnotationFault> {
+        if range.start >= range.end {
+            return Err(AnnotationFault::Reversed);
+        }
+        let start = self
+            .document
+            .blocks
+            .get(usize::try_from(range.start.block).map_err(|_| AnnotationFault::MissingText)?)
+            .and_then(Block::text)
+            .ok_or(AnnotationFault::MissingText)?;
+        let end = self
+            .document
+            .blocks
+            .get(usize::try_from(range.end.block).map_err(|_| AnnotationFault::MissingText)?)
+            .and_then(Block::text)
+            .ok_or(AnnotationFault::MissingText)?;
+        let start_at =
+            usize::try_from(range.start.offset).map_err(|_| AnnotationFault::MissingText)?;
+        let end_at = usize::try_from(range.end.offset).map_err(|_| AnnotationFault::MissingText)?;
+        if !is_grapheme_boundary(start, start_at) || !is_grapheme_boundary(end, end_at) {
+            return Err(AnnotationFault::NotGraphemeBoundary);
+        }
+        Ok(())
     }
 
     /// The page a block lands on.
@@ -1063,7 +1354,16 @@ impl Reader {
                 Kind::Rule => screen.divider(),
                 Kind::Break => screen.spacer(kobo_ui::Space::Small),
                 Kind::Body | Kind::Preformatted => {
-                    if piece.spans.is_empty()
+                    if let Some(offset) = piece.source_offset {
+                        screen.selectable_rich_text_linking(
+                            piece.text.clone(),
+                            piece.spans.clone(),
+                            piece.presentation,
+                            u64::from(piece.block),
+                            offset,
+                            self.links_in(piece),
+                        )
+                    } else if piece.spans.is_empty()
                         && piece.presentation == kobo_ui::ParagraphPresentation::default()
                     {
                         screen.text_linking(piece.text.clone(), self.links_in(piece))
@@ -1324,10 +1624,27 @@ impl Reader {
         let mut screen = ScreenBuilder::new("reader-marks").top_bar(title);
         let marks = self.highlights();
         let places = self.bookmarks();
-        if marks.is_empty() && places.is_empty() {
+        let annotations = self.annotations();
+        if marks.is_empty() && places.is_empty() && annotations.is_empty() {
             screen = screen.secondary(
                 "Nothing is marked in this book yet. Mark a paragraph to keep the words, or bookmark a page to keep your place.",
             );
+        }
+        if !annotations.is_empty() {
+            screen = screen.heading("Highlights & marginalia");
+            for annotation in annotations {
+                let selected = self.text_in(annotation.range).map_or_else(
+                    || "Unavailable passage".to_owned(),
+                    |text| first_words(&text),
+                );
+                let label = annotation.note.as_ref().map_or(selected.clone(), |note| {
+                    format!("{selected} — {}", first_words(note))
+                });
+                screen = screen.button(
+                    format!("{}{}", action::GO, annotation.range.start.block),
+                    label,
+                );
+            }
         }
         if !marks.is_empty() {
             screen = screen.heading("Marked passages");
@@ -1698,6 +2015,116 @@ fn force_page_break(pages: &mut Vec<Vec<Piece>>, page: &mut Vec<Piece>, used: &m
     }
 }
 
+fn decorate_annotation_ranges(
+    document: &Document,
+    annotations: &BTreeMap<AnnotationId, Annotation>,
+    pages: &mut [Vec<Piece>],
+) {
+    let mut cursors = BTreeMap::<Locator, usize>::new();
+    for piece in pages.iter_mut().flat_map(|page| page.iter_mut()) {
+        let Some(source) = document
+            .blocks
+            .get(usize::try_from(piece.block).unwrap_or(usize::MAX))
+            .and_then(Block::text)
+        else {
+            continue;
+        };
+        let cursor = cursors.entry(piece.block).or_default();
+        let Some(relative) = source
+            .get(*cursor..)
+            .and_then(|rest| rest.find(&piece.text))
+        else {
+            continue;
+        };
+        let piece_from = *cursor + relative;
+        let piece_to = piece_from + piece.text.len();
+        *cursor = piece_to;
+        piece.source_offset = u32::try_from(piece_from).ok();
+        let mut ranges = Vec::new();
+        for annotation in annotations.values() {
+            if piece.block < annotation.range.start.block
+                || piece.block > annotation.range.end.block
+            {
+                continue;
+            }
+            let from = if piece.block == annotation.range.start.block {
+                usize::try_from(annotation.range.start.offset).unwrap_or(usize::MAX)
+            } else {
+                0
+            };
+            let to = if piece.block == annotation.range.end.block {
+                usize::try_from(annotation.range.end.offset).unwrap_or(0)
+            } else {
+                source.len()
+            };
+            let start = from.max(piece_from);
+            let end = to.min(piece_to);
+            if start < end {
+                ranges.push((start - piece_from, end - piece_from));
+            }
+        }
+        if !ranges.is_empty() {
+            piece.spans = highlighted_spans(&piece.spans, piece.text.len(), &ranges);
+        }
+    }
+}
+
+fn highlighted_spans(
+    publisher: &[kobo_ui::RichTextSpan],
+    length: usize,
+    highlights: &[(usize, usize)],
+) -> Vec<kobo_ui::RichTextSpan> {
+    let mut boundaries = BTreeSet::from([0, length]);
+    for span in publisher {
+        boundaries.insert(span.start.min(length));
+        boundaries.insert(span.end.min(length));
+    }
+    for &(start, end) in highlights {
+        boundaries.insert(start.min(length));
+        boundaries.insert(end.min(length));
+    }
+    let boundaries = boundaries.into_iter().collect::<Vec<_>>();
+    let mut spans: Vec<kobo_ui::RichTextSpan> = Vec::new();
+    for window in boundaries.windows(2) {
+        let (start, end) = (window[0], window[1]);
+        if start >= end {
+            continue;
+        }
+        let mut presentation = publisher
+            .iter()
+            .find(|span| span.start <= start && start < span.end)
+            .map_or_else(kobo_ui::TextPresentation::default, |span| span.presentation);
+        presentation.highlighted = highlights
+            .iter()
+            .any(|&(from, to)| from < end && start < to);
+        if presentation == kobo_ui::TextPresentation::default() {
+            continue;
+        }
+        if let Some(last) = spans
+            .last_mut()
+            .filter(|last| last.end == start && last.presentation == presentation)
+        {
+            last.end = end;
+        } else {
+            spans.push(kobo_ui::RichTextSpan {
+                start,
+                end,
+                presentation,
+            });
+        }
+    }
+    if spans.len() > kobo_ui::MAX_RICH_TEXT_SPANS {
+        spans.truncate(kobo_ui::MAX_RICH_TEXT_SPANS);
+        if let Some(last) = spans.last_mut() {
+            last.end = length;
+            last.presentation.highlighted = highlights
+                .iter()
+                .any(|&(from, to)| from < length && last.start < to);
+        }
+    }
+    spans
+}
+
 // A packing loop: measure, place, and break when the page is full. Splitting
 // it would mean handing the same six pieces of state to each half, and the
 // hand-off is where an off-by-one in a page break would hide.
@@ -1783,6 +2210,7 @@ fn paginate(
                 kind,
                 spans: Vec::new(),
                 presentation: kobo_ui::ParagraphPresentation::default(),
+                source_offset: None,
             });
             continue;
         }
@@ -1802,6 +2230,7 @@ fn paginate(
                         kind,
                         spans: Vec::new(),
                         presentation: kobo_ui::ParagraphPresentation::default(),
+                        source_offset: None,
                     },
                     &mut Placing {
                         pages: &mut pages,
@@ -1868,6 +2297,7 @@ fn paginate(
                         kind,
                         spans,
                         presentation,
+                        source_offset: None,
                     });
                     placed = end;
                 }
@@ -1893,6 +2323,7 @@ fn paginate(
                 kind,
                 spans,
                 presentation,
+                source_offset: None,
             });
             placed += take;
         }
@@ -1957,6 +2388,7 @@ fn piece_presentation(
                 underline: span.style.underline,
                 superscript: span.style.superscript,
                 subscript: span.style.subscript,
+                highlighted: false,
             },
         });
     }
@@ -3333,6 +3765,148 @@ mod tests {
         assert_eq!(hits[0].at, 0);
         assert!(!hits[0].excerpt.contains('<'));
         assert!(reader.search("paper lantern", 0).is_empty());
+    }
+
+    #[test]
+    fn range_annotations_keep_exact_unicode_words_across_repagination_and_restart() {
+        let combined = "Cafe\u{301}";
+        let document = Document {
+            blocks: vec![Block::Paragraph(format!(
+                "{combined} and tea by the window."
+            ))],
+            ..Document::default()
+        };
+        let mut reader = Reader::open(document.clone(), Memory::default(), &panel());
+        let range = TextRange {
+            start: TextPosition {
+                block: 0,
+                offset: 0,
+            },
+            end: TextPosition {
+                block: 0,
+                offset: u32::try_from(combined.len()).expect("short fixture"),
+            },
+        };
+        let id = reader
+            .annotate(range, Some("Remember the accent ☕"), &panel())
+            .expect("annotation");
+        assert_eq!(reader.text_in(range).as_deref(), Some(combined));
+        reader.set_scale(TextScale::ExtraLarge, &panel());
+        assert_eq!(reader.annotations()[0].range, range);
+
+        let encoded = reader.memory().encode();
+        let reopened = Reader::open(document, Memory::decode(&encoded), &panel());
+        let annotation = reopened.annotations()[0];
+        assert_eq!(annotation.id, id);
+        assert_eq!(annotation.range, range);
+        assert_eq!(annotation.note.as_deref(), Some("Remember the accent ☕"));
+        assert_eq!(
+            reopened.text_in(annotation.range).as_deref(),
+            Some(combined)
+        );
+    }
+
+    #[test]
+    fn annotation_operations_are_idempotent_and_note_edits_cannot_move_the_range() {
+        let document = Document {
+            blocks: vec![Block::Paragraph("one two three".into())],
+            ..Document::default()
+        };
+        let mut reader = Reader::open(document, Memory::default(), &panel());
+        let range = TextRange {
+            start: TextPosition {
+                block: 0,
+                offset: 4,
+            },
+            end: TextPosition {
+                block: 0,
+                offset: 7,
+            },
+        };
+        reader
+            .create_annotation(42, range, None, &panel())
+            .expect("first delivery");
+        reader
+            .create_annotation(42, range, Some("duplicate"), &panel())
+            .expect("duplicate delivery");
+        assert_eq!(reader.annotations().len(), 1);
+        assert_eq!(reader.annotations()[0].note, None);
+        reader
+            .edit_annotation_note(42, Some("my note"))
+            .expect("edit note");
+        assert_eq!(reader.annotations()[0].range, range);
+        assert_eq!(reader.annotations()[0].note.as_deref(), Some("my note"));
+        assert_eq!(
+            reader
+                .remove_annotation(42, &panel())
+                .expect("remove")
+                .range,
+            range
+        );
+        assert!(reader.annotations().is_empty());
+    }
+
+    #[test]
+    fn a_range_highlight_marks_only_the_selected_words_on_the_page() {
+        let document = Document {
+            blocks: vec![Block::Paragraph("one two three".into())],
+            ..Document::default()
+        };
+        let mut reader = Reader::open(document, Memory::default(), &panel());
+        reader
+            .annotate(
+                TextRange {
+                    start: TextPosition {
+                        block: 0,
+                        offset: 4,
+                    },
+                    end: TextPosition {
+                        block: 0,
+                        offset: 7,
+                    },
+                },
+                None,
+                &panel(),
+            )
+            .expect("highlight");
+        let screen = reader.screen("Book");
+        let (text, spans) = screen
+            .nodes
+            .iter()
+            .find_map(|node| match node {
+                kobo_sdk::Node::RichText { text, spans, .. } => Some((text, spans)),
+                _ => None,
+            })
+            .expect("rich highlighted paragraph");
+        let highlighted = spans
+            .iter()
+            .filter(|span| span.presentation.highlighted)
+            .map(|span| &text[span.start..span.end])
+            .collect::<String>();
+        assert_eq!(highlighted, "two");
+    }
+
+    #[test]
+    fn selection_endpoints_never_split_a_grapheme() {
+        let document = Document {
+            blocks: vec![Block::Paragraph("e\u{301}lan".into())],
+            ..Document::default()
+        };
+        let mut reader = Reader::open(document, Memory::default(), &panel());
+        let split_combining_sequence = TextRange {
+            start: TextPosition {
+                block: 0,
+                offset: 0,
+            },
+            end: TextPosition {
+                block: 0,
+                offset: 1,
+            },
+        };
+        assert_eq!(
+            reader.annotate(split_combining_sequence, None, &panel()),
+            Err(AnnotationFault::NotGraphemeBoundary)
+        );
     }
 
     #[test]

--- a/crates/kobo-read/src/lib.rs
+++ b/crates/kobo-read/src/lib.rs
@@ -967,6 +967,19 @@ impl Reader {
         self.memory.scale
     }
 
+    /// Says the document stopped short of its own end.
+    ///
+    /// For a document fetched under a byte ceiling, where what arrived is
+    /// every word that was sent and still not every word there is. The last
+    /// page says so, which is the only place anybody could tell the difference
+    /// between a document that ended and one that simply stopped.
+    pub const fn mark_truncated(&mut self, truncated: bool) {
+        self.document.truncated = truncated;
+        if truncated {
+            self.cut = true;
+        }
+    }
+
     /// Brightens the front light by one step, stopping at full.
     pub fn brighter(&mut self) -> u8 {
         let level = self

--- a/crates/kobo-read/src/lib.rs
+++ b/crates/kobo-read/src/lib.rs
@@ -40,7 +40,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use kobo_doc::{Block, Document};
 use kobo_sdk::{BannerLevel, Screen, ScreenBuilder};
 use kobo_ui::TextScale;
-use kobo_ui::{quote_offsets, wrap_text_in, DisplayMetrics, Face, FontSize, ProseArea};
+use kobo_ui::{quote_offsets, wrap_text_in, DisplayMetrics, Face, FontSize, Glyph, ProseArea};
 use unicode_segmentation::UnicodeSegmentation;
 
 /// Where something is in a book, independent of how the book is set.
@@ -575,11 +575,14 @@ impl Reader {
             .height
             .saturating_sub(metrics.page_position_band())
             .max(1);
-        // Measured with the type at the size the screen will ask for. The
+        // Measured with the prose at the size the screen will ask for. The
         // scale has to be ambient while this runs, because the wrapper and the
         // line height both read it -- and the screen carries the same value,
-        // so what was measured here is what gets drawn.
-        let (mut pages, mut capped) = kobo_ui::with_text_scale(self.memory.scale, || {
+        // so what was measured here is what gets drawn. It is the reading
+        // scale rather than the interface one, so the bar above the page and
+        // the strip below it stay the size the reader set for the device and
+        // a larger book gets all of the room it asked for.
+        let (mut pages, mut capped) = kobo_ui::with_reading_scale(self.memory.scale, || {
             paginate(
                 &self.document,
                 &self.memory.highlights,
@@ -593,7 +596,7 @@ impl Reader {
         // this way round rather than the other cannot oscillate: more room
         // never turns one page into two.
         if pages.len() <= 1 {
-            let (whole, cut) = kobo_ui::with_text_scale(self.memory.scale, || {
+            let (whole, cut) = kobo_ui::with_reading_scale(self.memory.scale, || {
                 paginate(
                     &self.document,
                     &self.memory.highlights,
@@ -932,10 +935,8 @@ impl Reader {
 
     /// One step larger, if there is one. Returns whether anything changed.
     pub fn larger(&mut self, panel: &DisplayMetrics) -> bool {
-        let next = match self.memory.scale {
-            TextScale::Default => TextScale::Large,
-            TextScale::Large => TextScale::ExtraLarge,
-            TextScale::ExtraLarge => return false,
+        let Some(next) = self.memory.scale.larger() else {
+            return false;
         };
         self.set_scale(next, panel);
         true
@@ -943,10 +944,8 @@ impl Reader {
 
     /// One step smaller, if there is one. Returns whether anything changed.
     pub fn smaller(&mut self, panel: &DisplayMetrics) -> bool {
-        let next = match self.memory.scale {
-            TextScale::ExtraLarge => TextScale::Large,
-            TextScale::Large => TextScale::Default,
-            TextScale::Default => return false,
+        let Some(next) = self.memory.scale.smaller() else {
+            return false;
         };
         self.set_scale(next, panel);
         true
@@ -1294,9 +1293,15 @@ impl Reader {
             action::BOOKMARK.into(),
             action::HIGHLIGHTS.into(),
             action::MARKING.into(),
+            action::CONTENTS.into(),
+            action::LINKS.into(),
         ];
-        for step in 0..3 {
-            names.push(format!("{}{step}", action::SIZE));
+        // Every size there is, rather than a hard-coded three. The stepper's
+        // ends name the size either side of the one in force, so a range that
+        // grew without this list growing with it left the two controls tapping
+        // at nothing.
+        for scale in kobo_ui::TextScale::STEPS {
+            names.push(format!("{}{}", action::SIZE, scale.wire_value()));
         }
         // Only the blocks that are actually on a screen right now, so this
         // stays a few dozen comparisons rather than one per block in a novel.
@@ -1500,67 +1505,85 @@ impl Reader {
 
     /// What the light control opens: the front light and nothing else.
     fn light_panel(&self, panel: ScreenBuilder) -> ScreenBuilder {
-        // The level is drawn as well as stepped, because "dimmer" with no
-        // reading of what it is now tells somebody in a dark room nothing.
+        // The level is drawn as well as stepped, because a control that only
+        // says "dimmer" tells somebody in a dark room nothing about where they
+        // already are. The two ends carry a minus and a plus and no words at
+        // all: brightness is the one setting every device on earth draws the
+        // same way, and the reading between them is the label.
         let light = self.memory.light.unwrap_or(0);
         panel
-            .choose(
-                format!("Front light {light}%"),
-                [(action::DIMMER, "Dimmer"), (action::BRIGHTER, "Brighter")],
+            .stepper(
+                format!("{light}%"),
+                action::DIMMER,
+                Glyph::Minus,
+                action::BRIGHTER,
+                Glyph::Plus,
             )
-            .progress(light)
+            .stepper_ends(light > 0, light < 100)
+            .stepper_track(light)
     }
 
     /// What the "Aa" control opens: everything that is not the book itself.
     fn controls_panel(&self, panel: ScreenBuilder) -> ScreenBuilder {
-        let sizes = [
-            (TextScale::Default, "Standard"),
-            (TextScale::Large, "Large"),
-            (TextScale::ExtraLarge, "Largest"),
-        ];
-        let chosen = sizes
-            .iter()
-            .position(|(scale, _)| *scale == self.memory.scale)
-            .unwrap_or(0);
-        // The three sizes themselves rather than a plus and a minus. A stepper
-        // hides which size is in force and takes two taps and two full-page
-        // refreshes to cross the range; naming them says where the reader is
-        // and gets anywhere in one.
+        // A stepper rather than the three named sizes this used to offer.
+        // Naming them said where the reader was in one glance, which is worth
+        // something, but it cost three full-width boxes stacked down the panel
+        // and it fixed the range at three: somebody who found "Standard" a
+        // shade too small had nowhere to go but a size half again as large.
+        // Nine steps of ten percent, walked a notch at a time, is the shape
+        // every other device gives this setting, and it fits on one line.
+        let scale = self.memory.scale;
+        let smaller = scale.smaller().unwrap_or(scale);
+        let larger = scale.larger().unwrap_or(scale);
         let mut panel = panel
-            .choose(
-                "Type size",
-                sizes
-                    .iter()
-                    .enumerate()
-                    .map(|(step, (_, label))| (format!("{}{step}", action::SIZE), *label)),
+            .stepper(
+                format!("{}%", scale.percent()),
+                format!("{}{}", action::SIZE, smaller.wire_value()),
+                Glyph::Minus,
+                format!("{}{}", action::SIZE, larger.wire_value()),
+                Glyph::Plus,
             )
-            .chosen(chosen);
+            .stepper_ends(scale.smaller().is_some(), scale.larger().is_some())
+            .stepper_track(
+                u8::try_from(scale.step().saturating_mul(100) / (TextScale::STEPS.len() - 1))
+                    .unwrap_or(100),
+            );
 
+        // Everything else the panel holds is one tap that does one thing, and
+        // each of them has a picture the reader has already met somewhere: a
+        // ribbon for a bookmark, a pen for a mark, a book for its own contents.
+        // Set as a row of pictures rather than a column of sentences, the whole
+        // panel now ends about where the type size used to.
         panel = panel.divider();
-        panel = panel.button(
-            action::BOOKMARK,
+        let mut row = vec![(
+            action::BOOKMARK.to_owned(),
             if self.is_bookmarked() {
-                "Remove bookmark"
+                "Bookmarked"
             } else {
-                "Bookmark this page"
+                "Bookmark"
             },
-        );
+            Glyph::Bookmark,
+        )];
         if !self.markable().is_empty() {
-            panel = panel.button(action::MARKING, "Mark a paragraph");
+            row.push((action::MARKING.to_owned(), "Mark", Glyph::Tag));
         }
         // Offered only for a book that published its own contents. A button
         // that opens an empty list is a dead end somebody has to back out of,
         // and the parts worked out from headings are not a contents list.
         if !self.document.contents.is_empty() {
-            panel = panel.button(action::CONTENTS, "Contents");
+            row.push((action::CONTENTS.to_owned(), "Contents", Glyph::Book));
         }
         // Offered only where there is somewhere to go from, so the control
         // appears on the pages that have footnotes and stays out of the way
         // on the ones that do not.
         if !self.links_here().is_empty() {
-            panel = panel.button(action::LINKS, "Links on this page");
+            row.push((action::LINKS.to_owned(), "Links", Glyph::Globe));
         }
-        panel.button(action::HIGHLIGHTS, "Notes")
+        row.push((action::HIGHLIGHTS.to_owned(), "Notes", Glyph::Note));
+        // Four across at most: a fifth control on this panel would be narrower
+        // than a fingertip, and the row wraps rather than shrinking.
+        let columns = u8::try_from(row.len().min(4)).unwrap_or(4);
+        panel.controls(columns, row)
     }
 
     /// Where this page points, each line a way there.
@@ -3128,11 +3151,16 @@ mod tests {
         let layout = screen.layout_with(&panel(), &kobo_ui::Chrome::with_back(true));
         let on_panel = |name: &str| {
             let wanted = kobo_sdk::action_id(name);
-            layout.nodes.iter().any(|node| matches!(
-                node.kind,
-                kobo_ui::LayoutKind::Button(found, ..) | kobo_ui::LayoutKind::ChoiceOption(found, _)
-                if found == wanted
-            ))
+            layout.nodes.iter().any(|node| {
+                matches!(
+                    node.kind,
+                    kobo_ui::LayoutKind::Button(found, ..)
+                        | kobo_ui::LayoutKind::Cell(found, ..)
+                        | kobo_ui::LayoutKind::StepperControl(found, ..)
+                        | kobo_ui::LayoutKind::ChoiceOption(found, _)
+                    if found == wanted
+                )
+            })
         };
         assert!(on_panel(action::DIMMER), "dimmer is not on the light panel");
         assert!(
@@ -3192,6 +3220,8 @@ mod tests {
                 layout.nodes.iter().any(|node| matches!(
                     node.kind,
                     kobo_ui::LayoutKind::Button(found, ..)
+                        | kobo_ui::LayoutKind::Cell(found, ..)
+                        | kobo_ui::LayoutKind::StepperControl(found, ..)
                         | kobo_ui::LayoutKind::ChoiceOption(found, _)
                     if found == action
                 )),
@@ -3210,32 +3240,100 @@ mod tests {
         );
     }
 
-    /// Naming the sizes rather than stepping through them: one tap to any
-    /// size, and the panel says which one is in force.
+    /// Every control the two panels draw is one the reader answers.
+    ///
+    /// The defect this covers: the reverse lookup from a tapped identifier to
+    /// a name listed three type sizes, and the stepper offers nine. Both of
+    /// its ends hashed to something the list did not contain, so the panel
+    /// drew a working control that did nothing at all when tapped -- and the
+    /// same silence would have swallowed the contents and links buttons.
     #[test]
-    fn a_size_can_be_chosen_by_name_and_the_current_one_is_marked() {
+    fn every_control_on_a_panel_is_one_the_reader_answers() {
+        for chrome in [Chrome::Controls, Chrome::Light] {
+            for scale in kobo_ui::TextScale::STEPS {
+                let mut reader = reader(40);
+                reader.set_scale(scale, &panel());
+                reader.set_chrome(chrome, &panel());
+                let screen = reader.screen("Pride and Prejudice");
+                let layout = screen.layout_with(&panel(), &kobo_ui::Chrome::with_back(true));
+                let offered = layout
+                    .nodes
+                    .iter()
+                    .filter_map(|node| node.kind.acts_on())
+                    // The runtime owns its own back and overlay-close marks.
+                    .filter(|action| !action.is_reserved())
+                    .collect::<Vec<_>>();
+                assert!(
+                    !offered.is_empty(),
+                    "{chrome:?} at {scale:?} drew no controls at all"
+                );
+                for action in offered {
+                    let mut reader = reader.clone();
+                    assert_ne!(
+                        reader.act_on(action, &panel()),
+                        Outcome::Elsewhere,
+                        "{chrome:?} at {scale:?} draws {action:?}, which the reader does not answer"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The panel steps the size a notch at a time and says where the reader
+    /// has got to. Naming three sizes was one tap to any of them, which is
+    /// worth something, but it fixed the range at three and stacked three
+    /// full-width boxes down a panel drawn over the page to do it.
+    #[test]
+    fn the_size_is_stepped_a_notch_at_a_time_and_the_panel_says_where_it_is() {
         let mut reader = reader(40);
         reader.act(action::CONTROLS, &panel());
         assert_eq!(reader.scale(), TextScale::Default);
 
-        let outcome = reader.act(&format!("{}2", action::SIZE), &panel());
+        let step_up = format!("{}{}", action::SIZE, TextScale::Medium.wire_value());
+        let outcome = reader.act(&step_up, &panel());
         assert_eq!(outcome, Outcome::Save);
-        assert_eq!(reader.scale(), TextScale::ExtraLarge);
+        assert_eq!(reader.scale(), TextScale::Medium);
 
         let screen = reader.screen("Pride and Prejudice");
         let overlay = screen.overlay.as_ref().expect("a panel");
-        let marked = overlay.nodes.iter().find_map(|node| match node {
-            kobo_ui::Node::Choice { selected, .. } => *selected,
-            _ => None,
-        });
-        assert_eq!(marked, Some(2), "the panel did not mark the size in force");
+        let stepper = overlay
+            .nodes
+            .iter()
+            .find_map(|node| match node {
+                kobo_ui::Node::Stepper {
+                    label, less, more, ..
+                } => Some((label.clone(), less.action, more.action)),
+                _ => None,
+            })
+            .expect("a type size stepper");
+        assert_eq!(
+            stepper.0,
+            format!("{}%", TextScale::Medium.percent()),
+            "the panel did not say the size in force"
+        );
+        // The ends name the neighbouring sizes rather than a verb, so a tap is
+        // a size and the panel keeps no state of its own to know which.
+        assert_eq!(
+            stepper.1,
+            kobo_sdk::action_id(&format!(
+                "{}{}",
+                action::SIZE,
+                TextScale::Default.wire_value()
+            ))
+        );
+        assert_eq!(
+            stepper.2,
+            kobo_sdk::action_id(&format!(
+                "{}{}",
+                action::SIZE,
+                TextScale::Large.wire_value()
+            ))
+        );
 
         // Asking for the size it is already at is not a change to save, and it
-        // is not somebody else's action either.
-        assert_eq!(
-            reader.act(&format!("{}2", action::SIZE), &panel()),
-            Outcome::Repaint
-        );
+        // is not somebody else's action either. That is what the ends do once
+        // the reader has reached one end of the range.
+        assert_eq!(reader.act(&step_up, &panel()), Outcome::Repaint);
         assert_eq!(
             reader.act("reader-size-nonsense", &panel()),
             Outcome::Elsewhere
@@ -3310,14 +3408,25 @@ mod tests {
     #[test]
     fn the_type_size_stops_at_both_ends_rather_than_wrapping() {
         let mut reader = reader(10);
-        assert!(reader.larger(&panel()));
-        assert!(reader.larger(&panel()));
-        assert!(!reader.larger(&panel()), "there was a fourth size");
-        assert_eq!(reader.scale(), TextScale::ExtraLarge);
-        assert!(reader.smaller(&panel()));
-        assert!(reader.smaller(&panel()));
-        assert!(!reader.smaller(&panel()));
-        assert_eq!(reader.scale(), TextScale::Default);
+        // Walked from the middle to the top and back to the bottom, so that
+        // both ends are found by stepping rather than by naming them.
+        let above = TextScale::STEPS.len() - TextScale::Default.step() - 1;
+        for step in 0..above {
+            assert!(reader.larger(&panel()), "no size above step {step}");
+        }
+        assert!(
+            !reader.larger(&panel()),
+            "there was a size above the largest"
+        );
+        assert_eq!(reader.scale(), TextScale::Largest);
+        for step in 0..TextScale::STEPS.len() - 1 {
+            assert!(reader.smaller(&panel()), "no size below step {step}");
+        }
+        assert!(
+            !reader.smaller(&panel()),
+            "there was a size below the smallest"
+        );
+        assert_eq!(reader.scale(), TextScale::Smallest);
     }
 
     #[test]
@@ -3517,8 +3626,9 @@ mod tests {
         reader.toggle_bookmark();
         let target = reader.markable().first().unwrap().0;
         reader.toggle_highlight(target, &panel());
-        reader.larger(&panel());
-        reader.larger(&panel());
+        for _ in 0..4 {
+            reader.larger(&panel());
+        }
         reader.brighter();
 
         let kept = Memory::decode(&reader.memory().encode());
@@ -3779,11 +3889,12 @@ mod tests {
         let screen = reader.screen("Pride and Prejudice");
         let overlay = screen.overlay.as_ref().expect("a panel");
         assert!(
-            overlay.nodes.iter().any(|node| matches!(
-                node,
-                kobo_ui::Node::Button { action, .. }
-                    if *action == kobo_sdk::action_id(action::HIGHLIGHTS)
-            )),
+            overlay.nodes.iter().any(|node| match node {
+                kobo_ui::Node::Grid { cells, .. } => cells
+                    .iter()
+                    .any(|cell| cell.action == kobo_sdk::action_id(action::HIGHLIGHTS)),
+                _ => false,
+            }),
             "there is no way from the book to the marks"
         );
     }

--- a/crates/kobo-read/src/lib.rs
+++ b/crates/kobo-read/src/lib.rs
@@ -172,6 +172,13 @@ pub struct Piece {
     spans: Vec<kobo_ui::RichTextSpan>,
     presentation: kobo_ui::ParagraphPresentation,
     source_offset: Option<u32>,
+    /// The cells of a table row, and what each column of its table wants to
+    /// be. Empty for everything that is not a row.
+    ///
+    /// The widths are measured across the whole table when the first of its
+    /// rows is reached, and carried on every row of it, so a table split over
+    /// two pages keeps the same columns on both.
+    row: Option<(Vec<String>, Vec<u16>)>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -185,6 +192,10 @@ enum Kind {
     Caption,
     /// A picture the book set into its text.
     Picture,
+    /// One row of a table. Consecutive rows are drawn as one table.
+    Row {
+        header: bool,
+    },
     Rule,
     Break,
 }
@@ -884,7 +895,14 @@ impl Reader {
         let limit = limit.min(MAX_SEARCH_RESULTS);
         let mut hits = Vec::new();
         for (index, block) in self.document.blocks.iter().enumerate() {
-            let Some(text) = block.text() else { continue };
+            // A table row has no single string of its own -- that is the
+            // point of it -- but a reader searching for a word does not care
+            // which cell it sat in, so the row is joined for the search and
+            // for the excerpt that names it.
+            let joined = block.row_text();
+            let Some(text) = joined.as_deref().or_else(|| block.text()) else {
+                continue;
+            };
             let Some((from, to)) = find_folded(text, &query) else {
                 continue;
             };
@@ -1398,7 +1416,20 @@ impl Reader {
         if let Some(font) = self.publisher_font {
             screen = screen.reading_font(font);
         }
-        for piece in self.page() {
+        let pieces = self.page();
+        let mut at = 0;
+        while let Some(piece) = pieces.get(at) {
+            at += 1;
+            // Rows are gathered back into the table they were cut out of.
+            // Every row of it has to be handed over at once, because the
+            // columns can only be lined up by something that can see all of
+            // them -- which is the whole reason a table is not just prose.
+            if let Kind::Row { .. } = piece.kind {
+                let (rows, weights, next) = gather_table(pieces, at - 1);
+                at = next;
+                screen = screen.table(rows, weights);
+                continue;
+            }
             screen = match piece.kind {
                 Kind::Heading(_) => screen.heading(piece.text.clone()),
                 Kind::Marked | Kind::Quote | Kind::Item => {
@@ -1443,6 +1474,7 @@ impl Reader {
                         )
                     }
                 }
+                Kind::Row { .. } => screen,
             };
         }
         if let Some(problem) = &self.problem {
@@ -2304,6 +2336,134 @@ fn highlighted_spans(
     spans
 }
 
+/// Gathers the run of rows starting at `from` back into the one table they
+/// were cut out of.
+///
+/// Returns the rows, the widths their columns were measured at, and the index
+/// of the first piece after them.
+fn gather_table(pieces: &[Piece], from: usize) -> (Vec<kobo_ui::TableRow>, Vec<u16>, usize) {
+    let mut rows = Vec::new();
+    let mut weights = Vec::new();
+    let mut at = from;
+    while let Some(piece) = pieces.get(at) {
+        let (Kind::Row { header }, Some((cells, columns))) = (piece.kind, &piece.row) else {
+            break;
+        };
+        if weights.is_empty() {
+            weights.clone_from(columns);
+        }
+        rows.push(kobo_ui::TableRow {
+            header,
+            cells: cells.clone(),
+        });
+        at += 1;
+    }
+    (rows, weights, at)
+}
+
+/// Back to a plain index, for looking at the blocks around one.
+fn index_of(locator: Locator) -> usize {
+    usize::try_from(locator).unwrap_or(usize::MAX)
+}
+
+/// What each column of the table starting at `from` wants to be.
+///
+/// Measured over every row of the table at once, and in pixels, because that
+/// is the only unit both this and the layout agree on. The layout squeezes
+/// these to fit the panel; the point of measuring them here is that a table
+/// split across two pages is squeezed by the same amounts on both.
+fn table_columns(blocks: &[Block], from: usize, area: ProseArea) -> Vec<u16> {
+    let mut wants: Vec<u16> = Vec::new();
+    for block in &blocks[from.min(blocks.len())..] {
+        let Block::Row { cells, .. } = block else {
+            break;
+        };
+        for (column, cell) in cells.iter().take(kobo_ui::MAX_TABLE_COLUMNS).enumerate() {
+            let width = kobo_ui::measure_text_in(cell, FontSize::Body, area.face)
+                .0
+                .clamp(0, i32::from(u16::MAX));
+            let width = u16::try_from(width).unwrap_or(u16::MAX);
+            match wants.get_mut(column) {
+                Some(want) => *want = (*want).max(width),
+                None => wants.push(width),
+            }
+        }
+    }
+    wants
+}
+
+/// The width the layout will give each column of a table, and whether it
+/// gave up on columns and stacked the cells instead.
+///
+/// This repeats the layout's arithmetic rather than asking it, for the same
+/// reason [`picture_height`] repeats the picture's: pagination has to be a
+/// pure function of the document, or the page a row lands on depends on what
+/// happened to be drawn before it.
+fn column_widths(columns: &[u16], metrics: &DisplayMetrics, area: ProseArea) -> (Vec<i32>, bool) {
+    let count = columns.len().min(kobo_ui::MAX_TABLE_COLUMNS);
+    if count == 0 {
+        return (Vec::new(), true);
+    }
+    let gap = metrics.space(kobo_ui::Space::Small);
+    let between = gap.saturating_mul(i32::try_from(count).unwrap_or(1) - 1);
+    let usable = (area.width - between).max(0);
+    let minimum = metrics.tenth_mm(kobo_ui::MIN_TABLE_COLUMN_TENTH_MM);
+    let wants: Vec<i32> = columns[..count]
+        .iter()
+        .map(|want| i32::from(*want))
+        .collect();
+    let total: i32 = wants.iter().copied().fold(0, i32::saturating_add);
+    let widths: Vec<i32> = if total <= usable {
+        wants
+    } else if total > 0 {
+        wants
+            .iter()
+            .map(|want| want.saturating_mul(usable) / total)
+            .collect()
+    } else {
+        vec![usable / i32::try_from(count).unwrap_or(1); count]
+    };
+    let stacked = widths.iter().any(|width| *width < minimum);
+    (widths, stacked)
+}
+
+/// How tall a row will be drawn, so a page can be packed around it.
+fn row_height(cells: &[String], columns: &[u16], metrics: &DisplayMetrics, area: ProseArea) -> i32 {
+    let line = FontSize::Body.line_height_in(area.face).max(1);
+    let (widths, stacked) = column_widths(columns, metrics, area);
+    if widths.is_empty() {
+        return line;
+    }
+    // Past its floor the layout stops drawing columns and sets each cell as
+    // its own full-width lines, so the row is as tall as all of them
+    // together rather than as tall as the tallest of them.
+    if stacked {
+        let mut height = metrics.space(kobo_ui::Space::Small);
+        for cell in cells.iter().take(widths.len()) {
+            if cell.trim().is_empty() {
+                continue;
+            }
+            let lines = wrap_text_in(cell, area.width.max(1), FontSize::Body, area.face);
+            height = height.saturating_add(lines_high(lines.len(), line));
+        }
+        return height.max(line);
+    }
+    let mut tallest = line;
+    for (column, cell) in cells.iter().take(widths.len()).enumerate() {
+        let width = widths.get(column).copied().unwrap_or(0).max(1);
+        let lines = wrap_text_in(cell, width, FontSize::Body, area.face);
+        tallest = tallest.max(lines_high(lines.len(), line));
+    }
+    tallest
+}
+
+fn lines_high(lines: usize, line: i32) -> i32 {
+    i32::try_from(lines)
+        .unwrap_or(1)
+        .max(1)
+        .saturating_mul(line)
+}
+
 // A packing loop: measure, place, and break when the page is full. Splitting
 // it would mean handing the same six pieces of state to each half, and the
 // hand-off is where an off-by-one in a page break would hide.
@@ -2324,6 +2484,10 @@ fn paginate(
     }
     let mut capped = false;
     let chapter_starts = chapter_starts_of(document);
+    // What the columns of the table currently being laid out want to be,
+    // measured over all of its rows at once. Held across the loop so that a
+    // table taller than a page keeps its columns on the page it spills onto.
+    let mut columns: Vec<u16> = Vec::new();
 
     for (index, block) in document.blocks.iter().enumerate() {
         let rich = document.rich.get(&index);
@@ -2398,9 +2562,42 @@ fn paginate(
                 spans: Vec::new(),
                 presentation: kobo_ui::ParagraphPresentation::default(),
                 source_offset: None,
+                row: None,
             });
             continue;
         }
+
+        // A table row is placed whole. Its cells are laid out side by side,
+        // so unlike prose there is no first half of it that reads correctly
+        // on its own: half a row is the top half of several columns at once.
+        if let Block::Row { cells, .. } = block {
+            if columns.is_empty() {
+                columns = table_columns(&document.blocks, index_of(index), area);
+            }
+            let height = row_height(cells, &columns, metrics, area);
+            if !page.is_empty() && used + gap + height > area.height {
+                pages.push(std::mem::take(&mut page));
+                used = 0;
+            }
+            used += if page.is_empty() {
+                height
+            } else {
+                gap + height
+            };
+            page.push(Piece {
+                block: index,
+                text: String::new(),
+                kind,
+                spans: Vec::new(),
+                presentation: kobo_ui::ParagraphPresentation::default(),
+                source_offset: None,
+                row: Some((cells.clone(), columns.clone())),
+            });
+            continue;
+        }
+        // Anything that is not a row ends the table before it, so the next
+        // one is measured afresh.
+        columns.clear();
 
         // A picture is placed whole or moved to the next page: there is no
         // half of one to leave behind, which is what the line-by-line packing
@@ -2418,6 +2615,7 @@ fn paginate(
                         spans: Vec::new(),
                         presentation: kobo_ui::ParagraphPresentation::default(),
                         source_offset: None,
+                        row: None,
                     },
                     &mut Placing {
                         pages: &mut pages,
@@ -2487,6 +2685,7 @@ fn paginate(
                         spans,
                         presentation,
                         source_offset: None,
+                        row: None,
                     });
                     placed = end;
                 }
@@ -2515,6 +2714,7 @@ fn paginate(
                 spans,
                 presentation,
                 source_offset: None,
+                row: None,
             });
             placed += take;
         }
@@ -2540,6 +2740,7 @@ fn kind_of(block: &Block, marked: bool) -> Kind {
         Block::Item { .. } => Kind::Item,
         Block::Caption(_) => Kind::Caption,
         Block::Picture { .. } => Kind::Picture,
+        Block::Row { header, .. } => Kind::Row { header: *header },
         Block::Rule => Kind::Rule,
         Block::Break => Kind::Break,
     }
@@ -4453,5 +4654,200 @@ mod tests {
         );
         assert_eq!(reader.top(), origin);
         assert!(!reader.screen("Book").owns_back);
+    }
+
+    fn table_of(rows: &[(bool, &[&str])]) -> Document {
+        let blocks = rows
+            .iter()
+            .map(|(header, cells)| Block::Row {
+                header: *header,
+                cells: cells.iter().map(|cell| (*cell).to_string()).collect(),
+            })
+            .collect();
+        Document {
+            blocks,
+            ..Document::default()
+        }
+    }
+
+    #[test]
+    fn a_table_reaches_the_screen_as_one_node_with_all_of_its_rows() {
+        let document = table_of(&[
+            (true, &["Model", "Top-1", "Params"]),
+            (false, &["Small", "71.2", "5M"]),
+            (false, &["Large", "84.6", "300M"]),
+        ]);
+        let reader = Reader::open(document, Memory::default(), &panel());
+        let screen = reader.screen("Paper");
+
+        let tables: Vec<_> = screen
+            .nodes
+            .iter()
+            .filter_map(|node| match node {
+                kobo_ui::Node::Table { rows, weights, .. } => Some((rows, weights)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(tables.len(), 1, "three rows are one table, not three");
+        let (rows, weights) = tables[0];
+        assert_eq!(rows.len(), 3);
+        assert!(rows[0].header);
+        assert!(!rows[1].header);
+        assert_eq!(rows[1].cells, vec!["Small", "71.2", "5M"]);
+        assert_eq!(weights.len(), 3, "one measured width per column");
+    }
+
+    #[test]
+    fn a_table_split_over_two_pages_keeps_the_same_columns_on_both() {
+        let mut rows: Vec<(bool, Vec<String>)> = vec![(true, vec!["Model".into(), "Score".into()])];
+        for index in 0..200 {
+            rows.push((false, vec![format!("Row {index}"), format!("{index}.5")]));
+        }
+        let blocks = rows
+            .iter()
+            .map(|(header, cells)| Block::Row {
+                header: *header,
+                cells: cells.clone(),
+            })
+            .collect();
+        let mut reader = Reader::open(
+            Document {
+                blocks,
+                ..Document::default()
+            },
+            Memory::default(),
+            &panel(),
+        );
+        assert!(reader.page_count() > 1, "200 rows do not fit on one page");
+
+        let first = columns_on_page(&reader);
+        assert!(!first.is_empty(), "the columns were never measured");
+        assert!(first.iter().all(|width| *width > 0));
+        reader.act("reader-next", &panel());
+        let second = columns_on_page(&reader);
+        assert_eq!(
+            first, second,
+            "columns measured per page would shift on a turn"
+        );
+        no_cell_falls_off_a_page(&reader);
+    }
+
+    /// Checks every page against the layout that will actually draw it.
+    ///
+    /// Pagination guesses how tall a row comes out; only the layout knows.
+    /// A page that agrees with its own wrong guess still pours cells off the
+    /// bottom of the panel, so the guess is never what is measured here.
+    fn no_cell_falls_off_a_page(reader: &Reader) {
+        let panel = panel();
+        let floor = panel.height - panel.page_position_band();
+        let mut turned = reader.clone();
+        turned.go_to(0, &panel);
+        for number in 0..reader.page_count() {
+            let bottom = turned
+                .screen("Paper")
+                .layout_for(&panel)
+                .nodes
+                .iter()
+                .filter(|node| {
+                    matches!(
+                        node.kind,
+                        kobo_ui::LayoutKind::TableCell | kobo_ui::LayoutKind::TableHeaderCell
+                    )
+                })
+                .map(|node| node.rect.y + node.rect.height)
+                .max()
+                .unwrap_or(0);
+            assert!(
+                bottom <= floor,
+                "page {number} sets a cell down to {bottom}, past the {floor} the page ends at"
+            );
+            turned.act("reader-next", &panel);
+        }
+    }
+
+    fn columns_on_page(reader: &Reader) -> Vec<u16> {
+        reader
+            .screen("Paper")
+            .nodes
+            .iter()
+            .find_map(|node| match node {
+                kobo_ui::Node::Table { weights, .. } => Some(weights.clone()),
+                _ => None,
+            })
+            .expect("a table on the page")
+    }
+
+    #[test]
+    fn a_word_inside_a_cell_is_still_found_by_search() {
+        let document = table_of(&[
+            (true, &["Model", "Top-1"]),
+            (false, &["Chinchilla", "70.1"]),
+        ]);
+        let reader = Reader::open(document, Memory::default(), &panel());
+
+        let hits = reader.search("chinchilla", 8);
+        assert_eq!(hits.len(), 1);
+        assert!(hits[0].excerpt.contains("Chinchilla"));
+    }
+
+    // Nine columns cannot be drawn nine columns wide, so the layout stacks
+    // them. Pagination has to know that, or it packs each row as one line
+    // tall and pours nine lines of it off the bottom of the panel.
+    #[test]
+    fn a_table_too_wide_for_columns_is_paginated_as_the_stack_it_becomes() {
+        let blocks = (0..30)
+            .map(|index| Block::Row {
+                header: false,
+                cells: (0..9)
+                    .map(|column| format!("cell {index} column {column} with words"))
+                    .collect(),
+            })
+            .collect();
+        let reader = Reader::open(
+            Document {
+                blocks,
+                ..Document::default()
+            },
+            Memory::default(),
+            &panel(),
+        );
+
+        assert!(reader.page_count() > 1, "thirty stacked rows need pages");
+        // Measured against what the layout actually does, not against the
+        // same guess pagination made: a page that agrees with its own wrong
+        // arithmetic still pours words off the panel.
+        no_cell_falls_off_a_page(&reader);
+    }
+
+    #[test]
+    fn a_row_is_never_cut_in_half_by_a_page_break() {
+        let blocks = (0..400)
+            .map(|index| Block::Row {
+                header: false,
+                cells: vec![format!("Left {index}"), format!("Right {index}")],
+            })
+            .collect();
+        let reader = Reader::open(
+            Document {
+                blocks,
+                ..Document::default()
+            },
+            Memory::default(),
+            &panel(),
+        );
+
+        for page in 0..reader.page_count() {
+            let mut seen = Vec::new();
+            for piece in &reader.pages[page] {
+                if let Some((cells, _)) = &piece.row {
+                    seen.push(cells.len());
+                }
+            }
+            assert!(
+                seen.iter().all(|count| *count == 2),
+                "page {page} holds a row missing a cell"
+            );
+        }
+        no_cell_falls_off_a_page(&reader);
     }
 }

--- a/crates/kobo-read/src/lib.rs
+++ b/crates/kobo-read/src/lib.rs
@@ -66,6 +66,8 @@ const MIN_KEEP_LINES: usize = 2;
 /// document that somehow produced millions of them would take the memory of a
 /// device with 256 MB for everything.
 const MAX_PAGES: usize = 16_384;
+const MAX_NAVIGATION_HISTORY: usize = 64;
+pub const MAX_SEARCH_RESULTS: usize = 256;
 
 /// How near the foot of the downloaded text a chunk-in-flight is worth saying.
 ///
@@ -127,6 +129,8 @@ pub struct Piece {
     pub block: Locator,
     pub text: String,
     kind: Kind,
+    spans: Vec<kobo_ui::RichTextSpan>,
+    presentation: kobo_ui::ParagraphPresentation,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -281,6 +285,16 @@ pub mod action {
     pub const CONTENTS: &str = "reader-contents";
     /// Opens the links the page being read points at.
     pub const LINKS: &str = "reader-links";
+    /// One internal link target, distinct from a TOC/mark jump because it
+    /// records an origin that Back can return to.
+    pub const LINK: &str = "reader-link-";
+}
+
+/// One bounded in-book search match.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SearchHit {
+    pub at: Locator,
+    pub excerpt: String,
 }
 
 /// What an application still has to do about an action the reader handled.
@@ -329,6 +343,10 @@ pub struct Reader {
     /// one's description instead, and every other part of the book is
     /// unaffected.
     pictures: BTreeMap<String, kobo_ui::TilePicture>,
+    /// Publisher face installed by the application for this reading session.
+    publisher_font: Option<kobo_ui::FontHandle>,
+    /// Origins of internal links/search jumps, newest last and session-only.
+    navigation: Vec<Locator>,
 }
 
 impl Reader {
@@ -341,6 +359,8 @@ impl Reader {
     pub fn open(document: Document, memory: Memory, panel: &DisplayMetrics) -> Self {
         let mut reader = Self {
             pictures: BTreeMap::new(),
+            publisher_font: None,
+            navigation: Vec::new(),
             document,
             memory,
             pages: Vec::new(),
@@ -360,6 +380,10 @@ impl Reader {
     /// first, pages second: the block index does not change when the setting
     /// does, which is the whole reason a position is stored the way it is.
     fn repaginate(&mut self, panel: &DisplayMetrics) {
+        kobo_ui::with_reading_font(self.publisher_font, || self.repaginate_selected_font(panel));
+    }
+
+    fn repaginate_selected_font(&mut self, panel: &DisplayMetrics) {
         // The panel measured at the size this reader is set to. A page
         // measured at one size and drawn at another loses its last lines, and
         // the layout engine drops them without saying anything.
@@ -485,6 +509,56 @@ impl Reader {
         self.memory.at = block;
         self.chrome = Chrome::Hidden;
         self.repaginate(panel);
+    }
+
+    /// Goes to a linked/search result while preserving an exact logical way
+    /// back. Page numbers are deliberately never stored here.
+    pub fn follow(&mut self, block: Locator, panel: &DisplayMetrics) {
+        if self.navigation.len() >= MAX_NAVIGATION_HISTORY {
+            self.navigation.remove(0);
+        }
+        self.navigation.push(self.top());
+        self.go_to(block, panel);
+    }
+
+    /// Returns from the most recent internal jump.
+    pub fn return_from_link(&mut self, panel: &DisplayMetrics) -> bool {
+        let Some(origin) = self.navigation.pop() else {
+            return false;
+        };
+        self.go_to(origin, panel);
+        true
+    }
+
+    /// Finds case-insensitive matches across the complete logical document.
+    ///
+    /// Results name blocks rather than derived pages, remain valid after
+    /// reflow, never include markup, and are capped before a hostile query can
+    /// make an unbounded result list.
+    #[must_use]
+    pub fn search(&self, query: &str, limit: usize) -> Vec<SearchHit> {
+        let query = query.trim().to_lowercase();
+        if query.is_empty() || limit == 0 {
+            return Vec::new();
+        }
+        let limit = limit.min(MAX_SEARCH_RESULTS);
+        let mut hits = Vec::new();
+        for (index, block) in self.document.blocks.iter().enumerate() {
+            let Some(text) = block.text() else { continue };
+            if text.to_lowercase().contains(&query) {
+                let Ok(at) = Locator::try_from(index) else {
+                    break;
+                };
+                hits.push(SearchHit {
+                    at,
+                    excerpt: search_excerpt(text),
+                });
+                if hits.len() >= limit {
+                    break;
+                }
+            }
+        }
+        hits
     }
 
     #[must_use]
@@ -842,6 +916,8 @@ impl Reader {
                 if let Some(block) = target_of(other) {
                     if other.starts_with(action::MARK) {
                         self.toggle_highlight(block, panel);
+                    } else if other.starts_with(action::LINK) {
+                        self.follow(block, panel);
                     } else {
                         self.go_to(block, panel);
                     }
@@ -862,6 +938,10 @@ impl Reader {
     /// would have to keep its own copy of that list in step, and the failure
     /// when it drifted would be a control that silently did nothing.
     pub fn act_on(&mut self, action: kobo_ui::ActionId, panel: &DisplayMetrics) -> Outcome {
+        if action == kobo_ui::ActionId::BACK && !self.navigation.is_empty() {
+            self.return_from_link(panel);
+            return Outcome::Save;
+        }
         let mut names: Vec<String> = vec![
             action::FORWARD.into(),
             action::BACK.into(),
@@ -891,7 +971,7 @@ impl Reader {
             names.push(format!("{}{}", action::GO, entry.block));
         }
         for (_, block) in self.links_here() {
-            names.push(format!("{}{block}", action::GO));
+            names.push(format!("{}{block}", action::LINK));
         }
         let Some(name) = names
             .into_iter()
@@ -943,6 +1023,7 @@ impl Reader {
     fn book_screen(&self, title: &str) -> Screen {
         let mut screen = ScreenBuilder::new("reader")
             .reading(true)
+            .owns_back(!self.navigation.is_empty())
             .text_scale(self.memory.scale)
             // The book's name, ellipsised if it must be. The place it used to
             // hold moved to the foot, where a Kobo reader looks for it, which
@@ -957,6 +1038,9 @@ impl Reader {
             // is large enough to hide it.
             .top_bar_glyph(action::LIGHT, "Front light", kobo_ui::Glyph::Light)
             .top_bar_action(action::CONTROLS, "Aa");
+        if let Some(font) = self.publisher_font {
+            screen = screen.reading_font(font);
+        }
         for piece in self.page() {
             screen = match piece.kind {
                 Kind::Heading(_) => screen.heading(piece.text.clone()),
@@ -979,7 +1063,18 @@ impl Reader {
                 Kind::Rule => screen.divider(),
                 Kind::Break => screen.spacer(kobo_ui::Space::Small),
                 Kind::Body | Kind::Preformatted => {
-                    screen.text_linking(piece.text.clone(), self.links_in(piece))
+                    if piece.spans.is_empty()
+                        && piece.presentation == kobo_ui::ParagraphPresentation::default()
+                    {
+                        screen.text_linking(piece.text.clone(), self.links_in(piece))
+                    } else {
+                        screen.rich_text_linking(
+                            piece.text.clone(),
+                            piece.spans.clone(),
+                            piece.presentation,
+                            self.links_in(piece),
+                        )
+                    }
                 }
             };
         }
@@ -1137,7 +1232,7 @@ impl Reader {
                 .build();
         }
         for (text, block) in here {
-            screen = screen.button(format!("{}{block}", action::GO), text);
+            screen = screen.button(format!("{}{block}", action::LINK), text);
         }
         screen.build()
     }
@@ -1172,7 +1267,7 @@ impl Reader {
             if found.iter().any(|(_, from, to)| start < *to && *from < end) {
                 continue;
             }
-            found.push((format!("{}{block}", action::GO), start, end));
+            found.push((format!("{}{block}", action::LINK), start, end));
         }
         found
     }
@@ -1305,6 +1400,7 @@ impl Reader {
 pub fn target_of(name: &str) -> Option<Locator> {
     name.strip_prefix(action::MARK)
         .or_else(|| name.strip_prefix(action::GO))
+        .or_else(|| name.strip_prefix(action::LINK))
         .and_then(|rest| rest.parse().ok())
 }
 
@@ -1327,11 +1423,73 @@ fn first_words(text: &str) -> String {
     out
 }
 
+fn search_excerpt(text: &str) -> String {
+    // A result is context, not a second copy of a paragraph. Character
+    // iteration keeps the cut on a Unicode scalar boundary and `first_words`
+    // keeps it on a word where possible.
+    first_words(text)
+}
+
 /// Breaks a document into pages that fit, at their real sizes.
 ///
 /// Returns the pages, and whether it stopped at the ceiling with book left --
 /// which the caller has to say out loud rather than present as an ending.
 impl Reader {
+    /// Selects a publisher font already installed in the SDK and runtime.
+    ///
+    /// Pagination is rebuilt immediately because a different face changes
+    /// line widths even at the same nominal size.
+    pub fn set_publisher_font(
+        &mut self,
+        font: Option<kobo_ui::FontHandle>,
+        panel: &DisplayMetrics,
+    ) {
+        if self.publisher_font == font {
+            return;
+        }
+        self.publisher_font = font;
+        self.repaginate(panel);
+    }
+
+    /// The first usable TrueType/OpenType face embedded by the publisher.
+    ///
+    /// The map is deterministic, so the same book chooses the same face in
+    /// the simulator and on-device. Compressed web fonts remain available in
+    /// [`Document::fonts`] for diagnostics but are not misreported as usable.
+    #[must_use]
+    pub fn preferred_publisher_font(&self) -> Option<(&str, &[u8])> {
+        let requested = self
+            .document
+            .rich
+            .values()
+            .find_map(|rich| rich.style.font_family.as_deref());
+        self.document
+            .fonts
+            .iter()
+            .filter(|(_, font)| is_outline_font(&font.bytes))
+            .find(|(_, font)| {
+                requested.is_some_and(|requested| {
+                    font.family
+                        .as_deref()
+                        .is_some_and(|family| family.eq_ignore_ascii_case(requested))
+                })
+            })
+            .or_else(|| {
+                self.document
+                    .fonts
+                    .iter()
+                    .filter(|(_, font)| is_outline_font(&font.bytes))
+                    .find(|(_, font)| font.family.is_some())
+            })
+            .or_else(|| {
+                self.document
+                    .fonts
+                    .iter()
+                    .find(|(_, font)| is_outline_font(&font.bytes))
+            })
+            .map(|(name, font)| (name.as_str(), font.bytes.as_slice()))
+    }
+
     /// Hands over the pictures this book's text refers to.
     ///
     /// Keyed by the name the book stored each one under, which is what a
@@ -1418,6 +1576,13 @@ impl Reader {
         };
         self.pictures.get(name).copied()
     }
+}
+
+fn is_outline_font(bytes: &[u8]) -> bool {
+    bytes.starts_with(b"\0\x01\0\0")
+        || bytes.starts_with(b"OTTO")
+        || bytes.starts_with(b"true")
+        || bytes.starts_with(b"typ1")
 }
 
 /// The tallest a picture inside the text may be drawn, in millimetres.
@@ -1525,6 +1690,14 @@ fn break_page(pages: &mut Vec<Vec<Piece>>, page: &mut Vec<Piece>, used: &mut i32
     *used = 0;
 }
 
+/// Ends a non-empty page because the publisher explicitly requested one.
+fn force_page_break(pages: &mut Vec<Vec<Piece>>, page: &mut Vec<Piece>, used: &mut i32) {
+    if !page.is_empty() {
+        pages.push(std::mem::take(page));
+        *used = 0;
+    }
+}
+
 // A packing loop: measure, place, and break when the page is full. Splitting
 // it would mean handing the same six pieces of state to each half, and the
 // hand-off is where an off-by-one in a page break would hide.
@@ -1547,6 +1720,7 @@ fn paginate(
     let chapter_starts = chapter_starts_of(document);
 
     for (index, block) in document.blocks.iter().enumerate() {
+        let rich = document.rich.get(&index);
         let starts_chapter = chapter_starts.contains(&index);
         let Ok(index) = Locator::try_from(index) else {
             break;
@@ -1564,9 +1738,31 @@ fn paginate(
                 continue;
             }
         }
+        if rich.is_some_and(|rich| rich.style.page_break_before) {
+            force_page_break(&mut pages, &mut page, &mut used);
+        }
         let size = kind.size();
-        let height = size.line_height_in(area.face);
-        let (_, width) = quote_offsets(metrics, area.width, kind.depth());
+        let natural_height = size.line_height_in(area.face);
+        let height = rich.map_or(natural_height, |rich| {
+            natural_height.saturating_mul(i32::from(rich.style.line_height_percent.clamp(80, 250)))
+                / 100
+        });
+        let (_, mut width) = quote_offsets(metrics, area.width, kind.depth());
+        let rich_layout = rich.filter(|_| matches!(kind, Kind::Body | Kind::Preformatted));
+        let extra_height = rich_layout.map_or(0, |rich| {
+            natural_height.saturating_mul(i32::from(
+                rich.style
+                    .margin_before_em
+                    .saturating_add(rich.style.margin_after_em),
+            )) / 100
+        });
+        if let Some(rich) = rich_layout {
+            let indent = kobo_ui::measure_text_in("M", kobo_ui::FontSize::Body, area.face)
+                .0
+                .saturating_mul(i32::from(rich.style.first_line_indent_em))
+                / 100;
+            width = width.saturating_sub(indent.max(0)).max(1);
+        }
 
         // Furniture takes a line's worth of room and carries no words, so it
         // is placed rather than wrapped -- and never left alone at the top of
@@ -1585,6 +1781,8 @@ fn paginate(
                 block: index,
                 text: String::new(),
                 kind,
+                spans: Vec::new(),
+                presentation: kobo_ui::ParagraphPresentation::default(),
             });
             continue;
         }
@@ -1602,6 +1800,8 @@ fn paginate(
                         block: index,
                         text: alt.clone(),
                         kind,
+                        spans: Vec::new(),
+                        presentation: kobo_ui::ParagraphPresentation::default(),
                     },
                     &mut Placing {
                         pages: &mut pages,
@@ -1629,12 +1829,13 @@ fn paginate(
         }
 
         let mut placed = 0;
+        let mut source_at = 0usize;
         while placed < lines.len() {
             let room = area.height - used - if page.is_empty() { 0 } else { gap };
-            let fits = if room < height {
+            let fits = if room < height.saturating_add(extra_height) {
                 0
             } else {
-                usize::try_from(room / height).unwrap_or(usize::MAX)
+                usize::try_from((room - extra_height) / height).unwrap_or(usize::MAX)
             };
             let left = lines.len() - placed;
             // Either the rest fits, or enough of it fits to be worth breaking:
@@ -1652,12 +1853,21 @@ fn paginate(
                     // One paragraph taller than the whole page. Cutting it
                     // anywhere beats looping forever, and the reader would far
                     // rather see the words than an empty panel.
-                    let forced = usize::try_from(area.height / height).unwrap_or(1).max(1);
+                    let forced = usize::try_from(
+                        area.height.saturating_sub(extra_height).max(height) / height,
+                    )
+                    .unwrap_or(1)
+                    .max(1);
                     let end = (placed + forced).min(lines.len());
+                    let text = lines[placed..end].join(" ");
+                    let (spans, presentation) =
+                        piece_presentation(rich, text.as_str(), &mut source_at);
                     page.push(Piece {
                         block: index,
-                        text: lines[placed..end].join(" "),
+                        text,
                         kind,
+                        spans,
+                        presentation,
                     });
                     placed = end;
                 }
@@ -1671,13 +1881,23 @@ fn paginate(
             if !page.is_empty() {
                 used += gap;
             }
-            used += i32::try_from(take).unwrap_or(i32::MAX) * height;
+            used += i32::try_from(take)
+                .unwrap_or(i32::MAX)
+                .saturating_mul(height)
+                .saturating_add(extra_height);
+            let text = lines[placed..placed + take].join(" ");
+            let (spans, presentation) = piece_presentation(rich, text.as_str(), &mut source_at);
             page.push(Piece {
                 block: index,
-                text: lines[placed..placed + take].join(" "),
+                text,
                 kind,
+                spans,
+                presentation,
             });
             placed += take;
+        }
+        if rich.is_some_and(|rich| rich.style.page_break_after) {
+            force_page_break(&mut pages, &mut page, &mut used);
         }
     }
     if !page.is_empty() {
@@ -1699,6 +1919,62 @@ fn kind_of(block: &Block, marked: bool) -> Kind {
         Block::Picture { .. } => Kind::Picture,
         Block::Rule => Kind::Rule,
         Block::Break => Kind::Break,
+    }
+}
+
+fn piece_presentation(
+    rich: Option<&kobo_doc::RichBlock>,
+    piece: &str,
+    source_at: &mut usize,
+) -> (Vec<kobo_ui::RichTextSpan>, kobo_ui::ParagraphPresentation) {
+    let Some(rich) = rich else {
+        return (Vec::new(), kobo_ui::ParagraphPresentation::default());
+    };
+    let whole: String = rich.spans.iter().map(|span| span.text.as_str()).collect();
+    let Some(relative) = whole.get(*source_at..).and_then(|rest| rest.find(piece)) else {
+        return (Vec::new(), paragraph_presentation(&rich.style));
+    };
+    let from = *source_at + relative;
+    let to = from + piece.len();
+    *source_at = to;
+    let mut spans = Vec::new();
+    let mut cursor = 0usize;
+    for span in &rich.spans {
+        let span_from = cursor;
+        let span_to = cursor + span.text.len();
+        cursor = span_to;
+        let start = span_from.max(from);
+        let end = span_to.min(to);
+        if start >= end {
+            continue;
+        }
+        spans.push(kobo_ui::RichTextSpan {
+            start: start - from,
+            end: end - from,
+            presentation: kobo_ui::TextPresentation {
+                strong: span.style.strong,
+                emphasis: span.style.emphasis,
+                underline: span.style.underline,
+                superscript: span.style.superscript,
+                subscript: span.style.subscript,
+            },
+        });
+    }
+    (spans, paragraph_presentation(&rich.style))
+}
+
+fn paragraph_presentation(style: &kobo_doc::BlockStyle) -> kobo_ui::ParagraphPresentation {
+    kobo_ui::ParagraphPresentation {
+        alignment: match style.alignment {
+            kobo_doc::TextAlignment::Start => kobo_ui::ParagraphAlignment::Start,
+            kobo_doc::TextAlignment::Center => kobo_ui::ParagraphAlignment::Center,
+            kobo_doc::TextAlignment::End => kobo_ui::ParagraphAlignment::End,
+            kobo_doc::TextAlignment::Justify => kobo_ui::ParagraphAlignment::Justify,
+        },
+        line_height_percent: style.line_height_percent,
+        margin_before_em: style.margin_before_em,
+        margin_after_em: style.margin_after_em,
+        first_line_indent_em: style.first_line_indent_em,
     }
 }
 
@@ -1998,7 +2274,7 @@ mod tests {
                 run.rect.y + run.rect.height / 2,
             )
             .expect("the tap fell through to the page turn underneath");
-        assert_eq!(touched, kobo_sdk::action_id(&format!("{}1", action::GO)));
+        assert_eq!(touched, kobo_sdk::action_id(&format!("{}1", action::LINK)));
 
         // And the prose either side of it still turns the page, which is the
         // thing a hit target over a whole paragraph would have taken away.
@@ -3033,7 +3309,136 @@ mod tests {
     fn a_targets_block_is_read_back_off_its_action_name() {
         assert_eq!(target_of("reader-mark-17"), Some(17));
         assert_eq!(target_of("reader-go-17"), Some(17));
+        assert_eq!(target_of("reader-link-17"), Some(17));
         assert_eq!(target_of("reader-forward"), None);
         assert_eq!(target_of("reader-go--3"), None);
+    }
+
+    #[test]
+    fn search_returns_bounded_logical_locations_without_markup() {
+        let document = Document {
+            blocks: vec![
+                Block::Paragraph("A paper lantern at the beginning.".into()),
+                Block::Picture {
+                    name: "lantern.png".into(),
+                    alt: "paper lantern".into(),
+                },
+                Block::Paragraph("The PAPER LANTERN at the end.".into()),
+            ],
+            ..Document::default()
+        };
+        let reader = Reader::open(document, Memory::default(), &panel());
+        let hits = reader.search("paper lantern", 1);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].at, 0);
+        assert!(!hits[0].excerpt.contains('<'));
+        assert!(reader.search("paper lantern", 0).is_empty());
+    }
+
+    #[test]
+    fn xhtml_emphasis_and_paragraph_style_reach_the_reading_screen() {
+        let document = kobo_doc::html::parse(
+            r#"<p style="text-align:center; line-height:140%">plain <strong><em>styled</em></strong></p>"#,
+        );
+        let reader = Reader::open(document, Memory::default(), &panel());
+        let screen = reader.screen("Book");
+        let rich = screen.nodes.iter().find_map(|node| match node {
+            kobo_sdk::Node::RichText {
+                spans,
+                presentation,
+                ..
+            } => Some((spans, presentation)),
+            _ => None,
+        });
+        let (spans, presentation) = rich.expect("rich text node");
+        assert_eq!(presentation.alignment, kobo_ui::ParagraphAlignment::Center);
+        assert_eq!(presentation.line_height_percent, 140);
+        assert!(spans
+            .iter()
+            .any(|span| { span.presentation.strong && span.presentation.emphasis }));
+    }
+
+    #[test]
+    fn an_explicit_publisher_page_break_is_not_discarded_as_a_short_page() {
+        let document = kobo_doc::html::parse(
+            r#"<p style="page-break-after: always">A short title page.</p><p>The chapter.</p>"#,
+        );
+        let reader = Reader::open(document, Memory::default(), &panel());
+        assert_eq!(reader.page_count(), 2);
+        assert_eq!(reader.pages[0][0].text, "A short title page.");
+        assert_eq!(reader.pages[1][0].text, "The chapter.");
+    }
+
+    #[test]
+    fn publisher_spacing_does_not_push_paginated_prose_off_the_panel() {
+        let source = (0..80)
+            .map(|index| {
+                format!(
+                    r#"<p style="margin-top: 1em; margin-bottom: 1em; line-height: 150%">Paragraph {index} has enough words to wrap across the reading column.</p>"#
+                )
+            })
+            .collect::<String>();
+        let reader = Reader::open(kobo_doc::html::parse(&source), Memory::default(), &panel());
+        for page in 0..reader.page_count() {
+            let mut on_page = reader.clone();
+            on_page.page = page;
+            let screen = on_page.screen("Book");
+            assert!(
+                screen.validate(&panel()).is_empty(),
+                "page {page}: {:?}",
+                screen.validate(&panel())
+            );
+        }
+    }
+
+    #[test]
+    fn the_font_family_requested_by_the_book_wins_over_filename_order() {
+        let mut document =
+            kobo_doc::html::parse(r#"<p style="font-family: Intended">Publisher prose.</p>"#);
+        document.fonts.insert(
+            "a-wrong.otf".into(),
+            kobo_doc::EmbeddedFont {
+                media_type: "font/otf".into(),
+                family: Some("Other".into()),
+                bytes: b"OTTOfirst".to_vec(),
+            },
+        );
+        document.fonts.insert(
+            "z-intended.otf".into(),
+            kobo_doc::EmbeddedFont {
+                media_type: "font/otf".into(),
+                family: Some("Intended".into()),
+                bytes: b"OTTOsecond".to_vec(),
+            },
+        );
+        let reader = Reader::open(document, Memory::default(), &panel());
+        assert_eq!(
+            reader.preferred_publisher_font().map(|(name, _)| name),
+            Some("z-intended.otf")
+        );
+    }
+
+    #[test]
+    fn following_a_footnote_and_back_preserves_the_logical_origin() {
+        let mut document = book(40);
+        document.anchors.insert("note".into(), 30);
+        document.links.push(kobo_doc::Link {
+            block: 1,
+            text: "footnote".into(),
+            target: "note".into(),
+        });
+        let mut reader = Reader::open(document, Memory::default(), &panel());
+        reader.go_to(1, &panel());
+        let origin = reader.top();
+
+        assert_eq!(reader.act("reader-link-30", &panel()), Outcome::Save);
+        assert_ne!(reader.top(), origin);
+        assert!(reader.screen("Book").owns_back);
+        assert_eq!(
+            reader.act_on(kobo_ui::ActionId::BACK, &panel()),
+            Outcome::Save
+        );
+        assert_eq!(reader.top(), origin);
+        assert!(!reader.screen("Book").owns_back);
     }
 }

--- a/crates/kobo-read/src/lib.rs
+++ b/crates/kobo-read/src/lib.rs
@@ -182,6 +182,7 @@ enum Kind {
     Quote,
     Preformatted,
     Item,
+    Caption,
     /// A picture the book set into its text.
     Picture,
     Rule,
@@ -195,6 +196,7 @@ impl Kind {
             // Level three is already small enough that the title size would
             // barely distinguish it from the text under it.
             Kind::Heading(_) => FontSize::Title,
+            Kind::Caption => FontSize::Caption,
             _ => FontSize::Body,
         }
     }
@@ -595,6 +597,11 @@ impl Reader {
 
     /// Creates a range highlight or marginal note exactly once for an
     /// operation identifier supplied by the caller.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnnotationFault`] when the range is invalid, the annotation
+    /// limit is reached, or the note exceeds its bound.
     pub fn create_annotation(
         &mut self,
         operation: AnnotationId,
@@ -627,6 +634,11 @@ impl Reader {
     }
 
     /// Allocates a local operation identity and creates one annotation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnnotationFault`] when the range is invalid, the annotation
+    /// limit is reached, or the note exceeds its bound.
     pub fn annotate(
         &mut self,
         range: TextRange,
@@ -639,6 +651,11 @@ impl Reader {
     }
 
     /// Changes only an annotation's marginal note, never its selected words.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnnotationFault::NotFound`] for an unknown identity or
+    /// [`AnnotationFault::NoteTooLong`] when the replacement exceeds its bound.
     pub fn edit_annotation_note(
         &mut self,
         id: AnnotationId,
@@ -654,6 +671,11 @@ impl Reader {
         Ok(())
     }
 
+    /// Removes one annotation without changing any other reader state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AnnotationFault::NotFound`] for an unknown identity.
     pub fn remove_annotation(
         &mut self,
         id: AnnotationId,
@@ -1338,6 +1360,7 @@ impl Reader {
                 Kind::Marked | Kind::Quote | Kind::Item => {
                     screen.quote(HIGHLIGHT_DEPTH, piece.text.clone())
                 }
+                Kind::Caption => screen.secondary(piece.text.clone()),
                 Kind::Picture => {
                     // The handle is the application's to supply, because
                     // handing pixels to the runtime needs a `Context` and this
@@ -2291,6 +2314,8 @@ fn paginate(
                     let text = lines[placed..end].join(" ");
                     let (spans, presentation) =
                         piece_presentation(rich, text.as_str(), &mut source_at);
+                    let presentation =
+                        fragment_presentation(presentation, placed == 0, end == lines.len());
                     page.push(Piece {
                         block: index,
                         text,
@@ -2311,12 +2336,14 @@ fn paginate(
             if !page.is_empty() {
                 used += gap;
             }
+            let text = lines[placed..placed + take].join(" ");
+            let (spans, presentation) = piece_presentation(rich, text.as_str(), &mut source_at);
+            let presentation =
+                fragment_presentation(presentation, placed == 0, placed + take == lines.len());
             used += i32::try_from(take)
                 .unwrap_or(i32::MAX)
                 .saturating_mul(height)
-                .saturating_add(extra_height);
-            let text = lines[placed..placed + take].join(" ");
-            let (spans, presentation) = piece_presentation(rich, text.as_str(), &mut source_at);
+                .saturating_add(presentation_height(presentation, natural_height));
             page.push(Piece {
                 block: index,
                 text,
@@ -2347,6 +2374,7 @@ fn kind_of(block: &Block, marked: bool) -> Kind {
         Block::Quote(_) => Kind::Quote,
         Block::Preformatted(_) => Kind::Preformatted,
         Block::Item { .. } => Kind::Item,
+        Block::Caption(_) => Kind::Caption,
         Block::Picture { .. } => Kind::Picture,
         Block::Rule => Kind::Rule,
         Block::Break => Kind::Break,
@@ -2408,6 +2436,29 @@ fn paragraph_presentation(style: &kobo_doc::BlockStyle) -> kobo_ui::ParagraphPre
         margin_after_em: style.margin_after_em,
         first_line_indent_em: style.first_line_indent_em,
     }
+}
+
+fn fragment_presentation(
+    mut presentation: kobo_ui::ParagraphPresentation,
+    first: bool,
+    last: bool,
+) -> kobo_ui::ParagraphPresentation {
+    if !first {
+        presentation.margin_before_em = 0;
+        presentation.first_line_indent_em = 0;
+    }
+    if !last {
+        presentation.margin_after_em = 0;
+    }
+    presentation
+}
+
+fn presentation_height(presentation: kobo_ui::ParagraphPresentation, natural_height: i32) -> i32 {
+    natural_height.saturating_mul(i32::from(
+        presentation
+            .margin_before_em
+            .saturating_add(presentation.margin_after_em),
+    )) / 100
 }
 
 #[cfg(test)]
@@ -3945,13 +3996,8 @@ mod tests {
 
     #[test]
     fn publisher_spacing_does_not_push_paginated_prose_off_the_panel() {
-        let source = (0..80)
-            .map(|index| {
-                format!(
-                    r#"<p style="margin-top: 1em; margin-bottom: 1em; line-height: 150%">Paragraph {index} has enough words to wrap across the reading column.</p>"#
-                )
-            })
-            .collect::<String>();
+        let source = r#"<p style="margin-top: 1em; margin-bottom: 1em; line-height: 150%">A paragraph has enough words to wrap across the reading column.</p>"#
+            .repeat(80);
         let reader = Reader::open(kobo_doc::html::parse(&source), Memory::default(), &panel());
         for page in 0..reader.page_count() {
             let mut on_page = reader.clone();
@@ -3990,6 +4036,34 @@ mod tests {
             reader.preferred_publisher_font().map(|(name, _)| name),
             Some("z-intended.otf")
         );
+    }
+
+    #[test]
+    fn paragraph_fragments_only_keep_spacing_at_the_real_edges() {
+        let whole = kobo_ui::ParagraphPresentation {
+            alignment: kobo_ui::ParagraphAlignment::Justify,
+            line_height_percent: 140,
+            margin_before_em: 75,
+            margin_after_em: 50,
+            first_line_indent_em: 125,
+        };
+
+        let first = fragment_presentation(whole, true, false);
+        assert_eq!(first.margin_before_em, 75);
+        assert_eq!(first.first_line_indent_em, 125);
+        assert_eq!(first.margin_after_em, 0);
+
+        let middle = fragment_presentation(whole, false, false);
+        assert_eq!(middle.margin_before_em, 0);
+        assert_eq!(middle.first_line_indent_em, 0);
+        assert_eq!(middle.margin_after_em, 0);
+
+        let last = fragment_presentation(whole, false, true);
+        assert_eq!(last.margin_before_em, 0);
+        assert_eq!(last.first_line_indent_em, 0);
+        assert_eq!(last.margin_after_em, 50);
+        assert_eq!(last.alignment, kobo_ui::ParagraphAlignment::Justify);
+        assert_eq!(last.line_height_percent, 140);
     }
 
     #[test]

--- a/crates/kobo-read/src/lib.rs
+++ b/crates/kobo-read/src/lib.rs
@@ -335,7 +335,16 @@ impl Memory {
                     }
                 }
                 "next-ann" => {
-                    memory.next_annotation_id = value.parse().unwrap_or(1).max(1);
+                    // Never below what the annotations already read require.
+                    // A truncated or hand-edited memory file that names a low
+                    // identity would otherwise make the next new highlight
+                    // collide with an existing one, and creation is
+                    // idempotent by identity, so the new highlight would
+                    // silently never appear.
+                    memory.next_annotation_id = memory
+                        .next_annotation_id
+                        .max(value.parse().unwrap_or(1))
+                        .max(1);
                 }
                 _ => {}
             }
@@ -377,18 +386,24 @@ fn decode_annotation(value: &str) -> Option<Annotation> {
     let end_block = fields.next()?.parse().ok()?;
     let end_offset = fields.next()?.parse().ok()?;
     let note = String::from_utf8(hex_decode(fields.next().unwrap_or_default())?).ok()?;
+    let range = TextRange {
+        start: TextPosition {
+            block: start_block,
+            offset: start_offset,
+        },
+        end: TextPosition {
+            block: end_block,
+            offset: end_offset,
+        },
+    };
+    // A stored range that does not select anything cannot be repaired, and
+    // keeping it would hold an identity that a real highlight wants.
+    if range.start >= range.end {
+        return None;
+    }
     Some(Annotation {
         id,
-        range: TextRange {
-            start: TextPosition {
-                block: start_block,
-                offset: start_offset,
-            },
-            end: TextPosition {
-                block: end_block,
-                offset: end_offset,
-            },
-        },
+        range,
         note: (!note.is_empty()).then_some(note),
     })
 }
@@ -449,6 +464,9 @@ pub mod action {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SearchHit {
     pub at: Locator,
+    /// Byte offset of the match in the block's canonical text, on a character
+    /// boundary. Lets a result be navigated to and marked exactly.
+    pub offset: u32,
     pub excerpt: String,
 }
 
@@ -645,7 +663,13 @@ impl Reader {
         note: Option<&str>,
         panel: &DisplayMetrics,
     ) -> Result<AnnotationId, AnnotationFault> {
-        let id = self.memory.next_annotation_id.max(1);
+        // Creation is idempotent by identity, so a fresh annotation needs an
+        // identity nothing else holds. Reusing one would quietly return the
+        // annotation already there instead of marking the words just chosen.
+        let mut id = self.memory.next_annotation_id.max(1);
+        while self.memory.annotations.contains_key(&id) {
+            id = id.checked_add(1).ok_or(AnnotationFault::TooMany)?;
+        }
         self.create_annotation(id, range, note, panel)?;
         Ok(id)
     }
@@ -843,32 +867,34 @@ impl Reader {
         true
     }
 
-    /// Finds case-insensitive matches across the complete logical document.
+    /// Finds case-insensitive matches across the complete logical text.
     ///
-    /// Results name blocks rather than derived pages, remain valid after
-    /// reflow, never include markup, and are capped before a hostile query can
-    /// make an unbounded result list.
+    /// Results name blocks and offsets rather than derived pages, remain valid
+    /// after reflow, never include markup, and are capped before a hostile
+    /// query can make an unbounded result list.
     #[must_use]
     pub fn search(&self, query: &str, limit: usize) -> Vec<SearchHit> {
         let query = query.trim().to_lowercase();
-        if query.is_empty() || limit == 0 {
+        if query.is_empty() || query.len() > MAX_SEARCH_QUERY_BYTES || limit == 0 {
             return Vec::new();
         }
         let limit = limit.min(MAX_SEARCH_RESULTS);
         let mut hits = Vec::new();
         for (index, block) in self.document.blocks.iter().enumerate() {
             let Some(text) = block.text() else { continue };
-            if text.to_lowercase().contains(&query) {
-                let Ok(at) = Locator::try_from(index) else {
-                    break;
-                };
-                hits.push(SearchHit {
-                    at,
-                    excerpt: search_excerpt(text),
-                });
-                if hits.len() >= limit {
-                    break;
-                }
+            let Some((from, to)) = find_folded(text, &query) else {
+                continue;
+            };
+            let Ok(at) = Locator::try_from(index) else {
+                break;
+            };
+            hits.push(SearchHit {
+                at,
+                offset: u32::try_from(from).unwrap_or(u32::MAX),
+                excerpt: search_excerpt(text, from, to),
+            });
+            if hits.len() >= limit {
+                break;
             }
         }
         hits
@@ -1763,11 +1789,83 @@ fn first_words(text: &str) -> String {
     out
 }
 
-fn search_excerpt(text: &str) -> String {
-    // A result is context, not a second copy of a paragraph. Character
-    // iteration keeps the cut on a Unicode scalar boundary and `first_words`
-    // keeps it on a word where possible.
-    first_words(text)
+/// The longest query the in-book scanner will run.
+///
+/// The scan is proportional to query length, so this is what keeps a hostile
+/// query from turning a page turn into a long walk over the whole book.
+pub const MAX_SEARCH_QUERY_BYTES: usize = 128;
+
+/// The bounds in `text` of the first match of the already-lowercased `query`.
+///
+/// The book's own characters are folded as the scan walks them rather than
+/// searching a lowercased copy of the block: case folding can change a
+/// string's length, and an offset taken from the copy would not name the same
+/// words. A match that would end part-way through a character is not
+/// reported, so a result can never cut a character in half.
+fn find_folded(text: &str, query: &str) -> Option<(usize, usize)> {
+    if query.is_empty() {
+        return None;
+    }
+    'start: for (at, _) in text.char_indices() {
+        let mut needle = query.chars();
+        let mut end = at;
+        for character in text[at..].chars() {
+            for folded in character.to_lowercase() {
+                match needle.next() {
+                    Some(wanted) if wanted == folded => {}
+                    // The characters differ, or the query would end inside
+                    // this one. Neither is a match starting here.
+                    _ => continue 'start,
+                }
+            }
+            end += character.len_utf8();
+            if needle.clone().next().is_none() {
+                return Some((at, end));
+            }
+        }
+    }
+    None
+}
+
+/// Context around one match, with the matched words inside it.
+///
+/// A result is context rather than a second copy of a paragraph, and it is
+/// the words that were searched for that a reader is looking to recognise, so
+/// the window is placed around the match rather than at the start of the
+/// block. Cuts are on character boundaries, and on words where there is one
+/// close enough to cut at.
+fn search_excerpt(text: &str, from: usize, to: usize) -> String {
+    const BEFORE: usize = 24;
+    const AFTER: usize = 48;
+
+    let mut start = from;
+    for (offset, _) in text[..from].char_indices().rev().take(BEFORE) {
+        start = offset;
+    }
+    // Begin at a word, unless that would eat into the match itself.
+    if start > 0 {
+        if let Some(space) = text[start..from].find(' ') {
+            start += space + 1;
+        }
+    }
+    let mut end = to;
+    for (offset, character) in text[to..].char_indices().take(AFTER) {
+        end = to + offset + character.len_utf8();
+    }
+    if end < text.len() {
+        if let Some(space) = text[to..end].rfind(' ') {
+            end = to + space;
+        }
+    }
+    let mut excerpt = String::new();
+    if start > 0 {
+        excerpt.push('\u{2026}');
+    }
+    excerpt.push_str(text[start..end].trim());
+    if end < text.len() {
+        excerpt.push('\u{2026}');
+    }
+    excerpt
 }
 
 /// Breaks a document into pages that fit, at their real sizes.
@@ -2057,6 +2155,12 @@ fn decorate_annotation_ranges(
             .get(*cursor..)
             .and_then(|rest| rest.find(&piece.text))
         else {
+            // This piece could not be placed in its block. Leaving the cursor
+            // where it is would let a later piece match text this one already
+            // covered, which puts a highlight on the wrong words. Retiring the
+            // block instead costs selection on the rest of it and keeps every
+            // offset that is reported truthful.
+            *cursor = source.len();
             continue;
         };
         let piece_from = *cursor + relative;
@@ -2087,24 +2191,40 @@ fn decorate_annotation_ranges(
             }
         }
         if !ranges.is_empty() {
-            piece.spans = highlighted_spans(&piece.spans, piece.text.len(), &ranges);
+            piece.spans = highlighted_spans(&piece.spans, &piece.text, &ranges);
         }
     }
 }
 
+/// Moves `offset` back to the nearest character boundary at or before it.
+///
+/// A stored annotation names an offset in the book as it was parsed. If the
+/// bytes behind it change -- a re-downloaded edition, a book re-parsed at a
+/// different boundary -- that offset can land inside a character. A span cut
+/// there is refused by the wire encoding, which would take the reading
+/// application down rather than draw the page.
+fn snapped(text: &str, offset: usize) -> usize {
+    let mut offset = offset.min(text.len());
+    while !text.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
+}
+
 fn highlighted_spans(
     publisher: &[kobo_ui::RichTextSpan],
-    length: usize,
+    text: &str,
     highlights: &[(usize, usize)],
 ) -> Vec<kobo_ui::RichTextSpan> {
+    let length = text.len();
     let mut boundaries = BTreeSet::from([0, length]);
     for span in publisher {
-        boundaries.insert(span.start.min(length));
-        boundaries.insert(span.end.min(length));
+        boundaries.insert(snapped(text, span.start));
+        boundaries.insert(snapped(text, span.end));
     }
     for &(start, end) in highlights {
-        boundaries.insert(start.min(length));
-        boundaries.insert(end.min(length));
+        boundaries.insert(snapped(text, start));
+        boundaries.insert(snapped(text, end));
     }
     let boundaries = boundaries.into_iter().collect::<Vec<_>>();
     let mut spans: Vec<kobo_ui::RichTextSpan> = Vec::new();
@@ -2193,10 +2313,18 @@ fn paginate(
         }
         let size = kind.size();
         let natural_height = size.line_height_in(area.face);
-        let height = rich.map_or(natural_height, |rich| {
-            natural_height.saturating_mul(i32::from(rich.style.line_height_percent.clamp(80, 250)))
-                / 100
-        });
+        // A publisher face reports its own metrics, and a structurally valid
+        // font whose ascent, descent and line gap are all zero would make this
+        // a divisor of zero further down. A book must not be able to choose
+        // the panic, so a line is at least one pixel tall.
+        let natural_height = natural_height.max(1);
+        let height = rich
+            .map_or(natural_height, |rich| {
+                natural_height
+                    .saturating_mul(i32::from(rich.style.line_height_percent.clamp(80, 250)))
+                    / 100
+            })
+            .max(1);
         let (_, mut width) = quote_offsets(metrics, area.width, kind.depth());
         let rich_layout = rich.filter(|_| matches!(kind, Kind::Body | Kind::Preformatted));
         let extra_height = rich_layout.map_or(0, |rich| {
@@ -2391,6 +2519,9 @@ fn piece_presentation(
     };
     let whole: String = rich.spans.iter().map(|span| span.text.as_str()).collect();
     let Some(relative) = whole.get(*source_at..).and_then(|rest| rest.find(piece)) else {
+        // Retire the block rather than leave the cursor behind: a later piece
+        // that matched earlier text would be given another piece's emphasis.
+        *source_at = whole.len();
         return (Vec::new(), paragraph_presentation(&rich.style));
     };
     let from = *source_at + relative;
@@ -3816,6 +3947,116 @@ mod tests {
         assert_eq!(hits[0].at, 0);
         assert!(!hits[0].excerpt.contains('<'));
         assert!(reader.search("paper lantern", 0).is_empty());
+    }
+
+    #[test]
+    fn a_search_result_shows_the_words_that_were_searched_for() {
+        let filler = "word ".repeat(80);
+        let document = Document {
+            blocks: vec![Block::Paragraph(format!(
+                "{filler}the paper lantern was lit{filler}"
+            ))],
+            ..Document::default()
+        };
+        let reader = Reader::open(document, Memory::default(), &panel());
+        let hits = reader.search("PAPER LANTERN", 4);
+        assert_eq!(hits.len(), 1);
+        // The match is deep inside the block, so an excerpt taken from the
+        // start of the paragraph would not contain it.
+        assert!(
+            hits[0].excerpt.to_lowercase().contains("paper lantern"),
+            "excerpt was {:?}",
+            hits[0].excerpt
+        );
+        let offset = usize::try_from(hits[0].offset).expect("an offset");
+        assert_eq!(offset, filler.len() + "the ".len());
+    }
+
+    #[test]
+    fn a_search_offset_names_the_matched_words_exactly() {
+        let document = Document {
+            blocks: vec![Block::Paragraph("A Café au lait, please.".into())],
+            ..Document::default()
+        };
+        let reader = Reader::open(document, Memory::default(), &panel());
+        let hits = reader.search("café", 4);
+        assert_eq!(hits.len(), 1);
+        let at = usize::try_from(hits[0].offset).expect("an offset");
+        let text = "A Café au lait, please.";
+        assert_eq!(&text[at..at + "Café".len()], "Café");
+    }
+
+    #[test]
+    fn a_query_longer_than_its_bound_is_refused_rather_than_walked() {
+        let document = Document {
+            blocks: vec![Block::Paragraph("Short.".into())],
+            ..Document::default()
+        };
+        let reader = Reader::open(document, Memory::default(), &panel());
+        let query = "a".repeat(MAX_SEARCH_QUERY_BYTES + 1);
+        assert!(reader.search(&query, 8).is_empty());
+    }
+
+    #[test]
+    fn a_stale_annotation_offset_inside_a_character_still_draws() {
+        // The stored range names byte 2, which is inside the 'é' of "café"
+        // once the edition behind it has changed. A span cut there is refused
+        // by the wire encoding, so it must never reach one.
+        let document = Document {
+            blocks: vec![Block::Paragraph("café au lait".into())],
+            ..Document::default()
+        };
+        let memory = Memory::decode(b"ann 1 0 2 0 7 \nnext-ann 2\n");
+        assert_eq!(memory.annotations.len(), 1);
+        let reader = Reader::open(document, memory, &panel());
+        for span in reader.pages.iter().flatten().flat_map(|piece| &piece.spans) {
+            let text = &reader
+                .pages
+                .iter()
+                .flatten()
+                .find(|piece| !piece.text.is_empty())
+                .expect("a drawn piece")
+                .text;
+            assert!(text.is_char_boundary(span.start), "start {}", span.start);
+            assert!(text.is_char_boundary(span.end), "end {}", span.end);
+        }
+    }
+
+    #[test]
+    fn a_reversed_stored_annotation_is_dropped_rather_than_kept() {
+        let memory = Memory::decode(b"ann 1 0 9 0 3 \nnext-ann 2\n");
+        assert!(memory.annotations.is_empty());
+    }
+
+    #[test]
+    fn a_memory_naming_a_stale_next_identity_still_creates_new_annotations() {
+        let document = Document {
+            blocks: vec![Block::Paragraph("The words of the book.".into())],
+            ..Document::default()
+        };
+        // `next-ann` names an identity an annotation already holds, which is
+        // what a truncated or hand-edited memory file looks like.
+        let memory = Memory::decode(b"ann 7 0 0 0 3 \nnext-ann 1\n");
+        assert_eq!(memory.next_annotation_id, 8);
+        let mut reader = Reader::open(document, memory, &panel());
+        let id = reader
+            .annotate(
+                TextRange {
+                    start: TextPosition {
+                        block: 0,
+                        offset: 4,
+                    },
+                    end: TextPosition {
+                        block: 0,
+                        offset: 9,
+                    },
+                },
+                None,
+                &panel(),
+            )
+            .expect("a new annotation");
+        assert_ne!(id, 7);
+        assert_eq!(reader.annotations().len(), 2);
     }
 
     #[test]

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -2193,6 +2193,19 @@ impl ScreenBuilder {
     /// tap the same spot twice than read five labels to find the one above the
     /// one they have.
     ///
+    /// A table, drawn as columns that line up rather than as a sentence.
+    ///
+    /// Rows are given exactly as the document had them, headings included:
+    /// the widths are worked out from all of them together, which is the only
+    /// way the columns can agree, and that arithmetic belongs to the layout
+    /// rather than to whoever is describing the page.
+    #[must_use]
+    pub fn table(mut self, rows: Vec<kobo_ui::TableRow>, weights: Vec<u16>) -> Self {
+        let id = self.next_id();
+        self.nodes.push(Node::Table { id, rows, weights });
+        self
+    }
+
     /// The two ends carry pictures, not words, so the control needs no
     /// translating and no room for a label. Whichever end has nowhere further
     /// to go is drawn muted and stops answering taps.

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -10,7 +10,7 @@ pub use kobo_protocol::{
     Credential, DenyReason, DeviceError, DeviceRequest, DeviceResult, Frame, Header, Lifecycle,
     LogLevel, Message, SecretHeader, ShellError, ShellEvent, ShellRequest, StoreError,
     StoreRequest, StoreResult, StreamError, Task, TaskError, TaskId, TaskOutcome, WifiNetwork,
-    CACHE_PREFIX, MAX_CACHE_KEYS, MAX_HEADERS, MAX_HEADER_NAME, MAX_HEADER_VALUE,
+    CACHE_PREFIX, MAX_CACHE_KEYS, MAX_FONT_BYTES, MAX_HEADERS, MAX_HEADER_NAME, MAX_HEADER_VALUE,
     MAX_INLINE_PICTURE_BYTES, MAX_PICTURE_BYTES, MAX_PICTURE_CHUNK_BYTES, MAX_RADIO_DEVICES,
     MAX_RADIO_NAME, MAX_SHELF_CHUNK, MAX_SHELL_CHUNK, MAX_STORE_KEYS, MAX_STORE_VALUE,
     MAX_TASK_BYTES, MAX_URL_LEN,
@@ -19,12 +19,13 @@ pub use kobo_ui::QuoteRole;
 pub use kobo_ui::{
     terminal_grid, terminal_grid_for, typographic_cover, ActionId, BandAlign, BandSlot,
     BannerLevel, BarAction, BarStyle, BottomAction, Caret, Cell, Chip, Chrome, ControlState,
-    DiagnosticSeverity, DisplayMetrics, Emphasis, Fold, Freeform, Glyph, LayoutIssue,
-    LayoutIssueKind, NavBar, Node, NodeId, Overlay, OverlayKind, Percent, PictureHandle, ProseArea,
-    Row, RowLead, RowState, Screen, SlotWidth, Space, Tile, TilePicture, TileShape, TileState,
-    TopBar, TransferFailure, CLARA_BW_METRICS, MAX_BAND_SLOTS, MAX_CELLS, MAX_CHIPS,
-    MAX_CHOICE_OPTIONS, MAX_COLUMNS, MAX_QUOTE_DEPTH, MAX_ROWS, MAX_TABS, MAX_TERMINAL_COLUMNS,
-    MAX_TERMINAL_ROWS, TILE_BADGE_LIMIT,
+    DiagnosticSeverity, DisplayMetrics, Emphasis, Fold, FontHandle, Freeform, Glyph, LayoutIssue,
+    LayoutIssueKind, NavBar, Node, NodeId, Overlay, OverlayKind, ParagraphAlignment,
+    ParagraphPresentation, Percent, PictureHandle, ProseArea, RichTextSpan, Row, RowLead, RowState,
+    Screen, SlotWidth, Space, TextPresentation, Tile, TilePicture, TileShape, TileState, TopBar,
+    TransferFailure, CLARA_BW_METRICS, MAX_BAND_SLOTS, MAX_CELLS, MAX_CHIPS, MAX_CHOICE_OPTIONS,
+    MAX_COLUMNS, MAX_QUOTE_DEPTH, MAX_ROWS, MAX_TABS, MAX_TERMINAL_COLUMNS, MAX_TERMINAL_ROWS,
+    TILE_BADGE_LIMIT,
 };
 use std::collections::BTreeMap;
 use std::collections::VecDeque;
@@ -446,6 +447,7 @@ pub struct ScreenBuilder {
     text_scale: Option<kobo_ui::TextScale>,
     overlay: Option<Box<Overlay>>,
     reading: bool,
+    reading_font: Option<FontHandle>,
     actions: Vec<(String, ActionId)>,
     warnings: Vec<LayoutIssue>,
 }
@@ -466,6 +468,7 @@ impl ScreenBuilder {
             text_scale: None,
             overlay: None,
             reading: false,
+            reading_font: None,
             actions: Vec::new(),
             warnings: Vec::new(),
         }
@@ -488,6 +491,65 @@ impl ScreenBuilder {
             id,
             text: text.into(),
             links: Vec::new(),
+        });
+        self
+    }
+
+    /// Adds publisher-styled book prose without exposing arbitrary geometry.
+    #[must_use]
+    pub fn rich_text(
+        mut self,
+        text: impl Into<String>,
+        spans: Vec<RichTextSpan>,
+        presentation: ParagraphPresentation,
+    ) -> Self {
+        let id = self.next_id();
+        self.nodes.push(Node::RichText {
+            id,
+            text: text.into(),
+            spans,
+            links: Vec::new(),
+            presentation,
+        });
+        self
+    }
+
+    /// Publisher-styled prose with tappable inline destinations.
+    #[must_use]
+    pub fn rich_text_linking<I, N>(
+        mut self,
+        text: impl Into<String>,
+        spans: Vec<RichTextSpan>,
+        presentation: ParagraphPresentation,
+        links: I,
+    ) -> Self
+    where
+        I: IntoIterator<Item = (N, usize, usize)>,
+        N: AsRef<str>,
+    {
+        let id = self.next_id();
+        let text = text.into();
+        let links = links
+            .into_iter()
+            .take(kobo_ui::MAX_TEXT_LINKS)
+            .filter_map(|(name, start, end)| {
+                (start < end
+                    && end <= text.len()
+                    && text.is_char_boundary(start)
+                    && text.is_char_boundary(end))
+                .then(|| kobo_ui::TextLink {
+                    action: self.register(name.as_ref()),
+                    start,
+                    end,
+                })
+            })
+            .collect();
+        self.nodes.push(Node::RichText {
+            id,
+            text,
+            spans,
+            links,
+            presentation,
         });
         self
     }
@@ -1192,6 +1254,13 @@ impl ScreenBuilder {
     #[must_use]
     pub const fn reading(mut self, reading: bool) -> Self {
         self.reading = reading;
+        self
+    }
+
+    /// Uses a publisher font previously handed to the runtime for book prose.
+    #[must_use]
+    pub const fn reading_font(mut self, font: FontHandle) -> Self {
+        self.reading_font = Some(font);
         self
     }
 
@@ -2310,6 +2379,7 @@ impl ScreenBuilder {
             text_scale: self.text_scale,
             overlay: self.overlay,
             reading: self.reading,
+            reading_font: self.reading_font,
         }
     }
 
@@ -2437,6 +2507,14 @@ pub enum Command {
     },
     /// Release a picture the runtime is holding.
     DropPicture(PictureHandle),
+    /// Give the runtime a publisher font to hold for reading screens.
+    PutFont {
+        handle: FontHandle,
+        name: String,
+        bytes: Vec<u8>,
+    },
+    /// Release a publisher font and its glyph cache.
+    DropFont(FontHandle),
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -2928,6 +3006,43 @@ impl Context {
     /// application exits, so this is for one that outlives its usefulness.
     pub fn drop_picture(&mut self, handle: PictureHandle) {
         self.commands.push(Command::DropPicture(handle));
+    }
+
+    /// Hands a bounded embedded font to both local pagination and the runtime.
+    ///
+    /// Returns the handle only when the bytes are a supported TrueType or
+    /// OpenType face. Unsupported WOFF data and malformed fonts leave the
+    /// approved system reading face in place.
+    pub fn put_font(
+        &mut self,
+        handle: FontHandle,
+        name: impl Into<String>,
+        bytes: Vec<u8>,
+    ) -> Option<FontHandle> {
+        let name = name.into();
+        if bytes.is_empty()
+            || bytes.len() > MAX_FONT_BYTES
+            || name.len() > kobo_protocol::MAX_STRING_LEN
+        {
+            return None;
+        }
+        #[cfg(feature = "text")]
+        {
+            let font = kobo_text::BookFont::from_bytes(&bytes, &name, self.metrics).ok()?;
+            kobo_ui::put_book_typesetter(handle, Box::new(font));
+        }
+        self.commands.push(Command::PutFont {
+            handle,
+            name,
+            bytes,
+        });
+        Some(handle)
+    }
+
+    /// Releases a publisher font locally and in the runtime.
+    pub fn drop_font(&mut self, handle: FontHandle) {
+        kobo_ui::drop_book_typesetter(handle);
+        self.commands.push(Command::DropFont(handle));
     }
 
     /// Hands work to the runtime so the event loop keeps running.
@@ -4548,6 +4663,16 @@ impl Client {
                 Command::Launch(name) => Message::Launch { name },
                 Command::PutPicture { .. } => unreachable!("handled above"),
                 Command::DropPicture(handle) => Message::DropPicture { handle },
+                Command::PutFont {
+                    handle,
+                    name,
+                    bytes,
+                } => Message::PutFont {
+                    handle,
+                    name,
+                    bytes,
+                },
+                Command::DropFont(handle) => Message::DropFont { handle },
             };
             self.send(message)?;
         }

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -4611,8 +4611,16 @@ impl<A: KoboApp> AppRunner<A> {
                 true
             }
             // Anything that can hand the panel to somebody else invalidates
-            // what we believe is on it.
-            Command::Launch(_) | Command::Exit => {
+            // what we believe is on it, and so does handing over pixels. A
+            // screen refers to a picture by handle, so filling that handle in
+            // later changes what is on the panel without changing a byte of
+            // the tree that describes it -- and the tree is all the
+            // comparison above can see. A book of plates opened on an
+            // illustration and showed an empty frame until something
+            // unrelated happened to redraw the page, because every repaint
+            // the pipeline asked for was thrown away here for being identical
+            // to the one already displayed.
+            Command::Launch(_) | Command::Exit | Command::PutPicture { .. } => {
                 self.displayed = None;
                 true
             }
@@ -4967,6 +4975,60 @@ mod tests {
             sent(&runner.action(ActionId(1))),
             1,
             "a transfer that has moved must still repaint"
+        );
+    }
+
+    /// A picture arriving after the screen that refers to it still repaints.
+    ///
+    /// A screen names a picture by handle, so filling that handle in later
+    /// changes the panel without changing the tree. On the reader this was a
+    /// book of plates opening on an illustration and drawing an empty frame:
+    /// the pipeline decoded the plate, handed over the pixels and asked for a
+    /// repaint, and the repaint was thrown away for being identical to the
+    /// screen already displayed. The frame stayed empty until a page turn
+    /// happened to change the tree for some other reason.
+    #[test]
+    fn pixels_handed_over_after_the_screen_that_names_them_still_reach_the_panel() {
+        #[derive(Default)]
+        struct Plate {
+            filled: bool,
+        }
+        impl KoboApp for Plate {
+            fn on_start(&mut self, context: &mut Context) {
+                Self::paint(context);
+            }
+            fn on_action(&mut self, context: &mut Context, _action: ActionId) {
+                if !self.filled {
+                    self.filled = true;
+                    let _ = context.put_picture(PictureHandle(1), 2, 2, vec![0, 1, 2, 3]);
+                }
+                Self::paint(context);
+            }
+        }
+        impl Plate {
+            fn paint(context: &mut Context) {
+                // The same tree either way: what changed is behind the handle.
+                context.set_screen(ScreenBuilder::new("plate").text("A plate.").build());
+            }
+        }
+
+        let mut runner = AppRunner::new(Plate::default());
+        let sent = |commands: &[Command]| {
+            commands
+                .iter()
+                .filter(|command| matches!(command, Command::SetScreen(_)))
+                .count()
+        };
+        assert_eq!(sent(&runner.start()), 1, "the first screen always goes");
+        assert_eq!(
+            sent(&runner.action(ActionId(1))),
+            1,
+            "the plate was handed over and the page was never redrawn to show it"
+        );
+        assert_eq!(
+            sent(&runner.action(ActionId(1))),
+            0,
+            "an unchanged screen with no new pixels still costs nothing"
         );
     }
 

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -2184,6 +2184,80 @@ impl ScreenBuilder {
         self
     }
 
+    /// Offers a value that moves one notch at a time.
+    ///
+    /// This is the shape a setting takes when its values form a line rather
+    /// than a set: type size, brightness, playback speed. A list of named
+    /// options would say the same thing in five rows of full-width boxes, and
+    /// on a panel that repaints in tenths of a second the reader would rather
+    /// tap the same spot twice than read five labels to find the one above the
+    /// one they have.
+    ///
+    /// The two ends carry pictures, not words, so the control needs no
+    /// translating and no room for a label. Whichever end has nowhere further
+    /// to go is drawn muted and stops answering taps.
+    #[must_use]
+    pub fn stepper(
+        mut self,
+        label: impl Into<String>,
+        less: impl AsRef<str>,
+        less_glyph: Glyph,
+        more: impl AsRef<str>,
+        more_glyph: Glyph,
+    ) -> Self {
+        let id = self.next_id();
+        let less =
+            BarAction::new(self.register(less.as_ref()), String::new()).with_glyph(less_glyph);
+        let more =
+            BarAction::new(self.register(more.as_ref()), String::new()).with_glyph(more_glyph);
+        self.nodes.push(Node::Stepper {
+            id,
+            label: label.into(),
+            less,
+            more,
+            less_state: ControlState::Enabled,
+            more_state: ControlState::Enabled,
+            fill: None,
+        });
+        self
+    }
+
+    /// Says which ends of the stepper just declared still have somewhere to go.
+    #[must_use]
+    pub fn stepper_ends(mut self, less: bool, more: bool) -> Self {
+        if let Some(Node::Stepper {
+            less_state,
+            more_state,
+            ..
+        }) = self.nodes.last_mut()
+        {
+            *less_state = if less {
+                ControlState::Enabled
+            } else {
+                ControlState::Disabled
+            };
+            *more_state = if more {
+                ControlState::Enabled
+            } else {
+                ControlState::Disabled
+            };
+        }
+        self
+    }
+
+    /// Draws a hairline under the stepper just declared showing where in its
+    /// range the value sits, as a percentage of the way along.
+    ///
+    /// Worth having where the reading is a number without a natural sense of
+    /// scale: "60%" says little until you can see it is past the middle.
+    #[must_use]
+    pub fn stepper_track(mut self, percent: u8) -> Self {
+        if let Some(Node::Stepper { fill, .. }) = self.nodes.last_mut() {
+            *fill = Some(percent.min(100));
+        }
+        self
+    }
+
     /// Asks a question by offering answers.
     ///
     /// Prefer this over a text field. Typing on this device means summoning a
@@ -2640,11 +2714,13 @@ impl Context {
         nav_bar: bool,
         scale: kobo_ui::TextScale,
     ) -> Vec<Vec<String>> {
-        // Measured with the type actually at that size. Setting it on the
+        // Measured with the prose actually at that size. Setting it on the
         // metrics alone moves the margins and leaves the words the size they
         // were, which is how a page comes out measured for one size and drawn
-        // at another.
-        kobo_ui::with_text_scale(scale, || {
+        // at another. Only the prose moves: the bars above and below are
+        // interface and keep the reader's own size, which is what makes the
+        // page area the same whatever size the book is set at.
+        kobo_ui::with_reading_scale(scale, || {
             let metrics = self.metrics_at(scale);
             let mut area = metrics.prose_area_in(true, nav_bar, kobo_ui::Face::Reading);
             area.height = area

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -7,13 +7,13 @@
 
 pub use kobo_protocol::{
     AppInfo, AudioPlaybackState, AudioSource, BatteryDetail, BluetoothDevice, BluetoothDeviceKind,
-    Credential, DenyReason, DeviceError, DeviceRequest, DeviceResult, Frame, Header, Lifecycle,
-    LogLevel, Message, SecretHeader, ShellError, ShellEvent, ShellRequest, StoreError,
-    StoreRequest, StoreResult, StreamError, Task, TaskError, TaskId, TaskOutcome, WifiNetwork,
-    CACHE_PREFIX, MAX_CACHE_KEYS, MAX_FONT_BYTES, MAX_HEADERS, MAX_HEADER_NAME, MAX_HEADER_VALUE,
-    MAX_INLINE_PICTURE_BYTES, MAX_PICTURE_BYTES, MAX_PICTURE_CHUNK_BYTES, MAX_RADIO_DEVICES,
-    MAX_RADIO_NAME, MAX_SHELF_CHUNK, MAX_SHELL_CHUNK, MAX_STORE_KEYS, MAX_STORE_VALUE,
-    MAX_TASK_BYTES, MAX_URL_LEN,
+    Credential, DenyReason, DeviceError, DeviceRequest, DeviceResult, DictionaryEntry, Frame,
+    Header, Lifecycle, LogLevel, Message, SecretHeader, ShellError, ShellEvent, ShellRequest,
+    StoreError, StoreRequest, StoreResult, StreamError, Task, TaskError, TaskId, TaskOutcome,
+    WifiNetwork, CACHE_PREFIX, MAX_CACHE_KEYS, MAX_FONT_BYTES, MAX_HEADERS, MAX_HEADER_NAME,
+    MAX_HEADER_VALUE, MAX_INLINE_PICTURE_BYTES, MAX_LOOKUP_WORD_BYTES, MAX_PICTURE_BYTES,
+    MAX_PICTURE_CHUNK_BYTES, MAX_RADIO_DEVICES, MAX_RADIO_NAME, MAX_SHELF_CHUNK, MAX_SHELL_CHUNK,
+    MAX_STORE_KEYS, MAX_STORE_VALUE, MAX_TASK_BYTES, MAX_URL_LEN,
 };
 pub use kobo_ui::QuoteRole;
 pub use kobo_ui::{
@@ -4030,6 +4030,32 @@ impl Device<'_> {
         self.request(DeviceRequest::SetAudioVolume {
             percent: percent.min(100),
         });
+    }
+
+    /// Looks up one word using runtime-installed dictionaries without opening
+    /// the radio. The answer arrives through `on_device_result` as
+    /// `DeviceResult::Dictionary`, including an explicit empty result.
+    pub fn lookup_word(
+        &mut self,
+        word: impl Into<String>,
+        language: Option<impl Into<String>>,
+    ) -> bool {
+        let word = word.into();
+        let language = language.map(Into::into);
+        if word.trim().is_empty()
+            || word.len() > MAX_LOOKUP_WORD_BYTES
+            || language.as_deref().is_some_and(|language| {
+                language.is_empty()
+                    || language.len() > 16
+                    || !language
+                        .bytes()
+                        .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+            })
+        {
+            return false;
+        }
+        self.request(DeviceRequest::LookupWord { word, language });
+        true
     }
 
     /// Replaces the installed Cobalt with a published release archive.

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -22,10 +22,10 @@ pub use kobo_ui::{
     DiagnosticSeverity, DisplayMetrics, Emphasis, Fold, FontHandle, Freeform, Glyph, LayoutIssue,
     LayoutIssueKind, NavBar, Node, NodeId, Overlay, OverlayKind, ParagraphAlignment,
     ParagraphPresentation, Percent, PictureHandle, ProseArea, RichTextSpan, Row, RowLead, RowState,
-    Screen, SlotWidth, Space, TextPresentation, Tile, TilePicture, TileShape, TileState, TopBar,
-    TransferFailure, CLARA_BW_METRICS, MAX_BAND_SLOTS, MAX_CELLS, MAX_CHIPS, MAX_CHOICE_OPTIONS,
-    MAX_COLUMNS, MAX_QUOTE_DEPTH, MAX_ROWS, MAX_TABS, MAX_TERMINAL_COLUMNS, MAX_TERMINAL_ROWS,
-    TILE_BADGE_LIMIT,
+    Screen, SlotWidth, Space, TextHit, TextPresentation, TextSelection, Tile, TilePicture,
+    TileShape, TileState, TopBar, TransferFailure, CLARA_BW_METRICS, MAX_BAND_SLOTS, MAX_CELLS,
+    MAX_CHIPS, MAX_CHOICE_OPTIONS, MAX_COLUMNS, MAX_QUOTE_DEPTH, MAX_ROWS, MAX_TABS,
+    MAX_TERMINAL_COLUMNS, MAX_TERMINAL_ROWS, TILE_BADGE_LIMIT,
 };
 use std::collections::BTreeMap;
 use std::collections::VecDeque;
@@ -510,6 +510,7 @@ impl ScreenBuilder {
             spans,
             links: Vec::new(),
             presentation,
+            selection: None,
         });
         self
     }
@@ -550,6 +551,50 @@ impl ScreenBuilder {
             spans,
             links,
             presentation,
+            selection: None,
+        });
+        self
+    }
+
+    /// Publisher-styled reading prose whose words can be resolved on a hold.
+    #[must_use]
+    pub fn selectable_rich_text_linking<I, N>(
+        mut self,
+        text: impl Into<String>,
+        spans: Vec<RichTextSpan>,
+        presentation: ParagraphPresentation,
+        context: u64,
+        offset: u32,
+        links: I,
+    ) -> Self
+    where
+        I: IntoIterator<Item = (N, usize, usize)>,
+        N: AsRef<str>,
+    {
+        let id = self.next_id();
+        let text = text.into();
+        let links = links
+            .into_iter()
+            .take(kobo_ui::MAX_TEXT_LINKS)
+            .filter_map(|(name, start, end)| {
+                (start < end
+                    && end <= text.len()
+                    && text.is_char_boundary(start)
+                    && text.is_char_boundary(end))
+                .then(|| kobo_ui::TextLink {
+                    action: self.register(name.as_ref()),
+                    start,
+                    end,
+                })
+            })
+            .collect();
+        self.nodes.push(Node::RichText {
+            id,
+            text,
+            spans,
+            links,
+            presentation,
+            selection: Some(kobo_ui::TextSelection { context, offset }),
         });
         self
     }
@@ -4053,6 +4098,13 @@ pub trait KoboApp {
     fn on_start(&mut self, context: &mut Context);
     fn on_action(&mut self, context: &mut Context, action: ActionId);
 
+    /// Receives a held word in stable application text coordinates.
+    /// Applications that have not opted into selection retain the historical
+    /// hold action behavior.
+    fn on_text_hold(&mut self, context: &mut Context, action: ActionId, _hit: TextHit) {
+        self.on_action(context, action);
+    }
+
     fn on_resume(&mut self, _context: &mut Context) {}
 
     fn on_suspend(&mut self, _context: &mut Context) {}
@@ -4259,6 +4311,10 @@ impl<A: KoboApp> AppRunner<A> {
             return self.dispatch(|_, context| context.launch(NETWORK_SETTINGS_APP));
         }
         self.dispatch(|app, context| app.on_action(context, action))
+    }
+
+    pub fn text_hold(&mut self, action: ActionId, hit: TextHit) -> Vec<Command> {
+        self.dispatch(|app, context| app.on_text_hold(context, action, hit))
     }
 
     pub fn resume(&mut self) -> Vec<Command> {
@@ -4493,6 +4549,10 @@ impl<A: KoboApp> AppRunner<A> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ClientEvent {
     Action(ActionId),
+    TextHold {
+        action: ActionId,
+        hit: TextHit,
+    },
     Device(DeviceResult),
     Task {
         task: TaskId,
@@ -4688,6 +4748,19 @@ impl Client {
     pub fn next_event(&mut self) -> Result<ClientEvent, ClientError> {
         match kobo_protocol::read_from(&mut self.stream)?.message {
             Message::Action { action } => Ok(ClientEvent::Action(action)),
+            Message::TextHold {
+                action,
+                context,
+                start,
+                end,
+            } => Ok(ClientEvent::TextHold {
+                action,
+                hit: TextHit {
+                    context,
+                    start,
+                    end,
+                },
+            }),
             Message::DeviceResult(result) => Ok(ClientEvent::Device(result)),
             Message::TaskOutcome { task, outcome } => Ok(ClientEvent::Task { task, outcome }),
             Message::StoreResult(result) => Ok(ClientEvent::Store(result)),
@@ -6087,7 +6160,7 @@ pub fn run_on<A: KoboApp>(name: &str, app: A, socket: &Path) -> Result<(), Clien
                 ClientEvent::CoverChanged(present) => {
                     client.send_commands(runner.cover_changed(present))?;
                 }
-                ClientEvent::Action(_) | ClientEvent::Exit => break,
+                ClientEvent::Action(_) | ClientEvent::TextHold { .. } | ClientEvent::Exit => break,
             }
         }
         client.send_commands([Command::Exit])?;
@@ -6097,6 +6170,7 @@ pub fn run_on<A: KoboApp>(name: &str, app: A, socket: &Path) -> Result<(), Clien
     loop {
         let commands = match client.next_event()? {
             ClientEvent::Action(action) => runner.action(action),
+            ClientEvent::TextHold { action, hit } => runner.text_hold(action, hit),
             ClientEvent::Device(result) => runner.device_result(result),
             ClientEvent::Task { task, outcome } => runner.task_outcome(task, outcome),
             ClientEvent::Store(result) => runner.store_result(result),

--- a/crates/kobo-sim/src/lib.rs
+++ b/crates/kobo-sim/src/lib.rs
@@ -690,6 +690,27 @@ fn current_user_id() -> io::Result<u32> {
 /// Split out only so the message loop stays readable; the cache is the same
 /// one the device runtime uses.
 fn hold(state: &Arc<Mutex<AppState>>, message: Message) -> io::Result<()> {
+    match message {
+        Message::PutFont {
+            handle,
+            name,
+            bytes,
+        } => match kobo_text::BookFont::from_bytes(&bytes, &name, profile_metrics()) {
+            Ok(font) => {
+                kobo_ui::put_book_typesetter(handle, Box::new(font));
+                Ok(())
+            }
+            Err(error) => note(state, &format!("font {} refused: {error}", handle.0)),
+        },
+        Message::DropFont { handle } => {
+            kobo_ui::drop_book_typesetter(handle);
+            Ok(())
+        }
+        other => hold_picture(state, other),
+    }
+}
+
+fn hold_picture(state: &Arc<Mutex<AppState>>, message: Message) -> io::Result<()> {
     let diagnostic = {
         let mut held = state
             .lock()
@@ -762,6 +783,8 @@ fn is_picture_message(message: &Message) -> bool {
             | Message::PictureChunk { .. }
             | Message::CommitPicture { .. }
             | Message::DropPicture { .. }
+            | Message::PutFont { .. }
+            | Message::DropFont { .. }
     )
 }
 

--- a/crates/kobo-text/src/lib.rs
+++ b/crates/kobo-text/src/lib.rs
@@ -567,6 +567,74 @@ pub struct SystemFonts {
     reading: Typeface,
 }
 
+/// A bounded publisher face used only for book prose.
+///
+/// EPUB fonts never replace interface chrome. The runtime constructs this
+/// from bytes that already passed document and protocol limits, then installs
+/// it under an application-local handle in `kobo-ui`.
+pub struct BookFont {
+    face: Typeface,
+}
+
+impl BookFont {
+    /// Parses a TrueType/OpenType publisher face from memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Malformed`] when the bytes are not an outline font
+    /// supported by the rasterizer (including compressed WOFF assets).
+    pub fn from_bytes(bytes: &[u8], name: &str, metrics: DisplayMetrics) -> Result<Self, Error> {
+        Ok(Self {
+            face: Typeface::from_bytes(bytes, name, metrics)?,
+        })
+    }
+}
+
+impl Typesetter for BookFont {
+    fn measure(&self, text: &str, size: FontSize, _face: Face) -> (i32, i32) {
+        self.face.measure_run(text, size, None, None)
+    }
+
+    fn line_height(&self, size: FontSize, _face: Face) -> i32 {
+        let natural = self.face.height(size);
+        natural + natural / 5
+    }
+
+    fn draw(
+        &self,
+        text: &str,
+        x: i32,
+        y: i32,
+        size: FontSize,
+        _face: Face,
+        plot: &mut dyn FnMut(i32, i32, u8),
+    ) {
+        self.face.draw_run(text, x, y, size, None, None, plot);
+    }
+
+    fn has_glyph(&self, character: char, _face: Face) -> bool {
+        self.face.has(character)
+    }
+
+    fn line_breaks(&self, text: &str) -> Vec<(usize, BreakOpportunity)> {
+        linebreaks(text)
+            .map(|(offset, opportunity)| {
+                let opportunity = match opportunity {
+                    UnicodeBreakOpportunity::Allowed => BreakOpportunity::Allowed,
+                    UnicodeBreakOpportunity::Mandatory => BreakOpportunity::Mandatory,
+                };
+                (offset, opportunity)
+            })
+            .collect()
+    }
+
+    fn grapheme_boundaries(&self, text: &str) -> Vec<usize> {
+        UnicodeSegmentation::grapheme_indices(text, true)
+            .map(|(offset, grapheme)| offset + grapheme.len())
+            .collect()
+    }
+}
+
 impl SystemFonts {
     /// Finds the reader's own face for prose and compiles in the one for grids.
     ///

--- a/crates/kobo-text/src/lib.rs
+++ b/crates/kobo-text/src/lib.rs
@@ -1290,7 +1290,7 @@ mod tests {
                 .pick(missing, Some(&other))
                 .expect("a letter is not invisible");
             assert!(
-                std::ptr::eq(drawn, &other) && glyph == missing,
+                std::ptr::eq(drawn, std::ptr::from_ref(&other)) && glyph == missing,
                 "{missing:?} was not borrowed from the face that has it"
             );
             let boxed = ink(&face, &missing.to_string());

--- a/crates/kobo-text/src/lib.rs
+++ b/crates/kobo-text/src/lib.rs
@@ -597,7 +597,10 @@ impl Typesetter for BookFont {
 
     fn line_height(&self, size: FontSize, _face: Face) -> i32 {
         let natural = self.face.height(size);
-        natural + natural / 5
+        // A publisher font supplies its own metrics, and a structurally valid
+        // face can report an ascent, descent and line gap of zero. Callers
+        // divide a page height by this, so it is never allowed to be zero.
+        (natural + natural / 5).max(1)
     }
 
     fn draw(

--- a/crates/kobo-text/src/lib.rs
+++ b/crates/kobo-text/src/lib.rs
@@ -307,7 +307,7 @@ impl Typeface {
     }
 
     /// The em size in pixels for a semantic size on this panel.
-    fn pixels(&self, size: FontSize) -> f32 {
+    fn pixels(&self, size: FontSize, face: Face) -> f32 {
         // `tenth_mm` is the panel-independent definition; this is the only place
         // it becomes a pixel count, so a different panel needs no other change.
         //
@@ -316,7 +316,7 @@ impl Typeface {
         // life of the process, so a reader who makes a book larger would
         // otherwise be changing a value nothing reads: the glyphs would come
         // back the same size while the layout around them moved.
-        let tenths = (size.tenth_mm() * kobo_ui::text_scale().percent() + 50) / 100;
+        let tenths = (size.tenth_mm() * kobo_ui::scale_percent(face) + 50) / 100;
         let pixels = self.metrics.tenth_mm(tenths);
         pixels.max(1) as f32
     }
@@ -419,6 +419,7 @@ impl Typeface {
         &self,
         text: &str,
         size: FontSize,
+        face: Face,
         cell: Option<i32>,
         fallback: Option<&Self>,
     ) -> (i32, i32) {
@@ -429,9 +430,9 @@ impl Typeface {
             // the drawn column disagree is a terminal that corrupts its own
             // display the first time it repaints part of a line.
             let cells = i32::try_from(text.chars().count()).unwrap_or(i32::MAX);
-            return (cells.saturating_mul(cell), self.height(size));
+            return (cells.saturating_mul(cell), self.height(size, face));
         }
-        let pixels = self.pixels(size);
+        let pixels = self.pixels(size, face);
         let mut width = 0f32;
         let mut previous: Option<(&Self, char)> = None;
         for character in text.chars() {
@@ -448,12 +449,12 @@ impl Typeface {
             width += face.font.metrics(glyph, pixels).advance_width;
             previous = Some((face, glyph));
         }
-        (width.round() as i32, self.height(size))
+        (width.round() as i32, self.height(size, face))
     }
 
     /// The baseline-to-baseline distance for this face.
-    fn height(&self, size: FontSize) -> i32 {
-        let pixels = self.pixels(size);
+    fn height(&self, size: FontSize, face: Face) -> i32 {
+        let pixels = self.pixels(size, face);
         self.font.horizontal_line_metrics(pixels).map_or_else(
             || (pixels * 1.3) as i32,
             |line| (line.ascent - line.descent + line.line_gap).ceil() as i32,
@@ -477,11 +478,12 @@ impl Typeface {
         x: i32,
         y: i32,
         size: FontSize,
+        face: Face,
         cell: Option<i32>,
         fallback: Option<&Self>,
         plot: &mut dyn FnMut(i32, i32, u8),
     ) {
-        let pixels = self.pixels(size);
+        let pixels = self.pixels(size, face);
         // Taken from this face rather than from whichever one draws each
         // glyph, so a letter borrowed from another face sits on the same line
         // as the letters around it instead of a line of its own.
@@ -542,8 +544,8 @@ impl Typeface {
     /// Returns `None` for a proportional face rather than an average, because
     /// an average is exactly the wrong answer for a grid: it is right for no
     /// character at all.
-    fn fixed_advance(&self, size: FontSize) -> Option<i32> {
-        let pixels = self.pixels(size);
+    fn fixed_advance(&self, size: FontSize, face: Face) -> Option<i32> {
+        let pixels = self.pixels(size, face);
         let reference = self.font.metrics('0', pixels).advance_width;
         for probe in ['i', 'm', 'W', '.'] {
             let advance = self.font.metrics(probe, pixels).advance_width;
@@ -592,11 +594,11 @@ impl BookFont {
 
 impl Typesetter for BookFont {
     fn measure(&self, text: &str, size: FontSize, _face: Face) -> (i32, i32) {
-        self.face.measure_run(text, size, None, None)
+        self.face.measure_run(text, size, Face::Reading, None, None)
     }
 
     fn line_height(&self, size: FontSize, _face: Face) -> i32 {
-        let natural = self.face.height(size);
+        let natural = self.face.height(size, Face::Reading);
         // A publisher font supplies its own metrics, and a structurally valid
         // face can report an ascent, descent and line gap of zero. Callers
         // divide a page height by this, so it is never allowed to be zero.
@@ -612,7 +614,8 @@ impl Typesetter for BookFont {
         _face: Face,
         plot: &mut dyn FnMut(i32, i32, u8),
     ) {
-        self.face.draw_run(text, x, y, size, None, None, plot);
+        self.face
+            .draw_run(text, x, y, size, Face::Reading, None, None, plot);
     }
 
     fn has_glyph(&self, character: char, _face: Face) -> bool {
@@ -733,12 +736,17 @@ impl SystemFonts {
 
 impl Typesetter for SystemFonts {
     fn measure(&self, text: &str, size: FontSize, face: Face) -> (i32, i32) {
-        self.cut(size, face)
-            .measure_run(text, size, self.cell(size, face), self.fallback(face))
+        self.cut(size, face).measure_run(
+            text,
+            size,
+            face,
+            self.cell(size, face),
+            self.fallback(face),
+        )
     }
 
     fn line_height(&self, size: FontSize, face: Face) -> i32 {
-        let natural = self.cut(size, face).height(size);
+        let natural = self.cut(size, face).height(size, face);
         match face {
             // A font's own line height is set for a paragraph in a document,
             // not for a page of a novel. Typesetters have always opened books
@@ -766,6 +774,7 @@ impl Typesetter for SystemFonts {
             x,
             y,
             size,
+            face,
             self.cell(size, face),
             self.fallback(face),
             plot,
@@ -806,8 +815,13 @@ impl Typesetter for SystemFonts {
         // Falls back to measuring rather than refusing, so a future face that
         // is very nearly fixed pitch still produces a usable grid.
         self.mono
-            .fixed_advance(size)
-            .unwrap_or_else(|| self.mono.measure_run("0", size, None, None).0.max(1))
+            .fixed_advance(size, Face::Mono)
+            .unwrap_or_else(|| {
+                self.mono
+                    .measure_run("0", size, Face::Mono, None, None)
+                    .0
+                    .max(1)
+            })
     }
 }
 
@@ -1120,8 +1134,9 @@ mod tests {
         let at = |scale| {
             kobo_ui::with_text_scale(scale, || {
                 (
-                    face.measure_run("Readable", FontSize::Body, None, None).0,
-                    face.height(FontSize::Body),
+                    face.measure_run("Readable", FontSize::Body, Face::Text, None, None)
+                        .0,
+                    face.height(FontSize::Body, Face::Text),
                 )
             })
         };
@@ -1262,8 +1277,14 @@ mod tests {
             "this test is pointless unless the face really lacks the character"
         );
 
-        let (plain, _) = face.measure_run("one-to-one", FontSize::Body, None, None);
-        let (fancy, _) = face.measure_run("one\u{2011}to\u{2011}one", FontSize::Body, None, None);
+        let (plain, _) = face.measure_run("one-to-one", FontSize::Body, Face::Text, None, None);
+        let (fancy, _) = face.measure_run(
+            "one\u{2011}to\u{2011}one",
+            FontSize::Body,
+            Face::Text,
+            None,
+            None,
+        );
         assert_eq!(plain, fancy, "the substitute must measure as what it draws");
         assert_eq!(
             ink(&face, "one\u{2011}to\u{2011}one"),
@@ -1303,6 +1324,7 @@ mod tests {
                 0,
                 0,
                 FontSize::Body,
+                Face::Text,
                 None,
                 Some(&other),
                 &mut |x, y, coverage| {
@@ -1360,8 +1382,8 @@ mod tests {
             );
             let text = format!("wo{invisible}rd");
             assert_eq!(
-                face.measure_run(&text, FontSize::Body, None, None),
-                face.measure_run("word", FontSize::Body, None, None),
+                face.measure_run(&text, FontSize::Body, Face::Text, None, None),
+                face.measure_run("word", FontSize::Body, Face::Text, None, None),
                 "{invisible:?} widened the line it should have left alone"
             );
             assert_eq!(ink(&face, &text), ink(&face, "word"));
@@ -1376,10 +1398,13 @@ mod tests {
     #[test]
     fn a_grid_gives_every_character_a_column_even_an_invisible_one() {
         let mono = Typeface::from_bytes(MONO_FONT, "mono", CLARA).expect("mono");
-        let cell = mono.fixed_advance(FontSize::Body).expect("a fixed advance");
+        let cell = mono
+            .fixed_advance(FontSize::Body, Face::Mono)
+            .expect("a fixed advance");
         let text = "a\u{200b}b";
         assert_eq!(
-            mono.measure_run(text, FontSize::Body, Some(cell), None).0,
+            mono.measure_run(text, FontSize::Body, Face::Text, Some(cell), None)
+                .0,
             cell * 3
         );
         let mut columns = Vec::new();
@@ -1388,6 +1413,7 @@ mod tests {
             0,
             0,
             FontSize::Body,
+            Face::Text,
             Some(cell),
             None,
             &mut |x, _, coverage| {
@@ -1460,6 +1486,7 @@ mod tests {
             0,
             0,
             FontSize::Body,
+            Face::Text,
             None,
             None,
             &mut |x, y, coverage| {
@@ -1476,8 +1503,8 @@ mod tests {
         let Some(face) = face() else {
             return;
         };
-        let lower = face.measure_run("aaaa", FontSize::Body, None, None);
-        let upper = face.measure_run("AAAA", FontSize::Body, None, None);
+        let lower = face.measure_run("aaaa", FontSize::Body, Face::Text, None, None);
+        let upper = face.measure_run("AAAA", FontSize::Body, Face::Text, None, None);
         // The built-in bitmap folded case away entirely, so these were equal.
         assert_ne!(lower, upper, "case is still being folded away");
     }
@@ -1487,8 +1514,8 @@ mod tests {
         let Some(face) = face() else {
             return;
         };
-        let narrow = face.measure_run("iiii", FontSize::Body, None, None);
-        let wide = face.measure_run("mmmm", FontSize::Body, None, None);
+        let narrow = face.measure_run("iiii", FontSize::Body, Face::Text, None, None);
+        let wide = face.measure_run("mmmm", FontSize::Body, Face::Text, None, None);
         assert!(narrow.0 < wide.0, "text is still monospaced");
     }
 
@@ -1497,8 +1524,12 @@ mod tests {
         let Some(face) = face() else {
             return;
         };
-        let once = face.measure_run("kobo", FontSize::Body, None, None).0;
-        let twice = face.measure_run("kobokobo", FontSize::Body, None, None).0;
+        let once = face
+            .measure_run("kobo", FontSize::Body, Face::Text, None, None)
+            .0;
+        let twice = face
+            .measure_run("kobokobo", FontSize::Body, Face::Text, None, None)
+            .0;
         let drift = (twice - once * 2).abs();
         assert!(
             drift <= once / 10,
@@ -1512,13 +1543,22 @@ mod tests {
             return;
         };
         let text = "Reading";
-        let (width, height) = face.measure_run(text, FontSize::Body, None, None);
+        let (width, height) = face.measure_run(text, FontSize::Body, Face::Text, None, None);
         let mut out_of_bounds = 0;
-        face.draw_run(text, 0, 0, FontSize::Body, None, None, &mut |x, y, _| {
-            if x < 0 || y < 0 || x > width || y > height {
-                out_of_bounds += 1;
-            }
-        });
+        face.draw_run(
+            text,
+            0,
+            0,
+            FontSize::Body,
+            Face::Text,
+            None,
+            None,
+            &mut |x, y, _| {
+                if x < 0 || y < 0 || x > width || y > height {
+                    out_of_bounds += 1;
+                }
+            },
+        );
         assert_eq!(out_of_bounds, 0, "glyphs escaped the box they measured");
     }
 
@@ -1533,6 +1573,7 @@ mod tests {
             0,
             0,
             FontSize::Body,
+            Face::Text,
             None,
             None,
             &mut |_, _, coverage| {
@@ -1555,6 +1596,7 @@ mod tests {
             0,
             0,
             FontSize::Title,
+            Face::Text,
             None,
             None,
             &mut |_, _, coverage| {
@@ -1571,8 +1613,8 @@ mod tests {
         let Some(face) = face() else {
             return;
         };
-        let caption = face.measure_run("Chapter", FontSize::Caption, None, None);
-        let heading = face.measure_run("Chapter", FontSize::Heading, None, None);
+        let caption = face.measure_run("Chapter", FontSize::Caption, Face::Text, None, None);
+        let heading = face.measure_run("Chapter", FontSize::Heading, Face::Text, None, None);
         assert!(caption.0 < heading.0);
         assert!(caption.1 < heading.1);
     }
@@ -1631,9 +1673,11 @@ mod tests {
     #[test]
     fn every_monospace_glyph_has_the_same_advance() {
         let mono = Typeface::from_bytes(MONO_FONT, "mono", CLARA).expect("mono");
-        let cell = mono.fixed_advance(FontSize::Body).expect("fixed pitch");
+        let cell = mono
+            .fixed_advance(FontSize::Body, Face::Mono)
+            .expect("fixed pitch");
         for probe in ["i", "m", "W", ".", "0", "|"] {
-            let (width, _) = mono.measure_run(probe, FontSize::Body, Some(cell), None);
+            let (width, _) = mono.measure_run(probe, FontSize::Body, Face::Text, Some(cell), None);
             assert_eq!(width, cell, "{probe} is not one cell wide");
         }
     }
@@ -1641,10 +1685,18 @@ mod tests {
     #[test]
     fn a_monospace_run_is_exactly_its_length_in_cells() {
         let mono = Typeface::from_bytes(MONO_FONT, "mono", CLARA).expect("mono");
-        let cell = mono.fixed_advance(FontSize::Body).expect("fixed pitch");
+        let cell = mono
+            .fixed_advance(FontSize::Body, Face::Mono)
+            .expect("fixed pitch");
         // A grid is addressed by column, so this has to hold exactly rather
         // than approximately, or column 60 is not where column 60 was drawn.
-        let (width, _) = mono.measure_run("cat /proc/uptime", FontSize::Body, Some(cell), None);
+        let (width, _) = mono.measure_run(
+            "cat /proc/uptime",
+            FontSize::Body,
+            Face::Text,
+            Some(cell),
+            None,
+        );
         assert_eq!(width, cell * 16);
     }
 
@@ -1654,7 +1706,7 @@ mod tests {
             return;
         };
         assert!(
-            face.fixed_advance(FontSize::Body).is_none(),
+            face.fixed_advance(FontSize::Body, Face::Mono).is_none(),
             "a proportional face claimed a single cell width"
         );
     }
@@ -1681,12 +1733,14 @@ mod tests {
         // over a line, which shows up as uneven spacing and as wrapping that
         // disagrees with what is drawn.
         let line = "n".repeat(60);
-        let pixels = face.pixels(FontSize::Body);
+        let pixels = face.pixels(FontSize::Body, Face::Text);
         let exact: f32 = line
             .chars()
             .map(|character| face.font.metrics(character, pixels).advance_width)
             .sum();
-        let measured = face.measure_run(&line, FontSize::Body, None, None).0;
+        let measured = face
+            .measure_run(&line, FontSize::Body, Face::Text, None, None)
+            .0;
         assert!(
             (measured as f32 - exact).abs() <= 1.0,
             "measured {measured} against an exact {exact}"
@@ -1699,9 +1753,11 @@ mod tests {
         // Body only 41 columns. Anything much narrower than 50 and ordinary
         // command output wraps into unreadable rubble, so this is the floor a
         // future face change must not silently drop below.
-        let cell = mono.fixed_advance(FontSize::Caption).expect("fixed pitch");
+        let cell = mono
+            .fixed_advance(FontSize::Caption, Face::Mono)
+            .expect("fixed pitch");
         let columns = 1072 / cell;
-        let rows = 1448 / mono.height(FontSize::Caption);
+        let rows = 1448 / mono.height(FontSize::Caption, Face::Text);
         assert!(columns >= 50, "only {columns} columns fit");
         assert!(rows >= 30, "only {rows} rows fit");
     }
@@ -1927,7 +1983,7 @@ mod tests {
         let regular = Typeface::from_bytes(TEXT_FONT, "regular", CLARA).expect("regular");
         for size in [FontSize::Title, FontSize::Heading] {
             let (bold_width, _) = fonts.measure("Connections", size, Face::Text);
-            let (plain_width, _) = regular.measure_run("Connections", size, None, None);
+            let (plain_width, _) = regular.measure_run("Connections", size, Face::Text, None, None);
             assert!(
                 bold_width > plain_width,
                 "{size:?} was set no wider than the regular cut: {bold_width} against {plain_width}"
@@ -1937,7 +1993,7 @@ mod tests {
         // a screen shouting every word of itself.
         for size in [FontSize::Caption, FontSize::Body] {
             let (through, _) = fonts.measure("Connections", size, Face::Text);
-            let (plain, _) = regular.measure_run("Connections", size, None, None);
+            let (plain, _) = regular.measure_run("Connections", size, Face::Text, None, None);
             assert_eq!(through, plain, "{size:?} was not set in the regular cut");
         }
     }

--- a/crates/kobo-ui/Cargo.toml
+++ b/crates/kobo-ui/Cargo.toml
@@ -10,3 +10,6 @@ description = "Declarative E Ink UI, layout, and rendering primitives for Kobo a
 
 [lints]
 workspace = true
+
+[dependencies]
+unicode-segmentation = "1.13.3"

--- a/crates/kobo-ui/src/lib.rs
+++ b/crates/kobo-ui/src/lib.rs
@@ -4,6 +4,7 @@
     clippy::cast_possible_truncation,
     clippy::cast_possible_wrap,
     clippy::cast_sign_loss,
+    clippy::match_same_arms,
     clippy::only_used_in_recursion,
     clippy::too_many_lines
 )]

--- a/crates/kobo-ui/src/lib.rs
+++ b/crates/kobo-ui/src/lib.rs
@@ -13,11 +13,13 @@
 use std::cmp::{max, min};
 use std::collections::BTreeMap;
 use std::sync::{Mutex, OnceLock};
+use unicode_segmentation::UnicodeSegmentation;
 
 pub const DISPLAY_WIDTH: i32 = 1072;
 pub const DISPLAY_HEIGHT: i32 = 1448;
 const MAX_LAYOUT_NODES: usize = 512;
 const MAX_LAYOUT_DEPTH: usize = 16;
+const MAX_TEXT_HITS: usize = 1024;
 /// Beyond a handful of options a list stops being a choice and becomes a menu,
 /// which is what [`Node::PagedList`] is for.
 pub const MAX_CHOICE_OPTIONS: usize = 6;
@@ -2210,6 +2212,9 @@ pub struct TextPresentation {
     pub underline: bool,
     pub superscript: bool,
     pub subscript: bool,
+    /// A reader annotation behind this exact run, rendered as a light ink
+    /// wash that remains distinct from selection focus in grayscale.
+    pub highlighted: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -2217,6 +2222,26 @@ pub struct RichTextSpan {
     pub start: usize,
     pub end: usize,
     pub presentation: TextPresentation,
+}
+
+/// Stable document coordinates attached to publisher-styled reading text.
+///
+/// The UI layer deliberately treats `context` as opaque. A reading
+/// application can use it as a block, resource, or document identifier while
+/// the runtime adds the byte offsets resolved from the touched word.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TextSelection {
+    pub context: u64,
+    pub offset: u32,
+}
+
+/// One word under a finger, expressed in the reading application's logical
+/// coordinate system rather than in pixels.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TextHit {
+    pub context: u64,
+    pub start: u32,
+    pub end: u32,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -2274,6 +2299,7 @@ pub enum Node {
         spans: Vec<RichTextSpan>,
         links: Vec<TextLink>,
         presentation: ParagraphPresentation,
+        selection: Option<TextSelection>,
     },
     /// A line about the content rather than the content: a date, an author, a
     /// size, a count, a status.
@@ -3686,6 +3712,10 @@ pub struct Layout {
     pub page_turns: Option<PageTurns>,
     /// Set when the screen asked to hear about a held finger.
     pub hold: Option<ActionId>,
+    /// Word rectangles derived during layout. These are kept outside `nodes`
+    /// so selectable prose does not spend the bounded semantic-node budget on
+    /// every word in a novel.
+    pub text_hits: Vec<(Rect, TextHit)>,
     /// The face this screen's prose was wrapped in, and must be drawn in.
     ///
     /// Kept on the layout rather than on each node because it is a property of
@@ -3977,6 +4007,20 @@ impl Layout {
             return None;
         }
         Some(hold)
+    }
+
+    /// The logical word under a held finger. Controls always win, matching
+    /// ordinary tap hit testing and preventing a held link or toolbar button
+    /// from unexpectedly selecting book text beneath it.
+    #[must_use]
+    pub fn hit_text(&self, x: i32, y: i32) -> Option<TextHit> {
+        if !self.content.contains(x, y) || self.hit_control(x, y).is_some() {
+            return None;
+        }
+        self.text_hits
+            .iter()
+            .rev()
+            .find_map(|(rect, hit)| rect.contains(x, y).then_some(*hit))
     }
 
     /// The page turn a tap on empty content means, if any.
@@ -4552,6 +4596,7 @@ fn layout_node(
             spans,
             links,
             presentation,
+            selection,
         } => {
             let natural = FontSize::Body.line_height_in(prose).max(1);
             let line_height = natural
@@ -4620,6 +4665,35 @@ fn layout_node(
                             kind: LayoutKind::InlineLink(link.action),
                             text_lines: Vec::new(),
                         });
+                    }
+                }
+                if let Some(selection) = selection {
+                    for (relative, word) in line.unicode_word_indices() {
+                        if layout.text_hits.len() >= MAX_TEXT_HITS {
+                            break;
+                        }
+                        let start = from.saturating_add(relative);
+                        let end = start.saturating_add(word.len());
+                        let (Ok(start_offset), Ok(end_offset)) =
+                            (u32::try_from(start), u32::try_from(end))
+                        else {
+                            continue;
+                        };
+                        let before = measure_text_in(&text[from..start], FontSize::Body, prose).0;
+                        let through = measure_text_in(&text[from..end], FontSize::Body, prose).0;
+                        layout.text_hits.push((
+                            Rect {
+                                x: line_x.saturating_add(before),
+                                y: line_y,
+                                width: through.saturating_sub(before).max(1),
+                                height: line_height,
+                            },
+                            TextHit {
+                                context: selection.context,
+                                start: selection.offset.saturating_add(start_offset),
+                                end: selection.offset.saturating_add(end_offset),
+                            },
+                        ));
                     }
                 }
                 line_y = line_y.saturating_add(line_height);
@@ -9787,6 +9861,9 @@ fn render_all_with_selected_font(
             ),
             LayoutKind::RichText(presentation) => {
                 if let Some(text) = node.text_lines.first() {
+                    if presentation.highlighted {
+                        fill_clipped(surface, node.rect, tone::SURFACE, clip);
+                    }
                     draw_rich_text(
                         surface,
                         text,
@@ -11171,6 +11248,7 @@ mod tests {
                     line_height_percent: 140,
                     ..ParagraphPresentation::default()
                 },
+                selection: None,
             }],
         )
         .with_reading(true);
@@ -11189,6 +11267,40 @@ mod tests {
             .find(|node| matches!(node.kind, LayoutKind::RichText(_)))
             .expect("rich run");
         assert!(first.rect.x > CLARA_BW_METRICS.screen_margin());
+    }
+
+    #[test]
+    fn a_held_unicode_word_resolves_to_stable_document_offsets() {
+        let screen = Screen::new(
+            1,
+            vec![Node::RichText {
+                id: NodeId(1),
+                text: "naïve café".into(),
+                spans: Vec::new(),
+                links: Vec::new(),
+                presentation: ParagraphPresentation::default(),
+                selection: Some(TextSelection {
+                    context: 19,
+                    offset: 100,
+                }),
+            }],
+        )
+        .with_reading(true)
+        .with_hold(ActionId(7));
+        let layout = screen.layout();
+        let (rect, expected) = layout.text_hits.last().expect("selectable word");
+        assert_eq!(
+            layout.hit_text(rect.x + rect.width / 2, rect.y + rect.height / 2),
+            Some(*expected)
+        );
+        assert_eq!(
+            *expected,
+            TextHit {
+                context: 19,
+                start: 107,
+                end: 112,
+            }
+        );
     }
 
     #[test]

--- a/crates/kobo-ui/src/lib.rs
+++ b/crates/kobo-ui/src/lib.rs
@@ -70,6 +70,23 @@ const FACTS_LABEL_LIMIT_EIGHTHS: i32 = 3;
 /// application is asked to arrange.
 pub const MIN_BAND_SLOT_TENTH_MM: i32 = 120;
 
+/// The narrowest a table column is allowed to be before the table stacks.
+///
+/// Twelve millimetres holds about four characters of body text at the default
+/// size. A column narrower than that wraps every cell to one word a line and
+/// turns a three column table into a tall grey block nobody can read across.
+pub const MIN_TABLE_COLUMN_TENTH_MM: i32 = 120;
+
+/// The most rows one [`Node::Table`] will draw.
+///
+/// A page holds a few dozen lines and a table row is at least one of them, so
+/// a table longer than this cannot be on one page anyway. The reader splits a
+/// long table across pages before it reaches here.
+pub const MAX_TABLE_ROWS: usize = 64;
+
+/// The most columns one [`Node::Table`] will draw.
+pub const MAX_TABLE_COLUMNS: usize = 12;
+
 /// What a paragraph of a threaded discussion is for.
 ///
 /// A comment is two different things printed one above the other: a line
@@ -2593,6 +2610,33 @@ pub enum Node {
         id: NodeId,
         rows: Vec<Row>,
     },
+    /// A table, drawn as columns that line up.
+    ///
+    /// The one arrangement in the reader that cannot be expressed as a
+    /// downward flow of full-width blocks. A table's meaning is entirely in
+    /// which value sits under which heading, and a table read out as prose --
+    /// which is what flattening its cells into a sentence amounts to -- keeps
+    /// every word and loses all of it.
+    ///
+    /// Column widths are shared by every row and worked out from the widest
+    /// cell in each column, then squeezed proportionally to fit the panel.
+    /// When the columns cannot each keep [`MIN_TABLE_COLUMN_TENTH_MM`], the
+    /// table stacks each row as its own short block instead, the way
+    /// [`Node::Band`] does: a stacked row is always readable and a four
+    /// character column never is.
+    Table {
+        id: NodeId,
+        rows: Vec<TableRow>,
+        /// What each column wants to be, measured across the whole table
+        /// rather than across the rows sent here.
+        ///
+        /// A table taller than a page is split, and each part would otherwise
+        /// be measured on its own and come out with different columns -- so a
+        /// reader turning the page would watch the table move under them.
+        /// Empty means "measure the rows given", which is what a caller with
+        /// the whole table in hand can leave it as.
+        weights: Vec<u16>,
+    },
     /// A grid of large tappable tiles, the launcher's primary surface.
     TileGrid {
         id: NodeId,
@@ -3112,6 +3156,16 @@ pub const MAX_CELLS: usize = 81;
 /// The most columns a grid may ask for.
 pub const MAX_COLUMNS: u8 = 12;
 
+/// One row of a [`Node::Table`].
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct TableRow {
+    /// Whether this row names the columns rather than filling them. Drawn in
+    /// the body face rather than a bolder one, and underlined by a rule,
+    /// because on sixteen greys a rule separates more clearly than weight.
+    pub header: bool,
+    pub cells: Vec<String>,
+}
+
 /// One entry in a [`Node::Rows`] list.
 ///
 /// A title identifies, a summary explains and a glyph makes the row findable
@@ -3489,6 +3543,7 @@ impl Node {
             | Self::PagedList { id, .. }
             | Self::Grid { id, .. }
             | Self::Rows { id, .. }
+            | Self::Table { id, .. }
             | Self::TileGrid { id, .. }
             | Self::Choice { id, .. }
             | Self::Stepper { id, .. }
@@ -3723,6 +3778,13 @@ pub enum LayoutKind {
     Row(ActionId),
     Cell(ActionId, CellStyle),
     CellLabel,
+    /// One cell of a table, drawn in the body face.
+    TableCell,
+    /// One cell of a table's heading row, drawn muted so the rule under it
+    /// reads as the edge of the heading rather than an arbitrary line.
+    TableHeaderCell,
+    /// The rule under a table's heading row.
+    TableRule,
     RowTitle,
     /// A title whose work is finished: muted and struck through.
     RowTitleDone,
@@ -5368,6 +5430,139 @@ fn layout_node(
             let height = cursor.saturating_sub(y);
             layout.nodes[index].rect.height = height;
             y.saturating_add(height)
+        }
+        Node::Table { id, rows, weights } => {
+            let rows = &rows[..min(rows.len(), MAX_TABLE_ROWS)];
+            let columns = min(
+                rows.iter().map(|row| row.cells.len()).max().unwrap_or(0),
+                MAX_TABLE_COLUMNS,
+            );
+            if columns == 0 {
+                return y;
+            }
+            // A column is only told apart from the next one by the space
+            // between them, so the gap has to be wider than a word space or
+            // two columns of prose read as one ragged paragraph.
+            let gap = metrics.space(Space::Small);
+            let size = FontSize::Body;
+            let line = size.line_height_in(prose);
+            let between = gap.saturating_mul(i32::try_from(columns).unwrap_or(1) - 1);
+            let usable = max(0, width.saturating_sub(between));
+            let minimum = metrics.tenth_mm(MIN_TABLE_COLUMN_TENTH_MM);
+
+            // One measurement for the whole table. A column is as wide as its
+            // widest cell wants to be, and the columns are then squeezed in
+            // proportion to those wants until they fit -- so a table of one
+            // long sentence and two numbers gives the sentence the room and
+            // does not give a two character column a third of the panel.
+            let mut wants = vec![0_i32; columns];
+            for row in rows {
+                for (column, cell) in row.cells.iter().take(columns).enumerate() {
+                    wants[column] = max(wants[column], measure_text_in(cell, size, prose).0);
+                }
+            }
+            for (column, want) in wants.iter_mut().enumerate() {
+                if let Some(weight) = weights.get(column) {
+                    *want = i32::from(*weight);
+                }
+            }
+            let total: i32 = wants.iter().copied().fold(0, i32::saturating_add);
+            let widths: Vec<i32> = if total <= usable {
+                wants.clone()
+            } else if total > 0 {
+                wants
+                    .iter()
+                    .map(|want| max(minimum, want.saturating_mul(usable) / total))
+                    .collect()
+            } else {
+                vec![usable / i32::try_from(columns).unwrap_or(1); columns]
+            };
+
+            // Squeezing has a floor, and past it a table is not a table any
+            // more. Rather than draw columns four characters wide, each row
+            // is stacked as its own lines, which is always readable.
+            if widths.iter().copied().fold(0, i32::saturating_add) > usable
+                || widths.iter().any(|column| *column < minimum)
+            {
+                let mut cursor = y;
+                for row in rows {
+                    for cell in row.cells.iter().take(columns) {
+                        if cell.trim().is_empty() || layout.nodes.len() >= MAX_LAYOUT_NODES {
+                            continue;
+                        }
+                        let lines = wrap_text_in(cell, width, size, prose);
+                        let height = max(line, lines.len() as i32 * line);
+                        layout.nodes.push(LayoutNode {
+                            id: *id,
+                            rect: Rect {
+                                x,
+                                y: cursor,
+                                width,
+                                height,
+                            },
+                            kind: if row.header {
+                                LayoutKind::TableHeaderCell
+                            } else {
+                                LayoutKind::TableCell
+                            },
+                            text_lines: lines,
+                        });
+                        cursor = cursor.saturating_add(height);
+                    }
+                    cursor = cursor.saturating_add(gap);
+                }
+                return cursor;
+            }
+
+            let mut cursor = y;
+            for row in rows {
+                let mut tallest = line;
+                let mut column_x = x;
+                for (column, width) in widths.iter().enumerate() {
+                    let cell = row.cells.get(column).map_or("", String::as_str);
+                    if !cell.is_empty() && layout.nodes.len() < MAX_LAYOUT_NODES {
+                        let lines = wrap_text_in(cell, *width, size, prose);
+                        let height = max(line, lines.len() as i32 * line);
+                        tallest = max(tallest, height);
+                        layout.nodes.push(LayoutNode {
+                            id: *id,
+                            rect: Rect {
+                                x: column_x,
+                                y: cursor,
+                                width: *width,
+                                height,
+                            },
+                            kind: if row.header {
+                                LayoutKind::TableHeaderCell
+                            } else {
+                                LayoutKind::TableCell
+                            },
+                            text_lines: lines,
+                        });
+                    }
+                    column_x = column_x.saturating_add(*width).saturating_add(gap);
+                }
+                cursor = cursor.saturating_add(tallest);
+                // The rule belongs under the headings, where it says the
+                // table has started rather than that a section has ended.
+                if row.header && layout.nodes.len() < MAX_LAYOUT_NODES {
+                    let thickness = metrics.rule_thickness();
+                    layout.nodes.push(LayoutNode {
+                        id: *id,
+                        rect: Rect {
+                            x,
+                            y: cursor.saturating_add(gap / 2),
+                            width,
+                            height: thickness,
+                        },
+                        kind: LayoutKind::TableRule,
+                        text_lines: Vec::new(),
+                    });
+                    cursor = cursor.saturating_add(gap).saturating_add(thickness);
+                }
+                cursor = cursor.saturating_add(gap / 2);
+            }
+            cursor
         }
         Node::Facts { id, entries } => {
             let entries = &entries[..min(entries.len(), MAX_FACTS)];
@@ -8763,6 +8958,7 @@ fn tones_used(layout: &Layout) -> usize {
             LayoutKind::Secondary
             | LayoutKind::TileSubtitle
             | LayoutKind::RowSummary
+            | LayoutKind::TableHeaderCell
             | LayoutKind::FactLabel
             | LayoutKind::PagePosition
             | LayoutKind::ActivityBytes
@@ -8925,6 +9121,24 @@ fn validate_node(
             }
             for cell in cells {
                 check_text_coverage(id, &cell.label, Face::Text, issues);
+            }
+        }
+        Node::Table { rows, .. } => {
+            if rows.len() > MAX_TABLE_ROWS {
+                issues.push(limit_issue(id, "table rows", rows.len(), MAX_TABLE_ROWS));
+            }
+            for row in rows.iter().take(MAX_TABLE_ROWS) {
+                if row.cells.len() > MAX_TABLE_COLUMNS {
+                    issues.push(limit_issue(
+                        id,
+                        "table columns",
+                        row.cells.len(),
+                        MAX_TABLE_COLUMNS,
+                    ));
+                }
+                for cell in row.cells.iter().take(MAX_TABLE_COLUMNS) {
+                    check_text_coverage(id, cell, Face::Text, issues);
+                }
             }
         }
         Node::Rows { rows, .. } => {
@@ -9215,6 +9429,7 @@ fn layout_text_style(node: &LayoutNode) -> Option<(FontSize, Face)> {
         LayoutKind::OverlayTitle => FontSize::Title,
         LayoutKind::Secondary
         | LayoutKind::Section
+        | LayoutKind::TableHeaderCell
         | LayoutKind::FactLabel
         | LayoutKind::RowTrailing
         | LayoutKind::RowSummary
@@ -9230,6 +9445,7 @@ fn layout_text_style(node: &LayoutNode) -> Option<(FontSize, Face)> {
         | LayoutKind::NavDestinationSelected(..) => FontSize::Caption,
         LayoutKind::Text
         | LayoutKind::FieldValue(_)
+        | LayoutKind::TableCell
         | LayoutKind::FactValue
         | LayoutKind::Quote(..)
         | LayoutKind::Button(..)
@@ -9746,6 +9962,25 @@ fn render_all_with_selected_font(
                 tone::INK,
                 clip,
             ),
+            LayoutKind::TableCell => draw_lines(
+                surface,
+                &node.text_lines,
+                node.rect.x,
+                node.rect.y,
+                FontSize::Body,
+                tone::INK,
+                clip,
+            ),
+            LayoutKind::TableHeaderCell => draw_lines(
+                surface,
+                &node.text_lines,
+                node.rect.x,
+                node.rect.y,
+                FontSize::Body,
+                tone::MUTED,
+                clip,
+            ),
+            LayoutKind::TableRule => fill_clipped(surface, node.rect, tone::RULE, clip),
             // Paper, not surface, and a heavy border. An overlay has to look
             // like a separate sheet laid on the page, and the only two things
             // available to say so without shading everything else are the

--- a/crates/kobo-ui/src/lib.rs
+++ b/crates/kobo-ui/src/lib.rs
@@ -203,24 +203,78 @@ pub struct DisplayMetrics {
 /// Applications continue to ask for semantic sizes such as [`FontSize::Body`].
 /// The runtime applies this preference to every face, so pagination performed
 /// in an application and rendering performed on the device remain identical.
+///
+/// The steps are close enough together that a reader who finds one size a
+/// little too small has somewhere to go: three sizes meant the only move from
+/// "slightly too small" was a fifth larger, which is a different book. The
+/// wire values of the original three are unchanged, because they are written
+/// into every reading position already saved on every device.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 #[repr(u8)]
 pub enum TextScale {
+    Smallest = 3,
+    Smaller = 4,
     #[default]
     Default = 0,
+    Medium = 5,
     Large = 1,
+    Larger = 6,
     ExtraLarge = 2,
+    Huge = 7,
+    Largest = 8,
 }
 
 impl TextScale {
+    /// Every step, smallest first, which is the order a stepper walks.
+    pub const STEPS: [Self; 9] = [
+        Self::Smallest,
+        Self::Smaller,
+        Self::Default,
+        Self::Medium,
+        Self::Large,
+        Self::Larger,
+        Self::ExtraLarge,
+        Self::Huge,
+        Self::Largest,
+    ];
+
     /// Percentage applied to the physical type size.
     #[must_use]
     pub const fn percent(self) -> i32 {
         match self {
+            Self::Smallest => 80,
+            Self::Smaller => 90,
             Self::Default => 100,
+            Self::Medium => 110,
             Self::Large => 120,
+            Self::Larger => 130,
             Self::ExtraLarge => 140,
+            Self::Huge => 155,
+            Self::Largest => 170,
         }
+    }
+
+    /// Where this size sits among [`Self::STEPS`].
+    #[must_use]
+    pub fn step(self) -> usize {
+        Self::STEPS
+            .iter()
+            .position(|scale| *scale == self)
+            .unwrap_or(2)
+    }
+
+    /// The next size up, or `None` at the top of the range.
+    #[must_use]
+    pub fn larger(self) -> Option<Self> {
+        Self::STEPS.get(self.step().saturating_add(1)).copied()
+    }
+
+    /// The next size down, or `None` at the bottom of the range.
+    #[must_use]
+    pub fn smaller(self) -> Option<Self> {
+        self.step()
+            .checked_sub(1)
+            .and_then(|step| Self::STEPS.get(step).copied())
     }
 
     /// A stable wire representation used by `kobo-protocol`.
@@ -236,19 +290,35 @@ impl TextScale {
             0 => Some(Self::Default),
             1 => Some(Self::Large),
             2 => Some(Self::ExtraLarge),
+            3 => Some(Self::Smallest),
+            4 => Some(Self::Smaller),
+            5 => Some(Self::Medium),
+            6 => Some(Self::Larger),
+            7 => Some(Self::Huge),
+            8 => Some(Self::Largest),
             _ => None,
         }
     }
 
     /// Parses values accepted by the runtime's `KOBO_TEXT_SCALE` setting.
+    ///
+    /// A bare percentage is matched against the steps rather than rounded to
+    /// one, so a setting naming a size that no longer exists is refused and
+    /// falls back to the default instead of silently becoming a neighbour.
     #[must_use]
     pub fn from_name(value: &str) -> Option<Self> {
-        match value.trim().to_ascii_lowercase().as_str() {
-            "default" | "100" | "100%" => Some(Self::Default),
-            "large" | "120" | "120%" => Some(Self::Large),
-            "extra-large" | "extra_large" | "xl" | "140" | "140%" => Some(Self::ExtraLarge),
-            _ => None,
+        let value = value.trim().to_ascii_lowercase();
+        match value.as_str() {
+            "default" | "standard" => return Some(Self::Default),
+            "large" => return Some(Self::Large),
+            "extra-large" | "extra_large" | "xl" => return Some(Self::ExtraLarge),
+            _ => {}
         }
+        let digits = value.strip_suffix('%').unwrap_or(&value);
+        let percent = digits.parse::<i32>().ok()?;
+        Self::STEPS
+            .into_iter()
+            .find(|step| step.percent() == percent)
     }
 }
 
@@ -756,6 +826,14 @@ pub enum CellStyle {
     #[default]
     Board,
     Key,
+    /// A cell that is nothing but the picture in it.
+    ///
+    /// For a row of actions everybody already knows by their drawing. A key
+    /// needs its field because a keyboard is forty-five targets packed edge to
+    /// edge and the eye has to be told where one ends; four icons with a
+    /// finger's width of paper between them are already separate, and putting
+    /// each on a grey slab turns a quiet row into four boxes.
+    Plain,
 }
 
 /// Whether a control can currently be activated.
@@ -2526,6 +2604,37 @@ pub enum Node {
     /// Typing on a device with no keyboard and a refresh measured in tens of
     /// milliseconds is markedly worse than tapping, so the shape of the node
     /// pushes authors toward offering answers rather than demanding prose.
+    /// One quantity, its two directions, and where it stands in its range.
+    ///
+    /// The answer to a setting with an order to it: a type size, a brightness,
+    /// a volume. A [`Node::Choice`] can express the same thing by naming every
+    /// step, and for three steps that was defensible; past that it becomes a
+    /// stack of full-width boxes taller than the page it is covering, and it
+    /// still cannot say that "Large" is one notch above "Standard".
+    ///
+    /// The two controls carry pictures rather than words on purpose. Minus and
+    /// plus are read the same in every language and at a glance in the dark,
+    /// which is when a reader reaches for the light. What the value *is* stays
+    /// written out beside them, because a stepper with no reading is the one
+    /// thing worse than a list: it says which way to go and never says where
+    /// you are.
+    Stepper {
+        id: NodeId,
+        /// What is being adjusted, and its present value, already written for
+        /// reading: "Type size 110%".
+        label: String,
+        /// The two ends, and whether either has anywhere left to go. A
+        /// control at the end of its range is drawn muted rather than removed,
+        /// so the row keeps its shape and the other end does not slide under
+        /// the finger already reaching for it.
+        less: BarAction,
+        more: BarAction,
+        less_state: ControlState,
+        more_state: ControlState,
+        /// How far along the range the value sits, drawn as a filled track
+        /// under the row. `None` for a quantity with no meaningful extent.
+        fill: Option<u8>,
+    },
     Choice {
         id: NodeId,
         prompt: String,
@@ -3290,6 +3399,12 @@ pub enum Glyph {
     /// application wore [`Self::Download`] before this existed, which said
     /// "fetch something" about the one place on the device that plays sound.
     Headphones,
+    /// Take away, and the other half of every stepper on the device.
+    ///
+    /// A single stroke carries no language at all, which is the whole reason
+    /// to draw it: "Dimmer" and "Smaller" are words somebody has to read, and
+    /// a reader adjusting the light in the dark is not reading anything.
+    Minus,
 }
 
 impl Glyph {
@@ -3300,7 +3415,7 @@ impl Glyph {
     /// the set was twenty-one: `Light` and `Close` were authored, shipped, and
     /// covered by none of the tests that walk every glyph. A glyph nobody
     /// rasterises in a test is a blank space beside a label on the panel.
-    pub const ALL: [Self; 44] = [
+    pub const ALL: [Self; 45] = [
         Self::App,
         Self::Book,
         Self::Note,
@@ -3345,6 +3460,7 @@ impl Glyph {
         Self::Next,
         Self::Plus,
         Self::Headphones,
+        Self::Minus,
     ];
 }
 
@@ -3375,6 +3491,7 @@ impl Node {
             | Self::Rows { id, .. }
             | Self::TileGrid { id, .. }
             | Self::Choice { id, .. }
+            | Self::Stepper { id, .. }
             | Self::Banner { id, .. }
             | Self::Skeleton { id, .. }
             | Self::Picture { id, .. }
@@ -3637,6 +3754,17 @@ pub enum LayoutKind {
     /// it to fit only if the application handed over something larger.
     Picture(PictureHandle),
     ChoicePrompt,
+    /// A stepper's reading: what is being adjusted and where it stands. Set in
+    /// the middle of the row, between the two controls, and not itself a
+    /// target -- a stepper has two answers and neither of them is "the label".
+    StepperValue,
+    /// One end of a stepper. The glyph says which way it goes and the
+    /// [`ControlState`] says whether there is anywhere left to go: a control at
+    /// the end of its range is drawn muted and answers nothing, rather than
+    /// disappearing and moving the other one under the reader's finger.
+    StepperControl(ActionId, ControlState, Glyph),
+    /// The track under a stepper, filled as far as the value has gone.
+    StepperTrack(u8),
     ChoiceOption(ActionId, bool),
     ChoiceFreeform(ActionId),
     Banner(BannerLevel),
@@ -3685,6 +3813,7 @@ impl LayoutKind {
             | Self::RowMenu(action)
             | Self::Cell(action, ..)
             | Self::ChoiceOption(action, _)
+            | Self::StepperControl(action, ControlState::Enabled, _)
             | Self::ChoiceFreeform(action)
             | Self::QuoteFold(action, _)
             | Self::PagePrevious(action)
@@ -3948,6 +4077,7 @@ impl Layout {
                         | LayoutKind::Chip(_, _)
                         | LayoutKind::Tab(_, _)
                         | LayoutKind::ChoiceOption(_, _)
+                        | LayoutKind::StepperControl(_, ControlState::Enabled, _)
                         | LayoutKind::ChoiceFreeform(_)
                 )
             })
@@ -4139,6 +4269,7 @@ impl Layout {
                 | LayoutKind::Chip(candidate, _)
                 | LayoutKind::Tab(candidate, _)
                 | LayoutKind::ChoiceOption(candidate, _)
+                | LayoutKind::StepperControl(candidate, ControlState::Enabled, _)
                 | LayoutKind::Cell(candidate, ..)
                 | LayoutKind::ChoiceFreeform(candidate) => candidate == action,
                 _ => false,
@@ -5391,8 +5522,12 @@ fn layout_node(
             // A square cell is what makes a board read as a board. A grid that
             // is not square is a keyboard, and there one row of touch target
             // is exactly right and anything taller wastes the panel.
+            // A row whose every cell carries a picture is a row of actions,
+            // not a keyboard, and it is drawn as the pictures alone.
             let (cell_height, style) = if *square {
                 (cell_width, CellStyle::Board)
+            } else if cells.iter().all(|cell| cell.glyph.is_some()) {
+                (metrics.touch_target_default(), CellStyle::Plain)
             } else {
                 (metrics.touch_target_default(), CellStyle::Key)
             };
@@ -5889,6 +6024,78 @@ fn layout_node(
             layout.nodes[index].rect.height = height;
             y.saturating_add(height)
         }
+        Node::Stepper {
+            id,
+            label,
+            less,
+            more,
+            less_state,
+            more_state,
+            fill,
+        } => {
+            // Square controls at both ends, the reading between them. Square
+            // because a stepper is two targets side by side and a finger is
+            // round: making them the height of the row and no wider is what
+            // keeps the gap between minus and plus wide enough that neither is
+            // hit by accident.
+            let row = metrics.touch_target_default();
+            let side = row.min(width / 3).max(1);
+            let middle = width.saturating_sub(side.saturating_mul(2)).max(1);
+            let control =
+                |action: &BarAction, state: ControlState, fallback: Glyph, at: i32| LayoutNode {
+                    id: *id,
+                    rect: Rect {
+                        x: at,
+                        y,
+                        width: side,
+                        height: row,
+                    },
+                    kind: LayoutKind::StepperControl(
+                        action.action,
+                        state,
+                        action.glyph.unwrap_or(fallback),
+                    ),
+                    text_lines: Vec::new(),
+                };
+            layout
+                .nodes
+                .push(control(less, *less_state, Glyph::Minus, x));
+            layout.nodes.push(LayoutNode {
+                id: *id,
+                rect: Rect {
+                    x: x.saturating_add(side),
+                    y,
+                    width: middle,
+                    height: row,
+                },
+                kind: LayoutKind::StepperValue,
+                text_lines: vec![clamp_lines(label, middle, FontSize::Body, 1)],
+            });
+            layout.nodes.push(control(
+                more,
+                *more_state,
+                Glyph::Plus,
+                x.saturating_add(side).saturating_add(middle),
+            ));
+            let mut cursor = y.saturating_add(row);
+            if let Some(fill) = fill {
+                let track = metrics.tenth_mm(8);
+                cursor = cursor.saturating_add(metrics.space(Space::Tight));
+                layout.nodes.push(LayoutNode {
+                    id: *id,
+                    rect: Rect {
+                        x,
+                        y: cursor,
+                        width,
+                        height: track,
+                    },
+                    kind: LayoutKind::StepperTrack(*fill),
+                    text_lines: Vec::new(),
+                });
+                cursor = cursor.saturating_add(track);
+            }
+            cursor
+        }
         Node::Choice {
             id,
             prompt,
@@ -6347,7 +6554,7 @@ impl FontSize {
     #[must_use]
     pub fn line_height_in(self, face: Face) -> i32 {
         with_typesetter(face, |typesetter| typesetter.line_height(self, face))
-            .unwrap_or_else(|| self.fallback_line_height())
+            .unwrap_or_else(|| self.fallback_line_height_in(face))
     }
 
     /// The built-in bitmap's line height, at the current type size.
@@ -6357,7 +6564,14 @@ impl FontSize {
     /// tested without hardware.
     #[must_use]
     pub fn fallback_line_height(self) -> i32 {
-        (self.unscaled_fallback_line_height() * text_scale().percent() + 50) / 100
+        self.fallback_line_height_in(Face::Text)
+    }
+
+    /// The same, for a named face, so prose follows the reading size and the
+    /// interface around it does not.
+    #[must_use]
+    pub fn fallback_line_height_in(self, face: Face) -> i32 {
+        (self.unscaled_fallback_line_height() * scale_percent(face) + 50) / 100
     }
 
     const fn unscaled_fallback_line_height(self) -> i32 {
@@ -6566,6 +6780,7 @@ fn with_typesetter<T>(face: Face, body: impl FnOnce(&dyn Typesetter) -> T) -> Op
 // it.
 thread_local! {
     static TEXT_SCALE: std::cell::Cell<u8> = const { std::cell::Cell::new(0) };
+    static READING_SCALE: std::cell::Cell<u8> = const { std::cell::Cell::new(0) };
 }
 
 /// Sets the type size for everything measured or drawn after this.
@@ -6581,6 +6796,40 @@ pub fn set_text_scale(scale: TextScale) {
 #[must_use]
 pub fn text_scale() -> TextScale {
     TextScale::from_wire(TEXT_SCALE.with(std::cell::Cell::get)).unwrap_or_default()
+}
+
+/// Sets the size of book prose, and of nothing else.
+///
+/// Separate from [`set_text_scale`] because the two answer different people.
+/// The text scale is an accessibility preference: somebody has said how large
+/// they need an interface to be, and a title bar, a page number and a button
+/// are all interface. The reading scale is a reader saying how large they want
+/// *this book*, which is a decision about the page and not about the device.
+///
+/// They were one value until a reader on a Clara found that making a novel
+/// larger also grew the book's name in the bar above it, took the height out
+/// of the page to do it, and left less room for the larger type than there had
+/// been for the smaller.
+pub fn set_reading_scale(scale: TextScale) {
+    READING_SCALE.with(|slot| slot.set(scale.wire_value()));
+}
+
+/// The size book prose is currently being set at.
+#[must_use]
+pub fn reading_scale() -> TextScale {
+    TextScale::from_wire(READING_SCALE.with(std::cell::Cell::get)).unwrap_or_default()
+}
+
+/// The percentage in force for one face.
+///
+/// The single place that decides which of the two ambient sizes a face obeys,
+/// so a new caller cannot get the answer half right.
+#[must_use]
+pub fn scale_percent(face: Face) -> i32 {
+    match face {
+        Face::Reading => reading_scale().percent(),
+        Face::Text | Face::Mono => text_scale().percent(),
+    }
 }
 
 /// Runs `body` with the type at `scale`, putting it back afterwards.
@@ -6600,6 +6849,22 @@ pub fn with_text_scale<T>(scale: TextScale, body: impl FnOnce() -> T) -> T {
     }
     let _restore = Restore(text_scale());
     set_text_scale(scale);
+    body()
+}
+
+/// Runs `body` with book prose at `scale`, putting it back afterwards.
+///
+/// What an application calls to measure a book at a size it is not showing
+/// yet, which is every repagination after the reader touches the stepper.
+pub fn with_reading_scale<T>(scale: TextScale, body: impl FnOnce() -> T) -> T {
+    struct Restore(TextScale);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            set_reading_scale(self.0);
+        }
+    }
+    let _restore = Restore(reading_scale());
+    set_reading_scale(scale);
     body()
 }
 
@@ -6638,7 +6903,7 @@ pub fn measure_text_in(text: &str, size: FontSize, face: Face) -> (i32, i32) {
     }
     let scale = size.scale();
     let glyphs = i32::try_from(text.chars().count()).unwrap_or(i32::MAX);
-    let percent = text_scale().percent();
+    let percent = scale_percent(face);
     let width = glyphs.saturating_mul(6).saturating_mul(scale);
     (
         (width.saturating_mul(percent) + 50) / 100,
@@ -6672,7 +6937,7 @@ pub fn undrawable_in(text: &str, face: Face) -> Option<char> {
 #[must_use]
 pub fn mono_cell(size: FontSize) -> (i32, i32) {
     TYPESETTER.get().map_or_else(
-        || (6 * size.scale(), size.fallback_line_height()),
+        || (6 * size.scale(), size.fallback_line_height_in(Face::Mono)),
         |typesetter| {
             (
                 max(1, typesetter.cell_width(size)),
@@ -8679,6 +8944,9 @@ fn validate_node(
                 }
             }
         }
+        Node::Stepper { label, .. } => {
+            check_text_coverage(id, label, Face::Text, issues);
+        }
         Node::Choice {
             prompt,
             options,
@@ -8925,6 +9193,7 @@ const fn is_tappable(kind: LayoutKind) -> bool {
             | LayoutKind::Chip(_, _)
             | LayoutKind::Tab(_, _)
             | LayoutKind::ChoiceOption(_, _)
+            | LayoutKind::StepperControl(_, ControlState::Enabled, _)
             | LayoutKind::ChoiceFreeform(_)
             | LayoutKind::PagePrevious(_)
             | LayoutKind::PageNext(_)
@@ -8971,6 +9240,7 @@ fn layout_text_style(node: &LayoutNode) -> Option<(FontSize, Face)> {
         | LayoutKind::CellLabel
         | LayoutKind::ChoicePrompt
         | LayoutKind::ChoiceOption(_, _)
+        | LayoutKind::StepperValue
         | LayoutKind::ChoiceFreeform(_)
         | LayoutKind::Banner(_)
         | LayoutKind::ActivityLabel => FontSize::Body,
@@ -9641,6 +9911,8 @@ fn render_all_with_selected_font(
             // A key is the field it is printed on, with no rule at all. The
             // gaps between the keys separate them, which is how a keyboard has
             // always been read, and it takes forty-five outlines off the panel.
+            // Nothing at all: the picture is the whole of it.
+            LayoutKind::Cell(_, CellStyle::Plain) => {}
             LayoutKind::Cell(_, CellStyle::Key) => fill_rounded_clipped(
                 surface,
                 node.rect,
@@ -10155,6 +10427,64 @@ fn render_all_with_selected_font(
                 tone::INK,
                 clip,
             ),
+            // The two ends carry a picture and nothing else at all: no word,
+            // no outline and no field. A minus and a plus either side of a
+            // reading are already a stepper on every device ever made, and
+            // drawing a box round each of them turns a quiet line into two
+            // more things to look at. The target stays a full touch target
+            // whatever the picture inside it measures.
+            LayoutKind::StepperControl(_, state, glyph) => {
+                let tone = if state.is_enabled() {
+                    tone::INK
+                } else {
+                    tone::RULE
+                };
+                let size = FontSize::Heading.line_height();
+                draw_glyph_icon_in(
+                    surface,
+                    glyph,
+                    Rect {
+                        x: node.rect.x + (node.rect.width - size) / 2,
+                        y: node.rect.y + (node.rect.height - size) / 2,
+                        width: size,
+                        height: size,
+                    },
+                    clip,
+                    tone,
+                );
+            }
+            // Centred between the two controls, because a reading that sits
+            // against one of them reads as a label for that control.
+            LayoutKind::StepperValue => {
+                let (measured, _) = measure_text(
+                    node.text_lines.first().map_or("", String::as_str),
+                    FontSize::Body,
+                );
+                draw_lines(
+                    surface,
+                    &node.text_lines,
+                    node.rect.x + max(0, (node.rect.width - measured) / 2),
+                    node.rect.y + (node.rect.height - FontSize::Body.line_height()) / 2,
+                    FontSize::Body,
+                    tone::INK,
+                    clip,
+                );
+            }
+            // A hairline track rather than an outlined bar: it says where in
+            // the range the value sits and is not itself a control, so it must
+            // not carry as much ink as the two things that are.
+            LayoutKind::StepperTrack(fill) => {
+                fill_clipped(surface, node.rect, tone::RULE, clip);
+                fill_clipped(
+                    surface,
+                    Rect {
+                        width: node.rect.width.saturating_mul(min(100, i32::from(fill))) / 100,
+                        ..node.rect
+                    },
+                    tone::INK,
+                    clip,
+                );
+            }
             LayoutKind::ChoiceOption(_, chosen) => {
                 stroke_clipped(
                     surface,
@@ -12976,6 +13306,15 @@ mod loading_tests {
                 }],
             },
             Node::Divider { id: NodeId(6) },
+            Node::Stepper {
+                id: NodeId(96),
+                label: "120%".into(),
+                less: BarAction::new(ActionId(30), String::new()).with_glyph(Glyph::Minus),
+                more: BarAction::new(ActionId(31), String::new()).with_glyph(Glyph::Plus),
+                less_state: ControlState::Enabled,
+                more_state: ControlState::Disabled,
+                fill: Some(75),
+            },
             Node::Spacer {
                 id: NodeId(7),
                 space: Space::Medium,
@@ -13104,6 +13443,7 @@ mod loading_tests {
                 | LayoutKind::Row(action)
                 | LayoutKind::Cell(action, ..)
                 | LayoutKind::ChoiceOption(action, _)
+                | LayoutKind::StepperControl(action, ControlState::Enabled, _)
                 | LayoutKind::ChoiceFreeform(action) => Some((action, node.rect)),
                 _ => None,
             })

--- a/crates/kobo-ui/src/lib.rs
+++ b/crates/kobo-ui/src/lib.rs
@@ -4626,12 +4626,22 @@ fn layout_node(
                 let mut cursor = from;
                 let mut run_x = line_x;
                 while cursor < to {
-                    let (mut end, styled) = rich_run_at(cursor, to, spans);
+                    let (mut end, mut styled) = rich_run_at(cursor, to, spans);
                     if end <= cursor || end > to || !text.is_char_boundary(end) {
                         end = text[cursor..to]
                             .char_indices()
                             .nth(1)
                             .map_or(to, |(offset, _)| cursor + offset);
+                    }
+                    // One node per styled run per line. A block carrying the
+                    // permitted number of runs would otherwise spend the whole
+                    // page's node budget inside this one paragraph, and every
+                    // block after it would be dropped without a word. The rest
+                    // of the line goes out as a single plain run instead, which
+                    // loses emphasis rather than losing the book.
+                    if layout.nodes.len().saturating_add(1) >= MAX_LAYOUT_NODES {
+                        end = to;
+                        styled = TextPresentation::default();
                     }
                     let run = &text[cursor..end];
                     let run_width = measure_text_in(run, FontSize::Body, prose).0;

--- a/crates/kobo-ui/src/lib.rs
+++ b/crates/kobo-ui/src/lib.rs
@@ -11,7 +11,8 @@
 //! A small retained UI tree and grayscale rasterizer for the Kobo display.
 
 use std::cmp::{max, min};
-use std::sync::OnceLock;
+use std::collections::BTreeMap;
+use std::sync::{Mutex, OnceLock};
 
 pub const DISPLAY_WIDTH: i32 = 1072;
 pub const DISPLAY_HEIGHT: i32 = 1448;
@@ -1110,6 +1111,13 @@ pub struct Screen {
     /// misread, which is a different job and a different answer.
     pub reading: bool,
 
+    /// A publisher font already held by the runtime for this application.
+    ///
+    /// Only reading prose uses it; chrome and controls remain in the system
+    /// face so an EPUB cannot make the way out illegible. Missing handles fall
+    /// back to the approved reading face without losing any text.
+    pub reading_font: Option<FontHandle>,
+
     /// A text size this screen asks for, overriding the reader's own setting.
     ///
     /// `None` means inherit, which is what almost every screen should do: the
@@ -1236,6 +1244,7 @@ impl Screen {
             page_turns: None,
             owns_back: false,
             reading: false,
+            reading_font: None,
             text_scale: None,
             hold: None,
             overlay: None,
@@ -1257,6 +1266,13 @@ impl Screen {
     #[must_use]
     pub const fn with_reading(mut self, reading: bool) -> Self {
         self.reading = reading;
+        self
+    }
+
+    /// Selects a runtime-held publisher face for book prose.
+    #[must_use]
+    pub const fn with_reading_font(mut self, font: Option<FontHandle>) -> Self {
+        self.reading_font = font;
         self
     }
 
@@ -1326,6 +1342,12 @@ impl Screen {
     /// Lays the screen out for a panel, including runtime-owned decoration.
     #[must_use]
     pub fn layout_with(&self, metrics: &DisplayMetrics, chrome: &Chrome) -> Layout {
+        with_reading_font(self.reading_font, || {
+            self.layout_with_selected_font(metrics, chrome)
+        })
+    }
+
+    fn layout_with_selected_font(&self, metrics: &DisplayMetrics, chrome: &Chrome) -> Layout {
         let margin = metrics.screen_margin();
         let gap = metrics.space(Space::Tight);
         let prose = if self.reading {
@@ -2178,6 +2200,54 @@ pub struct TextLink {
 /// the layout and a tap target in the hit test. Sixteen is far past any
 /// paragraph anybody reads and well short of a paragraph that costs anything.
 pub const MAX_TEXT_LINKS: usize = 16;
+pub const MAX_RICH_TEXT_SPANS: usize = 256;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct TextPresentation {
+    pub strong: bool,
+    pub emphasis: bool,
+    pub underline: bool,
+    pub superscript: bool,
+    pub subscript: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RichTextSpan {
+    pub start: usize,
+    pub end: usize,
+    pub presentation: TextPresentation,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ParagraphAlignment {
+    #[default]
+    Start,
+    Center,
+    End,
+    Justify,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ParagraphPresentation {
+    pub alignment: ParagraphAlignment,
+    pub line_height_percent: u16,
+    pub margin_before_em: u16,
+    pub margin_after_em: u16,
+    pub first_line_indent_em: i16,
+}
+
+impl Default for ParagraphPresentation {
+    fn default() -> Self {
+        Self {
+            alignment: ParagraphAlignment::Start,
+            line_height_percent: 100,
+            margin_before_em: 0,
+            margin_after_em: 0,
+            first_line_indent_em: 0,
+        }
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Node {
@@ -2196,6 +2266,14 @@ pub enum Node {
         /// to be split into three nodes to carry one would wrap, measure and
         /// paginate as three separate paragraphs.
         links: Vec<TextLink>,
+    },
+    /// EPUB prose retaining bounded inline emphasis and paragraph styling.
+    RichText {
+        id: NodeId,
+        text: String,
+        spans: Vec<RichTextSpan>,
+        links: Vec<TextLink>,
+        presentation: ParagraphPresentation,
     },
     /// A line about the content rather than the content: a date, an author, a
     /// size, a count, a status.
@@ -2640,6 +2718,12 @@ impl BandSlot {
 /// applications may use the same number without colliding.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct PictureHandle(pub u32);
+
+/// An outline font the runtime is holding on an application's behalf.
+///
+/// Handles are application-local, exactly like [`PictureHandle`]s.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct FontHandle(pub u32);
 
 /// A picture on a tile, together with the size it was handed over at.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -3243,6 +3327,7 @@ impl Node {
         match self {
             Self::Heading { id, .. }
             | Self::Text { id, .. }
+            | Self::RichText { id, .. }
             | Self::Secondary { id, .. }
             | Self::Section { id, .. }
             | Self::Quote { id, .. }
@@ -3402,6 +3487,7 @@ pub enum LayoutKind {
     StatusBattery(Option<Percent>, bool),
     Heading,
     Text,
+    RichText(TextPresentation),
     /// A run inside a paragraph that goes somewhere.
     ///
     /// Drawn as an underline under words the paragraph node has already set,
@@ -4352,6 +4438,21 @@ fn lead_rect(
     }
 }
 
+fn rich_run_at(start: usize, line_end: usize, spans: &[RichTextSpan]) -> (usize, TextPresentation) {
+    for span in spans.iter().take(MAX_RICH_TEXT_SPANS) {
+        if span.start <= start && start < span.end {
+            return (span.end.min(line_end).max(start + 1), span.presentation);
+        }
+        if span.start > start {
+            return (
+                span.start.min(line_end).max(start + 1),
+                TextPresentation::default(),
+            );
+        }
+    }
+    (line_end.max(start + 1), TextPresentation::default())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn layout_node(
     node: &Node,
@@ -4444,6 +4545,86 @@ fn layout_node(
                 }
             }
             y.saturating_add(height)
+        }
+        Node::RichText {
+            id,
+            text,
+            spans,
+            links,
+            presentation,
+        } => {
+            let natural = FontSize::Body.line_height_in(prose).max(1);
+            let line_height = natural
+                .saturating_mul(i32::from(presentation.line_height_percent.clamp(80, 250)))
+                / 100;
+            let before = natural.saturating_mul(i32::from(presentation.margin_before_em)) / 100;
+            let after = natural.saturating_mul(i32::from(presentation.margin_after_em)) / 100;
+            let indent = measure_text_in("M", FontSize::Body, prose)
+                .0
+                .saturating_mul(i32::from(presentation.first_line_indent_em))
+                / 100;
+            let measure = width.saturating_sub(indent.max(0)).max(1);
+            let ranges = wrap_ranges(text, measure, FontSize::Body, prose);
+            let mut line_y = y.saturating_add(before);
+            for (line_index, &(from, to)) in ranges.iter().enumerate() {
+                let line = &text[from..to];
+                let line_width = measure_text_in(line, FontSize::Body, prose).0;
+                let first_indent = if line_index == 0 { indent } else { 0 };
+                let available = width.saturating_sub(first_indent.max(0));
+                let aligned = match presentation.alignment {
+                    ParagraphAlignment::Center => (available - line_width).max(0) / 2,
+                    ParagraphAlignment::End => (available - line_width).max(0),
+                    ParagraphAlignment::Start | ParagraphAlignment::Justify => 0,
+                };
+                let line_x = x.saturating_add(first_indent).saturating_add(aligned);
+                let mut cursor = from;
+                let mut run_x = line_x;
+                while cursor < to {
+                    let (mut end, styled) = rich_run_at(cursor, to, spans);
+                    if end <= cursor || end > to || !text.is_char_boundary(end) {
+                        end = text[cursor..to]
+                            .char_indices()
+                            .nth(1)
+                            .map_or(to, |(offset, _)| cursor + offset);
+                    }
+                    let run = &text[cursor..end];
+                    let run_width = measure_text_in(run, FontSize::Body, prose).0;
+                    layout.nodes.push(LayoutNode {
+                        id: *id,
+                        rect: Rect {
+                            x: run_x,
+                            y: line_y,
+                            width: run_width,
+                            height: line_height,
+                        },
+                        kind: LayoutKind::RichText(styled),
+                        text_lines: vec![run.to_owned()],
+                    });
+                    run_x = run_x.saturating_add(run_width);
+                    cursor = end;
+                }
+                for link in links.iter().take(MAX_TEXT_LINKS) {
+                    let start = max(from, link.start);
+                    let end = min(to, link.end);
+                    if start < end && text.is_char_boundary(start) && text.is_char_boundary(end) {
+                        let before = measure_text_in(&text[from..start], FontSize::Body, prose).0;
+                        let through = measure_text_in(&text[from..end], FontSize::Body, prose).0;
+                        layout.nodes.push(LayoutNode {
+                            id: *id,
+                            rect: Rect {
+                                x: line_x.saturating_add(before),
+                                y: line_y,
+                                width: through.saturating_sub(before),
+                                height: line_height,
+                            },
+                            kind: LayoutKind::InlineLink(link.action),
+                            text_lines: Vec::new(),
+                        });
+                    }
+                }
+                line_y = line_y.saturating_add(line_height);
+            }
+            line_y.saturating_add(after)
         }
         Node::Secondary { id, text } => {
             // Measured at its own size, and with no minimum height. The floor
@@ -6080,10 +6261,8 @@ impl FontSize {
     /// height would overlap its own rows.
     #[must_use]
     pub fn line_height_in(self, face: Face) -> i32 {
-        TYPESETTER.get().map_or_else(
-            || self.fallback_line_height(),
-            |t| t.line_height(self, face),
-        )
+        with_typesetter(face, |typesetter| typesetter.line_height(self, face))
+            .unwrap_or_else(|| self.fallback_line_height())
     }
 
     /// The built-in bitmap's line height, at the current type size.
@@ -6214,6 +6393,70 @@ pub enum BreakOpportunity {
 /// type to arrive without touching a single application or example.
 static TYPESETTER: OnceLock<Box<dyn Typesetter>> = OnceLock::new();
 
+/// Publisher faces uploaded by the active application.
+///
+/// Parsing remains outside this crate; it receives the same bounded
+/// [`Typesetter`] interface as the system face. The map is intentionally
+/// process-local and handles are namespaced by the runtime's application
+/// session, so clearing it when an app leaves releases every glyph cache.
+static BOOK_TYPESETTERS: OnceLock<Mutex<BTreeMap<FontHandle, Box<dyn Typesetter>>>> =
+    OnceLock::new();
+
+thread_local! {
+    static READING_FONT: std::cell::Cell<Option<FontHandle>> = const { std::cell::Cell::new(None) };
+}
+
+/// Installs or replaces one bounded publisher face.
+pub fn put_book_typesetter(handle: FontHandle, typesetter: Box<dyn Typesetter>) {
+    if let Ok(mut fonts) = BOOK_TYPESETTERS
+        .get_or_init(|| Mutex::new(BTreeMap::new()))
+        .lock()
+    {
+        fonts.insert(handle, typesetter);
+    }
+}
+
+/// Releases a publisher face and its raster cache.
+pub fn drop_book_typesetter(handle: FontHandle) {
+    if let Some(fonts) = BOOK_TYPESETTERS.get() {
+        if let Ok(mut fonts) = fonts.lock() {
+            fonts.remove(&handle);
+        }
+    }
+}
+
+/// Runs layout or painting with one publisher face selected for reading prose.
+pub fn with_reading_font<T>(font: Option<FontHandle>, body: impl FnOnce() -> T) -> T {
+    struct Restore(Option<FontHandle>);
+    impl Drop for Restore {
+        fn drop(&mut self) {
+            READING_FONT.with(|slot| slot.set(self.0));
+        }
+    }
+    let previous = READING_FONT.with(|slot| {
+        let previous = slot.get();
+        slot.set(font);
+        previous
+    });
+    let _restore = Restore(previous);
+    body()
+}
+
+fn with_typesetter<T>(face: Face, body: impl FnOnce(&dyn Typesetter) -> T) -> Option<T> {
+    if face == Face::Reading {
+        if let Some(handle) = READING_FONT.with(std::cell::Cell::get) {
+            if let Some(fonts) = BOOK_TYPESETTERS.get() {
+                if let Ok(fonts) = fonts.lock() {
+                    if let Some(typesetter) = fonts.get(&handle) {
+                        return Some(body(typesetter.as_ref()));
+                    }
+                }
+            }
+        }
+    }
+    TYPESETTER.get().map(|typesetter| body(typesetter.as_ref()))
+}
+
 // The type size everything is currently being measured and drawn at.
 //
 // Why this is ambient rather than a parameter
@@ -6304,8 +6547,9 @@ pub fn measure_text(text: &str, size: FontSize) -> (i32, i32) {
 /// Returns integer pixel dimensions for one face of the installed typeface.
 #[must_use]
 pub fn measure_text_in(text: &str, size: FontSize, face: Face) -> (i32, i32) {
-    if let Some(typesetter) = TYPESETTER.get() {
-        return typesetter.measure(text, size, face);
+    if let Some(measured) = with_typesetter(face, |typesetter| typesetter.measure(text, size, face))
+    {
+        return measured;
     }
     let scale = size.scale();
     let glyphs = i32::try_from(text.chars().count()).unwrap_or(i32::MAX);
@@ -6329,9 +6573,10 @@ pub fn measure_text_in(text: &str, size: FontSize, face: Face) -> (i32, i32) {
 /// would condemn perfectly good text.
 #[must_use]
 pub fn undrawable_in(text: &str, face: Face) -> Option<char> {
-    let typesetter = TYPESETTER.get()?;
-    text.chars()
-        .find(|character| !character.is_whitespace() && !typesetter.has_glyph(*character, face))
+    with_typesetter(face, |typesetter| {
+        text.chars()
+            .find(|character| !character.is_whitespace() && !typesetter.has_glyph(*character, face))
+    })?
 }
 
 /// The size of one monospace cell: what a character grid is built from.
@@ -7285,17 +7530,14 @@ fn wrap_ranges(text: &str, max_width: i32, size: FontSize, face: Face) -> Vec<(u
     if text.is_empty() || max_width <= 0 {
         return Vec::new();
     }
-    let opportunities = TYPESETTER
-        .get()
-        .map_or_else(|| fallback_line_breaks(text), |face| face.line_breaks(text));
-    let graphemes = TYPESETTER.get().map_or_else(
-        || {
+    let opportunities = with_typesetter(face, |typesetter| typesetter.line_breaks(text))
+        .unwrap_or_else(|| fallback_line_breaks(text));
+    let graphemes = with_typesetter(face, |typesetter| typesetter.grapheme_boundaries(text))
+        .unwrap_or_else(|| {
             text.char_indices()
                 .map(|(offset, character)| offset + character.len_utf8())
                 .collect()
-        },
-        |face| face.grapheme_boundaries(text),
-    );
+        });
     let mut lines: Vec<(usize, usize)> = Vec::new();
     let mut start = 0;
     while start < text.len() {
@@ -8269,6 +8511,7 @@ fn validate_node(
     match node {
         Node::Heading { text, .. }
         | Node::Text { text, .. }
+        | Node::RichText { text, .. }
         | Node::Secondary { text, .. }
         | Node::Quote { text, .. }
         | Node::Banner { text, .. } => check_text_coverage(id, text, Face::Text, issues),
@@ -8976,6 +9219,19 @@ pub fn render_all(
     surface: &mut Surface,
     dirty: Option<Rect>,
 ) {
+    with_reading_font(screen.reading_font, || {
+        render_all_with_selected_font(screen, metrics, chrome, pictures, surface, dirty);
+    });
+}
+
+fn render_all_with_selected_font(
+    screen: &Screen,
+    metrics: &DisplayMetrics,
+    chrome: &Chrome,
+    pictures: &dyn Pictures,
+    surface: &mut Surface,
+    dirty: Option<Rect>,
+) {
     let clip = dirty.unwrap_or(Rect {
         x: 0,
         y: 0,
@@ -9529,6 +9785,19 @@ pub fn render_all(
                 tone::INK,
                 clip,
             ),
+            LayoutKind::RichText(presentation) => {
+                if let Some(text) = node.text_lines.first() {
+                    draw_rich_text(
+                        surface,
+                        text,
+                        node.rect,
+                        prose,
+                        presentation,
+                        tone::INK,
+                        clip,
+                    );
+                }
+            }
             // The bars themselves are only a background. Drawing them as
             // separate nodes is what lets a tab switch repaint the content
             // area and two small bands instead of the entire panel.
@@ -10641,15 +10910,82 @@ fn draw_text_in(
     tone: u8,
     clip: Rect,
 ) {
-    if let Some(typesetter) = TYPESETTER.get() {
+    if with_typesetter(face, |typesetter| {
         typesetter.draw(text, x, y, size, face, &mut |pixel_x, pixel_y, coverage| {
             if coverage > 0 && clip.contains(pixel_x, pixel_y) {
                 surface.blend(pixel_x, pixel_y, tone, coverage);
             }
         });
+    })
+    .is_some()
+    {
         return;
     }
     draw_fallback_text(surface, text, x, y, size, tone, clip);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draw_rich_text(
+    surface: &mut Surface,
+    text: &str,
+    rect: Rect,
+    face: Face,
+    presentation: TextPresentation,
+    tone: u8,
+    clip: Rect,
+) {
+    let line = FontSize::Body.line_height_in(face).max(1);
+    let vertical = if presentation.superscript {
+        -line / 4
+    } else if presentation.subscript {
+        line / 5
+    } else {
+        0
+    };
+    let y = rect.y.saturating_add(vertical);
+    if with_typesetter(face, |typesetter| {
+        typesetter.draw(
+            text,
+            rect.x,
+            y,
+            FontSize::Body,
+            face,
+            &mut |pixel_x, pixel_y, coverage| {
+                let skew = if presentation.emphasis {
+                    (line - (pixel_y - y)).clamp(0, line) / 7
+                } else {
+                    0
+                };
+                let x = pixel_x.saturating_add(skew);
+                if coverage > 0 && clip.contains(x, pixel_y) {
+                    surface.blend(x, pixel_y, tone, coverage);
+                    if presentation.strong && clip.contains(x + 1, pixel_y) {
+                        surface.blend(x + 1, pixel_y, tone, coverage);
+                    }
+                }
+            },
+        );
+    })
+    .is_none()
+    {
+        draw_fallback_text(surface, text, rect.x, y, FontSize::Body, tone, clip);
+        if presentation.strong {
+            draw_fallback_text(surface, text, rect.x + 1, y, FontSize::Body, tone, clip);
+        }
+    }
+    if presentation.underline {
+        fill_clipped(
+            surface,
+            Rect {
+                x: rect.x,
+                y: rect.y.saturating_add(line).saturating_sub(2),
+                width: rect.width,
+                height: 1,
+            },
+            tone,
+            clip,
+        );
+    }
 }
 
 /// Draws with the built-in bitmap when no typeface is installed.
@@ -10812,6 +11148,48 @@ fn glyph(character: char) -> [u8; 7] {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn publisher_styled_text_keeps_alignment_and_inline_emphasis() {
+        let screen = Screen::new(
+            1,
+            vec![Node::RichText {
+                id: NodeId(1),
+                text: "ordinary strong".into(),
+                spans: vec![RichTextSpan {
+                    start: 9,
+                    end: 15,
+                    presentation: TextPresentation {
+                        strong: true,
+                        emphasis: true,
+                        ..TextPresentation::default()
+                    },
+                }],
+                links: Vec::new(),
+                presentation: ParagraphPresentation {
+                    alignment: ParagraphAlignment::Center,
+                    line_height_percent: 140,
+                    ..ParagraphPresentation::default()
+                },
+            }],
+        )
+        .with_reading(true);
+        let layout = screen.layout();
+        assert!(layout.nodes.iter().any(|node| matches!(
+            node.kind,
+            LayoutKind::RichText(TextPresentation {
+                strong: true,
+                emphasis: true,
+                ..
+            })
+        )));
+        let first = layout
+            .nodes
+            .iter()
+            .find(|node| matches!(node.kind, LayoutKind::RichText(_)))
+            .expect("rich run");
+        assert!(first.rect.x > CLARA_BW_METRICS.screen_margin());
+    }
 
     #[test]
     fn a_cell_glyph_and_a_bottom_action_glyph_both_reach_the_layout() {

--- a/crates/kobo-ui/src/vector/tabler.rs
+++ b/crates/kobo-ui/src/vector/tabler.rs
@@ -71,6 +71,7 @@ pub(super) fn outline(glyph: Glyph) -> &'static [&'static [Cmd]] {
         Glyph::Battery => BATTERY,
         Glyph::Plus => PLUS,
         Glyph::Headphones => HEADPHONES,
+        Glyph::Minus => MINUS,
     }
 }
 
@@ -950,6 +951,9 @@ static PLUS: &[&[Cmd]] = &[
     &[Cmd::Move(500, 208), Cmd::Line(500, 792)],
     &[Cmd::Move(208, 500), Cmd::Line(792, 500)],
 ];
+
+/// `minus` from Tabler Icons.
+static MINUS: &[&[Cmd]] = &[&[Cmd::Move(208, 500), Cmd::Line(792, 500)]];
 
 /// `headphones` from Tabler Icons.
 static HEADPHONES: &[&[Cmd]] = &[

--- a/crates/kobod/src/app_store.rs
+++ b/crates/kobod/src/app_store.rs
@@ -859,6 +859,7 @@ fn glyph(name: &str) -> Option<Glyph> {
         "next" => Glyph::Next,
         "plus" => Glyph::Plus,
         "headphones" => Glyph::Headphones,
+        "minus" => Glyph::Minus,
         _ => return None,
     })
 }

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -1905,6 +1905,7 @@ fn host_applications(
                         Message::Hello { .. }
                         | Message::Welcome { .. }
                         | Message::Action { .. }
+                        | Message::TextHold { .. }
                         | Message::TaskOutcome { .. }
                         | Message::Lifecycle(_)
                         | Message::DeviceResult(_)
@@ -2467,6 +2468,27 @@ fn action_for(
     hit
 }
 
+fn text_hold_for(
+    event: TouchEvent,
+    screen: Option<&Screen>,
+    chrome: &Chrome,
+    held: bool,
+) -> Option<(ActionId, kobo_ui::TextHit)> {
+    if !held {
+        return None;
+    }
+    let TouchEvent::Up { x, y } = event else {
+        return None;
+    };
+    let screen = screen?;
+    let action = screen.hold?;
+    let (Ok(x), Ok(y)) = (i32::try_from(x), i32::try_from(y)) else {
+        return None;
+    };
+    let layout = screen.layout_with(&metrics_for(screen), chrome);
+    layout.hit_text(x, y).map(|hit| (action, hit))
+}
+
 fn trace_picture_evictions(handle: kobo_ui::PictureHandle, evicted: &[kobo_ui::PictureHandle]) {
     if evicted.is_empty() {
         return;
@@ -2582,6 +2604,22 @@ fn deliver_touch(
     chrome: &Chrome,
     held: bool,
 ) -> Result<Tap, String> {
+    if let Some((action, hit)) = text_hold_for(event, current, chrome, held) {
+        kobo_protocol::write_to(
+            stream,
+            &Frame {
+                request_id: 0,
+                message: Message::TextHold {
+                    action,
+                    context: hit.context,
+                    start: hit.start,
+                    end: hit.end,
+                },
+            },
+        )
+        .map_err(|error| format!("deliver a text hold: {error}"))?;
+        return Ok(Tap::Handled);
+    }
     let Some(action) = action_for(event, current, chrome, held) else {
         return Ok(Tap::Handled);
     };

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -107,15 +107,18 @@ const DATA_ROOT: &str = "/mnt/onboard/.adds/cobalt/data";
 /// lays this screen out has to agree, because layout is what decides where the
 /// controls are: rendering at one size and hit-testing at another moves every
 /// control away from where it can be seen.
+///
+/// What the screen asks for is the size of its *prose*. The interface keeps
+/// the reader's own accessibility scale, so a book set larger does not also
+/// grow the bar above it and take the room out of the page.
 fn metrics_for(screen: &Screen) -> kobo_ui::DisplayMetrics {
-    let mut metrics = display_metrics_from_env();
-    let scale = screen.text_scale.unwrap_or(metrics.text_scale);
-    metrics.text_scale = scale;
+    let metrics = display_metrics_from_env();
     // The typeface is installed once and lives as long as the process, so the
     // size it sets at has to be told to it rather than carried in the metrics
     // it was built with. Set here, where the screen's own answer is known, so
     // that measuring and drawing this frame cannot disagree.
-    kobo_ui::set_text_scale(scale);
+    kobo_ui::set_text_scale(metrics.text_scale);
+    kobo_ui::set_reading_scale(screen.text_scale.unwrap_or(metrics.text_scale));
     metrics
 }
 

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -44,14 +44,15 @@ use kobo_policy::{Backends, Capability, Declared, DeviceServices, PowerPolicy, T
 use kobo_profile::{DeviceProfile, CLARA_BW_391};
 use kobo_protocol::{Frame, Lifecycle, Message, TaskError, TaskOutcome};
 use kobo_ui::{
-    display_metrics_from_env, render_all, ActionId, Chrome, FramePlanner, PanelWaveform,
-    PictureCache, Screen, Surface,
+    display_metrics_from_env, render_all, ActionId, Chrome, FontHandle, FramePlanner,
+    PanelWaveform, PictureCache, Screen, Surface,
 };
+use std::collections::BTreeMap;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering as AtomicOrdering};
 use std::sync::mpsc::{self, RecvTimeoutError, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -784,6 +785,7 @@ fn restore_screen(
 /// nobody has looked at in a while is cheaper to start again than a device that
 /// runs out of memory while its owner is reading.
 const MAX_HOSTED: usize = 4;
+static NEXT_RUNTIME_FONT: AtomicU32 = AtomicU32::new(1);
 
 /// One application the runtime is hosting.
 ///
@@ -818,6 +820,8 @@ struct Hosted {
     /// cache cannot evict another's covers, and so that everything is released
     /// together when it exits.
     pictures: PictureCache,
+    /// Application-local font handles mapped onto runtime-global handles.
+    fonts: BTreeMap<FontHandle, FontHandle>,
     painted: u32,
     /// When this was last on the panel, for deciding what to stop first.
     used: Instant,
@@ -1330,7 +1334,10 @@ fn host_applications(
                         continue;
                     };
                     match frame.message {
-                        Message::SetScreen(screen) => {
+                        Message::SetScreen(mut screen) => {
+                            if let Some(local) = screen.reading_font {
+                                screen.reading_font = apps[index].fonts.get(&local).copied();
+                            }
                             let is_front = id == front;
                             if is_front {
                                 last_activity = Instant::now();
@@ -1408,6 +1415,33 @@ fn host_applications(
                             }
                         }
                         Message::DropPicture { handle } => apps[index].pictures.remove(handle),
+                        Message::PutFont {
+                            handle,
+                            name,
+                            bytes,
+                        } => {
+                            let runtime_handle =
+                                *apps[index].fonts.entry(handle).or_insert_with(|| {
+                                    FontHandle(
+                                        NEXT_RUNTIME_FONT.fetch_add(1, AtomicOrdering::Relaxed),
+                                    )
+                                });
+                            match kobo_text::BookFont::from_bytes(
+                                &bytes,
+                                &name,
+                                display_metrics_from_env(),
+                            ) {
+                                Ok(font) => {
+                                    kobo_ui::put_book_typesetter(runtime_handle, Box::new(font));
+                                }
+                                Err(error) => trace(&format!("font {} refused: {error}", handle.0)),
+                            }
+                        }
+                        Message::DropFont { handle } => {
+                            if let Some(runtime_handle) = apps[index].fonts.remove(&handle) {
+                                kobo_ui::drop_book_typesetter(runtime_handle);
+                            }
+                        }
                         // An application logs to explain itself, and the times
                         // it most needs to be believed are the times it took
                         // the reader down with it. Dropping the line here left
@@ -2259,6 +2293,7 @@ fn start_application(
         declared,
         screen: None,
         pictures: PictureCache::default(),
+        fonts: BTreeMap::new(),
         painted: 0,
         used: Instant::now(),
     });
@@ -2267,6 +2302,9 @@ fn start_application(
 
 /// Ends one hosted application and everything it started.
 fn stop_hosted(mut app: Hosted) {
+    for (_, handle) in std::mem::take(&mut app.fonts) {
+        kobo_ui::drop_book_typesetter(handle);
+    }
     app.tasks.shutdown();
     stop_application(&mut app.child, app.jail.as_deref());
     if let Some(root) = app.jail {

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -72,6 +72,7 @@ const SECRETS: &str = "/mnt/onboard/.adds/cobalt/secrets";
 /// the same reasons. A certificate here lets the runtime verify a daemon on
 /// the owner's own network exactly as it verifies a public host.
 const TRUST: &str = "/mnt/onboard/.adds/cobalt/trust";
+const DICTIONARIES: &str = "/mnt/onboard/.adds/cobalt/dictionaries";
 
 /// Where each application's own keyed state lives, one directory per name.
 const STATE_ROOT: &str = "/mnt/onboard/.adds/cobalt/state";
@@ -1018,6 +1019,8 @@ fn host_applications(
         PowerPolicy::DEFAULT,
         Backends::with(backends),
     );
+    let dictionaries = services.load_dictionaries(Path::new(DICTIONARIES));
+    println!("offline dictionaries loaded: {dictionaries}");
     if let Some(light) = &frontlight {
         if let Some(percent) = light.percent() {
             services.observe_frontlight(percent);
@@ -1431,8 +1434,11 @@ fn host_applications(
                                 &name,
                                 display_metrics_from_env(),
                             ) {
-                                Ok(font) => {
-                                    kobo_ui::put_book_typesetter(runtime_handle, Box::new(font));
+                                Ok(book_font) => {
+                                    kobo_ui::put_book_typesetter(
+                                        runtime_handle,
+                                        Box::new(book_font),
+                                    );
                                 }
                                 Err(error) => trace(&format!("font {} refused: {error}", handle.0)),
                             }

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -74,6 +74,15 @@ const SECRETS: &str = "/mnt/onboard/.adds/cobalt/secrets";
 const TRUST: &str = "/mnt/onboard/.adds/cobalt/trust";
 const DICTIONARIES: &str = "/mnt/onboard/.adds/cobalt/dictionaries";
 
+/// The most publisher faces one application may hold in the runtime at once.
+///
+/// The protocol bounds a single font frame, not how many frames arrive. A book
+/// needs a regular, an italic, a bold and a bold italic, and a handful more for
+/// small caps or a display face; past that an application is accumulating
+/// rather than typesetting, and every face held is parsed outlines and a glyph
+/// cache inside the privileged runtime.
+const MAX_APP_FONTS: usize = 16;
+
 /// Where each application's own keyed state lives, one directory per name.
 const STATE_ROOT: &str = "/mnt/onboard/.adds/cobalt/state";
 
@@ -1423,24 +1432,40 @@ fn host_applications(
                             name,
                             bytes,
                         } => {
-                            let runtime_handle =
-                                *apps[index].fonts.entry(handle).or_insert_with(|| {
-                                    FontHandle(
-                                        NEXT_RUNTIME_FONT.fetch_add(1, AtomicOrdering::Relaxed),
-                                    )
-                                });
-                            match kobo_text::BookFont::from_bytes(
-                                &bytes,
-                                &name,
-                                display_metrics_from_env(),
-                            ) {
-                                Ok(book_font) => {
-                                    kobo_ui::put_book_typesetter(
-                                        runtime_handle,
-                                        Box::new(book_font),
-                                    );
+                            // The map entry is only made once the face parses.
+                            // Creating it first let a refused font hold a slot,
+                            // and nothing bounded how many slots one
+                            // application could take: a loop over fresh handles
+                            // would grow the runtime until the device gave out.
+                            let known = apps[index].fonts.contains_key(&handle);
+                            if !known && apps[index].fonts.len() >= MAX_APP_FONTS {
+                                trace(&format!(
+                                    "font {} refused: {MAX_APP_FONTS} already held",
+                                    handle.0
+                                ));
+                            } else {
+                                match kobo_text::BookFont::from_bytes(
+                                    &bytes,
+                                    &name,
+                                    display_metrics_from_env(),
+                                ) {
+                                    Ok(book_font) => {
+                                        let runtime_handle =
+                                            *apps[index].fonts.entry(handle).or_insert_with(|| {
+                                                FontHandle(
+                                                    NEXT_RUNTIME_FONT
+                                                        .fetch_add(1, AtomicOrdering::Relaxed),
+                                                )
+                                            });
+                                        kobo_ui::put_book_typesetter(
+                                            runtime_handle,
+                                            Box::new(book_font),
+                                        );
+                                    }
+                                    Err(error) => {
+                                        trace(&format!("font {} refused: {error}", handle.0));
+                                    }
                                 }
-                                Err(error) => trace(&format!("font {} refused: {error}", handle.0)),
                             }
                         }
                         Message::DropFont { handle } => {

--- a/crates/kobod/src/main.rs
+++ b/crates/kobod/src/main.rs
@@ -321,6 +321,18 @@ fn host_trust_directory() -> PathBuf {
     )
 }
 
+fn host_dictionary_directory() -> PathBuf {
+    env::var_os("HOME").map_or_else(
+        || PathBuf::from(".kobo-dictionaries"),
+        |home| {
+            PathBuf::from(home)
+                .join(".config")
+                .join("kobo")
+                .join("dictionaries")
+        },
+    )
+}
+
 #[allow(
     clippy::too_many_lines,
     reason = "one arm per message type; splitting the dispatch hides it"
@@ -334,6 +346,8 @@ fn serve_application(
     // In simulation the daemon owns no hardware, so every hardware-touching
     // request is answered honestly rather than pretended.
     let mut services = DeviceServices::simulated();
+    let dictionaries = services.load_dictionaries(&host_dictionary_directory());
+    println!("offline dictionaries loaded: {dictionaries}");
     // There is no bezel here to hold a magnet against, so the state the hall
     // sensor reports is set on the way in. Without this the second half of
     // every cover-aware screen is unreachable off hardware.

--- a/crates/kobod/src/main.rs
+++ b/crates/kobod/src/main.rs
@@ -501,6 +501,7 @@ fn serve_application(
             Message::Hello { .. }
             | Message::Welcome { .. }
             | Message::Action { .. }
+            | Message::TextHold { .. }
             | Message::TaskOutcome { .. }
             | Message::DeviceResult(_)
             | Message::StoreResult(_)

--- a/crates/kobod/src/main.rs
+++ b/crates/kobod/src/main.rs
@@ -301,7 +301,7 @@ fn serve_simulation(socket_path: &Path, frame_path: &Path) -> Result<(), Box<dyn
             },
         },
     )?;
-    serve_application(&mut stream, frame_path, &name)
+    serve_application(&mut stream, frame_path, &name, metrics)
 }
 
 /// Where a host runtime looks for owner-installed TLS trust roots.
@@ -329,6 +329,7 @@ fn serve_application(
     stream: &mut UnixStream,
     frame_path: &Path,
     name: &str,
+    metrics: kobo_ui::DisplayMetrics,
 ) -> Result<(), Box<dyn Error>> {
     // In simulation the daemon owns no hardware, so every hardware-touching
     // request is answered honestly rather than pretended.
@@ -416,6 +417,15 @@ fn serve_application(
                 Some(_) => {}
             },
             Message::DropPicture { handle } => pictures.remove(handle),
+            Message::PutFont {
+                handle,
+                name,
+                bytes,
+            } => match kobo_text::BookFont::from_bytes(&bytes, &name, metrics) {
+                Ok(font) => kobo_ui::put_book_typesetter(handle, Box::new(font)),
+                Err(error) => println!("font {} refused: {error}", handle.0),
+            },
+            Message::DropFont { handle } => kobo_ui::drop_book_typesetter(handle),
             // This path renders one application to a file and owns no panel to
             // hand over, so the request is reported rather than performed.
             Message::Launch { name } => println!("launch requested: {name}"),

--- a/crates/kobod/src/main.rs
+++ b/crates/kobod/src/main.rs
@@ -635,14 +635,13 @@ fn write_screen(
     // was the one part of every screen that could not be looked at without a
     // reader, and it is the part that traps somebody when it is missing.
     let screen = kobo_ui::ensure_way_back(screen, chrome, name);
-    let mut metrics = kobo_ui::display_metrics_from_env();
-    if let Some(scale) = screen.text_scale {
-        metrics.text_scale = scale;
-    }
+    let metrics = kobo_ui::display_metrics_from_env();
     // The same reason as on the device: the typeface sets at the ambient
-    // scale, so a preview of a screen that asked for larger type has to say so
-    // or it is a preview of a screen nobody will see.
+    // scale, so a preview of a screen that asked for larger prose has to say
+    // so or it is a preview of a screen nobody will see. The interface around
+    // the prose keeps the reader's own size either way.
     kobo_ui::set_text_scale(metrics.text_scale);
+    kobo_ui::set_reading_scale(screen.text_scale.unwrap_or(metrics.text_scale));
     kobo_ui::render_all(&screen, &metrics, chrome, pictures, &mut surface, None);
 
     let temporary = path.with_extension(format!("raw.tmp-{}", std::process::id()));

--- a/docs/DICTIONARIES.md
+++ b/docs/DICTIONARIES.md
@@ -1,0 +1,40 @@
+# Offline dictionaries
+
+Cobalt's reader looks up selected words without starting Wi-Fi or sending the
+word anywhere. Dictionaries are loaded by the runtime, not by the reading app.
+
+On a Kobo, place UTF-8 TSV files in:
+
+```text
+/mnt/onboard/.adds/cobalt/dictionaries
+```
+
+The host simulator uses:
+
+```text
+~/.config/kobo/dictionaries
+```
+
+Each non-comment line contains a headword, one tab, and a definition. Optional
+metadata comments precede the entries:
+
+```text
+# name=My English dictionary
+# language=en
+# priority=10
+reader	A person who reads.
+reading	The act or practice of interpreting written text.
+```
+
+Higher priority dictionaries are shown first; ties are ordered by dictionary
+name. Language tags use short BCP 47-style values such as `en`, `fr`, or
+`pt-BR`. Files, entries, definitions, results, and the total index are bounded.
+A malformed line or file is skipped without disabling other dictionaries.
+
+Lookup performs Unicode compatibility normalization, case folding, surrounding
+punctuation removal, and small inflection hooks. It tries the exact normalized
+word before an inferred stem. An empty result is shown explicitly.
+
+The format intentionally contains no HTML or executable content. Dictionary
+licensing remains the owner's responsibility; Cobalt ships the service rather
+than redistributing a third-party dictionary corpus.

--- a/examples/gutenbird/Cargo.toml
+++ b/examples/gutenbird/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
+kobo-bookview = { path = "../../crates/kobo-bookview" }
 kobo-doc = { path = "../../crates/kobo-doc" }
 kobo-image = { path = "../../crates/kobo-image" }
 kobo-opds = { path = "../../crates/kobo-opds" }

--- a/examples/gutenbird/src/main.rs
+++ b/examples/gutenbird/src/main.rs
@@ -2594,16 +2594,6 @@ impl Gutenbird {
         }
     }
 
-    fn ask_light(&mut self, context: &mut Context) {
-        if self
-            .book
-            .reader()
-            .is_some_and(|reader| reader.light().is_none())
-        {
-            context.device().read_frontlight();
-        }
-    }
-
     fn took_book(&mut self, context: &mut Context, bytes: &[u8]) {
         let Some(download) = &mut self.download else {
             return;
@@ -2648,7 +2638,6 @@ impl Gutenbird {
             .is_some_and(|total| u64::from(self.fetched) >= total);
         self.complete = short || reached_total;
         self.reopen(context);
-        self.ask_light(context);
         if self.complete && self.download.is_some() {
             self.keep_book(context);
         }
@@ -3148,11 +3137,7 @@ impl KoboApp for Gutenbird {
         let kobo_sdk::DeviceResult::Frontlight { percent } = result else {
             return;
         };
-        if self
-            .book
-            .reader_mut()
-            .is_some_and(|reader| reader.seed_light(percent))
-        {
+        if self.book.took_light(percent) {
             self.show(context);
         }
     }
@@ -5155,6 +5140,8 @@ Please read this before you distribute or use this work.\n";
             .iter()
             .filter_map(|node| match node.kind {
                 LayoutKind::Button(action, kobo_ui::ControlState::Enabled, _)
+                | LayoutKind::StepperControl(action, kobo_ui::ControlState::Enabled, _)
+                | LayoutKind::Cell(action, ..)
                 | LayoutKind::ChoiceOption(action, _) => Some((action, node.rect)),
                 _ => None,
             })
@@ -5230,7 +5217,7 @@ Please read this before you distribute or use this work.\n";
         let steps = layout
             .nodes
             .iter()
-            .filter(|node| matches!(node.kind, LayoutKind::ChoiceOption(..)))
+            .filter(|node| matches!(node.kind, LayoutKind::StepperControl(..)))
             .count();
         assert_eq!(
             steps, 2,

--- a/examples/gutenbird/src/main.rs
+++ b/examples/gutenbird/src/main.rs
@@ -371,6 +371,7 @@ enum View {
     Search,
     Details,
     Reading,
+    Note,
 }
 
 /// What a feed answer, once parsed, should become.
@@ -572,6 +573,7 @@ struct Gutenbird {
     /// catalog's own history rather than the application's.
     trail: Vec<View>,
     keyboard: Keyboard,
+    pending_annotation: Option<kobo_read::AnnotationId>,
 
     catalogs: Vec<Catalog>,
     current: usize,
@@ -663,6 +665,7 @@ impl Default for Gutenbird {
             view: View::Catalogs,
             trail: Vec::new(),
             keyboard: Keyboard::new(),
+            pending_annotation: None,
             catalogs: CATALOGS
                 .iter()
                 .map(|(name, root)| Catalog::new(*name, *root, false))
@@ -733,6 +736,7 @@ impl Gutenbird {
             View::Search => self.search_screen(),
             View::Details => self.details_screen(context),
             View::Reading => self.reading_screen(context),
+            View::Note => self.note_screen(),
         };
         // The application draws its own Back wherever it has somewhere to go,
         // which is every screen except the catalog list with nothing open over
@@ -1523,6 +1527,18 @@ impl Gutenbird {
                 screen.keyboard(&self.keyboard, "Search").build()
             }
         }
+    }
+
+    fn note_screen(&self) -> kobo_sdk::Screen {
+        ScreenBuilder::new("gutenbird-note")
+            .top_bar("Marginal note")
+            .secondary(
+                "Write beside the highlighted words. The highlight remains if the note is blank.",
+            )
+            .field("annotation-note", self.keyboard.text(), "Your note")
+            .field_clear("annotation-note-clear")
+            .keyboard(&self.keyboard, "Save note")
+            .build()
     }
 
     // ---------------------------------------------------------------
@@ -3320,6 +3336,38 @@ impl KoboApp for Gutenbird {
         }
     }
 
+    fn on_text_hold(&mut self, context: &mut Context, action: ActionId, hit: kobo_sdk::TextHit) {
+        if self.view != View::Reading || action != kobo_sdk::action_id(kobo_read::action::MARKING) {
+            self.on_action(context, action);
+            return;
+        }
+        let Ok(block) = u32::try_from(hit.context) else {
+            return;
+        };
+        let range = kobo_read::TextRange {
+            start: kobo_read::TextPosition {
+                block,
+                offset: hit.start,
+            },
+            end: kobo_read::TextPosition {
+                block,
+                offset: hit.end,
+            },
+        };
+        let metrics = context.metrics();
+        let created = self
+            .reader
+            .as_mut()
+            .and_then(|reader| reader.annotate(range, None, &metrics).ok());
+        if let Some(id) = created {
+            self.pending_annotation = Some(id);
+            self.keyboard.clear();
+            self.save_place(context);
+            self.go(View::Note);
+            self.show(context);
+        }
+    }
+
     #[allow(clippy::too_many_lines)]
     fn on_action(&mut self, context: &mut Context, action: ActionId) {
         if action == ActionId::BACK {
@@ -3381,6 +3429,28 @@ impl KoboApp for Gutenbird {
                 None => {}
             }
         }
+        if self.view == View::Note {
+            match self.keyboard.press(action) {
+                Some(Pressed::Submitted) => {
+                    let note = self.keyboard.take();
+                    if let (Some(id), Some(reader)) =
+                        (self.pending_annotation.take(), self.reader.as_mut())
+                    {
+                        let note = (!note.trim().is_empty()).then_some(note.trim());
+                        let _ = reader.edit_annotation_note(id, note);
+                        self.save_place(context);
+                    }
+                    self.back_to(View::Reading);
+                    self.show(context);
+                    return;
+                }
+                Some(Pressed::Edited | Pressed::Shifted) => {
+                    self.show(context);
+                    return;
+                }
+                None => {}
+            }
+        }
         if self.view == View::AddCatalog {
             match self.keyboard.press(action) {
                 Some(Pressed::Submitted) => {
@@ -3425,6 +3495,11 @@ impl KoboApp for Gutenbird {
             return;
         }
         if action == action_id("catalog-url-clear") {
+            self.keyboard.clear();
+            self.show(context);
+            return;
+        }
+        if action == action_id("annotation-note-clear") {
             self.keyboard.clear();
             self.show(context);
             return;
@@ -3693,9 +3768,9 @@ impl KoboApp for Gutenbird {
 mod tests {
     use super::{
         book_keys, catalog_display_name, decode_registry, download_kind, encode_registry,
-        plate_box, read_offer, readable, Awaiting, BTreeMap, Catalog, DetailBlock, Download,
-        DownloadKind, FeedPurpose, FillStage, Gutenbird, Memory, ReadOffer, Reader, SearchState,
-        SearchWay, StackEntry, View, COVER_TRIES, OPEN_COVER_HANDLE,
+        plate_box, read_offer, readable, Awaiting, BTreeMap, BTreeSet, Catalog, DetailBlock,
+        Download, DownloadKind, FeedPurpose, FillStage, Gutenbird, Memory, ReadOffer, Reader,
+        SearchState, SearchWay, StackEntry, View, COVER_TRIES, OPEN_COVER_HANDLE,
     };
     use kobo_opds::{
         Acquisition, AcquisitionKind, Category, Feed, Image, ImageSource, Link, Navigation,
@@ -5021,8 +5096,10 @@ Please read this before you distribute or use this work.\n";
             let drawn = layout
                 .nodes
                 .iter()
-                .filter(|node| node.kind == LayoutKind::Text)
-                .count();
+                .filter(|node| matches!(node.kind, LayoutKind::Text | LayoutKind::RichText(_)))
+                .map(|node| node.id)
+                .collect::<BTreeSet<_>>()
+                .len();
             assert_eq!(
                 drawn, expected,
                 "page {page} measured as {expected} paragraphs but drew {drawn}"
@@ -5362,6 +5439,32 @@ Please read this before you distribute or use this work.\n";
             let hit = layout.hit_test(rect.x + rect.width / 2, rect.y + rect.height / 2);
             assert_eq!(hit, Some(action));
         }
+    }
+
+    #[test]
+    fn holding_a_word_opens_marginalia_and_saves_the_note_on_that_exact_word() {
+        let mut runner = AppRunner::new(Gutenbird {
+            view: View::Reading,
+            reader: Some(opened("café novel")),
+            complete: true,
+            ..Gutenbird::default()
+        });
+        runner.text_hold(
+            action_id(kobo_read::action::MARKING),
+            kobo_sdk::TextHit {
+                context: 0,
+                start: 0,
+                end: 5,
+            },
+        );
+        assert_eq!(runner.app().view, View::Note);
+        assert_eq!(runner.app().reader.as_ref().unwrap().annotations().len(), 1);
+
+        runner.action(action_id("kb.r0c0"));
+        runner.action(action_id("kb.enter"));
+        assert_eq!(runner.app().view, View::Reading);
+        let annotation = &runner.app().reader.as_ref().unwrap().annotations()[0];
+        assert_eq!(annotation.note.as_deref(), Some("q"));
     }
 
     #[test]

--- a/examples/gutenbird/src/main.rs
+++ b/examples/gutenbird/src/main.rs
@@ -41,9 +41,9 @@ use kobo_read::{Memory, Outcome, Reader};
 use kobo_sdk::keyboard::{Keyboard, Pressed};
 use kobo_sdk::{
     action_id, ActionId, BannerLevel, Chrome, Context, DiagnosticSeverity, DisplayMetrics, Failure,
-    Glyph, Header, KoboApp, LogLevel, PictureHandle, RowLead, ScreenBuilder, ShelfDownload,
-    ShelfProgress, ShelfUpload, StoreResult, Task, TaskId, TaskOutcome, Tile, TilePicture,
-    TileShape, TileState, MAX_STORE_VALUE,
+    FontHandle, Glyph, Header, KoboApp, LogLevel, PictureHandle, RowLead, ScreenBuilder,
+    ShelfDownload, ShelfProgress, ShelfUpload, StoreResult, Task, TaskId, TaskOutcome, Tile,
+    TilePicture, TileShape, TileState, MAX_STORE_VALUE,
 };
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::process::ExitCode;
@@ -208,6 +208,7 @@ const OPEN_COVER_PX: (u32, u32) = (DETAILS_COVER_MM as u32 * 8, DETAILS_COVER_MM
 
 /// The handle the open book's cover is always held against.
 const OPEN_COVER_HANDLE: PictureHandle = PictureHandle(u32::MAX);
+const PUBLISHER_FONT_HANDLE: FontHandle = FontHandle(1);
 
 /// How close to the end of what has been downloaded the reader may get before
 /// the next piece of a plain-text fallback book is requested.
@@ -625,6 +626,8 @@ struct Gutenbird {
     /// costing the device several megabytes of decoded greyscale while its
     /// owner was back on the shelf looking at covers.
     book_pictures: Vec<PictureHandle>,
+    /// The embedded face held for the open book, released with its pictures.
+    book_font: Option<FontHandle>,
     /// The open book's plates still to be turned into pixels, in the order the
     /// text refers to them, each with the bytes it was stored as.
     ///
@@ -686,6 +689,7 @@ impl Default for Gutenbird {
             complete: false,
             reader: None,
             book_pictures: Vec::new(),
+            book_font: None,
             plates: VecDeque::new(),
             dithering: None,
             plating: None,
@@ -2493,6 +2497,9 @@ impl Gutenbird {
             for handle in self.book_pictures.drain(..) {
                 context.drop_picture(handle);
             }
+            if let Some(handle) = self.book_font.take() {
+                context.drop_font(handle);
+            }
             // Taken off the document rather than left on it: the reader owns
             // the document from here, and holding the scanned bytes as well as
             // the decoded greyscale meant every plate was paid for twice.
@@ -2500,6 +2507,15 @@ impl Gutenbird {
             let pictures_ms = started.elapsed().as_millis();
             let started = std::time::Instant::now();
             let mut reader = Reader::open(document, memory, &context.metrics());
+            if let Some((name, bytes)) = reader
+                .preferred_publisher_font()
+                .map(|(name, bytes)| (name.to_owned(), bytes.to_vec()))
+            {
+                if let Some(handle) = context.put_font(PUBLISHER_FONT_HANDLE, name, bytes) {
+                    reader.set_publisher_font(Some(handle), &context.metrics());
+                    self.book_font = Some(handle);
+                }
+            }
             // Before the count is read, because the sizes are what an
             // illustrated book is measured at, and it is that count -- the one
             // it will actually be read at -- that the timing line is worth
@@ -2553,6 +2569,9 @@ impl Gutenbird {
         }
         for handle in self.book_pictures.drain(..) {
             context.drop_picture(handle);
+        }
+        if let Some(handle) = self.book_font.take() {
+            context.drop_font(handle);
         }
         // Whatever is still queued is source bytes for a book nobody is
         // reading any more. The sleep already in flight is left to land and be

--- a/examples/gutenbird/src/main.rs
+++ b/examples/gutenbird/src/main.rs
@@ -371,6 +371,7 @@ enum View {
     Search,
     Details,
     Reading,
+    Lookup,
     Note,
 }
 
@@ -574,6 +575,10 @@ struct Gutenbird {
     trail: Vec<View>,
     keyboard: Keyboard,
     pending_annotation: Option<kobo_read::AnnotationId>,
+    selected_range: Option<kobo_read::TextRange>,
+    lookup_word: String,
+    lookup_entries: Option<Vec<kobo_sdk::DictionaryEntry>>,
+    lookup_page: usize,
 
     catalogs: Vec<Catalog>,
     current: usize,
@@ -666,6 +671,10 @@ impl Default for Gutenbird {
             trail: Vec::new(),
             keyboard: Keyboard::new(),
             pending_annotation: None,
+            selected_range: None,
+            lookup_word: String::new(),
+            lookup_entries: None,
+            lookup_page: 0,
             catalogs: CATALOGS
                 .iter()
                 .map(|(name, root)| Catalog::new(*name, *root, false))
@@ -736,6 +745,7 @@ impl Gutenbird {
             View::Search => self.search_screen(),
             View::Details => self.details_screen(context),
             View::Reading => self.reading_screen(context),
+            View::Lookup => self.lookup_screen(),
             View::Note => self.note_screen(),
         };
         // The application draws its own Back wherever it has somewhere to go,
@@ -1538,6 +1548,46 @@ impl Gutenbird {
             .field("annotation-note", self.keyboard.text(), "Your note")
             .field_clear("annotation-note-clear")
             .keyboard(&self.keyboard, "Save note")
+            .build()
+    }
+
+    fn lookup_screen(&self) -> kobo_sdk::Screen {
+        let mut screen = ScreenBuilder::new("gutenbird-lookup")
+            .top_bar(self.lookup_word.clone())
+            .section("Offline dictionary");
+        match &self.lookup_entries {
+            None => {
+                screen = screen.activity("Looking up the selected word", None);
+            }
+            Some(entries) if entries.is_empty() => {
+                screen = screen.secondary(
+                    "No installed dictionary has this word. Add UTF-8 TSV dictionaries to Cobalt's dictionaries folder.",
+                );
+            }
+            Some(entries) => {
+                if let Some(entry) = entries.get(self.lookup_page.min(entries.len() - 1)) {
+                    screen = screen
+                        .heading(entry.headword.clone())
+                        .secondary(format!(
+                            "{} · {} · {} of {}",
+                            entry.dictionary,
+                            entry.language,
+                            self.lookup_page + 1,
+                            entries.len()
+                        ))
+                        .text(dictionary_excerpt(&entry.definition));
+                    if self.lookup_page > 0 {
+                        screen = screen.button("lookup-previous", "Previous definition");
+                    }
+                    if self.lookup_page + 1 < entries.len() {
+                        screen = screen.button("lookup-next", "Next definition");
+                    }
+                }
+            }
+        }
+        screen
+            .button("lookup-highlight", "Highlight")
+            .button("lookup-note", "Add note")
             .build()
     }
 
@@ -3014,6 +3064,15 @@ fn clean_field(field: &str) -> String {
     field.replace(['\t', '\n', '\r'], " ").trim().to_owned()
 }
 
+fn dictionary_excerpt(definition: &str) -> String {
+    const LIMIT: usize = 700;
+    let mut excerpt = definition.chars().take(LIMIT).collect::<String>();
+    if definition.chars().count() > LIMIT {
+        excerpt.push('…');
+    }
+    excerpt
+}
+
 fn decode_registry(bytes: &[u8]) -> Vec<Catalog> {
     String::from_utf8_lossy(bytes)
         .lines()
@@ -3321,9 +3380,21 @@ impl KoboApp for Gutenbird {
     fn on_device_result(
         &mut self,
         context: &mut Context,
-        _request: kobo_sdk::DeviceRequest,
+        request: kobo_sdk::DeviceRequest,
         result: kobo_sdk::DeviceResult,
     ) {
+        if let (
+            kobo_sdk::DeviceRequest::LookupWord { .. },
+            kobo_sdk::DeviceResult::Dictionary { word, entries },
+        ) = (&request, &result)
+        {
+            if self.view == View::Lookup && *word == self.lookup_word {
+                self.lookup_entries = Some(entries.clone());
+                self.lookup_page = 0;
+                self.show(context);
+            }
+            return;
+        }
         let kobo_sdk::DeviceResult::Frontlight { percent } = result else {
             return;
         };
@@ -3354,18 +3425,18 @@ impl KoboApp for Gutenbird {
                 offset: hit.end,
             },
         };
-        let metrics = context.metrics();
-        let created = self
+        let word = self
             .reader
-            .as_mut()
-            .and_then(|reader| reader.annotate(range, None, &metrics).ok());
-        if let Some(id) = created {
-            self.pending_annotation = Some(id);
-            self.keyboard.clear();
-            self.save_place(context);
-            self.go(View::Note);
-            self.show(context);
-        }
+            .as_ref()
+            .and_then(|reader| reader.text_in(range));
+        let Some(word) = word else { return };
+        self.selected_range = Some(range);
+        self.lookup_word.clone_from(&word);
+        self.lookup_entries = None;
+        self.lookup_page = 0;
+        let _ = context.device().lookup_word(word, None::<String>);
+        self.go(View::Lookup);
+        self.show(context);
     }
 
     #[allow(clippy::too_many_lines)]
@@ -3429,6 +3500,43 @@ impl KoboApp for Gutenbird {
                 None => {}
             }
         }
+        if self.view == View::Lookup
+            && (action == action_id("lookup-highlight") || action == action_id("lookup-note"))
+        {
+            let created = self.selected_range.and_then(|range| {
+                let metrics = context.metrics();
+                self.reader
+                    .as_mut()
+                    .and_then(|reader| reader.annotate(range, None, &metrics).ok())
+            });
+            if let Some(id) = created {
+                self.save_place(context);
+                if action == action_id("lookup-note") {
+                    self.pending_annotation = Some(id);
+                    self.keyboard.clear();
+                    self.go(View::Note);
+                } else {
+                    self.selected_range = None;
+                    self.back_to(View::Reading);
+                }
+                self.show(context);
+            }
+            return;
+        }
+        if self.view == View::Lookup && action == action_id("lookup-previous") {
+            self.lookup_page = self.lookup_page.saturating_sub(1);
+            self.show(context);
+            return;
+        }
+        if self.view == View::Lookup && action == action_id("lookup-next") {
+            let last = self
+                .lookup_entries
+                .as_ref()
+                .map_or(0, |entries| entries.len().saturating_sub(1));
+            self.lookup_page = self.lookup_page.saturating_add(1).min(last);
+            self.show(context);
+            return;
+        }
         if self.view == View::Note {
             match self.keyboard.press(action) {
                 Some(Pressed::Submitted) => {
@@ -3440,7 +3548,9 @@ impl KoboApp for Gutenbird {
                         let _ = reader.edit_annotation_note(id, note);
                         self.save_place(context);
                     }
+                    self.back_to(View::Lookup);
                     self.back_to(View::Reading);
+                    self.selected_range = None;
                     self.show(context);
                     return;
                 }
@@ -5457,6 +5567,25 @@ Please read this before you distribute or use this work.\n";
                 end: 5,
             },
         );
+        assert_eq!(runner.app().view, View::Lookup);
+        assert!(runner
+            .app()
+            .reader
+            .as_ref()
+            .unwrap()
+            .annotations()
+            .is_empty());
+        runner.device_result(kobo_sdk::DeviceResult::Dictionary {
+            word: "café".into(),
+            entries: vec![kobo_sdk::DictionaryEntry {
+                dictionary: "Pocket English".into(),
+                language: "en".into(),
+                headword: "café".into(),
+                definition: "A small coffee house.".into(),
+            }],
+        });
+        assert_eq!(runner.app().lookup_entries.as_ref().unwrap().len(), 1);
+        runner.action(action_id("lookup-note"));
         assert_eq!(runner.app().view, View::Note);
         assert_eq!(runner.app().reader.as_ref().unwrap().annotations().len(), 1);
 

--- a/examples/gutenbird/src/main.rs
+++ b/examples/gutenbird/src/main.rs
@@ -36,14 +36,15 @@
 //! reader who learns them in one should find them in the next. They live in
 //! `kobo-read`.
 
+use kobo_bookview::{BookView, Step};
 use kobo_opds::{AcquisitionKind, Category, Feed, ImageSource, Link, Publication, SearchTemplate};
 use kobo_read::{Memory, Outcome, Reader};
 use kobo_sdk::keyboard::{Keyboard, Pressed};
 use kobo_sdk::{
-    action_id, ActionId, BannerLevel, Chrome, Context, DiagnosticSeverity, DisplayMetrics, Failure,
-    FontHandle, Glyph, Header, KoboApp, LogLevel, PictureHandle, RowLead, ScreenBuilder,
-    ShelfDownload, ShelfProgress, ShelfUpload, StoreResult, Task, TaskId, TaskOutcome, Tile,
-    TilePicture, TileShape, TileState, MAX_STORE_VALUE,
+    action_id, ActionId, BannerLevel, Chrome, Context, DiagnosticSeverity, Failure, FontHandle,
+    Glyph, Header, KoboApp, LogLevel, PictureHandle, RowLead, ScreenBuilder, ShelfDownload,
+    ShelfProgress, ShelfUpload, StoreResult, Task, TaskId, TaskOutcome, Tile, TilePicture,
+    TileShape, TileState, MAX_STORE_VALUE,
 };
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::process::ExitCode;
@@ -146,30 +147,6 @@ const MIN_COVER_PX: u32 = 32;
 /// who has watched a progress bar for four minutes has already been charged
 /// for the failure.
 const MAX_BOOK_BYTES: u64 = 12 * 1024 * 1024;
-
-/// The most pictures decoded when a book opens.
-///
-/// Every one costs memory the reader shares with the firmware, and a novel's
-/// illustrations run to a few dozen. This is above that and far below the
-/// point where a book of photographs takes the device down with it.
-const MAX_BOOK_PICTURES: usize = 64;
-
-/// How large a picture inside a book is decoded to, in millimetres.
-///
-/// Fitted before it is handed over rather than after, so what the runtime
-/// holds is the size it will be drawn: a plate scanned at print resolution is
-/// several megabytes of pixels the panel has no way to show. The height
-/// matches the ceiling `kobo-read` draws pictures at, and the width is the
-/// column it has to fit inside.
-const PICTURE_WIDTH_MM: u16 = 80;
-const PICTURE_HEIGHT_MM: u16 = 90;
-
-/// Where a book's picture handles start.
-///
-/// The shelf is holding cover handles numbered from zero at the same time, and
-/// two pictures sharing a handle is the sort of fault that shows up as the
-/// wrong illustration rather than as an error.
-const PICTURE_HANDLE_BASE: u32 = 1_000;
 
 /// Where the handles for navigation tile pictures start, and how many of them
 /// are cycled through.
@@ -624,32 +601,17 @@ struct Gutenbird {
     download: Option<Download>,
     fetched: u32,
     complete: bool,
-    reader: Option<Reader>,
-    /// The handles the runtime is holding plates against for the open book.
+    /// The open book, and everything holding one costs the device.
     ///
-    /// Kept because a handle is the only thing that can give one back. The
-    /// runtime frees every picture when an application exits, which is no help
-    /// at all to an application that stays open: a book of plates was still
-    /// costing the device several megabytes of decoded greyscale while its
-    /// owner was back on the shelf looking at covers.
-    book_pictures: Vec<PictureHandle>,
+    /// The reader itself, the room reserved for each plate, the queue of
+    /// plates still to be turned into pixels and the handles the runtime is
+    /// holding them against all live in here, because every one of those is
+    /// the same problem in every application that opens a document. What used
+    /// to be four fields and six methods of this file is now the shared
+    /// [`BookView`], which arXiv reads its papers through as well.
+    book: BookView,
     /// The embedded face held for the open book, released with its pictures.
     book_font: Option<FontHandle>,
-    /// The open book's plates still to be turned into pixels, in the order the
-    /// text refers to them, each with the bytes it was stored as.
-    ///
-    /// Drained rather than iterated: a plate's source bytes are dropped the
-    /// moment it has been decoded, so what an illustrated book costs while it
-    /// opens falls as it goes rather than being both copies at once.
-    plates: VecDeque<(String, Vec<u8>)>,
-    /// A plate read from the book but not yet reduced to the panel's greys.
-    ///
-    /// The two halves of preparing a plate happen in separate callbacks
-    /// because together they are longer than one is allowed to be, so the
-    /// half-finished picture has to live somewhere in between.
-    dithering: Option<(String, kobo_image::Picture)>,
-    /// The sleep that will bring the next pass at the queue.
-    plating: Option<TaskId>,
     place: Option<Memory>,
     keeping: Option<ShelfUpload>,
     loading: Option<ShelfDownload>,
@@ -699,12 +661,8 @@ impl Default for Gutenbird {
             download: None,
             fetched: 0,
             complete: false,
-            reader: None,
-            book_pictures: Vec::new(),
+            book: BookView::new(),
             book_font: None,
-            plates: VecDeque::new(),
-            dithering: None,
-            plating: None,
             place: None,
             keeping: None,
             loading: None,
@@ -1138,13 +1096,10 @@ impl Gutenbird {
         self.download = None;
         self.fetched = 0;
         self.complete = false;
-        self.reader = None;
         // Unconditionally, unlike closing a book: arriving at another
         // publication abandons whatever was in flight, so there is nothing
-        // left that could ask for these back later.
-        for handle in self.book_pictures.drain(..) {
-            context.drop_picture(handle);
-        }
+        // left that could ask these back later.
+        self.book.close(context);
         self.place = None;
         self.loading = None;
         self.failed = None;
@@ -1876,10 +1831,10 @@ impl Gutenbird {
             || "Reading".to_owned(),
             |publication| publication.title.clone(),
         );
-        let Some(reader) = &self.reader else {
+        let Some(screen) = self.book.screen(&title) else {
             return self.details_screen(context);
         };
-        reader.screen(&title)
+        screen
     }
 
     // ---------------------------------------------------------------
@@ -2431,13 +2386,13 @@ impl Gutenbird {
         if self.download.as_ref().map(|download| download.kind) != Some(DownloadKind::Text) {
             return;
         }
-        let left = self.reader.as_ref().map_or(0, |reader| {
+        let left = self.book.reader().map_or(0, |reader| {
             reader.page_count().saturating_sub(reader.page_number())
         });
         if left <= TOP_UP_PAGES {
             self.ask_book(context);
             if self.awaiting_book() {
-                if let Some(reader) = &mut self.reader {
+                if let Some(reader) = self.book.reader_mut() {
                     reader.expect_more(true);
                 }
             }
@@ -2449,12 +2404,15 @@ impl Gutenbird {
     }
 
     fn read_action(&mut self, context: &mut Context, action: ActionId) -> bool {
-        let metrics = context.metrics();
-        let Some(reader) = &mut self.reader else {
+        // Offering the action to the shared view rather than to a reader held
+        // here is also what keeps the plates arriving: a page turn is the
+        // moment a plate on the page turned to is wanted, and the view takes
+        // that as its cue to carry the queue forward.
+        let Some(outcome) = self.book.act(context, action) else {
             return false;
         };
-        match reader.act_on(action, &metrics) {
-            Outcome::Elsewhere => return false,
+        match outcome {
+            Outcome::Elsewhere | Outcome::Repaint => {}
             Outcome::Close => self.back_to(View::Details),
             Outcome::Light(level) => {
                 context.device().set_frontlight(level);
@@ -2464,15 +2422,6 @@ impl Gutenbird {
                 self.save_place(context);
                 self.top_up(context);
             }
-            Outcome::Repaint => {}
-        }
-        // A page turn is also the moment a plate on the page turned to is
-        // wanted. Nothing to do while the queue is already going round; this
-        // is here for the case where the runtime had no room for the sleep
-        // that would have carried it, and the plates would otherwise stop
-        // arriving with no way to start again.
-        if self.plating.is_none() && (!self.plates.is_empty() || self.dithering.is_some()) {
-            self.decode_more_plates(context);
         }
         self.show(context);
         true
@@ -2482,10 +2431,10 @@ impl Gutenbird {
         let Some((_, place)) = self.open_keys() else {
             return;
         };
-        let Some(reader) = &self.reader else {
+        let Some(memory) = self.book.memory() else {
             return;
         };
-        let memory = reader.memory().encode();
+        let memory = memory.encode();
         context.store().save(place, memory);
     }
 
@@ -2532,10 +2481,10 @@ impl Gutenbird {
         if download.kind == DownloadKind::Epub && !self.complete {
             return;
         }
-        let memory = self.reader.as_ref().map_or_else(
-            || self.place.clone().unwrap_or_default(),
-            |reader| reader.memory().clone(),
-        );
+        let memory = self
+            .book
+            .memory()
+            .map_or_else(|| self.place.clone().unwrap_or_default(), Clone::clone);
         // Opening a book is the one thing this application does that has ever
         // blocked the panel for seconds at a time, and which of the three
         // stages costs that is not guessable from a screenshot: on a
@@ -2553,59 +2502,49 @@ impl Gutenbird {
         let read_ms = started.elapsed().as_millis();
         let downloaded = download.bytes.len();
         let _ = name;
-        if let Ok(mut document) = result {
+        if let Ok(document) = result {
             let blocks = document.blocks.len();
             let started = std::time::Instant::now();
             // Whatever the last reopen handed over is about to be replaced, so
             // it goes back first. A book read from the shelf reaches here a
             // second time, and without this the first set stayed decoded in
-            // the runtime with nothing left that could name it.
-            for handle in self.book_pictures.drain(..) {
-                context.drop_picture(handle);
-            }
+            // the runtime with nothing left that could name it. The plates are
+            // the view's to give back; the face is this application's.
             if let Some(handle) = self.book_font.take() {
                 context.drop_font(handle);
             }
-            // Taken off the document rather than left on it: the reader owns
-            // the document from here, and holding the scanned bytes as well as
-            // the decoded greyscale meant every plate was paid for twice.
-            let images = std::mem::take(&mut document.images);
-            let pictures_ms = started.elapsed().as_millis();
-            let started = std::time::Instant::now();
-            let mut reader = Reader::open(document, memory, &context.metrics());
-            if let Some((name, bytes)) = reader
-                .preferred_publisher_font()
-                .map(|(name, bytes)| (name.to_owned(), bytes.to_vec()))
-            {
+            // Parsing, reserving room for every plate and measuring the pages
+            // all happen in here, and none of them decodes a picture: that is
+            // what kept opening an illustrated book inside the watchdog's
+            // deadline.
+            self.book.open(context, document, memory);
+            // After the book is open, because the face is asked for by the
+            // book itself. Setting it measures the pages again, which is the
+            // price of type the publisher chose over type the reader did.
+            let wanted = self
+                .book
+                .reader()
+                .and_then(Reader::preferred_publisher_font)
+                .map(|(name, bytes)| (name.to_owned(), bytes.to_vec()));
+            if let Some((name, bytes)) = wanted {
                 if let Some(handle) = context.put_font(PUBLISHER_FONT_HANDLE, name, bytes) {
-                    reader.set_publisher_font(Some(handle), &context.metrics());
+                    let metrics = context.metrics();
+                    if let Some(reader) = self.book.reader_mut() {
+                        reader.set_publisher_font(Some(handle), &metrics);
+                    }
                     self.book_font = Some(handle);
                 }
             }
-            // Before the count is read, because the sizes are what an
-            // illustrated book is measured at, and it is that count -- the one
-            // it will actually be read at -- that the timing line is worth
-            // having.
-            let reserved = self.reserve_plates(&reader, &images, &context.metrics());
-            reader.set_pictures(reserved, &context.metrics());
-            let paginate_ms = started.elapsed().as_millis();
+            let open_ms = started.elapsed().as_millis();
             context.log(
                 LogLevel::Info,
                 format!(
-                    "opened {} bytes in {read_ms} ms read, {pictures_ms} ms pictures, \
-                     {paginate_ms} ms paginate ({blocks} blocks, {} pages, {} plates queued)",
-                    downloaded,
-                    reader.page_count(),
-                    self.plates.len()
+                    "opened {downloaded} bytes in {read_ms} ms read, {open_ms} ms open \
+                     ({blocks} blocks, {} pages, {} plates queued)",
+                    self.book.reader().map_or(0, Reader::page_count),
+                    self.book.queued()
                 ),
             );
-            self.reader = Some(reader);
-            // Handed to the runtime rather than started here. This callback
-            // has already spent its parse and its pagination; a plate on top
-            // of that is what put it over the deadline.
-            if !self.plates.is_empty() {
-                self.plating = context.spawn(Task::Sleep { seconds: 0 });
-            }
         } else {
             self.problem = Some("This book could not be read.".to_owned());
             if self.complete {
@@ -2633,189 +2572,13 @@ impl Gutenbird {
         if self.download.is_some() && !self.complete {
             return;
         }
-        for handle in self.book_pictures.drain(..) {
-            context.drop_picture(handle);
-        }
+        self.book.close(context);
         if let Some(handle) = self.book_font.take() {
             context.drop_font(handle);
         }
-        // Whatever is still queued is source bytes for a book nobody is
-        // reading any more. The sleep already in flight is left to land and be
-        // ignored: cancelling it would cost a message to save nothing.
-        self.plates.clear();
-        self.dithering = None;
-        self.reader = None;
         self.download = None;
         self.fetched = 0;
         self.complete = false;
-    }
-
-    /// Claims the room every plate in the book will take, decoding none of it.
-    ///
-    /// Opening a book used to decode, fit and dither every image the container
-    /// held before it returned, inside a lifecycle callback with a two hundred
-    /// and fifty millisecond deadline. The Tale of Peter Rabbit is twenty-eight
-    /// plates, and on a Clara BW that was two thousand seven hundred and
-    /// eighty-four milliseconds: parsing the book took ten and paginating it
-    /// thirty-two, so the images were ninety-nine per cent of a stall during
-    /// which nothing drew, no control answered, and three watchdogs counted.
-    ///
-    /// A picture's header states its size in its first few dozen bytes, and
-    /// size is the only thing pagination needs. Reading the headers costs
-    /// microseconds and gives the reader the same page count it would have got
-    /// from the pixels, so the book opens measured and correct and the plates
-    /// are drawn into the room already reserved for them as they decode. Until
-    /// each one does the panel draws an empty frame at exactly the right size,
-    /// which is what stops a page from resizing under somebody reading it.
-    ///
-    /// Only the pictures the text actually refers to, in the order it refers to
-    /// them, and at most `MAX_BOOK_PICTURES` of those: a container's spare
-    /// artwork is not something to spend a decode on, and the order is what
-    /// lets the plates arrive roughly as fast as they are read past.
-    fn reserve_plates(
-        &mut self,
-        reader: &Reader,
-        images: &BTreeMap<String, Vec<u8>>,
-        metrics: &DisplayMetrics,
-    ) -> BTreeMap<String, TilePicture> {
-        self.plates.clear();
-        self.book_pictures.clear();
-        let mut reserved = BTreeMap::new();
-        let Some((width, height)) = plate_box(metrics) else {
-            return reserved;
-        };
-        for (index, name) in reader
-            .pictures_wanted()
-            .into_iter()
-            .take(MAX_BOOK_PICTURES)
-            .enumerate()
-        {
-            let Some(bytes) = images.get(name) else {
-                continue;
-            };
-            // A header that will not parse is a plate that will not decode, so
-            // it is left out here and the page reads its description instead --
-            // which is what a book with a broken plate should look like.
-            let Ok(source) = kobo_image::size(bytes) else {
-                continue;
-            };
-            let (drawn_width, drawn_height) = kobo_image::fitted_size(source, width, height);
-            if drawn_width == 0 || drawn_height == 0 {
-                continue;
-            }
-            // Numbered from a base that cannot collide with the cover handles
-            // the shelf is holding at the same time.
-            let handle = PictureHandle(PICTURE_HANDLE_BASE + u32::try_from(index).unwrap_or(0));
-            reserved.insert(
-                name.to_owned(),
-                TilePicture::new(handle, drawn_width, drawn_height),
-            );
-            self.book_pictures.push(handle);
-            self.plates.push_back((name.to_owned(), bytes.clone()));
-        }
-        reserved
-    }
-
-    /// Carries one plate one step further towards the panel, and asks to be
-    /// called again while any step is left.
-    ///
-    /// One step, not as many as fit in a time budget. Nothing here can be
-    /// interrupted half way, so a budget can only be checked before starting
-    /// something, and the pass then runs for the budget plus however long that
-    /// something takes: on the panel a hundred and twenty millisecond budget
-    /// produced callbacks of 272, 293 and 311 milliseconds against a deadline
-    /// of 250. One whole plate per pass was no better -- 250 to 311 -- because
-    /// one whole plate is itself over the deadline on this processor.
-    ///
-    /// So a plate is taken in its two natural halves. Reading the file and
-    /// fitting it is one; reducing a million pixels to the sixteen greys the
-    /// panel can hold is the other, and on a development machine the two are
-    /// two milliseconds and three, which on the reader is about a hundred and
-    /// about a hundred and seventy. Either alone is comfortably inside the
-    /// deadline. There is no third half, and the honest fix is a runtime that
-    /// can decode off this thread at all; until then this is where the seam is.
-    ///
-    /// The page being looked at is decoded first. Everything else can arrive
-    /// while it is being read.
-    fn decode_more_plates(&mut self, context: &mut Context) {
-        let metrics = context.metrics();
-        let Some((width, height)) = plate_box(&metrics) else {
-            self.plates.clear();
-            self.dithering = None;
-            return;
-        };
-        let showing: Vec<String> = self.reader.as_ref().map_or_else(Vec::new, |reader| {
-            reader
-                .pictures_on_page()
-                .into_iter()
-                .map(str::to_owned)
-                .collect()
-        });
-        let mut on_this_page = false;
-        if let Some((name, mut picture)) = self.dithering.take() {
-            // The second half: the greys.
-            picture.dither(kobo_image::PANEL_GREYS);
-            let (drawn_width, drawn_height) = (picture.width(), picture.height());
-            if let Some(reserved) = self.handed_plate(&name) {
-                if context
-                    .put_picture(reserved, drawn_width, drawn_height, picture.into_grey())
-                    .is_some()
-                    && showing.contains(&name)
-                {
-                    on_this_page = true;
-                }
-            }
-        } else {
-            self.plates_first(&showing);
-            // The first half: the file. A plate that will not read costs
-            // nothing, so this goes past it rather than spending a whole round
-            // trip discovering there was nothing to draw, and stops on the
-            // first one that works.
-            while let Some((name, bytes)) = self.plates.pop_front() {
-                if self.handed_plate(&name).is_none() {
-                    continue;
-                }
-                let Ok(picture) = kobo_image::decode(&bytes) else {
-                    continue;
-                };
-                let Ok(picture) = picture.fit(width, height) else {
-                    continue;
-                };
-                self.dithering = Some((name, picture));
-                break;
-            }
-        }
-        // Only when the page in front of somebody actually changed. A plate
-        // twenty pages ahead landing is not a reason to flash an E Ink panel,
-        // and there are two dozen of them in an illustrated book.
-        if on_this_page {
-            self.show(context);
-        }
-        if self.plates.is_empty() && self.dithering.is_none() {
-            self.plating = None;
-            return;
-        }
-        self.plating = context.spawn(Task::Sleep { seconds: 0 });
-    }
-
-    /// Moves the named plates to the front of the queue, keeping their order.
-    fn plates_first(&mut self, names: &[String]) {
-        if names.is_empty() {
-            return;
-        }
-        let (wanted, rest): (VecDeque<_>, VecDeque<_>) = self
-            .plates
-            .drain(..)
-            .partition(|(name, _)| names.contains(name));
-        self.plates = wanted.into_iter().chain(rest).collect();
-    }
-
-    /// The handle a plate was reserved against, if it was.
-    fn handed_plate(&self, name: &str) -> Option<PictureHandle> {
-        self.reader
-            .as_ref()
-            .and_then(|reader| reader.picture_named(name))
-            .map(|picture| picture.handle)
     }
 
     /// A blob that arrived and will not parse is forgotten rather than kept,
@@ -2833,8 +2596,8 @@ impl Gutenbird {
 
     fn ask_light(&mut self, context: &mut Context) {
         if self
-            .reader
-            .as_ref()
+            .book
+            .reader()
             .is_some_and(|reader| reader.light().is_none())
         {
             context.device().read_frontlight();
@@ -2889,7 +2652,7 @@ impl Gutenbird {
         if self.complete && self.download.is_some() {
             self.keep_book(context);
         }
-        if self.reader.is_some() {
+        if self.book.is_open() {
             self.go(View::Reading);
         }
         // A chunk that lands is what asks for the one after it. Nothing else
@@ -2975,19 +2738,6 @@ fn book_keys(publication: &Publication) -> Option<(String, String)> {
 
 fn cover_key(url: &str) -> String {
     kobo_sdk::cache_key(format!("cover.{:08x}", stamp(url)))
-}
-
-/// The box an illustration inside a book is fitted into, in pixels.
-///
-/// `None` on a panel so small the box has no area, which is not a device this
-/// runs on but is a shape the arithmetic can produce.
-fn plate_box(metrics: &DisplayMetrics) -> Option<(u32, u32)> {
-    let width = metrics.tenth_mm(i32::from(PICTURE_WIDTH_MM) * 10);
-    let height = metrics.tenth_mm(i32::from(PICTURE_HEIGHT_MM) * 10);
-    match (u32::try_from(width), u32::try_from(height)) {
-        (Ok(width), Ok(height)) if width > 0 && height > 0 => Some((width, height)),
-        _ => None,
-    }
 }
 
 /// Centres a picture on a sheet of exactly `width` by `height`.
@@ -3312,7 +3062,7 @@ impl KoboApp for Gutenbird {
                         total,
                     });
                     self.reopen(context);
-                    if self.reader.is_some() {
+                    if self.book.is_open() {
                         self.go(View::Reading);
                     }
                     self.show(context);
@@ -3366,7 +3116,7 @@ impl KoboApp for Gutenbird {
                 value: Some(value), ..
             } => {
                 let memory = Memory::decode(&value);
-                if let Some(reader) = &mut self.reader {
+                if let Some(reader) = self.book.reader_mut() {
                     let metrics = context.metrics();
                     reader.restore(memory.clone(), &metrics);
                     self.show(context);
@@ -3399,8 +3149,8 @@ impl KoboApp for Gutenbird {
             return;
         };
         if self
-            .reader
-            .as_mut()
+            .book
+            .reader_mut()
             .is_some_and(|reader| reader.seed_light(percent))
         {
             self.show(context);
@@ -3425,10 +3175,7 @@ impl KoboApp for Gutenbird {
                 offset: hit.end,
             },
         };
-        let word = self
-            .reader
-            .as_ref()
-            .and_then(|reader| reader.text_in(range));
+        let word = self.book.reader().and_then(|reader| reader.text_in(range));
         let Some(word) = word else { return };
         self.selected_range = Some(range);
         self.lookup_word.clone_from(&word);
@@ -3444,7 +3191,7 @@ impl KoboApp for Gutenbird {
         if action == ActionId::BACK {
             if self.view == View::Reading {
                 let metrics = context.metrics();
-                if let Some(reader) = &mut self.reader {
+                if let Some(reader) = self.book.reader_mut() {
                     if reader.chrome() != kobo_read::Chrome::Hidden {
                         reader.set_chrome(kobo_read::Chrome::Hidden, &metrics);
                         self.show(context);
@@ -3505,8 +3252,8 @@ impl KoboApp for Gutenbird {
         {
             let created = self.selected_range.and_then(|range| {
                 let metrics = context.metrics();
-                self.reader
-                    .as_mut()
+                self.book
+                    .reader_mut()
                     .and_then(|reader| reader.annotate(range, None, &metrics).ok())
             });
             if let Some(id) = created {
@@ -3542,7 +3289,7 @@ impl KoboApp for Gutenbird {
                 Some(Pressed::Submitted) => {
                     let note = self.keyboard.take();
                     if let (Some(id), Some(reader)) =
-                        (self.pending_annotation.take(), self.reader.as_mut())
+                        (self.pending_annotation.take(), self.book.reader_mut())
                     {
                         let note = (!note.trim().is_empty()).then_some(note.trim());
                         let _ = reader.edit_annotation_note(id, note);
@@ -3735,14 +3482,16 @@ impl KoboApp for Gutenbird {
             self.next_cover(context);
             return;
         }
-        if self.plating == Some(task) {
-            self.plating = None;
-            // Only while a book is open. Leaving one empties the queue, and a
-            // sleep that was already in flight when it did lands here.
-            if self.reader.is_some() {
-                self.decode_more_plates(context);
+        // The picture pipeline's own sleep, if this was it. A sleep that was
+        // already in flight when a book was closed lands here too, and the
+        // view knows to do nothing with it.
+        match self.book.woke(context, task) {
+            Step::Elsewhere => {}
+            Step::Quiet => return,
+            Step::Repaint => {
+                self.show(context);
+                return;
             }
-            return;
         }
         if self.open_cover_task.is_some_and(|(id, _)| id == task) {
             let (_, tries) = self.open_cover_task.take().expect("just checked");
@@ -3841,7 +3590,7 @@ impl KoboApp for Gutenbird {
                         self.failed = Some(failure.advice.to_owned());
                         self.retryable = failure.retryable;
                         self.back_to(View::Details);
-                    } else if let Some(reader) = &mut self.reader {
+                    } else if let Some(reader) = self.book.reader_mut() {
                         reader.expect_more(false);
                     }
                 }
@@ -3878,9 +3627,9 @@ impl KoboApp for Gutenbird {
 mod tests {
     use super::{
         book_keys, catalog_display_name, decode_registry, download_kind, encode_registry,
-        plate_box, read_offer, readable, Awaiting, BTreeMap, BTreeSet, Catalog, DetailBlock,
-        Download, DownloadKind, FeedPurpose, FillStage, Gutenbird, Memory, ReadOffer, Reader,
-        SearchState, SearchWay, StackEntry, View, COVER_TRIES, OPEN_COVER_HANDLE,
+        read_offer, readable, Awaiting, BTreeSet, BookView, Catalog, DetailBlock, Download,
+        DownloadKind, FeedPurpose, FillStage, Gutenbird, Memory, ReadOffer, Reader, SearchState,
+        SearchWay, StackEntry, View, COVER_TRIES, OPEN_COVER_HANDLE, PUBLISHER_FONT_HANDLE,
     };
     use kobo_opds::{
         Acquisition, AcquisitionKind, Category, Feed, Image, ImageSource, Link, Navigation,
@@ -4457,7 +4206,7 @@ Please read this before you distribute or use this work.\n";
             TaskId(1),
             TaskOutcome::Completed(b"PK\x03\x04not a whole book".to_vec()),
         );
-        assert!(runner.app().reader.is_none(), "a partial EPUB was opened");
+        assert!(!runner.app().book.is_open(), "a partial EPUB was opened");
         assert!(!runner.app().complete);
     }
 
@@ -4487,7 +4236,7 @@ Please read this before you distribute or use this work.\n";
             runner.app().failed.as_deref(),
             Some("This book did not arrive.")
         );
-        assert!(runner.app().reader.is_none());
+        assert!(!runner.app().book.is_open());
     }
 
     fn epub_bytes() -> Vec<u8> {
@@ -4524,7 +4273,7 @@ Please read this before you distribute or use this work.\n";
         );
         runner.task_outcome(TaskId(1), TaskOutcome::Completed(bytes));
         assert!(
-            runner.app().reader.is_some(),
+            runner.app().book.is_open(),
             "the finished EPUB was not opened"
         );
         assert_eq!(runner.app().view, View::Reading);
@@ -5184,20 +4933,20 @@ Please read this before you distribute or use this work.\n";
         );
         let application = runner.app_mut();
         assert!(
-            application.reader.is_some(),
+            application.book.is_open(),
             "the chunk did not open as a book"
         );
         assert!(
             application
-                .reader
-                .as_ref()
+                .book
+                .reader()
                 .is_some_and(|reader| reader.page_count() > 1),
             "the whole chunk fitted a page"
         );
         let metrics = CLARA_BW_METRICS;
         loop {
             let (page, expected) = {
-                let reader = application.reader.as_ref().expect("a book");
+                let reader = application.book.reader().expect("a book");
                 (reader.page_number(), reader.page().len())
             };
             let layout = application
@@ -5214,7 +4963,7 @@ Please read this before you distribute or use this work.\n";
                 drawn, expected,
                 "page {page} measured as {expected} paragraphs but drew {drawn}"
             );
-            let reader = application.reader.as_mut().expect("a book");
+            let reader = application.book.reader_mut().expect("a book");
             if !reader.forward() {
                 break;
             }
@@ -5227,141 +4976,6 @@ Please read this before you distribute or use this work.\n";
             Memory::default(),
             &CLARA_BW_METRICS,
         )
-    }
-
-    /// A plate is measured from its header and decoded later.
-    ///
-    /// Opening The Tale of Peter Rabbit on the panel decoded twenty-eight
-    /// images inside a lifecycle callback and took 2,784 milliseconds doing
-    /// it, against a deadline of 250. Reading the headers costs microseconds
-    /// and answers the only question pagination has, so the book opens at the
-    /// page count it will be read at and the pixels arrive afterwards.
-    #[test]
-    fn a_book_of_plates_is_measured_from_its_headers_and_decoded_afterwards() {
-        let plate = kobo_image::encode_png_grey(1200, 2000, &vec![128; 1200 * 2000])
-            .expect("a png of a plate");
-        let images: BTreeMap<String, Vec<u8>> = [("plate.png".to_owned(), plate.clone())]
-            .into_iter()
-            .collect();
-        // Enough prose to fill the page it opens on, so that the room the
-        // plate takes is the difference between one page and two.
-        let mut blocks: Vec<kobo_doc::Block> = (0..12)
-            .map(|_| {
-                kobo_doc::Block::Paragraph(
-                    "Once upon a time there were four little rabbits, and their names were \
-                     Flopsy, Mopsy, Cotton-tail and Peter."
-                        .to_owned(),
-                )
-            })
-            .collect();
-        blocks.push(kobo_doc::Block::Picture {
-            name: "plate.png".to_owned(),
-            alt: "Four rabbits".to_owned(),
-        });
-        let document = kobo_doc::Document {
-            blocks,
-            ..kobo_doc::Document::default()
-        };
-        let mut reader = Reader::open(document, Memory::default(), &CLARA_BW_METRICS);
-        let without = reader.page_count();
-
-        let mut app = Gutenbird::default();
-        let reserved = app.reserve_plates(&reader, &images, &CLARA_BW_METRICS);
-
-        // The room, from the header alone, and the same room decoding would
-        // have asked for.
-        let (width, height) = plate_box(&CLARA_BW_METRICS).expect("a panel with room on it");
-        let decoded = kobo_image::decode(&plate)
-            .expect("decode")
-            .fit(width, height)
-            .expect("fit");
-        assert_eq!(
-            reserved.get("plate.png").map(|picture| picture.source),
-            Some((decoded.width(), decoded.height())),
-            "the size claimed from the header is not the size the decoder produces"
-        );
-        assert_eq!(
-            app.plates.len(),
-            1,
-            "the plate should be queued rather than decoded"
-        );
-
-        reader.set_pictures(reserved, &CLARA_BW_METRICS);
-        assert!(
-            reader.page_count() > without,
-            "the book was not measured around the room the plate takes"
-        );
-    }
-
-    /// And the pixels, when they come, go into the room already reserved.
-    #[test]
-    fn a_queued_plate_is_handed_over_against_the_handle_it_was_measured_at() {
-        let plate = kobo_image::encode_png_grey(1200, 2000, &vec![128; 1200 * 2000])
-            .expect("a png of a plate");
-        let images: BTreeMap<String, Vec<u8>> =
-            [("plate.png".to_owned(), plate)].into_iter().collect();
-        let document = kobo_doc::Document {
-            blocks: vec![kobo_doc::Block::Picture {
-                name: "plate.png".to_owned(),
-                alt: "Four rabbits".to_owned(),
-            }],
-            ..kobo_doc::Document::default()
-        };
-        let mut reader = Reader::open(document, Memory::default(), &CLARA_BW_METRICS);
-        let mut app = Gutenbird::default();
-        let reserved = app.reserve_plates(&reader, &images, &CLARA_BW_METRICS);
-        let claimed = reserved
-            .get("plate.png")
-            .copied()
-            .expect("the plate was reserved");
-        reader.set_pictures(reserved, &CLARA_BW_METRICS);
-        app.reader = Some(reader);
-        // The sleep that carries the queue round, answered.
-        app.plating = Some(TaskId(1));
-
-        let mut runner = AppRunner::new(app);
-        // The first pass reads the plate and asks for another; the second
-        // reduces it to the panel's greys and hands it over. Neither half is
-        // allowed to take as long as both would.
-        let first = runner.task_outcome(TaskId(1), TaskOutcome::Completed(Vec::new()));
-        assert!(
-            handed_pictures(&first).is_empty(),
-            "a plate was decoded and dithered in one callback"
-        );
-        assert!(
-            runner.app().plates.is_empty() && runner.app().dithering.is_some(),
-            "the plate was not read out of the book"
-        );
-        let plating = runner
-            .app()
-            .plating
-            .expect("another pass was not asked for");
-
-        let second = runner.task_outcome(plating, TaskOutcome::Completed(Vec::new()));
-        assert_eq!(
-            handed_pictures(&second),
-            vec![(claimed.handle, claimed.source.0, claimed.source.1)],
-            "the plate did not fill the frame that was standing in for it"
-        );
-        assert!(
-            runner.app().dithering.is_none(),
-            "the decoded plate was kept after it was drawn"
-        );
-    }
-
-    fn handed_pictures(commands: &[kobo_sdk::Command]) -> Vec<(PictureHandle, u32, u32)> {
-        commands
-            .iter()
-            .filter_map(|command| match command {
-                kobo_sdk::Command::PutPicture {
-                    handle,
-                    width,
-                    height,
-                    ..
-                } => Some((*handle, *width, *height)),
-                _ => None,
-            })
-            .collect()
     }
 
     #[test]
@@ -5380,30 +4994,34 @@ Please read this before you distribute or use this work.\n";
             // catalog, a shelf, the book's own page, and then reading it.
             trail: vec![View::Catalogs, View::Shelf, View::Details],
             complete: true,
-            reader: Some(opened("A book with plates in it.")),
+            book: BookView::holding(opened("A book with plates in it.")),
+            // A publisher's own face is one of the things a book costs while
+            // it is open, so the fixture is reading one.
+            book_font: Some(PUBLISHER_FONT_HANDLE),
             download: Some(Download {
                 url: "https://x/book.epub".to_owned(),
                 kind: DownloadKind::Epub,
                 bytes: vec![0; 1_510_370],
                 total: None,
             }),
-            book_pictures: vec![PictureHandle(1000), PictureHandle(1001)],
             ..Gutenbird::default()
         });
         let commands = runner.action(kobo_sdk::ActionId::BACK);
-        let given_back: Vec<PictureHandle> = commands
-            .iter()
-            .filter_map(|command| match command {
-                kobo_sdk::Command::DropPicture(handle) => Some(*handle),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(
-            given_back,
-            vec![PictureHandle(1000), PictureHandle(1001)],
-            "the runtime was left holding the plates"
+        // That every reserved handle goes back is `kobo-bookview`'s to prove,
+        // and it does. What matters here is that leaving the book is what asks
+        // it to: the fault this was written for was a Back that released
+        // nothing at all.
+        assert!(!runner.app().book.is_open(), "the parsed book was kept");
+        assert!(
+            commands
+                .iter()
+                .any(|command| matches!(command, kobo_sdk::Command::DropFont(_))),
+            "the embedded face was kept"
         );
-        assert!(runner.app().reader.is_none(), "the parsed book was kept");
+        assert!(
+            runner.app().book_font.is_none(),
+            "the embedded face was still recorded as held"
+        );
         assert!(
             runner.app().download.is_none(),
             "the downloaded bytes were kept"
@@ -5503,7 +5121,7 @@ Please read this before you distribute or use this work.\n";
             view: View::Reading,
             trail: vec![View::Catalogs, View::Shelf, View::Details],
             complete: false,
-            reader: Some(opened("The first chunk of a longer book.")),
+            book: BookView::holding(opened("The first chunk of a longer book.")),
             download: Some(Download {
                 url: "https://x/book.txt".to_owned(),
                 kind: DownloadKind::Text,
@@ -5525,7 +5143,7 @@ Please read this before you distribute or use this work.\n";
         reader.act(kobo_read::action::CONTROLS, &CLARA_BW_METRICS);
         let application = Gutenbird {
             view: View::Reading,
-            reader: Some(reader),
+            book: BookView::holding(reader),
             complete: true,
             ..Gutenbird::default()
         };
@@ -5555,7 +5173,7 @@ Please read this before you distribute or use this work.\n";
     fn holding_a_word_opens_marginalia_and_saves_the_note_on_that_exact_word() {
         let mut runner = AppRunner::new(Gutenbird {
             view: View::Reading,
-            reader: Some(opened("café novel")),
+            book: BookView::holding(opened("café novel")),
             complete: true,
             ..Gutenbird::default()
         });
@@ -5568,13 +5186,7 @@ Please read this before you distribute or use this work.\n";
             },
         );
         assert_eq!(runner.app().view, View::Lookup);
-        assert!(runner
-            .app()
-            .reader
-            .as_ref()
-            .unwrap()
-            .annotations()
-            .is_empty());
+        assert!(runner.app().book.reader().unwrap().annotations().is_empty());
         runner.device_result(kobo_sdk::DeviceResult::Dictionary {
             word: "café".into(),
             entries: vec![kobo_sdk::DictionaryEntry {
@@ -5587,12 +5199,12 @@ Please read this before you distribute or use this work.\n";
         assert_eq!(runner.app().lookup_entries.as_ref().unwrap().len(), 1);
         runner.action(action_id("lookup-note"));
         assert_eq!(runner.app().view, View::Note);
-        assert_eq!(runner.app().reader.as_ref().unwrap().annotations().len(), 1);
+        assert_eq!(runner.app().book.reader().unwrap().annotations().len(), 1);
 
         runner.action(action_id("kb.r0c0"));
         runner.action(action_id("kb.enter"));
         assert_eq!(runner.app().view, View::Reading);
-        let annotation = &runner.app().reader.as_ref().unwrap().annotations()[0];
+        let annotation = &runner.app().book.reader().unwrap().annotations()[0];
         assert_eq!(annotation.note.as_deref(), Some("q"));
     }
 
@@ -5602,7 +5214,7 @@ Please read this before you distribute or use this work.\n";
         reader.act(kobo_read::action::LIGHT, &CLARA_BW_METRICS);
         let application = Gutenbird {
             view: View::Reading,
-            reader: Some(reader),
+            book: BookView::holding(reader),
             complete: true,
             ..Gutenbird::default()
         };
@@ -5714,7 +5326,7 @@ Please read this before you distribute or use this work.\n";
                 "Something Else",
                 vec![text_acquisition("https://x/else.txt")],
             )),
-            reader: Some(opened("Chapter forty of something else.")),
+            book: BookView::holding(opened("Chapter forty of something else.")),
             complete: true,
             ..Gutenbird::default()
         });
@@ -5722,7 +5334,7 @@ Please read this before you distribute or use this work.\n";
         let application = runner.app_mut();
         assert!(application.download.is_none());
         assert_eq!(application.fetched, 0);
-        assert!(application.reader.is_none(), "the last book is still open");
+        assert!(!application.book.is_open(), "the last book is still open");
         assert!(!application.complete);
         assert_eq!(
             application.open.as_ref().map(|p| p.title.as_str()),
@@ -5820,7 +5432,7 @@ Please read this before you distribute or use this work.\n";
             key: place_key,
             value: Some(place.encode()),
         });
-        let reader = runner.app_mut().reader.as_ref().expect("a book");
+        let reader = runner.app_mut().book.reader().expect("a book");
         assert!(
             reader.page().iter().any(|piece| piece.block == 20),
             "the reader was not put back where they were left"

--- a/examples/gutenbird/src/main.rs
+++ b/examples/gutenbird/src/main.rs
@@ -3470,7 +3470,7 @@ impl KoboApp for Gutenbird {
         // The picture pipeline's own sleep, if this was it. A sleep that was
         // already in flight when a book was closed lands here too, and the
         // view knows to do nothing with it.
-        match self.book.woke(context, task) {
+        match self.book.woke(context, task, &outcome) {
             Step::Elsewhere => {}
             Step::Quiet => return,
             Step::Repaint => {

--- a/examples/settings/src/main.rs
+++ b/examples/settings/src/main.rs
@@ -940,6 +940,7 @@ impl KoboApp for Settings {
             | DeviceResult::Frontlight { .. }
             | DeviceResult::Cover { .. }
             | DeviceResult::Audio { .. }
+            | DeviceResult::Dictionary { .. }
             | DeviceResult::Apps { .. } => {}
         }
         self.show(context);

--- a/tools/icon-import/icons.txt
+++ b/tools/icon-import/icons.txt
@@ -52,3 +52,4 @@ Wifi                wifi
 Battery             battery
 Plus                plus
 Headphones          headphones
+Minus               minus


### PR DESCRIPTION
## Summary

Implements the highest-value focused-reader tranche from `READER_PLATFORM_IMPLEMENTATION_PLAN.md`: faithful EPUB/HTML presentation, stable reading locations, search/navigation, exact marginalia, and an offline dictionary service exposed through the public SDK.

- retain bounded rich XHTML runs rather than flattening EPUB prose to plain text
- preserve headings, paragraphs, lists, quotations, preformatted text, rules, illustrations, figure captions, internal links, footnotes, and spine/TOC order
- apply a safe publisher CSS subset: inline emphasis, alignment, line height, margins, first-line indent, inherited typography, and explicit page breaks
- extract bounded embedded TTF/OTF fonts, honor the requested `@font-face` family, and use the same face for pagination and rendering
- split long styled paragraphs without repeating publisher margins or first-line indentation on continuation pages
- add bounded case-insensitive in-book search and logical Back history
- add grapheme-safe range locators and durable, idempotent highlight/note CRUD that survives repagination and reopen
- resolve a held Unicode word from panel coordinates to stable document offsets
- make long press open an offline definition sheet first, with definition paging plus **Highlight** and **Add note** actions for that exact word
- add `kobo-dict`, a bounded Unicode-normalizing runtime dictionary index with simple inflection hooks, deterministic multi-dictionary ordering, malformed-file isolation, and zero network use
- expose typed bounded dictionary requests/results and a `context.device().lookup_word(...)` SDK facade; protocol v10 refuses incompatible peers cleanly
- load owner-installed UTF-8 TSV dictionaries from the documented host/device directories

The document/reader engine remains shared (`kobo-doc` + `kobo-read`), so EPUB, HTML, Markdown, and TXT clients inherit the rendering, pagination, navigation, image/caption, publisher-font, search, locator, and annotation behavior rather than recreating it in each app. The privileged lookup implementation stays runtime-owned; applications use only the bounded SDK contract.

## Bounds and failure behavior

- 256 KiB combined external + embedded stylesheet ceiling and 4,096 parsed rules
- 256 styled runs per block; excess styling degrades without losing text
- 2 MiB per embedded font and 4 MiB per book
- 64 internal-navigation origins and 256 search results
- 2,048 annotations and 4 KiB per marginal note
- up to 32 dictionaries, 8 MiB each, 64 MiB total, 8 results per lookup, and 4 KiB per definition
- malformed/unsupported fonts and dictionary files are isolated; missing assets retain readable alt/fallback text
- unsupported CSS is ignored; active HTML content remains disabled

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- targeted reader/dictionary/protocol/policy/SDK/Gutenbird/kobod tests
- `git diff --check`

Both review findings have direct regression tests and their threads are resolved.

## Deliberate remaining scope

This is a substantial focused-reader beta, not a false Kindle/Kobo-parity claim. The plan's shared library/import service, PDF/CBZ backends, full bidi/shaping work, multi-word drag handles, dictionary management UI/uninstall-during-lookup, optional consented Wikipedia/translation providers, sync, and complete device/soak gates remain follow-up milestones. WOFF/WOFF2 resources are retained but currently fall back because the rasterizer accepts TTF/OTF outlines only. Inline images retain exact reading order and render as fitted book components rather than implementing arbitrary browser float/position behavior.

Fixtures and tests are project-authored. This is a clean-room implementation and uses no Kindle/Kobo source, assets, strings, or tests.
