### PR TITLE
feat: support Kobo Clara HD 376

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,11 @@ new app can appear in Store without reinstalling or updating Cobalt.
 </p>
 
 > [!IMPORTANT]
-> The **Kobo Clara BW N365 (device code 391)** and **Kobo Elipsa 2E N605
-> (device code 389)** are fully hardware-tested on the exact firmware and
-> kernel versions in the support matrix.
-> See the [device support matrix](docs/DEVICES.md#device-support-matrix) before
+> The **Kobo Clara BW N365 (device code 391)**, **Kobo Elipsa 2E N605 (device
+> code 389)**, and **Kobo Clara HD N249 (device code 376)** are fully
+> hardware-tested on the exact firmware and kernel versions in the support
+> matrix. See the
+> [device support matrix](docs/DEVICES.md#device-support-matrix) before
 > installing.
 > It is an independent project and is not affiliated with Rakuten Kobo.
 

--- a/crates/kobo-abi/src/lib.rs
+++ b/crates/kobo-abi/src/lib.rs
@@ -708,7 +708,7 @@ pub mod sandbox {
     #[cfg(all(target_os = "linux", target_arch = "arm"))]
     use std::sync::atomic::{AtomicBool, Ordering};
     #[cfg(all(target_os = "linux", target_arch = "arm"))]
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     #[cfg(all(target_os = "linux", target_arch = "arm"))]
     use std::thread;
     #[cfg(all(target_os = "linux", target_arch = "arm"))]
@@ -851,7 +851,14 @@ pub mod sandbox {
     /// application cannot outlive the runtime that enforces its policy.
     #[cfg(all(target_os = "linux", target_arch = "arm"))]
     pub struct SyscallTrace {
-        detached: Arc<AtomicBool>,
+        state: Arc<TraceState>,
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    #[derive(Default)]
+    struct TraceState {
+        detached: AtomicBool,
+        failure: Mutex<Option<String>>,
     }
 
     #[cfg(all(target_os = "linux", target_arch = "arm"))]
@@ -868,8 +875,8 @@ pub mod sandbox {
         /// Returns an error when the tracing thread, application process or
         /// ptrace policy cannot be started.
         pub fn spawn(mut command: Command) -> io::Result<(Child, Self)> {
-            let detached = Arc::new(AtomicBool::new(false));
-            let finished = Arc::clone(&detached);
+            let state = Arc::new(TraceState::default());
+            let finished = Arc::clone(&state);
             let (sender, receiver) = std::sync::mpsc::sync_channel(1);
             thread::Builder::new()
                 .name("cobalt-syscall-trace".to_owned())
@@ -878,41 +885,61 @@ pub mod sandbox {
                         Ok(child) => child,
                         Err(error) => {
                             let _ignored = sender.send(Err(error));
-                            finished.store(true, Ordering::Release);
+                            finished.detached.store(true, Ordering::Release);
                             return;
                         }
                     };
                     let pid = match begin_trace(child.id()) {
                         Ok(pid) => pid,
                         Err(error) => {
-                            abort_trace(child.id());
+                            let error = abort_failure(child.id(), error);
                             let _ignored = child.wait();
                             let _ignored = sender.send(Err(error));
-                            finished.store(true, Ordering::Release);
+                            finished.detached.store(true, Ordering::Release);
                             return;
                         }
                     };
                     match sender.send(Ok(child)) {
-                        Ok(()) => trace_child(pid),
+                        Ok(()) => {
+                            if let Err(error) = trace_child(pid) {
+                                let error =
+                                    abort_failure(u32::try_from(pid).unwrap_or_default(), error);
+                                *finished
+                                    .failure
+                                    .lock()
+                                    .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                                    Some(error.to_string());
+                            }
+                        }
                         Err(error) => {
-                            abort_trace(u32::try_from(pid).unwrap_or_default());
+                            let _ignored = abort_trace(u32::try_from(pid).unwrap_or_default());
                             if let Ok(mut child) = error.0 {
                                 let _ignored = child.wait();
                             }
                         }
                     }
-                    finished.store(true, Ordering::Release);
+                    finished.detached.store(true, Ordering::Release);
                 })?;
             let child = receiver.recv().map_err(|_| {
                 io::Error::other("sandbox syscall tracer stopped before application launch")
             })??;
-            Ok((child, Self { detached }))
+            Ok((child, Self { state }))
         }
 
         /// Whether the tracer has released the process for ordinary reaping.
         #[must_use]
         pub fn is_detached(&self) -> bool {
-            self.detached.load(Ordering::Acquire)
+            self.state.detached.load(Ordering::Acquire)
+        }
+
+        /// The reason syscall supervision failed, if it ended abnormally.
+        #[must_use]
+        pub fn failure(&self) -> Option<String> {
+            self.state
+                .failure
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
         }
 
         /// Waits briefly for a terminating child to leave the tracing stop.
@@ -938,17 +965,33 @@ pub mod sandbox {
                 "sandboxed child did not stop at its exec boundary",
             ));
         }
-        let options =
-            libc::PTRACE_O_TRACESYSGOOD | libc::PTRACE_O_TRACEEXIT | libc::PTRACE_O_EXITKILL;
+        let options = libc::PTRACE_O_TRACESYSGOOD
+            | libc::PTRACE_O_TRACEFORK
+            | libc::PTRACE_O_TRACEVFORK
+            | libc::PTRACE_O_TRACECLONE
+            | libc::PTRACE_O_TRACEEXIT
+            | libc::PTRACE_O_EXITKILL;
         ptrace_value(libc::PTRACE_SETOPTIONS, pid, options)?;
         ptrace_syscall(pid, 0)?;
         Ok(pid)
     }
 
     #[cfg(all(target_os = "linux", target_arch = "arm"))]
-    fn abort_trace(pid: u32) {
-        let Ok(pid) = i32::try_from(pid) else { return };
-        let _ignored = ptrace_value(libc::PTRACE_KILL, pid, 0);
+    fn abort_trace(pid: u32) -> io::Result<()> {
+        let pid = i32::try_from(pid).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "child pid does not fit pid_t")
+        })?;
+        ptrace_value(libc::PTRACE_KILL, pid, 0)
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    fn abort_failure(pid: u32, failure: io::Error) -> io::Error {
+        match abort_trace(pid) {
+            Ok(()) => failure,
+            Err(abort) => io::Error::other(format!(
+                "{failure}; also failed to kill the stopped tracee: {abort}"
+            )),
+        }
     }
 
     #[cfg(any(test, all(target_os = "linux", target_arch = "arm")))]
@@ -992,28 +1035,33 @@ pub mod sandbox {
     }
 
     /// Inspects, rewrites and resumes one syscall stop as a single operation.
-    /// A register failure must leave the tracee stopped: resuming after a
-    /// failed entry rewrite could execute the syscall the policy denied.
+    /// An inspection or rewrite failure must leave the tracee stopped:
+    /// resuming after a failed entry rewrite could execute a denied syscall.
     #[cfg(any(test, all(target_os = "linux", target_arch = "arm")))]
