### PR TITLE
docs: guide device testing contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ change. Add tests for changed behavior and run the relevant workspace checks:
 
 ```sh
 cargo fmt --all --check
-cargo test --workspace --all-features
+cargo test --workspace --all-targets --all-features
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+Bug reports, fixes, applications, and device testing are welcome. Open an
+issue before a large change. Check open issues and pull requests first, then
+comment on the relevant thread with what you plan to change or test.
+
+## Applications
+
+Application contributions have their own guide:
+[docs/CONTRIBUTING_APPS.md](docs/CONTRIBUTING_APPS.md).
+
+## Device testing
+
+You do not need to write code to help support another Kobo.
+
+1. Find the matching porting issue linked from the README. If none exists,
+   open one before testing.
+2. Comment with the exact model, firmware, and whether the device is available
+   for attended testing. This also avoids duplicate ports.
+3. Begin with the read-only doctor report in
+   [docs/PORTING.md](docs/PORTING.md).
+4. Run display or touch tests only after a maintainer points you to a reviewed
+   candidate profile and commit.
+5. Post the command output and observations on the porting issue. The code PR
+   should link back to that evidence.
+
+Do not post full serial numbers, SSH keys, credentials, or personal network
+details.
+
+Hardware similarity and screenshots are useful context, but they do not make a
+profile write-ready. That requires the attended display, touch, exit, and
+recovery checks in the porting guide.
+
+## Device port pull requests
+
+Link the porting issue and keep `write_ready` false until the attended evidence
+has been reviewed. The pull request should record:
+
+- the exact model, device code, firmware, kernel, and tested commit;
+- the doctor report and attended test results;
+- the source used for a new controller ABI and tests for its struct layout,
+  ioctl values, and waveform mapping;
+- any untested hardware revision, firmware, button, stylus, suspend, or driver
+  behavior.
+
+Kernel or sandbox fallbacks must fail closed when isolation cannot be applied.
+
+## Testing fixes
+
+For installation or host-platform bugs, include the host OS, Kobo model and
+firmware, exact command, complete error, and any confirmed workaround. A
+documentation change should describe behavior that has been reproduced, not a
+guess.
+
+## Code changes
+
+Keep pull requests focused and explain any behavior or safety boundary they
+change. Add tests for changed behavior and run the relevant workspace checks:
+
+```sh
+cargo fmt --all --check
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+Report security issues privately as described in [SECURITY.md](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -29,14 +29,13 @@ new app can appear in Store without reinstalling or updating Cobalt.
 > It is an independent project and is not affiliated with Rakuten Kobo.
 
 > [!TIP]
-> **Own one of these Kobo models? Help test its port.** No coding is required.
+> **Own an unsupported Kobo? Help test its port.** No coding is required.
 > Read the thread and comment with your exact model, firmware, and whether you
 > can run attended tests:
 > [Libra Colour](https://github.com/BandarLabs/Cobalt/issues/28),
 > [Libra 2](https://github.com/BandarLabs/Cobalt/issues/29),
 > [Clara Colour](https://github.com/BandarLabs/Cobalt/issues/30),
-> [Aura](https://github.com/BandarLabs/Cobalt/issues/32), or
-> [Clara HD](https://github.com/BandarLabs/Cobalt/issues/33).
+> or [Aura](https://github.com/BandarLabs/Cobalt/issues/32).
 > Start with read-only checks; run panel tests only against the commit named by
 > a maintainer. See
 > [Contributing](CONTRIBUTING.md#device-testing).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ new app can appear in Store without reinstalling or updating Cobalt.
 > installing.
 > It is an independent project and is not affiliated with Rakuten Kobo.
 
+> [!TIP]
+> **Own one of these Kobo models? Help test its port.** No coding is required.
+> Read the thread and comment with your exact model, firmware, and whether you
+> can run attended tests:
+> [Libra Colour](https://github.com/BandarLabs/Cobalt/issues/28),
+> [Libra 2](https://github.com/BandarLabs/Cobalt/issues/29),
+> [Clara Colour](https://github.com/BandarLabs/Cobalt/issues/30),
+> [Aura](https://github.com/BandarLabs/Cobalt/issues/32), or
+> [Clara HD](https://github.com/BandarLabs/Cobalt/issues/33).
+> Start with read-only checks; run panel tests only against the commit named by
+> a maintainer. See
+> [Contributing](CONTRIBUTING.md#device-testing).
+
 ## Features
 
 - Signed Wi-Fi app installation, updates, and removal
@@ -206,6 +219,7 @@ cargo run -p kobo-cli -- run --sim --app sudoku
 
 Additional guides:
 
+- [Contributing](CONTRIBUTING.md)
 - [Developing Cobalt](docs/DEVELOPING.md)
 - [Working with devices](docs/DEVICES.md)
 - [Publishing apps](docs/APP_STORE.md)

--- a/SDK.md
+++ b/SDK.md
@@ -48,14 +48,13 @@ fn main() {
 
 ## 0. Your own application, end to end
 
-Before anything else: **this has only ever been run on a Kobo Clara BW (N365,
-device code 391).** It is AGPL-3.0 licensed and comes with no warranty. Every device
-write is gated on an exact hardware match, so another reader is refused rather
-than guessed at, but nobody can promise your device will be fine. Do not run it
-on a reader you cannot afford to lose. If you want to add another model, that
-is a pull request this project would genuinely welcome; open an issue first so
-the profile shape can be agreed. [Porting to another
-Kobo](docs/PORTING.md) sets out what is actually involved.
+Before anything else: Cobalt is hardware-tested on the exact Clara BW, Elipsa
+2E, and Clara HD identities in the
+[device support matrix](docs/DEVICES.md#device-support-matrix). It is
+AGPL-3.0 licensed and comes with no warranty. Every device write is gated on an
+exact hardware match; do not install it on an unlisted identity or firmware.
+To help support another model, start with
+[Porting to another Kobo](docs/PORTING.md).
 
 Six steps from nothing to a tile on the reader's launcher.
 

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -4439,9 +4439,9 @@ impl<A: KoboApp> AppRunner<A> {
 
     /// Runs an application against a specific panel.
     ///
-    /// [`AppRunner::new`] assumes the only panel with hardware support, which
-    /// is right for a test and wrong for the device: the runtime states which
-    /// panel it owns during the handshake.
+    /// [`AppRunner::new`] assumes the default Clara BW metrics, which is right
+    /// for a test and wrong for the device: the runtime states which panel it
+    /// owns during the handshake.
     #[must_use]
     pub fn with_metrics(app: A, metrics: DisplayMetrics) -> Self {
         #[cfg(feature = "text")]

--- a/crates/kobo-ui/src/lib.rs
+++ b/crates/kobo-ui/src/lib.rs
@@ -434,7 +434,7 @@ impl TextScale {
     }
 }
 
-/// The only panel with hardware support today.
+/// Default Clara BW metrics used by host-side helpers and the simulator.
 pub const CLARA_BW_METRICS: DisplayMetrics = DisplayMetrics {
     width: 1072,
     height: 1448,
@@ -442,7 +442,7 @@ pub const CLARA_BW_METRICS: DisplayMetrics = DisplayMetrics {
     text_scale: TextScale::Default,
 };
 
-/// Returns the supported panel with the process-level accessibility setting.
+/// Returns the default Clara BW metrics with the process-level text scale.
 #[must_use]
 pub fn display_metrics_from_env() -> DisplayMetrics {
     let mut metrics = CLARA_BW_METRICS;
@@ -746,7 +746,7 @@ pub enum Space {
 }
 
 impl Space {
-    /// Pixels on the only panel with hardware support.
+    /// Pixels using the default Clara BW metrics.
     ///
     /// Prefer [`DisplayMetrics::space`] wherever the target panel is known.
     #[must_use]
@@ -1520,7 +1520,7 @@ impl Screen {
         self
     }
 
-    /// Lays the screen out for the only panel with hardware support.
+    /// Lays the screen out using the default Clara BW metrics.
     #[must_use]
     pub fn layout(&self) -> Layout {
         self.layout_for(&CLARA_BW_METRICS)

--- a/docs/DEVICES.md
+++ b/docs/DEVICES.md
@@ -12,7 +12,7 @@ and touch profile. A matching model name alone is not sufficient.
 | Device | Exact tested identity | Evidence status | Installation status |
 |---|---|---|---|
 | Kobo Clara BW | N365, code 391, firmware 4.45.23697, kernel 4.9.77 | Read-only probe and owner-attended display, touch, exit, and recovery tests complete | Fully tested |
-| Kobo Clara HD | N249, code 376, firmware 4.38.23684 or 4.38.23697, kernel 4.1.15-00136-g12655eaaef89 | Read-only probe and owner-attended display, touch, exit, suspend/resume, sandbox, and recovery tests complete | Fully tested |
+| Kobo Clara HD | N249, code 376, firmware 4.38.23684 or 4.38.23697, kernel 4.1.15-00136-g12655eaaef89 | Read-only probe and owner-attended display, touch, exit, sandbox, and recovery tests complete | Fully tested |
 | Kobo Elipsa 2E | N605, code 389, firmware 4.38.23697, kernel 4.9.77 | Read-only probe and owner-attended display, touch, exit, suspend/resume, and recovery tests complete | Fully tested |
 
 `Read-only doctor match complete` means the profile describes the observed

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -13,8 +13,37 @@ read-only match is only a porting milestone, not permission to ship or install
 the profile. Review every other path that takes device ownership against the
 same identity boundary.
 
-This is a genuinely welcome pull request. Open an issue first so the profile
-shape can be agreed.
+Open or join a device issue before writing code. Check for an existing pull
+request and agree on the profile or backend shape there to avoid duplicate
+ports.
+
+## Help test a device
+
+Testing does not require a code contribution. Comment on the device's porting
+issue with its exact model and firmware, and say whether you can run attended
+tests. Mention any known hardware revision and whether the device has buttons
+or a stylus. Do not post the full serial number.
+
+Start with the read-only doctor report below. Panel and touch tests come later,
+after a maintainer has reviewed a candidate profile and named the exact commit
+to test. Keep the output and observations on the porting issue so the
+implementation PR and support matrix can link to the evidence.
+
+Do not infer support from a similar model. Normal writes remain blocked until
+the attended display, touch, exit, and recovery results have been reviewed.
+Additional testers are most useful on another firmware build or hardware
+revision.
+
+## Port stages
+
+1. **Identify:** post the complete read-only doctor report.
+2. **Implement:** add the narrow profile or backend with host tests. A profile
+   may remain registered with `write_ready: false` while evidence is pending.
+3. **Review:** a maintainer reviews the write boundary and names the exact
+   commit for attended testing.
+4. **Validate:** the device owner runs the bounded display stages, physical
+   touch check, recovery check, and clean exit.
+5. **Enable:** set `write_ready: true` only for the exact identity that passed.
 
 ## What is device-specific
 
@@ -127,3 +156,25 @@ session to the caller. It may ignore only the evidence-pending blocker;
 geometry, framebuffer safety, and exact identity remain mandatory. Normal
 runtime display, guard, synthetic-tap, and exclusive touch-grab paths stay
 blocked until `write_ready` is reviewed and enabled.
+
+## Evidence for write-ready support
+
+Post one evidence block on the porting issue and link it from the pull request:
+
+- tested commit, model prefix, device code, firmware, and kernel;
+- complete doctor output;
+- results for all four
+  [attended display stages](DEVICES.md#attended-display-smoke-tests);
+- a physical touch sample and an end-to-end tap;
+- guardian restoration and a clean return to the stock reader;
+- suspend/resume results when the port changes session or power behavior;
+- sandbox results when the kernel needs a different isolation path;
+- known gaps, including buttons, stylus support, driver quirks, firmware
+  coverage, or hardware revisions.
+
+Photos or recordings help review orientation and interaction, but they do not
+replace command output or restoration checks.
+
+For a new framebuffer controller, cite the vendor kernel or header used and add
+conformance tests for the ABI. Third-party projects can corroborate behavior,
+but should not be treated as proof that the target device passed the tests.

--- a/docs/index.html
+++ b/docs/index.html
@@ -577,7 +577,7 @@ kobo dev</code></pre>
     <p class="kicker">Install</p>
     <h2 class="measure">Installing from source.</h2>
     <ol class="steps">
-      <li><strong>Charge a fully supported reader</strong> and connect it over USB. The Clara BW N365 and Elipsa 2E N605 are fully tested at the exact versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>.</li>
+      <li><strong>Charge a fully supported reader</strong> and connect it over USB. The Clara BW N365, Elipsa 2E N605, and Clara HD N249 are fully tested at the exact versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>.</li>
       <li><strong>Run the setup:</strong></li>
     </ol>
 <pre><code>git clone https://github.com/BandarLabs/Cobalt.git
@@ -603,7 +603,7 @@ cargo run -p kobo-cli -- setup</code></pre>
       <li><strong>Run it on your own device.</strong> A real, fully supported reader, not just the Clara-sized simulator.</li>
       <li><strong>Open a PR with a gif or photos of it running.</strong> Once reviewed and merged, the publish workflow signs it and it appears in Store. No platform release needed.</li>
     </ol>
-    <p class="measure quiet" style="margin-top:22px">Own a different Kobo model? <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/PORTING.md">Porting</a> is welcome too; open an issue first so the device profile can be agreed. Full details in <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/CONTRIBUTING_APPS.md">docs/CONTRIBUTING_APPS.md</a>.</p>
+    <p class="measure quiet" style="margin-top:22px">Own an unsupported Kobo? No coding is required to help test it. Join the active <a href="https://github.com/BandarLabs/Cobalt/issues/28">Libra Colour</a>, <a href="https://github.com/BandarLabs/Cobalt/issues/29">Libra 2</a>, <a href="https://github.com/BandarLabs/Cobalt/issues/30">Clara Colour</a>, or <a href="https://github.com/BandarLabs/Cobalt/issues/32">Aura</a> thread and follow the <a href="https://github.com/BandarLabs/Cobalt/blob/main/CONTRIBUTING.md#device-testing">device testing guide</a>. App details are in <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/CONTRIBUTING_APPS.md">docs/CONTRIBUTING_APPS.md</a>.</p>
   </div>
 </section>
 
@@ -612,7 +612,7 @@ cargo run -p kobo-cli -- setup</code></pre>
     <p class="kicker">Safety</p>
     <h2>Device support and safety.</h2>
     <p>Cobalt does not replace Kobo's boot chain. Normal panel-write entry points require an exact hardware and firmware match, and a reboot returns to the stock reader. The first installation does modify files on the user storage partition, and it is provided without warranty.</p>
-    <p>The Clara BW N365 and Elipsa 2E N605 profiles are fully hardware-tested at the exact firmware and kernel versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>. Other identity or firmware combinations remain unsupported until separately verified. Cobalt is an independent project, not affiliated with Rakuten Kobo.</p>
+    <p>The Clara BW N365, Elipsa 2E N605, and Clara HD N249 profiles are fully hardware-tested at the exact firmware and kernel versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>. Other identity or firmware combinations remain unsupported until separately verified. Cobalt is an independent project, not affiliated with Rakuten Kobo.</p>
   </div>
 </section>
 

--- a/docs/sdk.html
+++ b/docs/sdk.html
@@ -272,7 +272,7 @@ footer nav { display: flex; gap: 20px; flex-wrap: wrap; }
 <span class="kw">fn</span> <span class="fn">main</span>() {
     <span class="kw">let</span> _ = kobo_sdk::<span class="fn">run</span>(<span class="str">"counter"</span>, <span class="ty">Counter</span>::<span class="fn">default</span>());
 }</code></pre>
-      <div class="note"><strong>Hardware support.</strong> The Kobo Clara BW N365, device code 391, and Kobo Elipsa 2E N605, device code 389, are fully hardware-tested at the exact firmware and kernel versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>.</div>
+      <div class="note"><strong>Hardware support.</strong> The Kobo Clara BW N365, device code 391; Kobo Elipsa 2E N605, device code 389; and Kobo Clara HD N249, device code 376 are fully hardware-tested at the exact firmware and kernel versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>.</div>
     </section>
 
     <section id="application-model">


### PR DESCRIPTION
## Summary

- link active device porting threads from the README and GitHub Pages site
- add a concise contribution path for testers and port authors
- document staged validation and write-ready evidence
- update public and API docs for Clara BW, Elipsa 2E, and Clara HD support

Documentation only.