### PR TITLE
Harden device-write readiness and complete Elipsa 2E validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,9 +708,7 @@ dependencies = [
 name = "kobo-smoke"
 version = "0.2.6"
 dependencies = [
- "kobo-abi",
  "kobo-hal",
- "kobo-profile",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ new app can appear in Store without reinstalling or updating Cobalt.
 </p>
 
 > [!IMPORTANT]
-> Cobalt currently is tested only on the **Kobo Clara BW N365 (device code 391)**.
+> The **Kobo Clara BW N365 (device code 391)** and **Kobo Elipsa 2E N605
+> (device code 389)** are fully hardware-tested on the exact firmware and
+> kernel versions in the support matrix.
+> See the [device support matrix](docs/DEVICES.md#device-support-matrix) before
+> installing.
 > It is an independent project and is not affiliated with Rakuten Kobo.
 
 ## Features
@@ -31,7 +35,7 @@ new app can appear in Store without reinstalling or updating Cobalt.
 - Per-app capability checks for network, storage, audio, frontlight, and other
   device services
 - Declarative e-ink UI toolkit and browser simulator
-- Full and partial refresh planning for the 1072 x 1448 Clara BW panel
+- Profile-driven full and partial refresh planning for supported panels
 - Static ARMv7 binaries with no device-side package manager
 - Recovery-safe app and catalog transactions
 
@@ -80,7 +84,8 @@ utilities.
 
 ## Install
 
-Install Rust, add the ARM target and connect a charged Clara BW over USB:
+Install Rust, add the ARM target and connect a charged, fully supported reader
+over USB:
 
 ```sh
 git clone https://github.com/BandarLabs/Cobalt.git
@@ -164,7 +169,7 @@ App contributions are regular pull requests:
 
 1. Add the app as a workspace package under `apps/<app-id>/`.
 2. Add its release metadata to `apps/catalog.json`.
-3. Add unit and Clara BW layout tests.
+3. Add unit tests and layout checks for every affected supported profile.
 4. Run the app in the browser and runtime simulators.
 5. Open a pull request.
 
@@ -213,8 +218,12 @@ by hardware and firmware identity, and a reboot returns to the stock reader.
 The first installation still modifies files on the user storage partition and
 is provided without warranty.
 
-Only the Clara BW profile has been tested. Do not install Cobalt on another
-model until that model has a reviewed and hardware-tested profile.
+Normal panel-write entry points require one of the exact hardware and firmware
+combinations in the
+[device support matrix](docs/DEVICES.md#device-support-matrix). Do not treat a
+read-only profile match as permission to install: normal use requires the
+profile's owner-attended display, touch, exit, and recovery evidence to be
+complete.
 
 ## License
 

--- a/crates/kobo-hal/src/display.rs
+++ b/crates/kobo-hal/src/display.rs
@@ -5,8 +5,9 @@
 //!
 //! 1. the probed hardware geometry matches the profile exactly,
 //! 2. the device code, serial model prefix, firmware version, and kernel
-//!    release match the profile exactly, and
-//! 3. the caller supplied the exact owner-attended unlock phrase.
+//!    release match the profile exactly,
+//! 3. the profile's owner-attended evidence is complete, and
+//! 4. the caller supplied the exact owner-attended unlock phrase.
 //!
 //! The module is compiled only with the non-default `device-write` feature, so
 //! a default build contains no callable display-write code at all.
@@ -15,20 +16,56 @@ use crate::probe::{probe_device, ProbeError};
 use crate::refresh::{Rect, RefreshPlan};
 use crate::surface::{self, RegionSnapshot, SurfaceError, SurfaceGeometry};
 use kobo_abi::hwtcon;
-use kobo_profile::{DeviceProfile, DeviceSnapshot};
+use kobo_profile::{DeviceProfile, DeviceSnapshot, WRITE_EVIDENCE_PENDING};
 use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Read};
 use std::path::Path;
+use std::thread::sleep;
+use std::time::Duration;
 
 /// The exact phrase an owner must supply to open a write session.
 pub const OWNER_UNLOCK_PHRASE: &str = "OWNER_ATTENDED_DISPLAY_WRITE";
+
+const SMOKE_FIXED_REGION: Rect = Rect {
+    x: 512,
+    y: 704,
+    width: 32,
+    height: 32,
+};
+const SMOKE_PATCH_REGION: Rect = Rect {
+    x: 408,
+    y: 600,
+    width: 256,
+    height: 256,
+};
+const SMOKE_VISIBLE_HOLD: Duration = Duration::from_millis(1200);
+const ATTENDED_SMOKE_UNLOCK_PHRASE: &str = "OWNER_ATTENDED_CANDIDATE_DISPLAY_VALIDATION";
+
+/// One bounded operation used to gather owner-attended display evidence.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AttendedSmokeStage {
+    DisplayOnly,
+    ReversiblePixels,
+    ScreenSnapshot,
+    FastFeedback,
+}
+
+impl AttendedSmokeStage {
+    const fn intent(self) -> crate::refresh::RefreshIntent {
+        match self {
+            Self::FastFeedback => crate::refresh::RefreshIntent::FastFeedback,
+            _ => crate::refresh::RefreshIntent::QualityContent,
+        }
+    }
+}
 
 #[derive(Debug)]
 pub enum DisplayError {
     UnlockMissing,
     ProfileRejected(Vec<String>),
-    IdentityRejected(Vec<String>),
+    WriteRejected(Vec<String>),
+    Smoke(String),
     Probe(ProbeError),
     Surface(SurfaceError),
     Io(io::Error),
@@ -47,13 +84,10 @@ impl fmt::Display for DisplayError {
                     reasons.join("; ")
                 )
             }
-            Self::IdentityRejected(reasons) => {
-                write!(
-                    formatter,
-                    "device identity rejected: {}",
-                    reasons.join("; ")
-                )
+            Self::WriteRejected(reasons) => {
+                write!(formatter, "device write rejected: {}", reasons.join("; "))
             }
+            Self::Smoke(reason) => write!(formatter, "attended display smoke: {reason}"),
             Self::Probe(error) => write!(formatter, "read-only probe: {error}"),
             Self::Surface(error) => write!(formatter, "{error}"),
             Self::Io(error) => write!(formatter, "display io: {error}"),
@@ -83,6 +117,12 @@ pub struct DisplaySession {
     snapshot: DeviceSnapshot,
 }
 
+#[derive(Clone, Copy)]
+enum WritePolicy {
+    ReadyOnly,
+    AttendedCandidateValidation,
+}
+
 impl DisplaySession {
     /// Probes the device and opens the framebuffer read-write.
     ///
@@ -101,21 +141,45 @@ impl DisplaySession {
                 "no supported hardware profile matched this device".to_owned()
             ])
         })?;
-        Self::open_verified(profile, snapshot, Path::new("/dev/fb0"))
+        Self::open_verified(
+            profile,
+            snapshot,
+            Path::new("/dev/fb0"),
+            WritePolicy::ReadyOnly,
+        )
+    }
+
+    fn open_for_attended_validation() -> Result<Self, DisplayError> {
+        let snapshot = probe_device().map_err(DisplayError::Probe)?;
+        let profile = kobo_profile::identify_profile(&snapshot).ok_or_else(|| {
+            DisplayError::ProfileRejected(vec![
+                "no supported hardware profile matched this device".to_owned()
+            ])
+        })?;
+        Self::open_verified(
+            profile,
+            snapshot,
+            Path::new("/dev/fb0"),
+            WritePolicy::AttendedCandidateValidation,
+        )
     }
 
     fn open_verified(
         profile: &'static DeviceProfile,
         snapshot: DeviceSnapshot,
         framebuffer_path: &Path,
+        policy: WritePolicy,
     ) -> Result<Self, DisplayError> {
         let report = profile.validate(&snapshot);
         if !report.mismatches.is_empty() {
             return Err(DisplayError::ProfileRejected(report.mismatches));
         }
-        let identity = profile.write_identity_blockers(&snapshot);
-        if !identity.is_empty() {
-            return Err(DisplayError::IdentityRejected(identity));
+        let mut blockers = report.write_blockers;
+        if matches!(policy, WritePolicy::AttendedCandidateValidation) {
+            blockers.retain(|blocker| blocker != WRITE_EVIDENCE_PENDING);
+        }
+        if !blockers.is_empty() {
+            return Err(DisplayError::WriteRejected(blockers));
         }
         let framebuffer = snapshot
             .framebuffer
@@ -204,6 +268,137 @@ impl DisplaySession {
     }
 }
 
+/// Runs one fixed, bounded, restoration-verified candidate display check.
+///
+/// This is the only operation allowed to ignore the evidence-pending blocker.
+/// It never exposes the underlying candidate-capable [`DisplaySession`]; the
+/// regions, waveform intent, restoration, and verification all remain owned by
+/// this hardware boundary. Geometry, framebuffer safety, and exact identity
+/// blockers are still enforced before the framebuffer is opened.
+///
+/// # Errors
+///
+/// Returns an error when probing or exact validation fails, a fixed region is
+/// invalid, a framebuffer operation fails, or restored bytes differ.
+pub fn run_attended_smoke(
+    stage: AttendedSmokeStage,
+    unlock: Option<&str>,
+) -> Result<String, DisplayError> {
+    if unlock != Some(ATTENDED_SMOKE_UNLOCK_PHRASE) {
+        return Err(DisplayError::UnlockMissing);
+    }
+    let session = DisplaySession::open_for_attended_validation()?;
+    let plan = RefreshPlan::new(
+        SMOKE_FIXED_REGION,
+        stage.intent(),
+        false,
+        session.geometry().width,
+        session.geometry().height,
+    )
+    .ok_or_else(|| DisplayError::Smoke("fixed region is not inside this screen".to_owned()))?;
+
+    match stage {
+        AttendedSmokeStage::DisplayOnly => {
+            session.refresh(plan)?;
+            Ok("display-only GC16 refresh completed; no pixel byte was written".to_owned())
+        }
+        AttendedSmokeStage::ReversiblePixels => {
+            let original = session.capture(SMOKE_FIXED_REGION)?;
+            smoke_show_and_restore(&session, plan, &original)?;
+            Ok(format!(
+                "reversible GC16 pixel test completed; {} bytes restored and verified",
+                original.pixels().len()
+            ))
+        }
+        AttendedSmokeStage::ScreenSnapshot => smoke_screen_snapshot_restore(&session),
+        AttendedSmokeStage::FastFeedback => {
+            let original = session.capture(SMOKE_FIXED_REGION)?;
+            smoke_show_and_restore(&session, plan, &original)?;
+            Ok(format!(
+                "reversible DU pixel test completed; {} bytes restored and verified",
+                original.pixels().len()
+            ))
+        }
+    }
+}
+
+fn smoke_screen_snapshot_restore(session: &DisplaySession) -> Result<String, DisplayError> {
+    let geometry = session.geometry();
+    let whole_screen = Rect {
+        x: 0,
+        y: 0,
+        width: geometry.width,
+        height: geometry.height,
+    };
+    let screen = session.capture(whole_screen)?;
+    let patch = session.capture(SMOKE_PATCH_REGION)?;
+    let patch_plan = smoke_plan_for(session, SMOKE_PATCH_REGION)?;
+    let screen_plan = smoke_plan_for(session, whole_screen)?;
+
+    let shown = session
+        .restore(&patch.inverted_rgb())
+        .and_then(|()| session.refresh(patch_plan));
+    if shown.is_ok() {
+        sleep(SMOKE_VISIBLE_HOLD);
+    }
+    let restored = session
+        .restore(&screen)
+        .and_then(|()| session.refresh(screen_plan));
+    shown?;
+    restored?;
+
+    let verify = session.capture(SMOKE_PATCH_REGION)?;
+    if !verify.matches(&patch) {
+        return Err(DisplayError::Smoke(
+            "the changed region was not restored by the whole-screen write".to_owned(),
+        ));
+    }
+    Ok(format!(
+        "whole-screen snapshot and restore completed; {} screen bytes captured, \
+         {} bytes changed and verified restored",
+        screen.pixels().len(),
+        patch.pixels().len()
+    ))
+}
+
+fn smoke_plan_for(session: &DisplaySession, region: Rect) -> Result<RefreshPlan, DisplayError> {
+    RefreshPlan::new(
+        region,
+        crate::refresh::RefreshIntent::QualityContent,
+        false,
+        session.geometry().width,
+        session.geometry().height,
+    )
+    .ok_or_else(|| DisplayError::Smoke(format!("region {region:?} is not inside this screen")))
+}
+
+fn smoke_show_and_restore(
+    session: &DisplaySession,
+    plan: RefreshPlan,
+    original: &RegionSnapshot,
+) -> Result<(), DisplayError> {
+    let shown = session
+        .restore(&original.inverted_rgb())
+        .and_then(|()| session.refresh(plan));
+    if shown.is_ok() {
+        sleep(SMOKE_VISIBLE_HOLD);
+    }
+    let restored = session
+        .restore(original)
+        .and_then(|()| session.refresh(plan));
+    shown?;
+    restored?;
+
+    let verify = session.capture(original.placement().region())?;
+    if verify.matches(original) {
+        Ok(())
+    } else {
+        Err(DisplayError::Smoke(
+            "restored region does not match the original bytes".to_owned(),
+        ))
+    }
+}
+
 /// Returns a random nonzero update marker.
 ///
 /// # Errors
@@ -219,65 +414,68 @@ fn unique_marker() -> Result<u32, DisplayError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{unique_marker, DisplayError, DisplaySession, OWNER_UNLOCK_PHRASE};
+    use super::{
+        unique_marker, AttendedSmokeStage, DisplayError, DisplaySession, Rect, RefreshPlan,
+        WritePolicy, ATTENDED_SMOKE_UNLOCK_PHRASE, OWNER_UNLOCK_PHRASE, SMOKE_FIXED_REGION,
+        SMOKE_PATCH_REGION, SMOKE_VISIBLE_HOLD,
+    };
+    use crate::surface::{RegionPlacement, SurfaceGeometry};
+    use kobo_abi::hwtcon;
     use kobo_profile::{
-        Bitfield, DeviceSnapshot, FramebufferSnapshot, IdentitySnapshot, TouchSnapshot,
-        CLARA_BW_391,
+        DeviceProfile, DeviceSnapshot, FramebufferSnapshot, IdentitySnapshot, TouchSnapshot,
+        CLARA_BW_391, ELIPSA_2E_389, WRITE_EVIDENCE_PENDING,
     };
     use std::path::Path;
 
     fn matched_snapshot() -> DeviceSnapshot {
-        let channel = Bitfield {
-            offset: 0,
-            length: 8,
-            msb_right: 0,
-        };
-        DeviceSnapshot {
-            compatible: vec!["mediatek,mt8110".into(), "mediatek,mt8512".into()],
-            model: Some("MediaTek MT8110 board".into()),
-            framebuffer: Some(FramebufferSnapshot {
-                id: "hwtcon".into(),
-                width: 1072,
-                height: 1448,
-                virtual_width: 1072,
-                virtual_height: 1448,
-                x_offset: 0,
-                y_offset: 0,
-                bits_per_pixel: 32,
-                grayscale: 0,
-                stride: 4288,
-                memory_length: 6_243_328,
-                kind: 0,
-                visual: 2,
-                rotation: 3,
-                red: channel,
-                green: Bitfield {
-                    offset: 8,
-                    ..channel
-                },
-                blue: Bitfield {
-                    offset: 16,
-                    ..channel
-                },
-                alpha: Bitfield {
-                    offset: 24,
-                    ..channel
-                },
-            }),
-            touch: Some(TouchSnapshot {
-                path: "/dev/input/event1".into(),
-                name: "cyttsp5_mt".into(),
-                x_min: 0,
-                x_max: 1447,
-                y_min: 0,
-                y_max: 1071,
-            }),
-            identity: IdentitySnapshot {
+        snapshot_for(
+            &CLARA_BW_391,
+            IdentitySnapshot {
                 serial_prefix: Some("N365".into()),
                 firmware_version: Some("4.45.23697".into()),
                 kernel_release: Some("4.9.77".into()),
                 device_code: Some(391),
             },
+        )
+    }
+
+    fn snapshot_for(profile: &DeviceProfile, identity: IdentitySnapshot) -> DeviceSnapshot {
+        DeviceSnapshot {
+            compatible: profile
+                .compatible_fragments
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect(),
+            model: Some(profile.device_tree_model.to_owned()),
+            framebuffer: Some(FramebufferSnapshot {
+                id: profile.framebuffer_id.to_owned(),
+                width: profile.width,
+                height: profile.height,
+                virtual_width: profile.virtual_width,
+                virtual_height: profile.virtual_height,
+                x_offset: profile.x_offset,
+                y_offset: profile.y_offset,
+                bits_per_pixel: profile.bits_per_pixel,
+                grayscale: profile.grayscale,
+                stride: profile.stride,
+                memory_length: profile.memory_length,
+                kind: profile.framebuffer_kind,
+                visual: profile.framebuffer_visual,
+                rotation: profile.rotation,
+                red: profile.red,
+                green: profile.green,
+                blue: profile.blue,
+                alpha: profile.alpha,
+            }),
+            touch: Some(TouchSnapshot {
+                path: "/dev/input/event1".into(),
+                name: profile.touch_name.into(),
+                x_min: profile.touch_x_min,
+                x_max: profile.touch_x_max,
+                y_min: profile.touch_y_min,
+                y_max: profile.touch_y_max,
+            }),
+            identity,
         }
     }
 
@@ -292,6 +490,15 @@ mod tests {
             Err(DisplayError::UnlockMissing)
         ));
         assert_eq!(OWNER_UNLOCK_PHRASE, "OWNER_ATTENDED_DISPLAY_WRITE");
+        assert!(matches!(
+            super::run_attended_smoke(AttendedSmokeStage::DisplayOnly, None),
+            Err(DisplayError::UnlockMissing)
+        ));
+        assert!(matches!(
+            super::run_attended_smoke(AttendedSmokeStage::DisplayOnly, Some("please")),
+            Err(DisplayError::UnlockMissing)
+        ));
+        assert_ne!(ATTENDED_SMOKE_UNLOCK_PHRASE, OWNER_UNLOCK_PHRASE);
     }
 
     #[test]
@@ -320,10 +527,113 @@ mod tests {
                 ..matched_snapshot()
             };
             assert!(matches!(
-                DisplaySession::open_verified(&CLARA_BW_391, snapshot, Path::new("/dev/null")),
-                Err(DisplayError::IdentityRejected(_))
+                DisplaySession::open_verified(
+                    &CLARA_BW_391,
+                    snapshot,
+                    Path::new("/dev/null"),
+                    WritePolicy::ReadyOnly,
+                ),
+                Err(DisplayError::WriteRejected(_))
             ));
         }
+    }
+
+    #[test]
+    fn ordinary_writes_refuse_a_candidate_but_attended_smoke_may_open_it() {
+        const CANDIDATE: kobo_profile::DeviceProfile = kobo_profile::DeviceProfile {
+            write_ready: false,
+            ..ELIPSA_2E_389
+        };
+        let identity = IdentitySnapshot {
+            serial_prefix: Some("N605".into()),
+            firmware_version: Some("4.38.23697".into()),
+            kernel_release: Some("4.9.77".into()),
+            device_code: Some(389),
+        };
+        let snapshot = snapshot_for(&CANDIDATE, identity);
+        let Err(error) = DisplaySession::open_verified(
+            &CANDIDATE,
+            snapshot.clone(),
+            Path::new("/dev/null"),
+            WritePolicy::ReadyOnly,
+        ) else {
+            panic!("ordinary display writes require completed evidence");
+        };
+        assert!(
+            matches!(error, DisplayError::WriteRejected(ref blockers) if blockers.iter().any(|blocker| blocker == WRITE_EVIDENCE_PENDING))
+        );
+
+        DisplaySession::open_verified(
+            &CANDIDATE,
+            snapshot,
+            Path::new("/dev/null"),
+            WritePolicy::AttendedCandidateValidation,
+        )
+        .expect("the bounded attended smoke path may gather the missing evidence");
+    }
+
+    #[test]
+    fn attended_smoke_never_bypasses_exact_identity() {
+        let snapshot = snapshot_for(&ELIPSA_2E_389, IdentitySnapshot::default());
+        assert!(matches!(
+            DisplaySession::open_verified(
+                &ELIPSA_2E_389,
+                snapshot,
+                Path::new("/dev/null"),
+                WritePolicy::AttendedCandidateValidation,
+            ),
+            Err(DisplayError::WriteRejected(_))
+        ));
+    }
+
+    #[test]
+    fn hal_owned_smoke_regions_are_bounded_on_every_registered_panel() {
+        for profile in [&CLARA_BW_391, &ELIPSA_2E_389] {
+            let geometry = SurfaceGeometry {
+                width: profile.width,
+                height: profile.height,
+                stride: profile.stride,
+                bits_per_pixel: profile.bits_per_pixel,
+                memory_length: u64::from(profile.memory_length),
+            };
+            let fixed = RegionPlacement::new(geometry, SMOKE_FIXED_REGION)
+                .expect("fixed smoke region fits the supported panel");
+            assert_eq!(fixed.total_bytes(), 32 * 32 * 4);
+            let patch = RegionPlacement::new(geometry, SMOKE_PATCH_REGION)
+                .expect("patch smoke region fits the supported panel");
+            assert_eq!(patch.total_bytes(), 256 * 256 * 4);
+
+            let whole = Rect {
+                x: 0,
+                y: 0,
+                width: profile.width,
+                height: profile.height,
+            };
+            RegionPlacement::new(geometry, whole).expect("whole panel is valid");
+        }
+    }
+
+    #[test]
+    fn hal_owned_smoke_stages_use_only_partial_gc16_or_du_updates() {
+        for (stage, waveform) in [
+            (AttendedSmokeStage::DisplayOnly, hwtcon::WAVEFORM_GC16),
+            (AttendedSmokeStage::ReversiblePixels, hwtcon::WAVEFORM_GC16),
+            (AttendedSmokeStage::ScreenSnapshot, hwtcon::WAVEFORM_GC16),
+            (AttendedSmokeStage::FastFeedback, hwtcon::WAVEFORM_DU),
+        ] {
+            let plan = RefreshPlan::new(
+                SMOKE_FIXED_REGION,
+                stage.intent(),
+                false,
+                CLARA_BW_391.width,
+                CLARA_BW_391.height,
+            )
+            .expect("fixed plan");
+            let update = plan.update_data(0x4000_0001);
+            assert_eq!(update.waveform_mode, waveform);
+            assert_eq!(update.update_mode, hwtcon::UPDATE_MODE_PARTIAL);
+        }
+        assert!(SMOKE_VISIBLE_HOLD.as_secs() < 5);
     }
 
     #[test]
@@ -331,7 +641,12 @@ mod tests {
         let mut snapshot = matched_snapshot();
         snapshot.framebuffer.as_mut().expect("framebuffer").stride = 4096;
         assert!(matches!(
-            DisplaySession::open_verified(&CLARA_BW_391, snapshot, Path::new("/dev/null")),
+            DisplaySession::open_verified(
+                &CLARA_BW_391,
+                snapshot,
+                Path::new("/dev/null"),
+                WritePolicy::ReadyOnly,
+            ),
             Err(DisplayError::ProfileRejected(_))
         ));
     }

--- a/crates/kobo-hal/src/probe.rs
+++ b/crates/kobo-hal/src/probe.rs
@@ -34,8 +34,10 @@ impl Error for ProbeError {
 ///
 /// # Errors
 ///
-/// Returns the first framebuffer or touch discovery error without guessing a
-/// fallback device.
+/// Returns a framebuffer query error or an error querying a recognized touch
+/// device without guessing a fallback device. The absence of a recognized
+/// touch device remains part of the snapshot so the doctor can report unknown
+/// hardware read-only.
 pub fn probe_device() -> Result<DeviceSnapshot, ProbeError> {
     let compatible = read_nul_list(&[
         "/sys/firmware/devicetree/base/compatible",
@@ -49,8 +51,9 @@ pub fn probe_device() -> Result<DeviceSnapshot, ProbeError> {
     ]);
 
     let framebuffer = probe_framebuffer(Path::new("/dev/fb0"))?;
-    let touch =
-        discover_touch_path("/proc/bus/input/devices").and_then(|path| probe_touch(&path).ok());
+    let touch = discover_touch_path("/proc/bus/input/devices")
+        .map(|path| probe_touch(&path))
+        .transpose()?;
 
     Ok(DeviceSnapshot {
         compatible,
@@ -189,6 +192,20 @@ H: Handlers=event0\n";
         assert_eq!(
             discover_touch_path_from(fixture).as_deref(),
             Some(Path::new("/dev/input/event1"))
+        );
+    }
+
+    #[test]
+    fn finds_elan_touch_handler() {
+        let fixture = "I: Bus=0018 Vendor=04f3 Product=0000 Version=0000\n\
+N: Name=\"Elan Touchscreen\"\n\
+H: Handlers=mouse0 event2\n\
+B: EV=b\n\n\
+N: Name=\"gpio-keys\"\n\
+H: Handlers=event0\n";
+        assert_eq!(
+            discover_touch_path_from(fixture).as_deref(),
+            Some(Path::new("/dev/input/event2"))
         );
     }
 }

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -51,6 +51,7 @@ pub const CLARA_BW_391: DeviceProfile = DeviceProfile {
     serial_prefix: "N365",
     firmware_version: "4.45.23697",
     kernel_release: "4.9.77",
+    write_ready: true,
 };
 
 pub const ELIPSA_2E_389: DeviceProfile = DeviceProfile {
@@ -102,6 +103,7 @@ pub const ELIPSA_2E_389: DeviceProfile = DeviceProfile {
     serial_prefix: "N605",
     firmware_version: "4.38.23697",
     kernel_release: "4.9.77",
+    write_ready: true,
 };
 
 pub const SUPPORTED_PROFILES: &[&DeviceProfile] = &[&CLARA_BW_391, &ELIPSA_2E_389];
@@ -114,8 +116,32 @@ pub fn identify_profile(snapshot: &DeviceSnapshot) -> Option<&'static DeviceProf
         .find(|profile| profile.validate(snapshot).readiness != Readiness::Rejected)
 }
 
-pub const READ_ONLY_WRITE_BLOCKER: &str =
-    "write profile is intentionally incomplete until read-only doctor output is reviewed";
+pub const WRITE_EVIDENCE_PENDING: &str =
+    "owner-attended display, touch, exit, and recovery evidence is incomplete";
+
+/// Returns the exact supported profile authorized for ordinary device writes.
+///
+/// A hardware match alone deliberately is not enough. The profile must have
+/// completed its attended evidence and every identity field must match the
+/// reviewed device and firmware exactly.
+///
+/// # Errors
+///
+/// Returns every write blocker when no supported profile matches, the profile
+/// is still awaiting attended evidence, or exact device identity is missing or
+/// different.
+pub fn write_ready_profile(
+    snapshot: &DeviceSnapshot,
+) -> Result<&'static DeviceProfile, Vec<String>> {
+    let profile = identify_profile(snapshot)
+        .ok_or_else(|| vec!["no supported hardware profile matched this device".to_owned()])?;
+    let report = profile.validate(snapshot);
+    if report.readiness == Readiness::WriteReady {
+        Ok(profile)
+    } else {
+        Err(report.write_blockers)
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Bitfield {
@@ -248,6 +274,8 @@ pub struct DeviceProfile {
     pub serial_prefix: &'static str,
     pub firmware_version: &'static str,
     pub kernel_release: &'static str,
+    /// True only after owner-attended hardware evidence has been reviewed.
+    pub write_ready: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -309,7 +337,10 @@ impl DeviceProfile {
             None => mismatches.push("touch probe unavailable".to_owned()),
         }
 
-        blockers.push(READ_ONLY_WRITE_BLOCKER.to_owned());
+        blockers.extend(self.write_identity_blockers(snapshot));
+        if !self.write_ready {
+            blockers.push(WRITE_EVIDENCE_PENDING.to_owned());
+        }
 
         let readiness = if !mismatches.is_empty() {
             Readiness::Rejected
@@ -643,8 +674,8 @@ fn compare_identity(blockers: &mut Vec<String>, name: &str, expected: &str, actu
 #[cfg(test)]
 mod tests {
     use super::{
-        Bitfield, DeviceSnapshot, FramebufferSnapshot, IdentitySnapshot, Readiness, TouchSnapshot,
-        CLARA_BW_391, ELIPSA_2E_389,
+        Bitfield, DeviceProfile, DeviceSnapshot, FramebufferSnapshot, IdentitySnapshot, Readiness,
+        TouchSnapshot, CLARA_BW_391, ELIPSA_2E_389, WRITE_EVIDENCE_PENDING,
     };
 
     #[test]
@@ -717,6 +748,30 @@ mod tests {
         assert_eq!(flipped_y, (109, 1337));
     }
 
+    /// Captured from a physical top-left touch on the real Elipsa 2E with
+    /// `kobo touch-probe`, read-only and ungrabbed. The raw controller sample
+    /// `(1838, 30)` mapped to display `(30, 34)`, matching where the owner
+    /// touched rather than merely mapping the controller's corner set onto the
+    /// panel's corner set.
+    #[test]
+    fn elipsa_touch_transform_matches_a_physically_measured_touch() {
+        let mapped = ELIPSA_2E_389
+            .touch_to_display(1838, 30)
+            .expect("the measured raw Elipsa sample is in range");
+        assert_eq!(mapped, (30, 34));
+
+        // Either plausible reversed axis still produces an in-range point,
+        // but places it far from the top-left location that was touched.
+        let flipped_x = ELIPSA_2E_389
+            .touch_to_display(1838, 1404 - 30)
+            .expect("in range");
+        let flipped_y = ELIPSA_2E_389
+            .touch_to_display(1872 - 1838, 30)
+            .expect("in range");
+        assert_eq!(flipped_x, (1373, 34));
+        assert_eq!(flipped_y, (30, 1837));
+    }
+
     #[test]
     fn empty_snapshot_is_rejected() {
         let report = CLARA_BW_391.validate(&DeviceSnapshot::default());
@@ -725,7 +780,7 @@ mod tests {
     }
 
     #[test]
-    fn measured_snapshot_remains_read_only_until_reviewed() {
+    fn reviewed_profile_with_exact_identity_is_write_ready() {
         let red = Bitfield {
             offset: 0,
             length: 8,
@@ -770,10 +825,18 @@ mod tests {
             },
         };
         let report = CLARA_BW_391.validate(&snapshot);
-        assert_eq!(report.readiness, Readiness::ReadOnlyMatched);
+        assert_eq!(report.readiness, Readiness::WriteReady);
         assert!(report.mismatches.is_empty());
-        assert!(!report.write_blockers.is_empty());
+        assert!(report.write_blockers.is_empty());
         assert!(CLARA_BW_391.write_identity_blockers(&snapshot).is_empty());
+
+        let candidate = DeviceProfile {
+            write_ready: false,
+            ..CLARA_BW_391
+        };
+        let report = candidate.validate(&snapshot);
+        assert_eq!(report.readiness, Readiness::ReadOnlyMatched);
+        assert_eq!(report.write_blockers, vec![WRITE_EVIDENCE_PENDING]);
     }
 
     #[test]

--- a/crates/kobo-smoke/Cargo.toml
+++ b/crates/kobo-smoke/Cargo.toml
@@ -9,7 +9,7 @@ autobins = false
 
 [features]
 default = []
-device-write = ["kobo-abi/device-write", "kobo-hal/device-write"]
+device-write = ["kobo-hal/device-write"]
 
 [[bin]]
 name = "kobo-smoke"
@@ -17,9 +17,7 @@ path = "src/main.rs"
 required-features = ["device-write"]
 
 [dependencies]
-kobo-abi = { path = "../kobo-abi", default-features = false }
 kobo-hal = { path = "../kobo-hal", default-features = false }
-kobo-profile = { path = "../kobo-profile" }
 
 [lints]
 workspace = true

--- a/crates/kobo-smoke/src/main.rs
+++ b/crates/kobo-smoke/src/main.rs
@@ -17,34 +17,16 @@
 //! and rewrites only the visible framebuffer. No other waveform, device, or
 //! file can be addressed, and nothing is written outside the framebuffer.
 
-use kobo_hal::display::{DisplaySession, OWNER_UNLOCK_PHRASE};
-use kobo_hal::{Rect, RefreshIntent, RefreshPlan, RegionSnapshot};
+use kobo_hal::display::{run_attended_smoke, AttendedSmokeStage};
 use std::env;
 use std::process::ExitCode;
-use std::thread::sleep;
-use std::time::Duration;
 
 const UNLOCK_ENV: &str = "KOBO_SMOKE_UNLOCK";
 const UNLOCK_DISPLAY_ONLY: &str = "OWNER_ATTENDED_DISPLAY_ONLY_GC16";
 const UNLOCK_REVERSIBLE_PIXELS: &str = "OWNER_ATTENDED_REVERSIBLE_PIXELS_GC16";
 const UNLOCK_SCREEN_SNAPSHOT: &str = "OWNER_ATTENDED_SCREEN_SNAPSHOT_RESTORE";
 const UNLOCK_FAST_FEEDBACK: &str = "OWNER_ATTENDED_REVERSIBLE_PIXELS_DU";
-
-const FIXED_REGION: Rect = Rect {
-    x: 512,
-    y: 704,
-    width: 32,
-    height: 32,
-};
-/// The larger region the snapshot stage changes, so a full-screen restore is
-/// visibly doing something rather than trivially succeeding.
-const PATCH_REGION: Rect = Rect {
-    x: 408,
-    y: 600,
-    width: 256,
-    height: 256,
-};
-const VISIBLE_HOLD: Duration = Duration::from_millis(1200);
+const HAL_VALIDATION_UNLOCK: &str = "OWNER_ATTENDED_CANDIDATE_DISPLAY_VALIDATION";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Stage {
@@ -54,12 +36,13 @@ enum Stage {
     FastFeedback,
 }
 
-impl Stage {
-    /// The refresh intent this stage exercises.
-    const fn intent(self) -> RefreshIntent {
-        match self {
-            Self::FastFeedback => RefreshIntent::FastFeedback,
-            _ => RefreshIntent::QualityContent,
+impl From<Stage> for AttendedSmokeStage {
+    fn from(stage: Stage) -> Self {
+        match stage {
+            Stage::DisplayOnly => Self::DisplayOnly,
+            Stage::ReversiblePixels => Self::ReversiblePixels,
+            Stage::ScreenSnapshot => Self::ScreenSnapshot,
+            Stage::FastFeedback => Self::FastFeedback,
         }
     }
 }
@@ -92,222 +75,15 @@ fn main() -> ExitCode {
 fn run(unlock: Option<&str>) -> Result<String, String> {
     let stage = Stage::from_unlock(unlock)
         .ok_or_else(|| "owner-attended smoke unlock is missing or incorrect".to_owned())?;
-    let session =
-        DisplaySession::open(Some(OWNER_UNLOCK_PHRASE)).map_err(|error| error.to_string())?;
-    let plan = RefreshPlan::new(
-        FIXED_REGION,
-        stage.intent(),
-        false,
-        session.geometry().width,
-        session.geometry().height,
-    )
-    .ok_or_else(|| "fixed region is not inside this screen".to_owned())?;
-
-    match stage {
-        Stage::DisplayOnly => {
-            session.refresh(plan).map_err(|error| error.to_string())?;
-            Ok("display-only GC16 refresh completed; no pixel byte was written".to_owned())
-        }
-        Stage::ReversiblePixels => {
-            let original = session
-                .capture(FIXED_REGION)
-                .map_err(|error| format!("capture region: {error}"))?;
-            show_and_restore(&session, plan, &original)?;
-            Ok(format!(
-                "reversible GC16 pixel test completed; {} bytes restored and verified",
-                original.pixels().len()
-            ))
-        }
-        Stage::ScreenSnapshot => screen_snapshot_restore(&session),
-        Stage::FastFeedback => {
-            // DU is the two-level waveform interactive feedback uses. It is
-            // driven through exactly the same capture, show, restore, verify
-            // path as the GC16 stage, so only the waveform differs.
-            let original = session
-                .capture(FIXED_REGION)
-                .map_err(|error| format!("capture region: {error}"))?;
-            show_and_restore(&session, plan, &original)?;
-            Ok(format!(
-                "reversible DU pixel test completed; {} bytes restored and verified",
-                original.pixels().len()
-            ))
-        }
-    }
-}
-
-/// Snapshots the whole screen, changes a larger region, then puts the entire
-/// screen back from that snapshot and proves the change is gone.
-///
-/// The full-screen snapshot is taken first and restored on every path,
-/// including every error path, so the reader's screen is never left changed.
-fn screen_snapshot_restore(session: &DisplaySession) -> Result<String, String> {
-    let geometry = session.geometry();
-    let whole_screen = Rect {
-        x: 0,
-        y: 0,
-        width: geometry.width,
-        height: geometry.height,
-    };
-    let screen = session
-        .capture(whole_screen)
-        .map_err(|error| format!("capture whole screen: {error}"))?;
-    let patch = session
-        .capture(PATCH_REGION)
-        .map_err(|error| format!("capture patch region: {error}"))?;
-
-    let patch_plan = plan_for(session, PATCH_REGION)?;
-    let screen_plan = plan_for(session, whole_screen)?;
-
-    // Change a large region, then put the whole screen back from the snapshot
-    // rather than from the region snapshot, so it is the full-screen restore
-    // that is being proven.
-    let shown = session
-        .restore(&patch.inverted_rgb())
-        .map_err(|error| format!("write inverted patch: {error}"))
-        .and_then(|()| {
-            session
-                .refresh(patch_plan)
-                .map_err(|error| format!("refresh inverted patch: {error}"))
-        });
-    if shown.is_ok() {
-        sleep(VISIBLE_HOLD);
-    }
-
-    let restored = session
-        .restore(&screen)
-        .map_err(|error| format!("restore whole screen: {error}"))
-        .and_then(|()| {
-            session
-                .refresh(screen_plan)
-                .map_err(|error| format!("refresh restored screen: {error}"))
-        });
-
-    shown?;
-    restored?;
-
-    let verify = session
-        .capture(PATCH_REGION)
-        .map_err(|error| format!("verify patch region: {error}"))?;
-    if !verify.matches(&patch) {
-        return Err("the changed region was not restored by the whole-screen write".to_owned());
-    }
-    Ok(format!(
-        "whole-screen snapshot and restore completed; {} screen bytes captured, \
-         {} bytes changed and verified restored",
-        screen.pixels().len(),
-        patch.pixels().len()
-    ))
-}
-
-fn plan_for(session: &DisplaySession, region: Rect) -> Result<RefreshPlan, String> {
-    RefreshPlan::new(
-        region,
-        RefreshIntent::QualityContent,
-        false,
-        session.geometry().width,
-        session.geometry().height,
-    )
-    .ok_or_else(|| format!("region {region:?} is not inside this screen"))
-}
-
-/// Inverts the captured region, shows it, then always restores the original
-/// bytes before returning, including on every error path.
-fn show_and_restore(
-    session: &DisplaySession,
-    plan: RefreshPlan,
-    original: &RegionSnapshot,
-) -> Result<(), String> {
-    let inverted = original.inverted_rgb();
-    let shown = session
-        .restore(&inverted)
-        .map_err(|error| format!("write inverted region: {error}"))
-        .and_then(|()| {
-            session
-                .refresh(plan)
-                .map_err(|error| format!("refresh inverted region: {error}"))
-        });
-    if shown.is_ok() {
-        sleep(VISIBLE_HOLD);
-    }
-
-    let restored = session
-        .restore(original)
-        .map_err(|error| format!("restore original region: {error}"))
-        .and_then(|()| {
-            session
-                .refresh(plan)
-                .map_err(|error| format!("refresh restored region: {error}"))
-        });
-
-    shown?;
-    restored?;
-
-    let verify = session
-        .capture(original.placement().region())
-        .map_err(|error| format!("verify restored region: {error}"))?;
-    if verify.matches(original) {
-        Ok(())
-    } else {
-        Err("restored region does not match the original bytes".to_owned())
-    }
+    run_attended_smoke(stage.into(), Some(HAL_VALIDATION_UNLOCK)).map_err(|error| error.to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        Stage, FIXED_REGION, PATCH_REGION, UNLOCK_DISPLAY_ONLY, UNLOCK_FAST_FEEDBACK,
-        UNLOCK_REVERSIBLE_PIXELS, UNLOCK_SCREEN_SNAPSHOT, VISIBLE_HOLD,
+        Stage, UNLOCK_DISPLAY_ONLY, UNLOCK_FAST_FEEDBACK, UNLOCK_REVERSIBLE_PIXELS,
+        UNLOCK_SCREEN_SNAPSHOT,
     };
-    use kobo_abi::hwtcon;
-    use kobo_hal::surface::{RegionPlacement, SurfaceGeometry};
-    use kobo_hal::{Rect, RefreshIntent, RefreshPlan};
-
-    const CLARA: SurfaceGeometry = SurfaceGeometry {
-        width: 1072,
-        height: 1448,
-        stride: 4288,
-        bits_per_pixel: 32,
-        memory_length: 6_243_328,
-    };
-
-    #[test]
-    fn the_patch_region_is_inside_the_screen_and_larger_than_the_fixed_region() {
-        let placement = RegionPlacement::new(CLARA, PATCH_REGION).expect("region is valid");
-        assert_eq!(placement.total_bytes(), 256 * 256 * 4);
-        const {
-            assert!(PATCH_REGION.x + PATCH_REGION.width <= CLARA.width);
-            assert!(PATCH_REGION.y + PATCH_REGION.height <= CLARA.height);
-        }
-    }
-
-    #[test]
-    fn a_whole_screen_region_is_a_valid_placement() {
-        let whole = Rect {
-            x: 0,
-            y: 0,
-            width: CLARA.width,
-            height: CLARA.height,
-        };
-        let placement = RegionPlacement::new(CLARA, whole).expect("whole screen is valid");
-        assert_eq!(
-            placement.total_bytes(),
-            (CLARA.stride as usize) * (CLARA.height as usize)
-        );
-        // A whole-screen update must still be a partial-mode update, because
-        // full mode is an untested code path on this controller.
-        let plan = RefreshPlan::new(
-            whole,
-            RefreshIntent::QualityContent,
-            false,
-            CLARA.width,
-            CLARA.height,
-        )
-        .expect("plan is valid");
-        assert_eq!(
-            plan.update_data(0x4000_0002).update_mode,
-            hwtcon::UPDATE_MODE_PARTIAL
-        );
-    }
 
     #[test]
     fn only_the_exact_unlock_phrases_select_a_stage() {
@@ -330,60 +106,5 @@ mod tests {
         ] {
             assert_eq!(Stage::from_unlock(wrong), None, "{wrong:?} must not unlock");
         }
-    }
-
-    #[test]
-    fn only_the_fast_feedback_stage_uses_the_du_waveform() {
-        for (stage, waveform) in [
-            (Stage::DisplayOnly, hwtcon::WAVEFORM_GC16),
-            (Stage::ReversiblePixels, hwtcon::WAVEFORM_GC16),
-            (Stage::ScreenSnapshot, hwtcon::WAVEFORM_GC16),
-            (Stage::FastFeedback, hwtcon::WAVEFORM_DU),
-        ] {
-            let plan = RefreshPlan::new(
-                FIXED_REGION,
-                stage.intent(),
-                false,
-                CLARA.width,
-                CLARA.height,
-            )
-            .expect("plan");
-            assert_eq!(plan.waveform, waveform, "wrong waveform for {stage:?}");
-            // No stage may ever submit a full-mode update: full is untested on
-            // this controller.
-            assert!(!plan.full);
-        }
-    }
-
-    #[test]
-    fn the_fixed_region_is_small_and_inside_the_screen() {
-        assert_eq!(FIXED_REGION.width, 32);
-        assert_eq!(FIXED_REGION.height, 32);
-        let placement = RegionPlacement::new(CLARA, FIXED_REGION).expect("region is valid");
-        assert_eq!(placement.total_bytes(), 4096);
-    }
-
-    #[test]
-    fn the_plan_is_always_a_partial_gc16_update() {
-        let plan = RefreshPlan::new(
-            FIXED_REGION,
-            RefreshIntent::QualityContent,
-            false,
-            CLARA.width,
-            CLARA.height,
-        )
-        .expect("plan is valid");
-        let update = plan.update_data(0x4000_0001);
-        assert_eq!(update.waveform_mode, hwtcon::WAVEFORM_GC16);
-        assert_eq!(update.update_mode, hwtcon::UPDATE_MODE_PARTIAL);
-        assert_eq!(update.update_region.left, FIXED_REGION.x);
-        assert_eq!(update.update_region.top, FIXED_REGION.y);
-        assert_eq!(update.update_region.width, FIXED_REGION.width);
-        assert_eq!(update.update_region.height, FIXED_REGION.height);
-    }
-
-    #[test]
-    fn the_visible_hold_fits_inside_the_remote_lease() {
-        assert!(VISIBLE_HOLD.as_secs() < 5);
     }
 }

--- a/crates/kobo-tap/src/main.rs
+++ b/crates/kobo-tap/src/main.rs
@@ -52,7 +52,7 @@
 use kobo_abi::input;
 use kobo_hal::probe_device;
 use kobo_hal::touch::InputEvent32;
-use kobo_profile::{identify_profile, DeviceProfile, DeviceSnapshot};
+use kobo_profile::{write_ready_profile, DeviceProfile, DeviceSnapshot};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::process::ExitCode;
@@ -138,14 +138,8 @@ fn tap() -> Result<(), String> {
 }
 
 fn writable_profile(snapshot: &DeviceSnapshot) -> Result<&'static DeviceProfile, String> {
-    let profile = identify_profile(snapshot)
-        .ok_or_else(|| "the probed device does not match a supported profile".to_owned())?;
-    let blockers = profile.write_identity_blockers(snapshot);
-    if blockers.is_empty() {
-        Ok(profile)
-    } else {
-        Err(format!("device write refused: {}", blockers.join("; ")))
-    }
+    write_ready_profile(snapshot)
+        .map_err(|blockers| format!("device write refused: {}", blockers.join("; ")))
 }
 
 /// One tap, and how long to wait before making it.
@@ -371,6 +365,22 @@ mod tests {
         let error = writable_profile(&snapshot).expect_err("identity gates every device write");
         assert!(error.contains("device write refused"), "{error}");
         assert!(error.contains("device code"), "{error}");
+    }
+
+    #[test]
+    fn reviewed_elipsa_with_exact_identity_can_receive_a_tap() {
+        let snapshot = snapshot_for(
+            &ELIPSA_2E_389,
+            IdentitySnapshot {
+                serial_prefix: Some("N605".into()),
+                firmware_version: Some("4.38.23697".into()),
+                kernel_release: Some("4.9.77".into()),
+                device_code: Some(389),
+            },
+        );
+        let profile = writable_profile(&snapshot)
+            .expect("completed attended evidence authorizes synthetic touch");
+        assert_eq!(profile.id, ELIPSA_2E_389.id);
     }
 
     #[test]

--- a/crates/kobod/src/main.rs
+++ b/crates/kobod/src/main.rs
@@ -120,8 +120,8 @@ fn touch_test(seconds: &str) -> Result<(), Box<dyn Error>> {
     let seconds: u64 = seconds.parse().unwrap_or(20).min(120);
 
     let snapshot = kobo_hal::probe_device()?;
-    let profile = kobo_profile::identify_profile(&snapshot)
-        .ok_or_else(|| "no supported hardware profile matched this device".to_owned())?;
+    let profile = kobo_profile::write_ready_profile(&snapshot)
+        .map_err(|blockers| format!("device write refused: {}", blockers.join("; ")))?;
     let touch_path = snapshot
         .touch
         .as_ref()

--- a/docs/DEVICES.md
+++ b/docs/DEVICES.md
@@ -4,6 +4,25 @@ Getting Cobalt onto a device, talking to it over Wi-Fi, keeping it awake long
 enough to work, and the attended tests that are allowed to write to the panel.
 Part of [Cobalt](../README.md).
 
+## Device support matrix
+
+Support is tied to an exact model, device code, firmware, kernel, framebuffer,
+and touch profile. A matching model name alone is not sufficient.
+
+| Device | Exact tested identity | Evidence status | Installation status |
+|---|---|---|---|
+| Kobo Clara BW | N365, code 391, firmware 4.45.23697, kernel 4.9.77 | Read-only probe and owner-attended display, touch, exit, and recovery tests complete | Fully tested |
+| Kobo Elipsa 2E | N605, code 389, firmware 4.38.23697, kernel 4.9.77 | Read-only probe and owner-attended display, touch, exit, suspend/resume, and recovery tests complete | Fully tested |
+
+`Read-only doctor match complete` means the profile describes the observed
+identity, framebuffer, and touch ranges. It does not prove the physical touch
+direction, panel refresh behavior, or recovery after Cobalt takes ownership of
+the device. Those claims require owner-attended hardware runs; simulator and
+fixture results are not substitutes.
+
+Firmware versions not listed here are unsupported even on the same model until
+a new read-only probe and the applicable attended evidence have been reviewed.
+
 ## Connecting a device
 
 The reader has to be on the same wireless network as the machine you work from.
@@ -497,6 +516,13 @@ phrase in the device process environment, an exact match of every probed
 hardware value against the profile, and an exact match of the device code,
 serial model prefix, firmware version and kernel release.
 
+Ordinary display, guard, synthetic-touch, and exclusive touch-grab paths also
+require the profile's reviewed `write_ready` flag. The HAL owns the smoke
+operation's fixed regions, waveform choices, restoration, and verification, so
+the caller never receives a general candidate-capable display session. It may
+ignore only the evidence-pending blocker. Any geometry, framebuffer, or
+identity blocker still refuses the smoke run before the framebuffer is opened.
+
 ```
 kobo smoke-display --device <address> --confirm DISPLAY_ONLY_GC16
 kobo smoke-display --device <address> --confirm REVERSIBLE_PIXELS_GC16
@@ -515,6 +541,14 @@ snapshot and restore; the DU waveform; the touch transform, against a physical
 touch; guardian restoration after a failed child; stopping and restarting the
 stock reader; an application rendered on the panel and taps reaching it; and
 HTTPS, including a 24 MB download.
+
+Proven on the physical N605: the same four bounded GC16, reversible-pixel,
+whole-screen restore, and DU stages; the Elan touch transform against a
+physical top-left touch; guardian restoration after a deliberate child
+failure; a Todo session rendered at 1404×1872 with physical taps reaching UI
+actions; release of panel and touch followed by a successful stock-reader
+restart; and suspend/resume with monotonic device uptime and no Cobalt process
+left running.
 
 Update markers are random and at least `0x40000000`, because markers are a
 global namespace shared with the stock reader and a low fixed marker could be

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,19 +1,26 @@
 # Installing Cobalt
 
-The full walkthrough for getting Cobalt onto a Kobo Clara BW over USB, what to
-do if a step doesn't go as described, and how to take it back off. Part of
-[Cobalt](../README.md).
+The full owner-facing walkthrough for getting Cobalt onto a supported Kobo over
+USB, what to do if a step does not go as described, and how to take it back
+off. Part of [Cobalt](../README.md).
 
-**Tested on one device: the Kobo Clara BW (N365, device code 391), firmware
-4.45.23697.** Every device write is gated on an exact match of framebuffer
-identity, geometry, device code, serial model prefix, firmware version and
-kernel release, so a different reader is refused rather than guessed at. On
-any other Kobo, Cobalt will decline to draw.
+The procedure below is fully hardware-tested on the **Kobo Clara BW N365
+(device code 391), firmware 4.45.23697** and the **Kobo Elipsa 2E N605 (device
+code 389), firmware 4.38.23697**. Support remains tied to the exact firmware,
+kernel, framebuffer, touch, and identity combination in the
+[device support matrix](DEVICES.md#device-support-matrix).
+
+Display and synthetic-touch writes require an exact match of framebuffer
+identity, geometry, device code, serial model prefix, firmware version, and
+kernel release. A different reader or firmware is refused rather than guessed
+at.
 
 ## What you need
 
-- A **Kobo Clara BW**, charged. The reader's own installer is gated on battery
-  level and fails silently, so charge it first.
+- A charged reader whose entry in the
+  [device support matrix](DEVICES.md#device-support-matrix) is fully tested.
+  The reader's own installer is gated on battery level and fails silently, so
+  charge it first.
 - A **USB cable** that carries data. Charge-only cables are common and they
   look identical; if the reader charges but never offers to connect, suspect
   the cable before anything else.

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -2,10 +2,16 @@
 
 Part of [Cobalt](../README.md).
 
-**Cobalt has only ever run on a Kobo Clara BW (N365, device code 391).** Every
-device write is gated on an exact hardware match, so a different reader is
-refused rather than guessed at. Nothing here bricks a device by trying; it
-simply declines.
+Cobalt selects a device profile at runtime. The Clara BW and Elipsa 2E profiles
+are fully hardware-tested at their recorded identity and firmware boundaries.
+The current status and exact boundaries are recorded in the
+[device support matrix](DEVICES.md#device-support-matrix).
+
+Display and synthetic-touch write entry points demand an exact hardware and
+firmware match, so an unknown reader is refused rather than guessed at. A
+read-only match is only a porting milestone, not permission to ship or install
+the profile. Review every other path that takes device ownership against the
+same identity boundary.
 
 This is a genuinely welcome pull request. Open an issue first so the profile
 shape can be agreed.
@@ -18,18 +24,22 @@ and every application are device-independent. What is measured is:
 1. **A `DeviceProfile`**, in `crates/kobo-profile/src/lib.rs`. Panel size and
    stride, framebuffer identity, the touch device and its axis ranges and
    rotation, and the identity fields (device code, serial prefix, firmware,
-   kernel). `CLARA_BW_391` is the worked example.
+   kernel). Its `write_ready` flag remains false until the attended evidence in
+   the device support matrix has been reviewed. `CLARA_BW_391` and
+   `ELIPSA_2E_389` are the current examples.
 2. **`DisplayMetrics`**, in `crates/kobo-ui/src/lib.rs`. Size and DPI, which is
    what the layout engine reasons about.
-3. **Which profile is compiled in.** There is no runtime device selection yet.
-   `kobod`, `kobo-tap`, `kobo-doctor`, `kobo-guard`, `kobo-smoke` and the
-   simulator each name `CLARA_BW_391` directly. Making that a choice rather
-   than a constant is most of the work of supporting a second device, and is
-   the part worth agreeing before anybody writes it.
+3. **Runtime profile registration.** `SUPPORTED_PROFILES` in `kobo-profile`
+   contains the profiles the runtime may identify. Device tools probe first and
+   select a matching hardware profile; panel-write entry points then apply the
+   shared `write_ready_profile` gate, which requires exact identity and reviewed
+   evidence. The browser/runtime simulator remains Clara BW-sized, so a new
+   profile also needs explicit layout coverage for its metrics.
 
-The hardware layer itself is already fine: every function in `kobo-hal` takes
-a `&DeviceProfile` rather than reaching for a global, so the framebuffer, the
-touch decoder and the refresh planner need no changes at all.
+The framebuffer, touch decoder, and refresh planner consume a `DeviceProfile`
+rather than assuming one model. A new device can still require narrow discovery
+support—for example, recognizing its touch device name—and tests proving that
+all write paths use the profile selected from the same probe.
 
 ## How to get the numbers
 
@@ -63,13 +73,23 @@ device-tree compatible: mediatek,mt8110, mediatek,mt8512
 framebuffer: id=hwtcon 1072x1448 virtual=1072x1448 offset=0,0 bpp=32 ...
 identity: model=N365 firmware=4.45.23697 kernel=4.9.77 device-code=391
 touch: cyttsp5_mt at /dev/input/event1 X=0..1447 Y=0..1071
-result: read-only matched
+result: write ready
 ```
 
-Every field a profile needs is on that page. It then validates what it found
-against the profile compiled into it and lists each mismatch, so on a device
-that is not a Clara BW the report *is* your starting profile: each mismatch
-names a field and the value your device actually has.
+The hardware-verified Elipsa 2E probe is:
+
+```
+profile: elipsa-2e-389 (Kobo Elipsa 2E)
+framebuffer: id=hwtcon 1404x1872 virtual=1404x1872 offset=0,0 bpp=32 ...
+identity: model=N605 firmware=4.38.23697 kernel=4.9.77 device-code=389
+touch: Elan Touchscreen at /dev/input/event2 X=0..1872 Y=0..1404
+result: write ready
+```
+
+Every field a profile needs is on that page. The doctor compares the probe with
+the registered profiles. A known device is named; an unknown device is reported
+as unsupported after its raw fields are printed, making that report the
+starting evidence for a new profile.
 
 The full serial number is deliberately never read past its four-character
 model prefix.
@@ -77,7 +97,16 @@ model prefix.
 ## What will refuse to work until the profile is right
 
 By design, all of it. `validate` returns `Rejected` on any mismatch, and every
-write path also demands an exact device code, serial prefix, firmware
-version and kernel release. A profile that is merely close is treated as a
-different device. That is the whole point: geometry alone is not proof of
-identity, and the failure mode of guessing is somebody else's reader.
+ordinary write or exclusive-ownership path uses `write_ready_profile`, which
+also demands an exact device code, serial prefix, firmware version, kernel
+release, and completed attended evidence. A profile that is merely close is
+treated as a different device. That is the whole point: geometry alone is not
+proof of identity, and the failure mode of guessing is somebody else's reader.
+
+The bounded `kobo smoke-display` operation is the only exception while evidence
+is being gathered. The HAL owns its fixed regions, waveform choices,
+restoration, and verification and never returns a candidate-capable display
+session to the caller. It may ignore only the evidence-pending blocker;
+geometry, framebuffer safety, and exact identity remain mandatory. Normal
+runtime display, guard, synthetic-tap, and exclusive touch-grab paths stay
+blocked until `write_ready` is reviewed and enabled.

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
 <link rel="icon" href="logo.svg" type="image/svg+xml">
 <meta property="og:type" content="website">
 <meta property="og:title" content="Cobalt: apps and an SDK for Kobo e-readers">
-<meta property="og:description" content="A launcher, a signed App Store, a Rust SDK, and a capability-isolated runtime for the Kobo Clara BW. Install once over USB; everything after that arrives over Wi-Fi.">
+<meta property="og:description" content="A launcher, a signed App Store, a Rust SDK, and a capability-isolated runtime for supported Kobo e-readers. Install once over USB; everything after that arrives over Wi-Fi.">
 <meta property="og:url" content="https://bandarlabs.github.io/Cobalt/">
 <meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
 <meta property="og:image:width" content="1200">
@@ -17,14 +17,14 @@
 <meta property="og:image:alt" content="The Cobalt launcher on a Kobo Clara BW: Settings, App Store, Terminal, AI Chat, Audiobooks, Components, Daily Brief, Feeds and Gutenbird.">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Cobalt: apps and an SDK for Kobo e-readers">
-<meta name="twitter:description" content="A launcher, a signed App Store, a Rust SDK, and a capability-isolated runtime for the Kobo Clara BW.">
+<meta name="twitter:description" content="A launcher, a signed App Store, a Rust SDK, and a capability-isolated runtime for supported Kobo e-readers.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   "name": "Cobalt",
-  "operatingSystem": "Linux (Kobo Clara BW)",
+  "operatingSystem": "Linux (supported Kobo e-readers)",
   "applicationCategory": "DeveloperApplication",
   "description": "An open-source application platform for Kobo e-readers: a launcher, a signed App Store, a Rust SDK, and a runtime with capability isolation.",
   "url": "https://bandarlabs.github.io/Cobalt/",
@@ -577,7 +577,7 @@ kobo dev</code></pre>
     <p class="kicker">Install</p>
     <h2 class="measure">Installing from source.</h2>
     <ol class="steps">
-      <li><strong>Charge a Kobo Clara BW (N365)</strong> and connect it over USB. Other models are refused, not guessed at.</li>
+      <li><strong>Charge a fully supported reader</strong> and connect it over USB. The Clara BW N365 and Elipsa 2E N605 are fully tested at the exact versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>.</li>
       <li><strong>Run the setup:</strong></li>
     </ol>
 <pre><code>git clone https://github.com/BandarLabs/Cobalt.git
@@ -600,7 +600,7 @@ cargo run -p kobo-cli -- setup</code></pre>
     <ol class="steps" style="margin-top:26px">
       <li><strong>Build it.</strong> Add the app as a workspace package under <code class="inline">apps/&lt;app-id&gt;/</code> and register it in <code class="inline">apps/catalog.json</code>.</li>
       <li><strong>Test it.</strong> Add unit and layout tests, and run it in the browser and runtime simulators.</li>
-      <li><strong>Run it on your own device.</strong> A real Clara BW, not just the simulator.</li>
+      <li><strong>Run it on your own device.</strong> A real, fully supported reader, not just the Clara-sized simulator.</li>
       <li><strong>Open a PR with a gif or photos of it running.</strong> Once reviewed and merged, the publish workflow signs it and it appears in Store. No platform release needed.</li>
     </ol>
     <p class="measure quiet" style="margin-top:22px">Own a different Kobo model? <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/PORTING.md">Porting</a> is welcome too; open an issue first so the device profile can be agreed. Full details in <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/CONTRIBUTING_APPS.md">docs/CONTRIBUTING_APPS.md</a>.</p>
@@ -611,8 +611,8 @@ cargo run -p kobo-cli -- setup</code></pre>
   <div class="wrap measure">
     <p class="kicker">Safety</p>
     <h2>Device support and safety.</h2>
-    <p>Cobalt does not replace Kobo's boot chain. Device writes are gated on an exact hardware and firmware match, and a reboot returns to the stock reader. The first installation does modify files on the user storage partition, and it is provided without warranty.</p>
-    <p>Only the Clara BW profile has been hardware-tested. Don't install on another model until it has a <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/PORTING.md">reviewed, hardware-tested profile</a>. Cobalt is an independent project, not affiliated with Rakuten Kobo.</p>
+    <p>Cobalt does not replace Kobo's boot chain. Normal panel-write entry points require an exact hardware and firmware match, and a reboot returns to the stock reader. The first installation does modify files on the user storage partition, and it is provided without warranty.</p>
+    <p>The Clara BW N365 and Elipsa 2E N605 profiles are fully hardware-tested at the exact firmware and kernel versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>. Other identity or firmware combinations remain unsupported until separately verified. Cobalt is an independent project, not affiliated with Rakuten Kobo.</p>
   </div>
 </section>
 

--- a/docs/sdk.html
+++ b/docs/sdk.html
@@ -272,7 +272,7 @@ footer nav { display: flex; gap: 20px; flex-wrap: wrap; }
 <span class="kw">fn</span> <span class="fn">main</span>() {
     <span class="kw">let</span> _ = kobo_sdk::<span class="fn">run</span>(<span class="str">"counter"</span>, <span class="ty">Counter</span>::<span class="fn">default</span>());
 }</code></pre>
-      <div class="note"><strong>Hardware support.</strong> Cobalt has been tested on the Kobo Clara BW N365, device code 391. Other Kobo models can be supported after hardware testing and review of their device profile.</div>
+      <div class="note"><strong>Hardware support.</strong> The Kobo Clara BW N365, device code 391, and Kobo Elipsa 2E N605, device code 389, are fully hardware-tested at the exact firmware and kernel versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>.</div>
     </section>
 
     <section id="application-model">


### PR DESCRIPTION
## Summary

Follow-up to #26 after completing the owner-attended Elipsa 2E hardware gate.

This change hardens the generic device-write boundary used by current and
future Kobo profiles, then promotes the exact tested Elipsa 2E profile to
write-ready.

### Platform-level changes

- Centralize ordinary device-write authorization behind exact profile identity
  and reviewed `write_ready` evidence.
- Keep candidate display validation inside a bounded HAL-owned smoke operation.
  Callers cannot obtain a general candidate-capable `DisplaySession`.
- Require separate exact owner-attended unlocks at the CLI and HAL boundaries.
- Make synthetic taps and exclusive touch tests use the probed write-ready
  profile.
- Preserve verified display metrics throughout an active device session.
- Propagate recognized touch-device probe failures instead of silently treating
  them as missing hardware.

### Elipsa 2E validation

- Recognize the Elan touchscreen discovered at `/dev/input/event2`.
- Add edge, bounds, round-trip, and measured physical-touch coverage.
- Promote only the exact N605/device-code-389 profile on firmware 4.38.23697
  and kernel 4.9.77.
- Update the public device support and installation documentation.

## Physical hardware evidence

Tested on a Kobo Elipsa 2E N605, device code 389, firmware 4.38.23697,
kernel 4.9.77:

- Read-only doctor matched the exact profile and reports `write ready`.
- GC16 display-only, reversible GC16, whole-screen snapshot/restore, and
  reversible DU stages completed with clean visual restoration.
- A physical top-left touch mapped raw `(1838, 30)` to display `(30, 34)`.
- The guardian restored all 10,513,152 framebuffer bytes after a deliberate
  child failure.
- Todo rendered at 1404×1872 and physical taps reached multiple UI actions.
- Normal shutdown released panel and touch ownership, restarted Nickel, and
  left no `kobod` process running.
- The device completed a long suspend/resume interval with monotonic uptime and
  returned to the stock reader normally.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace --all-targets --all-features`
- Affected-package Clippy with `-D warnings`
- Workspace Clippy excluding unrelated `icon-import`
- ARMv7 all-features workspace check
- `cargo run -p kobo-cli -- build --device`
- Independent device-boundary review: no material findings

Full local workspace Clippy currently encounters two unrelated Rust 1.97
`useless_borrows_in_formatting` findings in `tools/icon-import`. This PR does
not modify that package.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789839432&installation_model_id=20525&pr_number=27&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F27&signature=be23685b5ca3f677e5759dee6f0ca1e687e3ab5e620a08f5df5a4d772edc7dcd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->