-    fn advance_syscall_stop<Get, Set, Denied, Resume>(
+    fn advance_syscall_stop<Get, Set, SetSyscall, Denied, Resume>(
         state: &mut SyscallStopState,
         mut get_registers: Get,
         mut set_registers: Set,
+        set_syscall: SetSyscall,
         syscall_is_denied: Denied,
         resume: Resume,
     ) -> io::Result<()>
     where
         Get: FnMut() -> io::Result<ArmRegisters>,
         Set: FnMut(&ArmRegisters) -> io::Result<()>,
+        SetSyscall: FnOnce(i32) -> io::Result<()>,
         Denied: FnOnce(u32, u32) -> bool,
         Resume: FnOnce() -> io::Result<()>,
     {
         if state.entering {
-            let mut registers = get_registers()?;
+            let registers = get_registers()?;
             state.denied = syscall_is_denied(registers.r7, registers.r0);
             if state.denied {
-                registers.r7 = u32::MAX;
-                set_registers(&registers)?;
+                // ARM copies r7 into thread_info::syscall before this stop and
+                // dispatches from that field afterward. PTRACE_SET_SYSCALL is
+                // the architecture's only operation for changing the pending
+                // call; writing r7 here changes merely the saved user register.
+                set_syscall(-1)?;
             }
         } else if state.denied {
             let mut registers = get_registers()?;
@@ -1025,16 +1073,21 @@ pub mod sandbox {
     }
 
     #[cfg(all(target_os = "linux", target_arch = "arm"))]
-    fn trace_child(pid: i32) {
+    fn trace_child(pid: i32) -> io::Result<()> {
         let mut syscall_state = SyscallStopState::default();
         loop {
             let mut status = 0;
             if unsafe { libc::waitpid(pid, &raw mut status, 0) } < 0 {
-                abort_trace(u32::try_from(pid).unwrap_or_default());
-                break;
+                let error = io::Error::last_os_error();
+                if error.kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+                return Err(io::Error::other(format!(
+                    "wait for sandboxed syscall stop: {error}"
+                )));
             }
             if libc::WIFEXITED(status) || libc::WIFSIGNALED(status) {
-                break;
+                return Ok(());
             }
             if !libc::WIFSTOPPED(status) {
                 continue;
@@ -1042,22 +1095,41 @@ pub mod sandbox {
             let signal = libc::WSTOPSIG(status);
             let event = u32::try_from(status).unwrap_or_default() >> 16;
             if signal == libc::SIGTRAP && event == libc::PTRACE_EVENT_EXIT as u32 {
-                let _ignored = ptrace_value(libc::PTRACE_DETACH, pid, 0);
-                break;
+                return ptrace_value(libc::PTRACE_DETACH, pid, 0)
+                    .map_err(|error| io::Error::other(format!("detach exiting tracee: {error}")));
+            }
+            if signal == libc::SIGTRAP
+                && [
+                    libc::PTRACE_EVENT_FORK,
+                    libc::PTRACE_EVENT_VFORK,
+                    libc::PTRACE_EVENT_CLONE,
+                ]
+                .into_iter()
+                .any(|kind| u32::try_from(kind).ok() == Some(event))
+            {
+                let descendant = ptrace_event_message(pid).map_or_else(
+                    |error| format!("unreadable descendant pid ({error})"),
+                    |descendant| {
+                        let _ignored = abort_trace(descendant);
+                        descendant.to_string()
+                    },
+                );
+                return Err(io::Error::other(format!(
+                    "denied process creation executed and produced descendant {descendant}"
+                )));
             }
             if signal == (libc::SIGTRAP | 0x80) {
-                if advance_syscall_stop(
+                advance_syscall_stop(
                     &mut syscall_state,
                     || get_registers(pid),
                     |registers| set_registers(pid, registers),
+                    |number| set_syscall(pid, number),
                     syscall_is_denied,
                     || ptrace_syscall(pid, 0),
                 )
-                .is_err()
-                {
-                    abort_trace(u32::try_from(pid).unwrap_or_default());
-                    break;
-                }
+                .map_err(|error| {
+                    io::Error::other(format!("advance sandboxed syscall stop: {error}"))
+                })?;
                 continue;
             }
             let delivered = if signal == libc::SIGSTOP || signal == libc::SIGTRAP {
@@ -1065,10 +1137,9 @@ pub mod sandbox {
             } else {
                 signal
             };
-            if ptrace_syscall(pid, delivered).is_err() {
-                abort_trace(u32::try_from(pid).unwrap_or_default());
-                break;
-            }
+            ptrace_syscall(pid, delivered).map_err(|error| {
+                io::Error::other(format!("resume sandboxed signal stop: {error}"))
+            })?;
         }
     }
 
@@ -1125,6 +1196,32 @@ pub mod sandbox {
             Err(io::Error::last_os_error())
         } else {
             Ok(())
+        }
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    fn set_syscall(pid: i32, number: i32) -> io::Result<()> {
+        // PTRACE_SET_SYSCALL is ARM-specific and libc does not expose it on
+        // every build host. Its stable UAPI request number is 23.
+        const PTRACE_SET_SYSCALL: libc::c_int = 23;
+        ptrace_value(PTRACE_SET_SYSCALL, pid, number)
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    fn ptrace_event_message(pid: i32) -> io::Result<u32> {
+        let mut message: libc::c_ulong = 0;
+        let result = unsafe {
+            libc::ptrace(
+                libc::PTRACE_GETEVENTMSG,
+                pid,
+                std::ptr::null_mut::<libc::c_void>(),
+                std::ptr::from_mut(&mut message).cast::<libc::c_void>(),
+            )
+        };
+        if result < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(message)
         }
     }
 
@@ -1294,6 +1391,7 @@ pub mod sandbox {
                 &mut SyscallStopState::default(),
                 || Err(io::Error::other("PTRACE_GETREGS failed")),
                 |_| Ok(()),
+                |_| Ok(()),
                 |_, _| true,
                 || {
                     resumed.set(true);
@@ -1306,14 +1404,15 @@ pub mod sandbox {
         }
 
         #[test]
-        fn a_denied_syscall_rewrite_failure_does_not_resume_the_tracee() {
+        fn a_denied_syscall_selection_failure_does_not_resume_the_tracee() {
             let resumed = Cell::new(false);
             let result = advance_syscall_stop(
                 &mut SyscallStopState::default(),
                 || Ok(ArmRegisters::default()),
-                |registers| {
-                    assert_eq!(registers.r7, u32::MAX);
-                    Err(io::Error::other("PTRACE_SETREGS failed"))
+                |_| Ok(()),
+                |number| {
+                    assert_eq!(number, -1);
+                    Err(io::Error::other("PTRACE_SET_SYSCALL failed"))
                 },
                 |_, _| true,
                 || {
@@ -1324,6 +1423,79 @@ pub mod sandbox {
 
             assert!(result.is_err());
             assert!(!resumed.get());
+        }
+
+        #[test]
+        fn a_denied_syscall_result_rewrite_failure_does_not_resume_the_tracee() {
+            let resumed = Cell::new(false);
+            let mut state = SyscallStopState {
+                entering: false,
+                denied: true,
+            };
+            let result = advance_syscall_stop(
+                &mut state,
+                || Ok(ArmRegisters::default()),
+                |_| Err(io::Error::other("PTRACE_SETREGS failed")),
+                |_| panic!("an exit stop must not replace the pending syscall"),
+                |_, _| panic!("an exit stop must not classify the syscall"),
+                || {
+                    resumed.set(true);
+                    Ok(())
+                },
+            );
+
+            assert!(result.is_err());
+            assert!(!resumed.get());
+        }
+
+        #[test]
+        fn a_denied_syscall_is_replaced_then_reported_as_permission_denied() {
+            let selected = Cell::new(None);
+            let result = Cell::new(None);
+            let resumes = Cell::new(0);
+            let mut state = SyscallStopState::default();
+            let entry = ArmRegisters {
+                r0: libc::AF_INET as u32,
+                r7: 281,
+                ..ArmRegisters::default()
+            };
+
+            advance_syscall_stop(
+                &mut state,
+                || Ok(entry),
+                |_| panic!("entry denial must not rewrite general registers"),
+                |number| {
+                    selected.set(Some(number));
+                    Ok(())
+                },
+                |number, family| number == 281 && family == libc::AF_INET as u32,
+                || {
+                    resumes.set(resumes.get() + 1);
+                    Ok(())
+                },
+            )
+            .expect("deny the syscall at entry");
+
+            advance_syscall_stop(
+                &mut state,
+                || Ok(ArmRegisters::default()),
+                |registers| {
+                    result.set(Some(i32::from_ne_bytes(registers.r0.to_ne_bytes())));
+                    Ok(())
+                },
+                |_| panic!("exit must not replace the pending syscall"),
+                |_, _| panic!("exit must not classify the syscall"),
+                || {
+                    resumes.set(resumes.get() + 1);
+                    Ok(())
+                },
+            )
+            .expect("report the denial at exit");
+
+            assert_eq!(selected.get(), Some(-1));
+            assert_eq!(result.get(), Some(-libc::EPERM));
+            assert_eq!(resumes.get(), 2);
+            assert!(state.entering);
         }
     }
 }

--- a/crates/kobo-abi/src/lib.rs
+++ b/crates/kobo-abi/src/lib.rs
@@ -1,6 +1,6 @@
-//! Minimal Linux ABI declarations used by the Kobo Clara BW runtime.
+//! Minimal Linux ABI declarations used by the Kobo runtime.
 //!
-//! Query operations are always available. Mutating HWTCON requests are compiled
+//! Query operations are always available. Mutating panel requests are compiled
 //! only with the explicitly opt-in `device-write` feature.
 
 use std::ffi::{c_int, c_ulong, CString};
@@ -86,13 +86,17 @@ unsafe extern "C" {
     fn ioctl(fd: c_int, request: c_ulong, ...) -> c_int;
 }
 
+fn ioctl_request(request: u64) -> c_ulong {
+    c_ulong::try_from(request).unwrap_or(c_ulong::MAX)
+}
+
 fn query_ioctl<T>(file: &File, request: u64) -> io::Result<T> {
     let mut value = MaybeUninit::<T>::zeroed();
     // SAFETY: request is a query ioctl whose kernel ABI writes exactly one T.
     let result = unsafe {
         ioctl(
             file.as_raw_fd(),
-            request as c_ulong,
+            ioctl_request(request),
             value.as_mut_ptr().cast::<std::ffi::c_void>(),
         )
     };
@@ -109,7 +113,7 @@ fn query_ioctl_bytes(file: &File, request: u64, bytes: &mut [u8]) -> io::Result<
     let result = unsafe {
         ioctl(
             file.as_raw_fd(),
-            request as c_ulong,
+            ioctl_request(request),
             bytes.as_mut_ptr().cast::<std::ffi::c_void>(),
         )
     };
@@ -127,7 +131,7 @@ fn mutating_ioctl<T>(file: &File, request: u64, value: &mut T) -> io::Result<()>
     let result = unsafe {
         ioctl(
             file.as_raw_fd(),
-            request as c_ulong,
+            ioctl_request(request),
             std::ptr::from_mut(value).cast::<std::ffi::c_void>(),
         )
     };
@@ -145,7 +149,7 @@ fn mutating_ioctl<T>(file: &File, request: u64, value: &mut T) -> io::Result<()>
 fn value_ioctl(file: &File, request: u64, value: c_int) -> io::Result<()> {
     // SAFETY: this request takes its argument by value; no memory is read
     // through it.
-    let result = unsafe { ioctl(file.as_raw_fd(), request as c_ulong, value) };
+    let result = unsafe { ioctl(file.as_raw_fd(), ioctl_request(request), value) };
     if result < 0 {
         Err(io::Error::last_os_error())
     } else {
@@ -577,6 +581,103 @@ pub mod hwtcon {
     }
 }
 
+/// Mark 7 i.MX6SLL electrophoretic display controller ABI.
+///
+/// These declarations match Kobo's vendor `mxcfb_update_data_v2` interface.
+/// It uses the same ioctl numbers as HWTCON, but a different update structure
+/// and different numeric values for some waveforms. Keeping it as a separate
+/// module makes accidentally submitting one controller's structure to the
+/// other controller difficult.
+pub mod mxcfb {
+    use super::{iow, iowr};
+    #[cfg(feature = "device-write")]
+    use super::{mutating_ioctl, File};
+    #[cfg(feature = "device-write")]
+    use std::io;
+
+    pub const UPDATE_MODE_PARTIAL: u32 = 0;
+    pub const UPDATE_MODE_FULL: u32 = 1;
+    pub const WAVEFORM_INIT: u32 = 0;
+    pub const WAVEFORM_DU: u32 = 1;
+    pub const WAVEFORM_GC16: u32 = 2;
+    pub const WAVEFORM_GL16: u32 = 5;
+    pub const WAVEFORM_GLR16: u32 = 6;
+    pub const WAVEFORM_GLD16: u32 = 7;
+    pub const WAVEFORM_AUTO: u32 = 257;
+    pub const TEMP_USE_AMBIENT: i32 = 0x1000;
+    pub const DITHER_PASSTHROUGH: i32 = 0;
+
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    #[repr(C)]
+    pub struct MxcfbRect {
+        pub top: u32,
+        pub left: u32,
+        pub width: u32,
+        pub height: u32,
+    }
+
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    #[repr(C)]
+    pub struct MxcfbAltBufferData {
+        pub physical_address: u32,
+        pub width: u32,
+        pub height: u32,
+        pub update_region: MxcfbRect,
+    }
+
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    #[repr(C)]
+    pub struct MxcfbUpdateDataV2 {
+        pub update_region: MxcfbRect,
+        pub waveform_mode: u32,
+        pub update_mode: u32,
+        pub update_marker: u32,
+        pub temperature: i32,
+        pub flags: u32,
+        pub dither_mode: i32,
+        pub quant_bit: i32,
+        pub alt_buffer_data: MxcfbAltBufferData,
+    }
+
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    #[repr(C)]
+    pub struct MxcfbUpdateMarkerData {
+        pub update_marker: u32,
+        pub collision_test: u32,
+    }
+
+    const _: [(); 16] = [(); std::mem::size_of::<MxcfbRect>()];
+    const _: [(); 28] = [(); std::mem::size_of::<MxcfbAltBufferData>()];
+    const _: [(); 72] = [(); std::mem::size_of::<MxcfbUpdateDataV2>()];
+    const _: [(); 8] = [(); std::mem::size_of::<MxcfbUpdateMarkerData>()];
+
+    pub const MXCFB_SEND_UPDATE_V2: u64 = iow(b'F', 0x2e, 72);
+    pub const MXCFB_WAIT_FOR_UPDATE_COMPLETE_V3: u64 = iowr(b'F', 0x2f, 8);
+
+    /// Submits a Mark 7 MXCFB v2 update. Available only with `device-write`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the kernel error from `MXCFB_SEND_UPDATE_V2`.
+    #[cfg(feature = "device-write")]
+    pub fn send_update_v2(file: &File, update: &mut MxcfbUpdateDataV2) -> io::Result<()> {
+        mutating_ioctl(file, MXCFB_SEND_UPDATE_V2, update)
+    }
+
+    /// Waits for a Mark 7 MXCFB update marker.
+    ///
+    /// # Errors
+    ///
+    /// Returns the kernel error from `MXCFB_WAIT_FOR_UPDATE_COMPLETE_V3`.
+    #[cfg(feature = "device-write")]
+    pub fn wait_for_update_complete_v3(
+        file: &File,
+        marker: &mut MxcfbUpdateMarkerData,
+    ) -> io::Result<()> {
+        mutating_ioctl(file, MXCFB_WAIT_FOR_UPDATE_COMPLETE_V3, marker)
+    }
+}
+
 /// Kernel isolation applied to an application immediately before it starts.
 ///
 /// Device applications are ordinary static binaries, but they are not trusted
@@ -586,7 +687,8 @@ pub mod hwtcon {
 /// the unprivileged `nobody` identity. A seccomp filter permits local Unix
 /// sockets but refuses network sockets and prevents descendants from escaping
 /// their process group. If seccomp is unavailable, a private network namespace
-/// provides the network boundary instead.
+/// provides the network boundary instead. Older ARM vendor kernels that expose
+/// neither are supervised by an equivalent userspace syscall filter.
 pub mod sandbox {
     #[cfg(target_os = "linux")]
     use std::fs;
@@ -595,12 +697,22 @@ pub mod sandbox {
     use std::os::unix::fs::MetadataExt;
     use std::os::unix::process::CommandExt;
     use std::path::Path;
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    use std::process::Child;
     use std::process::Command;
 
     #[cfg(target_os = "linux")]
     use std::ffi::CString;
     #[cfg(target_os = "linux")]
     use std::os::unix::ffi::OsStrExt;
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    use std::sync::atomic::{AtomicBool, Ordering};
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    use std::sync::Arc;
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    use std::thread;
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    use std::time::{Duration, Instant};
 
     #[cfg(target_os = "linux")]
     const UNPRIVILEGED_ID: libc::uid_t = 65_534;
@@ -609,6 +721,8 @@ pub mod sandbox {
     pub struct Sandbox {
         #[cfg(target_os = "linux")]
         root: CString,
+        #[cfg(all(target_os = "linux", target_arch = "arm"))]
+        trace_syscalls: bool,
     }
 
     impl Sandbox {
@@ -623,7 +737,15 @@ pub mod sandbox {
                 let root = CString::new(root.as_os_str().as_bytes()).map_err(|_| {
                     io::Error::new(io::ErrorKind::InvalidInput, "sandbox path has NUL")
                 })?;
-                Ok(Self { root })
+                Ok(Self {
+                    root,
+                    #[cfg(target_arch = "arm")]
+                    // Kobo's 4.1 i.MX6SLL kernel exposes neither seccomp BPF
+                    // nor network namespaces. An absent net namespace is a
+                    // stable signal that the child needs the ptrace fallback;
+                    // newer kernels retain the cheaper in-kernel filter.
+                    trace_syscalls: !Path::new("/proc/self/ns/net").exists(),
+                })
             }
             #[cfg(not(target_os = "linux"))]
             {
@@ -635,7 +757,18 @@ pub mod sandbox {
         /// Configures `command` to enter this sandbox after fork and before
         /// exec. Keeping the unsafe hook inside the ABI crate means callers
         /// cannot accidentally run the transition in their own process.
-        pub fn configure(self, command: &mut Command) {
+        pub fn configure(self, command: &mut Command) -> bool {
+            #[cfg(target_os = "linux")]
+            let trace_syscalls = {
+                #[cfg(target_arch = "arm")]
+                {
+                    self.trace_syscalls
+                }
+                #[cfg(not(target_arch = "arm"))]
+                {
+                    false
+                }
+            };
             #[cfg(target_os = "linux")]
             // SAFETY: Command runs this only in the freshly forked child. The
             // prepared sandbox owns every byte the closure reads.
@@ -646,6 +779,14 @@ pub mod sandbox {
             {
                 let _ = self;
                 command.process_group(0);
+            }
+            #[cfg(target_os = "linux")]
+            {
+                trace_syscalls
+            }
+            #[cfg(not(target_os = "linux"))]
+            {
+                false
             }
         }
 
@@ -672,7 +813,23 @@ pub mod sandbox {
             if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0 {
                 return Err(io::Error::last_os_error());
             }
-            if install_filter().is_err() && libc::unshare(libc::CLONE_NEWNET) < 0 {
+            let filter = install_filter();
+            #[cfg(target_arch = "arm")]
+            if self.trace_syscalls {
+                if libc::ptrace(
+                    libc::PTRACE_TRACEME,
+                    0,
+                    std::ptr::null_mut::<libc::c_void>(),
+                    std::ptr::null_mut::<libc::c_void>(),
+                ) < 0
+                {
+                    return Err(io::Error::last_os_error());
+                }
+            } else if filter.is_err() && libc::unshare(libc::CLONE_NEWNET) < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            #[cfg(not(target_arch = "arm"))]
+            if filter.is_err() && libc::unshare(libc::CLONE_NEWNET) < 0 {
                 return Err(io::Error::last_os_error());
             }
             if libc::setgroups(0, std::ptr::null()) < 0
@@ -683,6 +840,267 @@ pub mod sandbox {
             }
             Ok(())
         }
+    }
+
+    /// A userspace syscall filter for ARM vendor kernels without seccomp BPF
+    /// or network namespaces.
+    ///
+    /// `PTRACE_TRACEME` stops the child on successful `exec`, before its first
+    /// application instruction. The tracer then refuses exactly the escape
+    /// syscalls the seccomp program refuses. `PTRACE_O_EXITKILL` also means an
+    /// application cannot outlive the runtime that enforces its policy.
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    pub struct SyscallTrace {
+        detached: Arc<AtomicBool>,
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    impl SyscallTrace {
+        /// Starts `command` on its tracing thread and lets it run under the
+        /// legacy syscall policy.
+        ///
+        /// `PTRACE_TRACEME` makes the thread that forks the application its
+        /// tracer. Starting the command here, rather than moving an already
+        /// started child onto a worker, preserves that kernel relationship.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error when the tracing thread, application process or
+        /// ptrace policy cannot be started.
+        pub fn spawn(mut command: Command) -> io::Result<(Child, Self)> {
+            let detached = Arc::new(AtomicBool::new(false));
+            let finished = Arc::clone(&detached);
+            let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+            thread::Builder::new()
+                .name("cobalt-syscall-trace".to_owned())
+                .spawn(move || {
+                    let mut child = match command.spawn() {
+                        Ok(child) => child,
+                        Err(error) => {
+                            let _ignored = sender.send(Err(error));
+                            finished.store(true, Ordering::Release);
+                            return;
+                        }
+                    };
+                    let pid = match begin_trace(child.id()) {
+                        Ok(pid) => pid,
+                        Err(error) => {
+                            abort_trace(child.id());
+                            let _ignored = child.wait();
+                            let _ignored = sender.send(Err(error));
+                            finished.store(true, Ordering::Release);
+                            return;
+                        }
+                    };
+                    match sender.send(Ok(child)) {
+                        Ok(()) => trace_child(pid),
+                        Err(error) => {
+                            abort_trace(u32::try_from(pid).unwrap_or_default());
+                            if let Ok(mut child) = error.0 {
+                                let _ignored = child.wait();
+                            }
+                        }
+                    }
+                    finished.store(true, Ordering::Release);
+                })?;
+            let child = receiver.recv().map_err(|_| {
+                io::Error::other("sandbox syscall tracer stopped before application launch")
+            })??;
+            Ok((child, Self { detached }))
+        }
+
+        /// Whether the tracer has released the process for ordinary reaping.
+        #[must_use]
+        pub fn is_detached(&self) -> bool {
+            self.detached.load(Ordering::Acquire)
+        }
+
+        /// Waits briefly for a terminating child to leave the tracing stop.
+        pub fn wait_until_detached(&self, timeout: Duration) {
+            let deadline = Instant::now() + timeout;
+            while !self.is_detached() && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(5));
+            }
+        }
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    fn begin_trace(pid: u32) -> io::Result<i32> {
+        let pid = i32::try_from(pid).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "child pid does not fit pid_t")
+        })?;
+        let mut status = 0;
+        if unsafe { libc::waitpid(pid, &raw mut status, 0) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if !libc::WIFSTOPPED(status) || libc::WSTOPSIG(status) != libc::SIGTRAP {
+            return Err(io::Error::other(
+                "sandboxed child did not stop at its exec boundary",
+            ));
+        }
+        let options =
+            libc::PTRACE_O_TRACESYSGOOD | libc::PTRACE_O_TRACEEXIT | libc::PTRACE_O_EXITKILL;
+        ptrace_value(libc::PTRACE_SETOPTIONS, pid, options)?;
+        ptrace_syscall(pid, 0)?;
+        Ok(pid)
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    fn abort_trace(pid: u32) {
+        let Ok(pid) = i32::try_from(pid) else { return };
+        let _ignored = ptrace_value(libc::PTRACE_KILL, pid, 0);
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    #[derive(Clone, Copy, Default)]
+    #[repr(C)]
+    struct ArmRegisters {
+        r0: u32,
+        r1: u32,
+        r2: u32,
+        r3: u32,
+        r4: u32,
+        r5: u32,
+        r6: u32,
+        r7: u32,
+        r8: u32,
+        r9: u32,
+        r10: u32,
+        frame_pointer: u32,
+        intra_procedure: u32,
+        stack_pointer: u32,
+        link_register: u32,
+        program_counter: u32,
+        status: u32,
+        original_r0: u32,
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    fn trace_child(pid: i32) {
+        let mut entering = true;
+        let mut denied = false;
+        loop {
+            let mut status = 0;
+            if unsafe { libc::waitpid(pid, &raw mut status, 0) } < 0 {
+                abort_trace(u32::try_from(pid).unwrap_or_default());
+                break;
+            }
+            if libc::WIFEXITED(status) || libc::WIFSIGNALED(status) {
+                break;
+            }
+            if !libc::WIFSTOPPED(status) {
+                continue;
+            }
+            let signal = libc::WSTOPSIG(status);
+            let event = u32::try_from(status).unwrap_or_default() >> 16;
+            if signal == libc::SIGTRAP && event == libc::PTRACE_EVENT_EXIT as u32 {
+                let _ignored = ptrace_value(libc::PTRACE_DETACH, pid, 0);
+                break;
+            }
+            if signal == (libc::SIGTRAP | 0x80) {
+                if entering {
+                    if let Ok(mut registers) = get_registers(pid) {
+                        denied = syscall_is_denied(registers.r7, registers.r0);
+                        if denied {
+                            registers.r7 = u32::MAX;
+                            let _ignored = set_registers(pid, &registers);
+                        }
+                    }
+                } else if denied {
+                    if let Ok(mut registers) = get_registers(pid) {
+                        registers.r0 = u32::from_ne_bytes((-libc::EPERM).to_ne_bytes());
+                        let _ignored = set_registers(pid, &registers);
+                    }
+                }
+                entering = !entering;
+                if ptrace_syscall(pid, 0).is_err() {
+                    abort_trace(u32::try_from(pid).unwrap_or_default());
+                    break;
+                }
+                continue;
+            }
+            let delivered = if signal == libc::SIGSTOP || signal == libc::SIGTRAP {
+                0
+            } else {
+                signal
+            };
+            if ptrace_syscall(pid, delivered).is_err() {
+                abort_trace(u32::try_from(pid).unwrap_or_default());
+                break;
+            }
+        }
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    fn syscall_is_denied(number: u32, first_argument: u32) -> bool {
+        let syscall = |value| u32::try_from(value).unwrap_or(u32::MAX);
+        (number == syscall(libc::SYS_socket) && first_argument != libc::AF_UNIX as u32)
+            || [
+                libc::SYS_setsid,
+                libc::SYS_setpgid,
+                libc::SYS_unshare,
+                libc::SYS_setns,
+                libc::SYS_fork,
+                libc::SYS_vfork,
+                libc::SYS_clone,
+                libc::SYS_clone3,
+            ]
+            .into_iter()
+            .map(syscall)
+            .any(|denied| number == denied)
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    fn get_registers(pid: i32) -> io::Result<ArmRegisters> {
+        let mut registers = ArmRegisters::default();
+        let result = unsafe {
+            libc::ptrace(
+                libc::PTRACE_GETREGS,
+                pid,
+                std::ptr::null_mut::<libc::c_void>(),
+                std::ptr::from_mut(&mut registers).cast::<libc::c_void>(),
+            )
+        };
+        if result < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(registers)
+        }
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    fn set_registers(pid: i32, registers: &ArmRegisters) -> io::Result<()> {
+        let result = unsafe {
+            libc::ptrace(
+                libc::PTRACE_SETREGS,
+                pid,
+                std::ptr::null_mut::<libc::c_void>(),
+                std::ptr::from_ref(registers)
+                    .cast_mut()
+                    .cast::<libc::c_void>(),
+            )
+        };
+        if result < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    fn ptrace_value(request: libc::c_int, pid: i32, value: libc::c_int) -> io::Result<()> {
+        let result =
+            unsafe { libc::ptrace(request, pid, std::ptr::null_mut::<libc::c_void>(), value) };
+        if result < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    fn ptrace_syscall(pid: i32, signal: i32) -> io::Result<()> {
+        ptrace_value(libc::PTRACE_SYSCALL, pid, signal)
     }
 
     /// Whether the current process has the privilege required to prepare and
@@ -1341,7 +1759,7 @@ mod pty_tests {
 
 #[cfg(test)]
 mod tests {
-    use super::{hwtcon, input, ior, iow, iowr};
+    use super::{hwtcon, input, ior, iow, iowr, mxcfb};
     #[cfg(feature = "device-write")]
     use std::fs::File;
 
@@ -1378,6 +1796,8 @@ mod tests {
         assert_eq!(input::EVIOCGABS_MT_POSITION_Y, 0x8018_4576);
         assert_eq!(hwtcon::HWTCON_SEND_UPDATE, 0x4024_462e);
         assert_eq!(hwtcon::HWTCON_WAIT_FOR_UPDATE_COMPLETE, 0xc008_462f);
+        assert_eq!(mxcfb::MXCFB_SEND_UPDATE_V2, 0x4048_462e);
+        assert_eq!(mxcfb::MXCFB_WAIT_FOR_UPDATE_COMPLETE_V3, 0xc008_462f);
         assert_eq!(ior(b'E', 0x75, 24), 0x8018_4575);
         assert_eq!(iow(b'F', 0x2e, 36), 0x4024_462e);
         assert_eq!(iowr(b'F', 0x2f, 8), 0xc008_462f);
@@ -1401,6 +1821,21 @@ mod tests {
         assert_eq!(offset_of!(hwtcon::HwtconUpdateData, dither_mode), 32);
     }
 
+    #[test]
+    fn mxcfb_v2_offsets_match_the_mark_7_vendor_c_layout() {
+        use std::mem::offset_of;
+
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateDataV2, update_region), 0);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateDataV2, waveform_mode), 16);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateDataV2, update_mode), 20);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateDataV2, update_marker), 24);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateDataV2, temperature), 28);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateDataV2, flags), 32);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateDataV2, dither_mode), 36);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateDataV2, quant_bit), 40);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateDataV2, alt_buffer_data), 44);
+    }
+
     #[cfg(feature = "device-write")]
     #[test]
     fn device_write_wrappers_have_vendor_requests() {
@@ -1408,7 +1843,11 @@ mod tests {
             hwtcon::send_update;
         let wait: fn(&File, &mut hwtcon::HwtconUpdateMarkerData) -> std::io::Result<()> =
             hwtcon::wait_for_update_complete;
-        let _ = (send, wait);
+        let mxcfb_send: fn(&File, &mut mxcfb::MxcfbUpdateDataV2) -> std::io::Result<()> =
+            mxcfb::send_update_v2;
+        let mxcfb_wait: fn(&File, &mut mxcfb::MxcfbUpdateMarkerData) -> std::io::Result<()> =
+            mxcfb::wait_for_update_complete_v3;
+        let _ = (send, wait, mxcfb_send, mxcfb_wait);
     }
 }
 

--- a/crates/kobo-abi/src/lib.rs
+++ b/crates/kobo-abi/src/lib.rs
@@ -951,7 +951,7 @@ pub mod sandbox {
         let _ignored = ptrace_value(libc::PTRACE_KILL, pid, 0);
     }
 
-    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    #[cfg(any(test, all(target_os = "linux", target_arch = "arm")))]
     #[derive(Clone, Copy, Default)]
     #[repr(C)]
     struct ArmRegisters {
@@ -975,10 +975,58 @@ pub mod sandbox {
         original_r0: u32,
     }
 
+    #[cfg(any(test, all(target_os = "linux", target_arch = "arm")))]
+    struct SyscallStopState {
+        entering: bool,
+        denied: bool,
+    }
+
+    #[cfg(any(test, all(target_os = "linux", target_arch = "arm")))]
+    impl Default for SyscallStopState {
+        fn default() -> Self {
+            Self {
+                entering: true,
+                denied: false,
+            }
+        }
+    }
+
+    /// Inspects, rewrites and resumes one syscall stop as a single operation.
+    /// A register failure must leave the tracee stopped: resuming after a
+    /// failed entry rewrite could execute the syscall the policy denied.
+    #[cfg(any(test, all(target_os = "linux", target_arch = "arm")))]
+    fn advance_syscall_stop<Get, Set, Denied, Resume>(
+        state: &mut SyscallStopState,
+        mut get_registers: Get,
+        mut set_registers: Set,
+        syscall_is_denied: Denied,
+        resume: Resume,
+    ) -> io::Result<()>
+    where
+        Get: FnMut() -> io::Result<ArmRegisters>,
+        Set: FnMut(&ArmRegisters) -> io::Result<()>,
+        Denied: FnOnce(u32, u32) -> bool,
+        Resume: FnOnce() -> io::Result<()>,
+    {
+        if state.entering {
+            let mut registers = get_registers()?;
+            state.denied = syscall_is_denied(registers.r7, registers.r0);
+            if state.denied {
+                registers.r7 = u32::MAX;
+                set_registers(&registers)?;
+            }
+        } else if state.denied {
+            let mut registers = get_registers()?;
+            registers.r0 = u32::from_ne_bytes((-libc::EPERM).to_ne_bytes());
+            set_registers(&registers)?;
+        }
+        state.entering = !state.entering;
+        resume()
+    }
+
     #[cfg(all(target_os = "linux", target_arch = "arm"))]
     fn trace_child(pid: i32) {
-        let mut entering = true;
-        let mut denied = false;
+        let mut syscall_state = SyscallStopState::default();
         loop {
             let mut status = 0;
             if unsafe { libc::waitpid(pid, &raw mut status, 0) } < 0 {
@@ -998,22 +1046,15 @@ pub mod sandbox {
                 break;
             }
             if signal == (libc::SIGTRAP | 0x80) {
-                if entering {
-                    if let Ok(mut registers) = get_registers(pid) {
-                        denied = syscall_is_denied(registers.r7, registers.r0);
-                        if denied {
-                            registers.r7 = u32::MAX;
-                            let _ignored = set_registers(pid, &registers);
-                        }
-                    }
-                } else if denied {
-                    if let Ok(mut registers) = get_registers(pid) {
-                        registers.r0 = u32::from_ne_bytes((-libc::EPERM).to_ne_bytes());
-                        let _ignored = set_registers(pid, &registers);
-                    }
-                }
-                entering = !entering;
-                if ptrace_syscall(pid, 0).is_err() {
+                if advance_syscall_stop(
+                    &mut syscall_state,
+                    || get_registers(pid),
+                    |registers| set_registers(pid, registers),
+                    syscall_is_denied,
+                    || ptrace_syscall(pid, 0),
+                )
+                .is_err()
+                {
                     abort_trace(u32::try_from(pid).unwrap_or_default());
                     break;
                 }
@@ -1237,6 +1278,52 @@ pub mod sandbox {
         {
             let _ = (root, signal_number);
             Ok(0)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{advance_syscall_stop, ArmRegisters, SyscallStopState};
+        use std::cell::Cell;
+        use std::io;
+
+        #[test]
+        fn a_register_read_failure_does_not_resume_the_tracee() {
+            let resumed = Cell::new(false);
+            let result = advance_syscall_stop(
+                &mut SyscallStopState::default(),
+                || Err(io::Error::other("PTRACE_GETREGS failed")),
+                |_| Ok(()),
+                |_, _| true,
+                || {
+                    resumed.set(true);
+                    Ok(())
+                },
+            );
+
+            assert!(result.is_err());
+            assert!(!resumed.get());
+        }
+
+        #[test]
+        fn a_denied_syscall_rewrite_failure_does_not_resume_the_tracee() {
+            let resumed = Cell::new(false);
+            let result = advance_syscall_stop(
+                &mut SyscallStopState::default(),
+                || Ok(ArmRegisters::default()),
+                |registers| {
+                    assert_eq!(registers.r7, u32::MAX);
+                    Err(io::Error::other("PTRACE_SETREGS failed"))
+                },
+                |_, _| true,
+                || {
+                    resumed.set(true);
+                    Ok(())
+                },
+            );
+
+            assert!(result.is_err());
+            assert!(!resumed.get());
         }
     }
 }

--- a/crates/kobo-hal/src/display.rs
+++ b/crates/kobo-hal/src/display.rs
@@ -15,8 +15,8 @@
 use crate::probe::{probe_device, ProbeError};
 use crate::refresh::{Rect, RefreshPlan};
 use crate::surface::{self, RegionSnapshot, SurfaceError, SurfaceGeometry};
-use kobo_abi::hwtcon;
-use kobo_profile::{DeviceProfile, DeviceSnapshot, WRITE_EVIDENCE_PENDING};
+use kobo_abi::{hwtcon, mxcfb};
+use kobo_profile::{DeviceProfile, DeviceSnapshot, FramebufferController, WRITE_EVIDENCE_PENDING};
 use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Read};
@@ -257,13 +257,26 @@ impl DisplaySession {
         // Validate the region against this exact surface before the kernel sees it.
         surface::RegionPlacement::new(self.geometry, plan.region)?;
         let marker = unique_marker()?;
-        let mut update = plan.update_data(marker);
-        hwtcon::send_update(&self.framebuffer, &mut update)?;
-        let mut wait = hwtcon::HwtconUpdateMarkerData {
-            update_marker: marker,
-            collision_test: 0,
-        };
-        hwtcon::wait_for_update_complete(&self.framebuffer, &mut wait)?;
+        match self.profile.framebuffer_controller {
+            FramebufferController::Hwtcon => {
+                let mut update = plan.hwtcon_update_data(marker);
+                hwtcon::send_update(&self.framebuffer, &mut update)?;
+                let mut wait = hwtcon::HwtconUpdateMarkerData {
+                    update_marker: marker,
+                    collision_test: 0,
+                };
+                hwtcon::wait_for_update_complete(&self.framebuffer, &mut wait)?;
+            }
+            FramebufferController::MxcfbV2 => {
+                let mut update = plan.mxcfb_update_data(marker);
+                mxcfb::send_update_v2(&self.framebuffer, &mut update)?;
+                let mut wait = mxcfb::MxcfbUpdateMarkerData {
+                    update_marker: marker,
+                    collision_test: 0,
+                };
+                mxcfb::wait_for_update_complete_v3(&self.framebuffer, &mut wait)?;
+            }
+        }
         Ok(())
     }
 }
@@ -423,7 +436,7 @@ mod tests {
     use kobo_abi::hwtcon;
     use kobo_profile::{
         DeviceProfile, DeviceSnapshot, FramebufferSnapshot, IdentitySnapshot, TouchSnapshot,
-        CLARA_BW_391, ELIPSA_2E_389, WRITE_EVIDENCE_PENDING,
+        CLARA_BW_391, CLARA_HD_376, ELIPSA_2E_389, WRITE_EVIDENCE_PENDING,
     };
     use std::path::Path;
 
@@ -588,7 +601,7 @@ mod tests {
 
     #[test]
     fn hal_owned_smoke_regions_are_bounded_on_every_registered_panel() {
-        for profile in [&CLARA_BW_391, &ELIPSA_2E_389] {
+        for profile in [&CLARA_BW_391, &CLARA_HD_376, &ELIPSA_2E_389] {
             let geometry = SurfaceGeometry {
                 width: profile.width,
                 height: profile.height,
@@ -629,7 +642,7 @@ mod tests {
                 CLARA_BW_391.height,
             )
             .expect("fixed plan");
-            let update = plan.update_data(0x4000_0001);
+            let update = plan.hwtcon_update_data(0x4000_0001);
             assert_eq!(update.waveform_mode, waveform);
             assert_eq!(update.update_mode, hwtcon::UPDATE_MODE_PARTIAL);
         }

--- a/crates/kobo-hal/src/lib.rs
+++ b/crates/kobo-hal/src/lib.rs
@@ -50,6 +50,6 @@ pub use battery::Battery;
 pub use display::{DisplayError, DisplaySession, OWNER_UNLOCK_PHRASE};
 pub use observe::{observe_touch, ObserveError, TouchObservation};
 pub use probe::{probe_device, ProbeError};
-pub use refresh::{Rect, RefreshIntent, RefreshPlan, UpdateMarker};
+pub use refresh::{Rect, RefreshIntent, RefreshPlan, RefreshWaveform, UpdateMarker};
 pub use surface::{read_region, RegionPlacement, RegionSnapshot, SurfaceError, SurfaceGeometry};
 pub use touch::{InputEvent32, TouchDecoder, TouchEvent};

--- a/crates/kobo-hal/src/refresh.rs
+++ b/crates/kobo-hal/src/refresh.rs
@@ -1,4 +1,4 @@
-use kobo_abi::hwtcon;
+use kobo_abi::{hwtcon, mxcfb};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Rect {
@@ -44,9 +44,16 @@ pub enum RefreshIntent {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RefreshWaveform {
+    Du,
+    Gl16,
+    Gc16,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RefreshPlan {
     pub region: Rect,
-    pub waveform: u32,
+    pub waveform: RefreshWaveform,
     pub full: bool,
 }
 
@@ -62,16 +69,16 @@ impl RefreshPlan {
         Some(Self {
             region: region.clipped(screen_width, screen_height)?,
             waveform: match intent {
-                RefreshIntent::FastFeedback => hwtcon::WAVEFORM_DU,
-                RefreshIntent::TextContent => hwtcon::WAVEFORM_GL16,
-                RefreshIntent::QualityContent => hwtcon::WAVEFORM_GC16,
+                RefreshIntent::FastFeedback => RefreshWaveform::Du,
+                RefreshIntent::TextContent => RefreshWaveform::Gl16,
+                RefreshIntent::QualityContent => RefreshWaveform::Gc16,
             },
             full,
         })
     }
 
     #[must_use]
-    pub fn update_data(self, marker: u32) -> hwtcon::HwtconUpdateData {
+    pub fn hwtcon_update_data(self, marker: u32) -> hwtcon::HwtconUpdateData {
         hwtcon::HwtconUpdateData {
             update_region: hwtcon::HwtconRect {
                 top: self.region.y,
@@ -79,7 +86,11 @@ impl RefreshPlan {
                 width: self.region.width,
                 height: self.region.height,
             },
-            waveform_mode: self.waveform,
+            waveform_mode: match self.waveform {
+                RefreshWaveform::Du => hwtcon::WAVEFORM_DU,
+                RefreshWaveform::Gl16 => hwtcon::WAVEFORM_GL16,
+                RefreshWaveform::Gc16 => hwtcon::WAVEFORM_GC16,
+            },
             update_mode: if self.full {
                 hwtcon::UPDATE_MODE_FULL
             } else {
@@ -88,6 +99,34 @@ impl RefreshPlan {
             update_marker: marker,
             flags: 0,
             dither_mode: 0,
+        }
+    }
+
+    #[must_use]
+    pub fn mxcfb_update_data(self, marker: u32) -> mxcfb::MxcfbUpdateDataV2 {
+        mxcfb::MxcfbUpdateDataV2 {
+            update_region: mxcfb::MxcfbRect {
+                top: self.region.y,
+                left: self.region.x,
+                width: self.region.width,
+                height: self.region.height,
+            },
+            waveform_mode: match self.waveform {
+                RefreshWaveform::Du => mxcfb::WAVEFORM_DU,
+                RefreshWaveform::Gl16 => mxcfb::WAVEFORM_GL16,
+                RefreshWaveform::Gc16 => mxcfb::WAVEFORM_GC16,
+            },
+            update_mode: if self.full {
+                mxcfb::UPDATE_MODE_FULL
+            } else {
+                mxcfb::UPDATE_MODE_PARTIAL
+            },
+            update_marker: marker,
+            temperature: mxcfb::TEMP_USE_AMBIENT,
+            flags: 0,
+            dither_mode: mxcfb::DITHER_PASSTHROUGH,
+            quant_bit: 0,
+            alt_buffer_data: mxcfb::MxcfbAltBufferData::default(),
         }
     }
 }
@@ -112,8 +151,8 @@ impl UpdateMarker {
 
 #[cfg(test)]
 mod tests {
-    use super::{Rect, RefreshIntent, RefreshPlan, UpdateMarker};
-    use kobo_abi::hwtcon;
+    use super::{Rect, RefreshIntent, RefreshPlan, RefreshWaveform, UpdateMarker};
+    use kobo_abi::{hwtcon, mxcfb};
 
     #[test]
     fn clips_regions_before_building_update() {
@@ -132,7 +171,33 @@ mod tests {
         .expect("region intersects screen");
         assert_eq!(plan.region.width, 12);
         assert_eq!(plan.region.height, 8);
-        assert_eq!(plan.waveform, hwtcon::WAVEFORM_GC16);
+        assert_eq!(plan.waveform, RefreshWaveform::Gc16);
+    }
+
+    #[test]
+    fn controller_specific_updates_use_each_vendor_waveform_number() {
+        let plan = RefreshPlan::new(
+            Rect {
+                x: 10,
+                y: 20,
+                width: 30,
+                height: 40,
+            },
+            RefreshIntent::TextContent,
+            false,
+            1072,
+            1448,
+        )
+        .expect("region is on screen");
+        assert_eq!(
+            plan.hwtcon_update_data(7).waveform_mode,
+            hwtcon::WAVEFORM_GL16
+        );
+        let mxcfb = plan.mxcfb_update_data(7);
+        assert_eq!(mxcfb.waveform_mode, mxcfb::WAVEFORM_GL16);
+        assert_eq!(mxcfb.temperature, mxcfb::TEMP_USE_AMBIENT);
+        assert_eq!(mxcfb.dither_mode, mxcfb::DITHER_PASSTHROUGH);
+        assert_eq!(mxcfb.update_marker, 7);
     }
 
     #[test]

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -56,7 +56,7 @@ pub const CLARA_BW_391: DeviceProfile = DeviceProfile {
     touch_y_min: 0,
     touch_y_max: 1071,
     serial_prefix: "N365",
-    firmware_version: "4.45.23697",
+    firmware_versions: &["4.45.23697"],
     kernel_release: "4.9.77",
     write_ready: true,
 };
@@ -109,7 +109,7 @@ pub const CLARA_HD_376: DeviceProfile = DeviceProfile {
     touch_y_min: 0,
     touch_y_max: 1071,
     serial_prefix: "N249",
-    firmware_version: "4.38.23684",
+    firmware_versions: &["4.38.23684", "4.38.23697"],
     kernel_release: "4.1.15-00136-g12655eaaef89",
     write_ready: true,
 };
@@ -162,7 +162,7 @@ pub const ELIPSA_2E_389: DeviceProfile = DeviceProfile {
     touch_y_min: 0,
     touch_y_max: 1404,
     serial_prefix: "N605",
-    firmware_version: "4.38.23697",
+    firmware_versions: &["4.38.23697"],
     kernel_release: "4.9.77",
     write_ready: true,
 };
@@ -334,7 +334,8 @@ pub struct DeviceProfile {
     pub touch_y_min: i32,
     pub touch_y_max: i32,
     pub serial_prefix: &'static str,
-    pub firmware_version: &'static str,
+    /// Exact firmware releases covered by owner-attended evidence.
+    pub firmware_versions: &'static [&'static str],
     pub kernel_release: &'static str,
     /// True only after owner-attended hardware evidence has been reviewed.
     pub write_ready: bool,
@@ -445,10 +446,10 @@ impl DeviceProfile {
             self.serial_prefix,
             identity.serial_prefix.as_deref(),
         );
-        compare_identity(
+        compare_identity_one_of(
             &mut blockers,
             "firmware version",
-            self.firmware_version,
+            self.firmware_versions,
             identity.firmware_version.as_deref(),
         );
         compare_identity(
@@ -733,6 +734,25 @@ fn compare_identity(blockers: &mut Vec<String>, name: &str, expected: &str, actu
     }
 }
 
+fn compare_identity_one_of(
+    blockers: &mut Vec<String>,
+    name: &str,
+    expected: &[&str],
+    actual: Option<&str>,
+) {
+    match actual {
+        Some(value) if expected.contains(&value) => {}
+        Some(value) => {
+            let wanted = match expected {
+                [only] => (*only).to_owned(),
+                choices => format!("one of {}", choices.join(", ")),
+            };
+            blockers.push(format!("{name}: expected {wanted}, found {value}"));
+        }
+        None => blockers.push(format!("{name} could not be read")),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -908,7 +928,7 @@ mod tests {
             length: 8,
             msb_right: 0,
         };
-        let snapshot = DeviceSnapshot {
+        let mut snapshot = DeviceSnapshot {
             compatible: vec!["fsl,imx6sll-lpddr3-arm2".into(), "fsl,imx6sll".into()],
             model: Some("Freescale i.MX6SLL NTX Board".into()),
             framebuffer: Some(FramebufferSnapshot {
@@ -955,11 +975,14 @@ mod tests {
                 device_code: Some(376),
             },
         };
-        let report = CLARA_HD_376.validate(&snapshot);
-        assert_eq!(report.readiness, Readiness::WriteReady);
-        assert!(report.mismatches.is_empty());
-        assert!(report.write_blockers.is_empty());
-        assert!(CLARA_HD_376.write_identity_blockers(&snapshot).is_empty());
+        for firmware in CLARA_HD_376.firmware_versions {
+            snapshot.identity.firmware_version = Some((*firmware).into());
+            let report = CLARA_HD_376.validate(&snapshot);
+            assert_eq!(report.readiness, Readiness::WriteReady);
+            assert!(report.mismatches.is_empty());
+            assert!(report.write_blockers.is_empty());
+            assert!(CLARA_HD_376.write_identity_blockers(&snapshot).is_empty());
+        }
         assert_eq!(super::identify_profile(&snapshot), Some(&CLARA_HD_376));
     }
 

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -2,6 +2,12 @@
 
 use std::fmt;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FramebufferController {
+    Hwtcon,
+    MxcfbV2,
+}
+
 pub const CLARA_BW_391: DeviceProfile = DeviceProfile {
     id: "clara-bw-391",
     model: "Kobo Clara BW",
@@ -9,6 +15,7 @@ pub const CLARA_BW_391: DeviceProfile = DeviceProfile {
     device_tree_model: "MediaTek MT8110 board",
     compatible_fragments: &["mediatek,mt8110", "mediatek,mt8512"],
     framebuffer_id: "hwtcon",
+    framebuffer_controller: FramebufferController::Hwtcon,
     width: 1072,
     height: 1448,
     pixels_per_inch: 300,
@@ -54,6 +61,59 @@ pub const CLARA_BW_391: DeviceProfile = DeviceProfile {
     write_ready: true,
 };
 
+pub const CLARA_HD_376: DeviceProfile = DeviceProfile {
+    id: "clara-hd-376",
+    model: "Kobo Clara HD",
+    device_code: 376,
+    device_tree_model: "Freescale i.MX6SLL NTX Board",
+    compatible_fragments: &["fsl,imx6sll-lpddr3-arm2", "fsl,imx6sll"],
+    framebuffer_id: "mxc_epdc_fb",
+    framebuffer_controller: FramebufferController::MxcfbV2,
+    width: 1072,
+    height: 1448,
+    pixels_per_inch: 300,
+    virtual_width: 1088,
+    virtual_height: 1536,
+    x_offset: 0,
+    y_offset: 0,
+    bits_per_pixel: 32,
+    grayscale: 0,
+    stride: 4352,
+    memory_length: 6_782_976,
+    framebuffer_kind: 0,
+    framebuffer_visual: 2,
+    rotation: 3,
+    red: Bitfield {
+        offset: 16,
+        length: 8,
+        msb_right: 0,
+    },
+    green: Bitfield {
+        offset: 8,
+        length: 8,
+        msb_right: 0,
+    },
+    blue: Bitfield {
+        offset: 0,
+        length: 8,
+        msb_right: 0,
+    },
+    alpha: Bitfield {
+        offset: 24,
+        length: 8,
+        msb_right: 0,
+    },
+    touch_name: "cyttsp5_mt",
+    touch_x_min: 0,
+    touch_x_max: 1447,
+    touch_y_min: 0,
+    touch_y_max: 1071,
+    serial_prefix: "N249",
+    firmware_version: "4.38.23684",
+    kernel_release: "4.1.15-00136-g12655eaaef89",
+    write_ready: true,
+};
+
 pub const ELIPSA_2E_389: DeviceProfile = DeviceProfile {
     id: "elipsa-2e-389",
     model: "Kobo Elipsa 2E",
@@ -61,6 +121,7 @@ pub const ELIPSA_2E_389: DeviceProfile = DeviceProfile {
     device_tree_model: "MediaTek MT8110 board",
     compatible_fragments: &["mediatek,mt8110", "mediatek,mt8512"],
     framebuffer_id: "hwtcon",
+    framebuffer_controller: FramebufferController::Hwtcon,
     width: 1404,
     height: 1872,
     pixels_per_inch: 227,
@@ -106,7 +167,7 @@ pub const ELIPSA_2E_389: DeviceProfile = DeviceProfile {
     write_ready: true,
 };
 
-pub const SUPPORTED_PROFILES: &[&DeviceProfile] = &[&CLARA_BW_391, &ELIPSA_2E_389];
+pub const SUPPORTED_PROFILES: &[&DeviceProfile] = &[&CLARA_BW_391, &CLARA_HD_376, &ELIPSA_2E_389];
 
 #[must_use]
 pub fn identify_profile(snapshot: &DeviceSnapshot) -> Option<&'static DeviceProfile> {
@@ -248,6 +309,7 @@ pub struct DeviceProfile {
     pub device_tree_model: &'static str,
     pub compatible_fragments: &'static [&'static str],
     pub framebuffer_id: &'static str,
+    pub framebuffer_controller: FramebufferController,
     pub width: u32,
     pub height: u32,
     pub pixels_per_inch: u16,
@@ -675,7 +737,7 @@ fn compare_identity(blockers: &mut Vec<String>, name: &str, expected: &str, actu
 mod tests {
     use super::{
         Bitfield, DeviceProfile, DeviceSnapshot, FramebufferSnapshot, IdentitySnapshot, Readiness,
-        TouchSnapshot, CLARA_BW_391, ELIPSA_2E_389, WRITE_EVIDENCE_PENDING,
+        TouchSnapshot, CLARA_BW_391, CLARA_HD_376, ELIPSA_2E_389, WRITE_EVIDENCE_PENDING,
     };
 
     #[test]
@@ -837,6 +899,102 @@ mod tests {
         let report = candidate.validate(&snapshot);
         assert_eq!(report.readiness, Readiness::ReadOnlyMatched);
         assert_eq!(report.write_blockers, vec![WRITE_EVIDENCE_PENDING]);
+    }
+
+    #[test]
+    fn clara_hd_doctor_snapshot_matches_its_strict_profile() {
+        let channel = Bitfield {
+            offset: 16,
+            length: 8,
+            msb_right: 0,
+        };
+        let snapshot = DeviceSnapshot {
+            compatible: vec!["fsl,imx6sll-lpddr3-arm2".into(), "fsl,imx6sll".into()],
+            model: Some("Freescale i.MX6SLL NTX Board".into()),
+            framebuffer: Some(FramebufferSnapshot {
+                id: "mxc_epdc_fb".into(),
+                width: 1072,
+                height: 1448,
+                virtual_width: 1088,
+                virtual_height: 1536,
+                x_offset: 0,
+                y_offset: 0,
+                bits_per_pixel: 32,
+                grayscale: 0,
+                stride: 4352,
+                memory_length: 6_782_976,
+                kind: 0,
+                visual: 2,
+                rotation: 3,
+                red: channel,
+                green: Bitfield {
+                    offset: 8,
+                    ..channel
+                },
+                blue: Bitfield {
+                    offset: 0,
+                    ..channel
+                },
+                alpha: Bitfield {
+                    offset: 24,
+                    ..channel
+                },
+            }),
+            touch: Some(TouchSnapshot {
+                path: "/dev/input/event1".into(),
+                name: "cyttsp5_mt".into(),
+                x_min: 0,
+                x_max: 1447,
+                y_min: 0,
+                y_max: 1071,
+            }),
+            identity: IdentitySnapshot {
+                serial_prefix: Some("N249".into()),
+                firmware_version: Some("4.38.23684".into()),
+                kernel_release: Some("4.1.15-00136-g12655eaaef89".into()),
+                device_code: Some(376),
+            },
+        };
+        let report = CLARA_HD_376.validate(&snapshot);
+        assert_eq!(report.readiness, Readiness::WriteReady);
+        assert!(report.mismatches.is_empty());
+        assert!(report.write_blockers.is_empty());
+        assert!(CLARA_HD_376.write_identity_blockers(&snapshot).is_empty());
+        assert_eq!(super::identify_profile(&snapshot), Some(&CLARA_HD_376));
+    }
+
+    #[test]
+    fn clara_hd_touch_edges_map_inside_the_panel_and_round_trip() {
+        for raw in [(0, 0), (0, 1071), (1447, 0), (1447, 1071)] {
+            let display = CLARA_HD_376
+                .touch_to_display(raw.0, raw.1)
+                .expect("measured Clara HD edge maps to the display");
+            assert!(display.0 < CLARA_HD_376.width, "x escaped: {display:?}");
+            assert!(display.1 < CLARA_HD_376.height, "y escaped: {display:?}");
+        }
+        for display in [(0, 0), (1071, 0), (0, 1447), (1071, 1447), (536, 724)] {
+            let raw = CLARA_HD_376
+                .display_to_touch(display.0, display.1)
+                .expect("Clara HD display point maps to the controller");
+            assert_eq!(CLARA_HD_376.touch_to_display(raw.0, raw.1), Some(display));
+        }
+    }
+
+    /// Captured from a physical touch about a centimetre in from the top-left
+    /// of the Clara HD. The axis ranges prove that the controller is rotated;
+    /// this sample proves the direction of both axes.
+    #[test]
+    fn clara_hd_touch_transform_matches_a_physically_measured_touch() {
+        assert_eq!(CLARA_HD_376.touch_to_display(160, 909), Some((162, 160)));
+
+        let flipped_x = CLARA_HD_376
+            .touch_to_display(160, 1071 - 909)
+            .expect("flipped sample remains in range");
+        let flipped_y = CLARA_HD_376
+            .touch_to_display(1447 - 160, 909)
+            .expect("flipped sample remains in range");
+        assert_eq!(flipped_x, (909, 160));
+        assert_eq!(flipped_y, (162, 1287));
     }
 
     #[test]

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -821,7 +821,7 @@ struct Hosted {
     path: PathBuf,
     /// Root-owned filesystem visible to this application on the device.
     jail: Option<PathBuf>,
-    child: Child,
+    child: ApplicationChild,
     stream: std::os::unix::net::UnixStream,
     store: kobo_policy::store::Store,
     shelf: kobo_policy::shelf::Shelf,
@@ -847,6 +847,57 @@ struct Hosted {
     painted: u32,
     /// When this was last on the panel, for deciding what to stop first.
     used: Instant,
+}
+
+/// An application process plus the legacy-kernel supervisor, when one is
+/// needed. Ordinary process APIs may reap a child only after ptrace has
+/// released its exit stop, so that ordering lives behind this type.
+struct ApplicationChild {
+    process: Child,
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    trace: Option<kobo_abi::sandbox::SyscallTrace>,
+}
+
+impl ApplicationChild {
+    fn ordinary(process: Child) -> Self {
+        Self {
+            process,
+            #[cfg(all(target_os = "linux", target_arch = "arm"))]
+            trace: None,
+        }
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    fn traced(process: Child, trace: kobo_abi::sandbox::SyscallTrace) -> Self {
+        Self {
+            process,
+            trace: Some(trace),
+        }
+    }
+
+    fn id(&self) -> u32 {
+        self.process.id()
+    }
+
+    fn try_wait(&mut self) -> std::io::Result<Option<std::process::ExitStatus>> {
+        #[cfg(all(target_os = "linux", target_arch = "arm"))]
+        if self
+            .trace
+            .as_ref()
+            .is_some_and(|trace| !trace.is_detached())
+        {
+            return Ok(None);
+        }
+        self.process.try_wait()
+    }
+
+    fn wait(&mut self) -> std::io::Result<std::process::ExitStatus> {
+        #[cfg(all(target_os = "linux", target_arch = "arm"))]
+        if let Some(trace) = &self.trace {
+            trace.wait_until_detached(APP_STOP_GRACE);
+        }
+        self.process.wait()
+    }
 }
 
 struct AppLaunch {
@@ -2243,12 +2294,26 @@ fn start_application(
         // left of a crash was the application no longer being there, and the
         // one question worth asking of a crash could not be answered at all.
         .stderr(Stdio::piped());
-    if let Some(sandbox) = sandbox {
-        sandbox.configure(&mut command);
+    let trace_syscalls = if let Some(sandbox) = sandbox {
+        sandbox.configure(&mut command)
     } else {
         kobo_abi::process_group::configure(&mut command);
-    }
-    let mut child = match command.spawn() {
+        false
+    };
+    let spawned = if trace_syscalls {
+        #[cfg(all(target_os = "linux", target_arch = "arm"))]
+        {
+            kobo_abi::sandbox::SyscallTrace::spawn(command)
+                .map(|(child, trace)| ApplicationChild::traced(child, trace))
+        }
+        #[cfg(not(all(target_os = "linux", target_arch = "arm")))]
+        {
+            unreachable!("syscall tracing is selected only on 32-bit ARM Linux")
+        }
+    } else {
+        command.spawn().map(ApplicationChild::ordinary)
+    };
+    let mut child = match spawned {
         Ok(child) => child,
         Err(error) => {
             let _ignored = fs::remove_file(&socket_path);
@@ -2258,7 +2323,7 @@ fn start_application(
             return Err(format!("start {}: {error}", path.display()));
         }
     };
-    if let Some(stderr) = child.stderr.take() {
+    if let Some(stderr) = child.process.stderr.take() {
         report_what_an_application_says(expected_name.clone(), stderr);
     }
     let greeting = greet(&listener, whole_screen, &expected_name);
@@ -2473,7 +2538,7 @@ const HOLD_TIME: Duration = Duration::from_millis(500);
 const HOLD_SLIP: i32 = 40;
 
 /// Ends the application, politely if it has already finished and firmly if not.
-fn stop_application(child: &mut Child, jail: Option<&Path>) {
+fn stop_application(child: &mut ApplicationChild, jail: Option<&Path>) {
     let group = child.id();
     let _ignored = kobo_abi::process_group::signal(group, kobo_abi::process_group::SIGTERM);
     if let Some(root) = jail {

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -898,6 +898,16 @@ impl ApplicationChild {
         }
         self.process.wait()
     }
+
+    fn trace_failure(&self) -> Option<String> {
+        #[cfg(all(target_os = "linux", target_arch = "arm"))]
+        if let Some(trace) = &self.trace {
+            return trace.failure();
+        }
+        #[cfg(not(all(target_os = "linux", target_arch = "arm")))]
+        let _ = self;
+        None
+    }
 }
 
 struct AppLaunch {
@@ -2273,6 +2283,17 @@ fn start_application(
     sender: &Sender<Event>,
 ) -> Result<u64, String> {
     let expected_name = installed_name(path)?;
+    // Capabilities are part of admission, not post-launch setup. Reading them
+    // before any process exists means a corrupt or concurrently removed
+    // manifest cannot leave an unowned child and jail behind.
+    let declared = if path.starts_with(Path::new(COBALT_ROOT).join("apps")) {
+        crate::app_store::declared(Path::new(COBALT_ROOT), &expected_name)
+            .ok_or_else(|| format!("read application manifest for {expected_name}"))?
+    } else if let Some(declared) = crate::app_store::builtin_declared(&expected_name) {
+        declared
+    } else {
+        Declared::all()
+    };
     let launch = AppLaunch::prepare(path, *next_id)?;
     let AppLaunch {
         listener,
@@ -2333,6 +2354,7 @@ fn start_application(
         Ok(greeting) => greeting,
         Err(error) => {
             stop_application(&mut child, jail.as_deref());
+            let error = with_trace_failure(error, &child);
             if let Some(root) = &jail {
                 let _ignored = fs::remove_dir_all(root);
             }
@@ -2343,6 +2365,7 @@ fn start_application(
     *next_id += 1;
     if let Err(error) = pump_application(&stream, sender, id) {
         stop_application(&mut child, jail.as_deref());
+        let error = with_trace_failure(error, &child);
         if let Some(root) = &jail {
             let _ignored = fs::remove_dir_all(root);
         }
@@ -2350,14 +2373,6 @@ fn start_application(
     }
     let waker = sender.clone();
     let credential_app = name.clone();
-    let declared = if path.starts_with(Path::new(COBALT_ROOT).join("apps")) {
-        crate::app_store::declared(Path::new(COBALT_ROOT), &name)
-            .ok_or_else(|| format!("read application manifest for {name}"))?
-    } else if let Some(declared) = crate::app_store::builtin_declared(&name) {
-        declared
-    } else {
-        Declared::all()
-    };
     let tasks = TaskRunner::simulated(std::env::temp_dir())
         .with_fetch(Arc::new(kobo_net::fetch_from))
         .with_post(Arc::new(kobo_net::post))
@@ -2450,6 +2465,13 @@ fn stop_hosted(mut app: Hosted) {
     }
     app.tasks.shutdown();
     stop_application(&mut app.child, app.jail.as_deref());
+    if let Some(failure) = app.child.trace_failure() {
+        trace(&format!(
+            "{} syscall supervisor failed: {failure}",
+            app.name
+        ));
+        println!("{} syscall supervisor failed: {failure}", app.name);
+    }
     if let Some(root) = app.jail {
         let _ignored = fs::remove_dir_all(root);
     }
@@ -2567,6 +2589,13 @@ fn stop_application(child: &mut ApplicationChild, jail: Option<&Path>) {
     }
     if child.try_wait().ok().flatten().is_none() {
         let _ignored = child.wait();
+    }
+}
+
+fn with_trace_failure(error: String, child: &ApplicationChild) -> String {
+    match child.trace_failure() {
+        Some(failure) => format!("{error}; syscall supervisor failed: {failure}"),
+        None => error,
     }
 }
 

--- a/docs/DEVICES.md
+++ b/docs/DEVICES.md
@@ -12,7 +12,7 @@ and touch profile. A matching model name alone is not sufficient.
 | Device | Exact tested identity | Evidence status | Installation status |
 |---|---|---|---|
 | Kobo Clara BW | N365, code 391, firmware 4.45.23697, kernel 4.9.77 | Read-only probe and owner-attended display, touch, exit, and recovery tests complete | Fully tested |
-| Kobo Clara HD | N249, code 376, firmware 4.38.23684, kernel 4.1.15-00136-g12655eaaef89 | Read-only probe and owner-attended display, touch, exit, suspend/resume, sandbox, and recovery tests complete | Fully tested |
+| Kobo Clara HD | N249, code 376, firmware 4.38.23684 or 4.38.23697, kernel 4.1.15-00136-g12655eaaef89 | Read-only probe and owner-attended display, touch, exit, suspend/resume, sandbox, and recovery tests complete | Fully tested |
 | Kobo Elipsa 2E | N605, code 389, firmware 4.38.23697, kernel 4.9.77 | Read-only probe and owner-attended display, touch, exit, suspend/resume, and recovery tests complete | Fully tested |
 
 `Read-only doctor match complete` means the profile describes the observed

--- a/docs/DEVICES.md
+++ b/docs/DEVICES.md
@@ -12,6 +12,7 @@ and touch profile. A matching model name alone is not sufficient.
 | Device | Exact tested identity | Evidence status | Installation status |
 |---|---|---|---|
 | Kobo Clara BW | N365, code 391, firmware 4.45.23697, kernel 4.9.77 | Read-only probe and owner-attended display, touch, exit, and recovery tests complete | Fully tested |
+| Kobo Clara HD | N249, code 376, firmware 4.38.23684, kernel 4.1.15-00136-g12655eaaef89 | Read-only probe and owner-attended display, touch, exit, suspend/resume, sandbox, and recovery tests complete | Fully tested |
 | Kobo Elipsa 2E | N605, code 389, firmware 4.38.23697, kernel 4.9.77 | Read-only probe and owner-attended display, touch, exit, suspend/resume, and recovery tests complete | Fully tested |
 
 `Read-only doctor match complete` means the profile describes the observed

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -7,8 +7,8 @@ off. Part of [Cobalt](../README.md).
 The procedure below is fully hardware-tested on the **Kobo Clara BW N365
 (device code 391), firmware 4.45.23697**, the **Kobo Elipsa 2E N605 (device
 code 389), firmware 4.38.23697**, and the **Kobo Clara HD N249 (device code
-376), firmware 4.38.23684**. Support remains tied to the exact firmware,
-kernel, framebuffer, touch, and identity combination in the
+376), firmware 4.38.23684 or 4.38.23697**. Support remains tied to the exact
+firmware, kernel, framebuffer, touch, and identity combination in the
 [device support matrix](DEVICES.md#device-support-matrix).
 
 Display and synthetic-touch writes require an exact match of framebuffer

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -5,8 +5,9 @@ USB, what to do if a step does not go as described, and how to take it back
 off. Part of [Cobalt](../README.md).
 
 The procedure below is fully hardware-tested on the **Kobo Clara BW N365
-(device code 391), firmware 4.45.23697** and the **Kobo Elipsa 2E N605 (device
-code 389), firmware 4.38.23697**. Support remains tied to the exact firmware,
+(device code 391), firmware 4.45.23697**, the **Kobo Elipsa 2E N605 (device
+code 389), firmware 4.38.23697**, and the **Kobo Clara HD N249 (device code
+376), firmware 4.38.23684**. Support remains tied to the exact firmware,
 kernel, framebuffer, touch, and identity combination in the
 [device support matrix](DEVICES.md#device-support-matrix).
 
@@ -102,8 +103,8 @@ you with an unbootable reader.
 
 On this firmware the entry is in the menu at the **bottom right** of the home
 screen. (NickelMenu puts its items in the top-left menu on old firmware and in
-the bottom-right one from 4.23.15505 onward, and the Clara BW is well past
-that.) Tap it and choose **Cobalt**.
+the bottom-right one from 4.23.15505 onward, and both tested profiles are well
+past that.) Tap it and choose **Cobalt**.
 
 The launcher appears with Cobalt's built-in applications. Store-only
 applications are deliberately absent until they are installed over Wi-Fi.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -103,7 +103,7 @@ you with an unbootable reader.
 
 On this firmware the entry is in the menu at the **bottom right** of the home
 screen. (NickelMenu puts its items in the top-left menu on old firmware and in
-the bottom-right one from 4.23.15505 onward, and both tested profiles are well
+the bottom-right one from 4.23.15505 onward, and all three tested profiles are well
 past that.) Tap it and choose **Cobalt**.
 
 The launcher appears with Cobalt's built-in applications. Store-only

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -2,10 +2,10 @@
 
 Part of [Cobalt](../README.md).
 
-Cobalt selects a device profile at runtime. The Clara BW and Elipsa 2E profiles
-are fully hardware-tested at their recorded identity and firmware boundaries.
-The current status and exact boundaries are recorded in the
-[device support matrix](DEVICES.md#device-support-matrix).
+Cobalt selects a device profile at runtime. The Clara BW, Elipsa 2E, and
+Clara HD profiles are fully hardware-tested at their recorded identity and
+firmware boundaries. The current status and exact boundaries are recorded in
+the [device support matrix](DEVICES.md#device-support-matrix).
 
 Display and synthetic-touch write entry points demand an exact hardware and
 firmware match, so an unknown reader is refused rather than guessed at. A
@@ -23,23 +23,27 @@ and every application are device-independent. What is measured is:
 
 1. **A `DeviceProfile`**, in `crates/kobo-profile/src/lib.rs`. Panel size and
    stride, framebuffer identity, the touch device and its axis ranges and
-   rotation, and the identity fields (device code, serial prefix, firmware,
-   kernel). Its `write_ready` flag remains false until the attended evidence in
-   the device support matrix has been reviewed. `CLARA_BW_391` and
-   `ELIPSA_2E_389` are the current examples.
-2. **`DisplayMetrics`**, in `crates/kobo-ui/src/lib.rs`. Size and DPI, which is
+   rotation, refresh controller, physical density, and the identity fields
+   (device code, serial prefix, firmware, kernel). Its `write_ready` flag
+   remains false until the attended evidence in the device support matrix has
+   been reviewed. `CLARA_BW_391`, `ELIPSA_2E_389`, and `CLARA_HD_376` are the
+   current examples.
+2. **A controller backend**, when the device does not use one already present.
+   Cobalt currently supports MediaTek HWTCON and Mark 7 MXCFB v2. Their ioctl
+   structures and waveform numbers are deliberately separate.
+3. **`DisplayMetrics`**, in `crates/kobo-ui/src/lib.rs`. Size and DPI, which is
    what the layout engine reasons about.
-3. **Runtime profile registration.** `SUPPORTED_PROFILES` in `kobo-profile`
+4. **Runtime profile registration.** `SUPPORTED_PROFILES` in `kobo-profile`
    contains the profiles the runtime may identify. Device tools probe first and
    select a matching hardware profile; panel-write entry points then apply the
    shared `write_ready_profile` gate, which requires exact identity and reviewed
-   evidence. The browser/runtime simulator remains Clara BW-sized, so a new
-   profile also needs explicit layout coverage for its metrics.
+   evidence.
 
-The framebuffer, touch decoder, and refresh planner consume a `DeviceProfile`
-rather than assuming one model. A new device can still require narrow discovery
-support—for example, recognizing its touch device name—and tests proving that
-all write paths use the profile selected from the same probe.
+The framebuffer, touch decoder, and refresh planner consume the selected
+`DeviceProfile` rather than assuming one model. The display backend dispatches
+on the profile's controller, so a new panel family needs its own backend plus
+tests proving that every write path uses the profile selected from the same
+probe.
 
 ## How to get the numbers
 
@@ -56,6 +60,7 @@ same partition your books are on.
 cargo run -p kobo-cli -- setup --enable-ssh --no-menu   # over USB, then eject
 cargo run -p kobo-cli -- devices                        # find the address
 cargo run -p kobo-cli -- doctor --device <address>
+cargo run -p kobo-cli -- touch-probe --device <address> --seconds 30
 ```
 
 `--no-menu` leaves the reader's own menus alone, which is what you want here:
@@ -86,10 +91,22 @@ touch: Elan Touchscreen at /dev/input/event2 X=0..1872 Y=0..1404
 result: write ready
 ```
 
+The hardware-verified Clara HD probe is:
+
+```
+profile: clara-hd-376 (Kobo Clara HD)
+device-tree compatible: fsl,imx6sll-lpddr3-arm2, fsl,imx6sll
+framebuffer: id=mxc_epdc_fb 1072x1448 virtual=1088x1536 offset=0,0 bpp=32 ...
+identity: model=N249 firmware=4.38.23684 kernel=4.1.15-00136-g12655eaaef89 device-code=376
+touch: cyttsp5_mt X=0..1447 Y=0..1071
+result: write ready
+```
+
 Every field a profile needs is on that page. The doctor compares the probe with
 the registered profiles. A known device is named; an unknown device is reported
 as unsupported after its raw fields are printed, making that report the
-starting evidence for a new profile.
+starting evidence for a new profile. The touch probe then checks a physical
+touch at a known corner against the proposed rotated transform.
 
 The full serial number is deliberately never read past its four-character
 model prefix.

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -97,7 +97,7 @@ The hardware-verified Clara HD probe is:
 profile: clara-hd-376 (Kobo Clara HD)
 device-tree compatible: fsl,imx6sll-lpddr3-arm2, fsl,imx6sll
 framebuffer: id=mxc_epdc_fb 1072x1448 virtual=1088x1536 offset=0,0 bpp=32 ...
-identity: model=N249 firmware=4.38.23684 kernel=4.1.15-00136-g12655eaaef89 device-code=376
+identity: model=N249 firmware=4.38.23697 kernel=4.1.15-00136-g12655eaaef89 device-code=376
 touch: cyttsp5_mt X=0..1447 Y=0..1071
 result: write ready
 ```


### PR DESCRIPTION
## Summary

- add an exact Kobo Clara HD N249 / device code 376 hardware profile for firmware 4.38.23684
- add the Mark 7 MXCFB v2 refresh ABI and dispatch refreshes by framebuffer controller
- add a fail-closed ptrace syscall-filter fallback for the Clara HD vendor kernel, which exposes neither seccomp BPF nor network namespaces
- authorize older Kobo firmware at its actual root home and document both hardware-tested models

## Hardware validation

On a physical Clara HD:

- strict doctor profile: matched
- MXCFB display-only GC16: passed
- reversible 32x32 GC16: framebuffer restored byte-for-byte
- full-screen snapshot/restore: framebuffer restored byte-for-byte
- reversible DU: framebuffer restored byte-for-byte
- physical top-left touch probe: transform matched
- end-to-end device tap: switched the gallery tab and repainted correctly
- gallery panel capture: upright 1072x1448 output
- timed session: stock reader and watchdog resumed normally
- sandbox probe: AF_INET socket and fork refused with EPERM; AF_UNIX allowed

## Verification

- `cargo test --workspace`
- strict ARM clippy for `kobo-abi` and `kobod` with device writes
- strict host clippy for changed packages
- `cargo fmt --check`
- static ARMv7 hard-float device build

Closes #33.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790000641&installation_model_id=20525&pr_number=34&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F34&signature=4ab0a944d02f6622bcc5a292868fffa23fa1131ef2f4d625f3c4254c6e50c3b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->