### PR TITLE
Read formulae as mathematics, keep headings with their text, search for phrases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 rust-version = "1.85"
 license = "AGPL-3.0-only"

--- a/apps/arxiv/src/main.rs
+++ b/apps/arxiv/src/main.rs
@@ -118,6 +118,26 @@ fn escape(text: &str) -> String {
     out
 }
 
+/// Wraps a search in quotes when it is more than one word.
+///
+/// arXiv reads an unquoted space as `OR`: `all:machine learning` comes back
+/// from the API as the query `all:machine OR all:learning`, which is every
+/// paper containing either word and is not what anybody typing two words
+/// meant. Quoting asks for the phrase, which is.
+///
+/// A quote somebody typed themselves is dropped rather than escaped. There is
+/// no escape for it in the API's syntax, and an unbalanced one turns the rest
+/// of the query into nonsense.
+fn phrase(words: &str) -> String {
+    let cleaned = words.replace('"', " ");
+    let cleaned = cleaned.split_whitespace().collect::<Vec<_>>().join(" ");
+    if cleaned.contains(' ') {
+        format!("\"{cleaned}\"")
+    } else {
+        cleaned
+    }
+}
+
 /// What a listing is a listing of.
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum Query {
@@ -227,7 +247,7 @@ impl Query {
     fn expression(&self, window: Window, today: u64) -> String {
         let subject = match self {
             Self::Subject { code, .. } => format!("cat:{}", escape(code)),
-            Self::Words(words) => format!("all:{}", escape(words)),
+            Self::Words(words) => format!("all:{}", escape(&phrase(words))),
         };
         // A window narrows whichever question was asked, so it is an AND
         // against the term rather than a term of its own.
@@ -1783,6 +1803,38 @@ mod tests {
                 "figures were still being fetched for a paper nobody is reading"
             );
         }
+    }
+
+    /// Two words meant both words, not either.
+    ///
+    /// arXiv reads an unquoted space as `OR` -- the API echoes the query back
+    /// as `all:machine OR all:learning` -- so searching for two words used to
+    /// return every paper containing either of them, which reads as search
+    /// being broken.
+    #[test]
+    fn a_search_for_two_words_asks_for_the_phrase_rather_than_either_word() {
+        let two = Query::Words("machine learning".into());
+        assert_eq!(
+            two.expression(Window::Any, 20_000),
+            "all:%22machine%20learning%22"
+        );
+        // One word needs no quoting, and quoting it would only make the URL
+        // longer and the query stricter than it was asked to be.
+        assert_eq!(
+            Query::Words("transformer".into()).expression(Window::Any, 20_000),
+            "all:transformer"
+        );
+        // Whatever somebody typed, the query has to stay balanced.
+        let hostile = Query::Words("say \"hello\" there".into()).expression(Window::Any, 20_000);
+        assert_eq!(
+            hostile.matches("%22").count() % 2,
+            0,
+            "unbalanced: {hostile}"
+        );
+        assert_eq!(hostile, "all:%22say%20hello%20there%22");
+        // And a window still narrows a phrase.
+        let narrowed = two.expression(Window::Week, 20_000);
+        assert!(narrowed.starts_with("all:%22machine%20learning%22%20AND%20"));
     }
 
     #[test]

--- a/apps/catalog.json
+++ b/apps/catalog.json
@@ -7,7 +7,7 @@
       "display_name": "arXiv",
       "short_label": "arXiv",
       "summary": "Browse, search and keep preprints, and read the ones with a rendering.",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "note",
       "capabilities": ["network"]

--- a/crates/kobo-doc/src/html.rs
+++ b/crates/kobo-doc/src/html.rs
@@ -35,17 +35,16 @@ const OPAQUE: [&str; 3] = ["script", "style", "iframe"];
 
 /// Elements that carry their own reading in an attribute.
 ///
-/// `MathML` is the case that matters. Every renderer that turns a paper into a
-/// web page -- `LaTeXML`, which is what arXiv uses, above all -- writes an
-/// equation as a tree of `<mi>`, `<mo>` and `<mrow>` whose text nodes are the
-/// individual symbols. Read as prose those come out as a run of unspaced
-/// letters and operators in the middle of a sentence: "where italic-x
-/// plus-or-minus 1" for something that was one formula.
+/// A drawing has no text in it, and what a converter can say about one is
+/// whatever the document said it showed.
 ///
-/// The same renderers put the source of the equation in `alttext`, which is
-/// the line the author actually wrote. It is not typeset, but it is a
-/// mathematician's notation rather than a machine's, and it reads.
-const ALT_TEXT: [&str; 2] = ["math", "svg"];
+/// `MathML` used to be in here too, and it was a mistake. The `alttext` a
+/// renderer writes is the LaTeX *source*, and putting source on a page is not
+/// a rendering of the formula, it is a picture of somebody else's keyboard:
+/// `\mathbb{R}^{k}\to\{\pm 1\}` in the middle of an English sentence.
+/// Formulae now go through [`kobo_html::math`], which reads the presentation
+/// markup the source was rendered into.
+const ALT_TEXT: [&str; 1] = ["svg"];
 
 /// Reads an HTML document.
 #[must_use]
@@ -94,6 +93,25 @@ pub fn parse_with_css(source: &str, external_css: &str) -> Document {
 
         let name = element_name(inside);
         let closing = inside.starts_with('/');
+        if !closing && name == "math" {
+            // The whole element, opening tag included, because the renderer
+            // reads the tree rather than the text: the children are the
+            // symbols and the structure between them is the formula.
+            let after = skip_element(rest, &name);
+            let taken = rest.len().saturating_sub(after.len());
+            let element = &tail[..(end + 1).saturating_add(taken)];
+            let drawn = kobo_html::math::render(element);
+            if !drawn.is_empty() {
+                // Spaced on both sides because an equation sits inside a
+                // sentence, and the tags either side of it carry no
+                // whitespace of their own.
+                state.words(" ");
+                state.words(&drawn);
+                state.words(" ");
+            }
+            rest = after;
+            continue;
+        }
         if !closing && ALT_TEXT.contains(&name.as_str()) {
             // Read from the attribute, never from the children: the point is
             // that the children are notation and the attribute is the reading
@@ -1034,11 +1052,15 @@ mod tests {
 
     /// An equation is read from its `alttext`, not from its symbols.
     ///
-    /// This is the shape `LaTeXML` gives every formula on arXiv. Reading the
-    /// element's children puts each symbol on the page as a separate word;
-    /// reading the attribute puts the line the author wrote.
+    /// This is the shape `LaTeXML` gives every formula on arXiv, and the
+    /// attribute it hangs beside the markup is the LaTeX the author typed.
+    /// The reader once put that attribute on the page, so a paper about the
+    /// Grothendieck constant told its reader `\frac{6\pi}{11}\leq K_{G}`
+    /// where the paper itself had an inequality. The markup says the same
+    /// thing in the characters a mathematician would have written, so we
+    /// read that and leave the source where the typesetter left it.
     #[test]
-    fn an_equation_is_read_from_the_line_the_author_wrote() {
+    fn an_equation_is_read_from_its_markup_rather_than_from_its_source() {
         let document = parse(
             "<p>We take <math alttext=\"x \\pm 1\" display=\"inline\">\
              <mi>x</mi><mo>&#xB1;</mo><mn>1</mn></math> as given.</p>",
@@ -1046,18 +1068,45 @@ mod tests {
         let Block::Paragraph(text) = &document.blocks[0] else {
             panic!("not a paragraph: {:?}", document.blocks[0]);
         };
-        assert_eq!(text, "We take x \\pm 1 as given.");
+        assert_eq!(text, "We take x\u{b1}1 as given.");
     }
 
-    /// A formula with no reading of its own says nothing rather than saying
-    /// its own markup.
+    /// A formula whose author gave no LaTeX still has its markup, and the
+    /// markup is the part we were going to read anyway.
     #[test]
-    fn an_equation_with_no_reading_is_left_out() {
+    fn an_equation_with_no_source_beside_it_is_still_read() {
         let document = parse("<p>We take <math><mi>x</mi><mn>1</mn></math> as given.</p>");
         let Block::Paragraph(text) = &document.blocks[0] else {
             panic!("not a paragraph: {:?}", document.blocks[0]);
         };
-        assert_eq!(text, "We take as given.");
+        assert_eq!(text, "We take x1 as given.");
+    }
+
+    /// Nothing that looks like LaTeX may reach the page.
+    ///
+    /// The photographs that reported this showed `K_{G}`, `\operatorname{sgn}`
+    /// and `\mathbb{R}^{k}\to\{\pm 1\}` set in the running text of a paper.
+    /// A backslash or a brace in a rendered paragraph means the source leaked
+    /// again, whatever else may have changed around it.
+    #[test]
+    fn no_part_of_a_formula_reaches_the_page_as_latex() {
+        let document = parse(
+            "<p>the constant <math alttext=\"K_{G}\"><semantics>\
+             <msub><mi>K</mi><mi>G</mi></msub>\
+             <annotation encoding=\"application/x-tex\">K_{G}</annotation>\
+             </semantics></math> is at least \
+             <math alttext=\"\\frac{6\\pi}{11}\"><semantics>\
+             <mfrac><mrow><mn>6</mn><mi>\u{3c0}</mi></mrow><mn>11</mn></mfrac>\
+             <annotation encoding=\"application/x-tex\">\\frac{6\\pi}{11}</annotation>\
+             </semantics></math>.</p>",
+        );
+        let Block::Paragraph(text) = &document.blocks[0] else {
+            panic!("not a paragraph: {:?}", document.blocks[0]);
+        };
+        assert!(!text.contains('\\'), "the source leaked: {text}");
+        assert!(!text.contains('{'), "the source leaked: {text}");
+        assert!(text.contains("K_G"), "the subscript was lost: {text}");
+        assert!(text.contains('\u{3c0}'), "the fraction was lost: {text}");
     }
 
     #[test]

--- a/crates/kobo-html/src/lib.rs
+++ b/crates/kobo-html/src/lib.rs
@@ -22,7 +22,8 @@
 //!   control characters are dropped instead of being handed to a renderer that
 //!   would have to decide what a `\u{7}` looks like.
 
-mod math;
+/// Reading `MathML` as a line of text.
+pub mod math;
 
 /// The most text one converted body may produce.
 ///

--- a/crates/kobo-html/src/math.rs
+++ b/crates/kobo-html/src/math.rs
@@ -40,6 +40,7 @@
 /// stand in its place. Anything it cannot make sense of comes back as the
 /// characters it found, which is what the converter would have produced
 /// anyway: this can leave a formula plain but never blanks one.
+#[must_use]
 pub fn render(element: &str) -> String {
     let nodes = parse(inner(element));
     let mut out = String::new();

--- a/crates/kobo-read/src/lib.rs
+++ b/crates/kobo-read/src/lib.rs
@@ -100,6 +100,20 @@ const HIGHLIGHT_DEPTH: u8 = 1;
 /// wrong rather than as prose continuing.
 const MIN_KEEP_LINES: usize = 2;
 
+/// The fewest lines of a section that must share the page with its heading.
+///
+/// A heading is a promise that something follows it, so a heading alone at the
+/// foot of a page breaks the promise: the eye reaches the bottom having been
+/// told a new section is starting and finds nothing of it, and the section
+/// turns out to begin on the other side of a page turn.
+///
+/// Every typesetting system has this rule and they broadly agree on the
+/// number. TeX hangs a large penalty on a break directly after a heading;
+/// CSS calls it `break-after: avoid`; a page layout program calls it "keep
+/// with next" and defaults to two or three lines. Two is the smallest number
+/// that actually reads as a section having started.
+const KEEP_WITH_HEADING: usize = 2;
+
 /// The most pages a book is broken into.
 ///
 /// A ceiling rather than a guess. Pagination allocates per page, and a
@@ -2366,6 +2380,69 @@ fn index_of(locator: Locator) -> usize {
     usize::try_from(locator).unwrap_or(usize::MAX)
 }
 
+/// How much room the start of the section after a heading needs.
+///
+/// Enough of whatever follows the heading to show that the section has begun:
+/// [`KEEP_WITH_HEADING`] lines of prose, or the whole of a shorter block. A
+/// second heading immediately under the first is its subtitle and needs to
+/// come with it rather than be measured as a section of its own, so it is
+/// followed through -- but only for a couple of steps, because a document can
+/// be nothing but headings and this is measuring a page, not walking a book.
+fn following_height(
+    document: &Document,
+    after: usize,
+    metrics: &kobo_ui::DisplayMetrics,
+    area: ProseArea,
+    gap: i32,
+) -> i32 {
+    let mut total = 0;
+    let mut at = after.saturating_add(1);
+    for _ in 0..3 {
+        let Some(block) = document.blocks.get(at) else {
+            // Nothing follows, so nothing has to fit: a heading at the very
+            // end of a document is the one that is allowed to stand alone.
+            return total;
+        };
+        let kind = kind_of(block, false);
+        if matches!(kind, Kind::Break | Kind::Rule) {
+            // A rule or a seam is not the section starting.
+            return total;
+        }
+        let size = kind.size();
+        let height = size.line_height_in(area.face).max(1);
+        let (_, width) = quote_offsets(metrics, area.width, kind.depth());
+        // A picture is placed whole and cannot be measured in lines, and a
+        // table row is a shape rather than prose. Asking for one line's worth
+        // is enough to keep the heading honest without demanding that a whole
+        // illustration share the page with it.
+        let Some(text) = block.text() else {
+            return total.saturating_add(height).saturating_add(gap);
+        };
+        let lines = wrap_text_in(text, width, size, area.face);
+        // How much of the block has to fit before any of it may be placed.
+        // Usually the opening couple of lines, but a block short enough that
+        // splitting it would strand a widow cannot be split at all, so for
+        // those the answer is the whole thing. Asking for two lines of a
+        // three-line paragraph reserves room the paragraph will refuse to
+        // use, and the heading is stranded anyway.
+        let wanted = if lines.len() < MIN_KEEP_LINES.saturating_mul(2) {
+            lines.len()
+        } else {
+            KEEP_WITH_HEADING
+        };
+        total = total.saturating_add(gap).saturating_add(
+            i32::try_from(wanted)
+                .unwrap_or(i32::MAX)
+                .saturating_mul(height),
+        );
+        if !matches!(kind, Kind::Heading(_)) {
+            return total;
+        }
+        at = at.saturating_add(1);
+    }
+    total
+}
+
 /// What each column of the table starting at `from` wants to be.
 ///
 /// Measured over every row of the table at once, and in pixels, because that
@@ -2642,6 +2719,28 @@ fn paginate(
             continue;
         }
 
+        // A heading goes over to the next page rather than sit alone at the
+        // foot of this one. Measured rather than guessed: the heading's own
+        // lines plus the opening lines of whatever follows it have to fit, or
+        // the page ends here and the section starts whole overleaf.
+        if matches!(kind, Kind::Heading(_)) && !page.is_empty() {
+            let wanted = i32::try_from(lines.len())
+                .unwrap_or(i32::MAX)
+                .saturating_mul(height)
+                .saturating_add(gap)
+                .saturating_add(following_height(
+                    document,
+                    index_of(index),
+                    metrics,
+                    area,
+                    gap,
+                ));
+            if used + wanted > area.height {
+                pages.push(std::mem::take(&mut page));
+                used = 0;
+            }
+        }
+
         let mut placed = 0;
         let mut source_at = 0usize;
         while placed < lines.len() {
@@ -2652,13 +2751,19 @@ fn paginate(
                 usize::try_from((room - extra_height) / height).unwrap_or(usize::MAX)
             };
             let left = lines.len() - placed;
-            // Either the rest fits, or enough of it fits to be worth breaking:
-            // two lines here and two over the page. Anything less and the
-            // whole paragraph goes over rather than leaving a widow behind.
+            // Either the rest fits, or enough of it fits to be worth
+            // breaking: two lines here and two over the page.
+            //
+            // When more fits than may be taken, the answer is to take less
+            // rather than to take none. A four-line paragraph with room for
+            // three used to move over whole, because leaving one line behind
+            // is a widow -- and the hole that left at the foot of the page
+            // was big enough to strand the heading above it. Two lines here
+            // and two overleaf breaks nothing and fills the page.
             let take = if fits >= left {
                 left
-            } else if fits >= MIN_KEEP_LINES && left - fits >= MIN_KEEP_LINES {
-                fits
+            } else if fits >= MIN_KEEP_LINES && left >= MIN_KEEP_LINES.saturating_mul(2) {
+                fits.min(left - MIN_KEEP_LINES)
             } else {
                 0
             };
@@ -4073,6 +4178,105 @@ mod tests {
             "the hold reached nothing"
         );
         assert_eq!(reader.chrome(), Chrome::Marking);
+    }
+
+    /// A heading is a promise that a section follows it. Left alone at the
+    /// foot of a page it breaks the promise, and the reader turns over to find
+    /// out what the heading was for.
+    #[test]
+    fn a_heading_is_never_left_alone_at_the_foot_of_a_page() {
+        // Enough prose to fill several pages, with a heading dropped in at
+        // every point where one could land badly. One of these is guaranteed
+        // to fall at the bottom of a page without the rule.
+        let mut blocks = Vec::new();
+        for section in 0..12 {
+            blocks.push(Block::Heading {
+                level: 2,
+                text: format!("Section {section}"),
+            });
+            for paragraph in 0..3 {
+                blocks.push(Block::Paragraph(format!(
+                    "Section {section} paragraph {paragraph}. {}",
+                    "The quick brown fox jumps over the lazy dog. ".repeat(4)
+                )));
+            }
+            // Varying the run length walks the heading through every offset
+            // in the page, so this does not depend on one lucky arrangement.
+            for filler in 0..section {
+                blocks.push(Block::Paragraph(format!(
+                    "Filler {filler}. {}",
+                    "Words to take up a line or two of the page. ".repeat(2)
+                )));
+            }
+        }
+        let count = blocks.len();
+        let reader = Reader::open(
+            Document {
+                title: None,
+                author: None,
+                blocks,
+                truncated: false,
+                ..Document::default()
+            },
+            Memory::default(),
+            &panel(),
+        );
+
+        let pages = reader.page_count();
+        assert!(pages > 4, "the test did not make enough pages: {pages}");
+        let mut checked = 0;
+        for number in 0..pages {
+            let Some(last) = reader.pages[number].last() else {
+                continue;
+            };
+            if !matches!(last.kind, Kind::Heading(_)) {
+                continue;
+            }
+            // The only heading allowed to end a page is one that ends the
+            // book, because nothing follows it to be stranded from.
+            assert_eq!(
+                index_of(last.block),
+                count - 1,
+                "page {number} ends with a heading and the section starts overleaf"
+            );
+            checked += 1;
+        }
+        assert!(
+            checked <= 1,
+            "more than one heading ended a page, so the rule is not being applied"
+        );
+    }
+
+    /// The rule must not do its job by emptying pages instead.
+    #[test]
+    fn keeping_a_heading_with_its_section_does_not_leave_a_blank_page() {
+        let mut blocks = Vec::new();
+        for section in 0..8 {
+            blocks.push(Block::Heading {
+                level: 2,
+                text: format!("Section {section}"),
+            });
+            blocks.push(Block::Paragraph(
+                "The quick brown fox jumps over the lazy dog. ".repeat(6),
+            ));
+        }
+        let reader = Reader::open(
+            Document {
+                title: None,
+                author: None,
+                blocks,
+                truncated: false,
+                ..Document::default()
+            },
+            Memory::default(),
+            &panel(),
+        );
+        for number in 0..reader.page_count() {
+            assert!(
+                !reader.pages[number].is_empty(),
+                "page {number} came out blank"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Three faults reported from a Kobo Clara, each visible in a photograph of the page rather than in any test we had.

### Formulae arrived as their own source

A paper on the Grothendieck constant told its reader `1.7135\ldots\;=\;\frac{6\pi}{11}\;\leq\;K_{G}` where the paper had an inequality, and `\operatorname{sgn}` and `\mathbb{R}^{k}\to\{\pm 1\}` were set in the middle of English sentences.

The reader's parser held a list of elements read from an attribute rather than from their children, and `math` was on it. For an `svg` that is right — its children are coordinates. But the attribute LaTeXML writes on a formula is `alttext`, and `alttext` is the LaTeX the author typed. So the one element whose children were already the reading was the one element we refused to read.

A renderer for that markup has been sitting in `kobo-html` all along, reaching the page only through `to_text`, which the reader does not call. It now serves both paths. The inequality above reads `1.7135... = (6π)/11 ≤ K_G`.

This is a leak stopped, not typesetting achieved. No maintained Rust crate does TeX math layout: ReX has not been touched since 2020, and pulldown-latex emits MathML rather than boxes. Real layout means the TeXbook's Appendix G over an OpenType MATH font, which is its own piece of work.

### Headings were left standing at the foot of the page

A heading would end a page with its section overleaf. Two faults, and the second was only visible once the first was fixed.

A heading now reserves room for the first two lines of what follows it, which is what CSS calls `break-after: avoid` and what LaTeX does with an infinite `\clubpenalty`. Two lines is the CSS default and what crengine and Kindle use.

Underneath that, the rule for splitting a paragraph across a break said: take the lines that fit, unless too few would be left behind, in which case take **none**. With a four-line paragraph and room for three, leaving one behind is a widow, so it took none — and the hole it left is what the heading fell into. The rule now takes fewer lines rather than none, keeping two on each side.

### Searching for two words found either of them

arXiv reads an unquoted space as OR, and says so if asked: a search for `machine learning` comes back as `all:machine OR all:learning`, which is every paper mentioning either word. Multi-word searches are now quoted, and `all:"machine learning"` returns the phrase.

### Verification

- 1,965 tests pass (1,961 before, 4 new); `cargo clippy --workspace --all-targets --all-features -- -D warnings` is clean.
- Every new test was mutation-tested. Restoring the `alttext` behaviour reproduces the photographed page verbatim: `the constant K_{G} is at least \frac{6\pi}{11}`.
- The math fix was checked against the reader's exact paper (arXiv 2608.11195v1): no rendered block contains a backslash.
- The search fix was checked against the live arXiv API.

Cobalt 0.2.6, arXiv 1.2.1.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789142092&installation_model_id=20525&pr_number=22&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F22&signature=2de6896ecc1a4d1fa04f3f0c48350d677b6b1edef2b33f3d14076bfc152b3c8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->