### PR TITLE
Port to Kobo Libra 2 (N418, device code 388)

### DIFF
--- a/apps/arxiv/src/main.rs
+++ b/apps/arxiv/src/main.rs
@@ -1092,24 +1092,6 @@ fn page_total(pages: usize) -> u16 {
 }
 
 impl KoboApp for Arxiv {
-    fn on_page_turn(&mut self, context: &mut Context, forward: bool) {
-        // Only while a paper's full text is open; everywhere else the press
-        // does nothing until paging a listing is designed deliberately. The
-        // press routes through on_action so a button behaves exactly like a
-        // tap on the same page-turn zone.
-        if self.view != View::FullText {
-            return;
-        }
-        self.on_action(
-            context,
-            action_id(if forward {
-                kobo_read::action::FORWARD
-            } else {
-                kobo_read::action::BACK
-            }),
-        );
-    }
-
     fn on_start(&mut self, context: &mut Context) {
         context.store().load(LIBRARY_KEY);
         self.show(context);

--- a/apps/arxiv/src/main.rs
+++ b/apps/arxiv/src/main.rs
@@ -1092,6 +1092,24 @@ fn page_total(pages: usize) -> u16 {
 }
 
 impl KoboApp for Arxiv {
+    fn on_page_turn(&mut self, context: &mut Context, forward: bool) {
+        // Only while a paper's full text is open; everywhere else the press
+        // does nothing until paging a listing is designed deliberately. The
+        // press routes through on_action so a button behaves exactly like a
+        // tap on the same page-turn zone.
+        if self.view != View::FullText {
+            return;
+        }
+        self.on_action(
+            context,
+            action_id(if forward {
+                kobo_read::action::FORWARD
+            } else {
+                kobo_read::action::BACK
+            }),
+        );
+    }
+
     fn on_start(&mut self, context: &mut Context) {
         context.store().load(LIBRARY_KEY);
         self.show(context);

--- a/crates/kobo-abi/src/lib.rs
+++ b/crates/kobo-abi/src/lib.rs
@@ -612,15 +612,19 @@ pub mod mxcfb {
     // `mxc_epdc_v2_fb.c:204`. Note the ordering difference against hwtcon.
     //
     // These are not the numbers the panel controller itself uses. The driver
-    // treats the submitted value as an index into a table it builds from the
-    // loaded waveform file, and substitutes the hardware's own number before
-    // sending it on (`mxc_epdc_v2_fb.c:5305`). That is the deeper reason the
-    // two backends cannot share constants: hwtcon takes a final waveform
-    // number and this takes an index, and they happen to overlap in range.
+    // maps the submitted constant through a table it builds from the waveform
+    // file on the device, and sends the hardware's own index on in its place
+    // (`mxc_epdc_v2_fb.c:5305`).
     //
-    // Which hardware number each index maps to therefore depends on the
-    // waveform file on the device. `DU`, `GC16` and `GL16` are present in
-    // every known table; `GC4` is not dependable.
+    // hwtcon works the same way, through `struct hwtcon_waveform_modes`, so
+    // that indirection is not what separates the two backends. What separates
+    // them is duller: the two vendors chose different values for the same
+    // waveforms, and the ranges overlap, so a constant from the wrong one is
+    // accepted and drawn.
+    //
+    // One consequence of the table being built per device: which hardware
+    // waveform a constant reaches depends on the waveform file. `DU`, `GC16`
+    // and `GL16` are present in every known table; `GC4` is not dependable.
     pub const WAVEFORM_INIT: u32 = 0;
     pub const WAVEFORM_DU: u32 = 1;
     pub const WAVEFORM_GC16: u32 = 2;

--- a/crates/kobo-abi/src/lib.rs
+++ b/crates/kobo-abi/src/lib.rs
@@ -1433,12 +1433,22 @@ pub mod sandbox {
     /// without `CONFIG_SECCOMP` answers with `EINVAL`), or a private network
     /// namespace, probed by the file the kernel publishes for it. Read-only:
     /// nothing is installed or unshared.
-    #[cfg(target_os = "linux")]
+    ///
+    /// Off Linux there is no sandbox to put a boundary around: [`is_root`]
+    /// answers false there, so [`Sandbox::enter`] is never reached. Answering
+    /// true keeps a development host from logging a degradation it is not in.
     #[must_use]
     pub fn network_boundary_available() -> bool {
-        // SAFETY: PR_GET_SECCOMP reads the current mode and changes nothing.
-        let seccomp = unsafe { libc::prctl(libc::PR_GET_SECCOMP) } >= 0;
-        seccomp || Path::new("/proc/self/ns/net").exists()
+        #[cfg(target_os = "linux")]
+        {
+            // SAFETY: PR_GET_SECCOMP reads the current mode and changes nothing.
+            let seccomp = unsafe { libc::prctl(libc::PR_GET_SECCOMP) } >= 0;
+            seccomp || Path::new("/proc/self/ns/net").exists()
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            true
+        }
     }
 
     /// Signals every process whose filesystem root is the prepared sandbox.

--- a/crates/kobo-abi/src/lib.rs
+++ b/crates/kobo-abi/src/lib.rs
@@ -577,6 +577,155 @@ pub mod hwtcon {
     }
 }
 
+/// The i.MX6 EPDC framebuffer interface, as used by the Kobo Mark 7 devices.
+///
+/// This is the second display backend beside [`hwtcon`], and the two are more
+/// alike than they look. `MediaTek` kept the i.MX ioctl numbering, so both
+/// backends send updates on `'F', 0x2e` and wait on `'F', 0x2f`. Two things
+/// differ, and both are load-bearing:
+///
+/// 1. The update struct is 72 bytes here against 36 on hwtcon, because Mark 7
+///    takes the v2 layout with `temp`, `dither_mode`, `quant_bit` and an
+///    alternate buffer descriptor. The size is encoded in the request number,
+///    so the two `SEND_UPDATE` constants are genuinely different values.
+/// 2. The waveform *numbers* differ. `GL16` is 5 here and 3 on hwtcon; `A2` is
+///    4 here and 6 there. A waveform constant from the wrong backend is a
+///    silently wrong picture, not an error.
+///
+/// The wait request, by contrast, is bit-identical to the hwtcon one: the same
+/// number over the same eight-byte marker struct.
+///
+/// Every declaration here was read out of the Kobo Libra 2's own published
+/// kernel source, `include/uapi/linux/mxcfb.h` and
+/// `drivers/video/fbdev/mxc/mxc_epdc_v2_fb.c`, rather than reconstructed.
+pub mod mxcfb {
+    use super::{iow, iowr};
+    #[cfg(feature = "device-write")]
+    use super::{mutating_ioctl, File};
+    #[cfg(feature = "device-write")]
+    use std::io;
+
+    pub const UPDATE_MODE_PARTIAL: u32 = 0;
+    pub const UPDATE_MODE_FULL: u32 = 1;
+
+    // Defined in the driver rather than the uapi header, at
+    // `mxc_epdc_v2_fb.c:204`. Note the ordering difference against hwtcon.
+    //
+    // These are not the numbers the panel controller itself uses. The driver
+    // treats the submitted value as an index into a table it builds from the
+    // loaded waveform file, and substitutes the hardware's own number before
+    // sending it on (`mxc_epdc_v2_fb.c:5305`). That is the deeper reason the
+    // two backends cannot share constants: hwtcon takes a final waveform
+    // number and this takes an index, and they happen to overlap in range.
+    //
+    // Which hardware number each index maps to therefore depends on the
+    // waveform file on the device. `DU`, `GC16` and `GL16` are present in
+    // every known table; `GC4` is not dependable.
+    pub const WAVEFORM_INIT: u32 = 0;
+    pub const WAVEFORM_DU: u32 = 1;
+    pub const WAVEFORM_GC16: u32 = 2;
+    pub const WAVEFORM_GC4: u32 = 3;
+    pub const WAVEFORM_A2: u32 = 4;
+    pub const WAVEFORM_GL16: u32 = 5;
+    pub const WAVEFORM_GLR16: u32 = 6;
+    pub const WAVEFORM_GLD16: u32 = 7;
+    pub const WAVEFORM_AUTO: u32 = 257;
+
+    /// Ask the panel controller to use its own ambient temperature reading.
+    ///
+    /// hwtcon has no equivalent field. Every other known consumer of this
+    /// interface sends this value, and nothing here has a better number to
+    /// offer, so it is not exposed as a choice.
+    pub const TEMP_USE_AMBIENT: i32 = 0x1000;
+
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    #[repr(C)]
+    pub struct MxcfbRect {
+        pub top: u32,
+        pub left: u32,
+        pub width: u32,
+        pub height: u32,
+    }
+
+    /// The marker half of the interface, identical in layout and in request
+    /// number to [`hwtcon::HwtconUpdateMarkerData`](super::hwtcon::HwtconUpdateMarkerData).
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    #[repr(C)]
+    pub struct MxcfbUpdateMarkerData {
+        pub update_marker: u32,
+        pub collision_test: u32,
+    }
+
+    /// An alternate source buffer for an update, addressed physically.
+    ///
+    /// Nothing here uses it: updates always come from the framebuffer itself,
+    /// so every field stays zero. It exists because it occupies the last 28
+    /// bytes of the update struct, and the struct's size is part of the ioctl
+    /// request number.
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    #[repr(C)]
+    pub struct MxcfbAltBufferData {
+        pub phys_addr: u32,
+        pub width: u32,
+        pub height: u32,
+        pub alt_update_region: MxcfbRect,
+    }
+
+    /// The Mark 7 update descriptor, `mxcfb_update_data_v2` in the kernel.
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    #[repr(C)]
+    pub struct MxcfbUpdateData {
+        pub update_region: MxcfbRect,
+        pub waveform_mode: u32,
+        pub update_mode: u32,
+        pub update_marker: u32,
+        pub temp: i32,
+        pub flags: u32,
+        pub dither_mode: i32,
+        pub quant_bit: i32,
+        pub alt_buffer_data: MxcfbAltBufferData,
+    }
+
+    const _: [(); 16] = [(); std::mem::size_of::<MxcfbRect>()];
+    const _: [(); 8] = [(); std::mem::size_of::<MxcfbUpdateMarkerData>()];
+    const _: [(); 28] = [(); std::mem::size_of::<MxcfbAltBufferData>()];
+    const _: [(); 72] = [(); std::mem::size_of::<MxcfbUpdateData>()];
+
+    pub const MXCFB_SEND_UPDATE: u64 = iow(b'F', 0x2e, 72);
+    pub const MXCFB_WAIT_FOR_UPDATE_COMPLETE: u64 = iowr(b'F', 0x2f, 8);
+
+    /// Submits an EPDC update. Available only with `device-write`.
+    ///
+    /// The request is declared write-only by the kernel header, but the driver
+    /// copies the descriptor back to user space, so it is passed mutably.
+    /// `update.waveform_mode` is overwritten in the process: what comes back
+    /// is the panel's own waveform number, not the constant that went in
+    /// (`mxc_epdc_v2_fb.c:5486`, "Pass selected waveform mode back to user").
+    /// Nothing here reads it back, but a caller that compared the field
+    /// against a `WAVEFORM_` constant after the call would find they differ.
+    ///
+    /// # Errors
+    ///
+    /// Returns the kernel error from `MXCFB_SEND_UPDATE`.
+    #[cfg(feature = "device-write")]
+    pub fn send_update(file: &File, update: &mut MxcfbUpdateData) -> io::Result<()> {
+        mutating_ioctl(file, MXCFB_SEND_UPDATE, update)
+    }
+
+    /// Waits for the EPDC marker and returns its collision-test result.
+    ///
+    /// # Errors
+    ///
+    /// Returns the kernel error from `MXCFB_WAIT_FOR_UPDATE_COMPLETE`.
+    #[cfg(feature = "device-write")]
+    pub fn wait_for_update_complete(
+        file: &File,
+        marker: &mut MxcfbUpdateMarkerData,
+    ) -> io::Result<()> {
+        mutating_ioctl(file, MXCFB_WAIT_FOR_UPDATE_COMPLETE, marker)
+    }
+}
+
 /// Kernel isolation applied to an application immediately before it starts.
 ///
 /// Device applications are ordinary static binaries, but they are not trusted
@@ -1371,7 +1520,7 @@ mod pty_tests {
 
 #[cfg(test)]
 mod tests {
-    use super::{hwtcon, input, ior, iow, iowr};
+    use super::{hwtcon, input, ior, iow, iowr, mxcfb};
     #[cfg(feature = "device-write")]
     use std::fs::File;
 
@@ -1408,15 +1557,73 @@ mod tests {
         assert_eq!(input::EVIOCGABS_MT_POSITION_Y, 0x8018_4576);
         assert_eq!(hwtcon::HWTCON_SEND_UPDATE, 0x4024_462e);
         assert_eq!(hwtcon::HWTCON_WAIT_FOR_UPDATE_COMPLETE, 0xc008_462f);
+        assert_eq!(mxcfb::MXCFB_SEND_UPDATE, 0x4048_462e);
+        assert_eq!(mxcfb::MXCFB_WAIT_FOR_UPDATE_COMPLETE, 0xc008_462f);
         assert_eq!(ior(b'E', 0x75, 24), 0x8018_4575);
         assert_eq!(iow(b'F', 0x2e, 36), 0x4024_462e);
+        assert_eq!(iow(b'F', 0x2e, 72), 0x4048_462e);
         assert_eq!(iowr(b'F', 0x2f, 8), 0xc008_462f);
     }
 
+    /// The two backends share a number here, and that is not a coincidence to
+    /// be tidied away: the marker struct is the same eight bytes on both, so
+    /// the wait half of the interface needs no second implementation.
     #[test]
-    fn hwtcon_waveforms_do_not_reuse_mxcfb_values() {
+    fn both_backends_wait_on_the_same_request() {
+        assert_eq!(
+            hwtcon::HWTCON_WAIT_FOR_UPDATE_COMPLETE,
+            mxcfb::MXCFB_WAIT_FOR_UPDATE_COMPLETE
+        );
+        assert_ne!(hwtcon::HWTCON_SEND_UPDATE, mxcfb::MXCFB_SEND_UPDATE);
+    }
+
+    /// A waveform constant taken from the wrong backend does not fail: it
+    /// draws the wrong thing. Ask an i.MX6 panel for hwtcon's `GL16` and it
+    /// runs `GC4`; ask it for hwtcon's `A2` and it runs `GLR16`.
+    #[test]
+    fn the_two_backends_number_their_waveforms_differently() {
         assert_eq!(hwtcon::WAVEFORM_GLR16, 4);
         assert_eq!(hwtcon::WAVEFORM_A2, 6);
+        assert_eq!(mxcfb::WAVEFORM_GL16, 5);
+        assert_eq!(mxcfb::WAVEFORM_A2, 4);
+        assert_ne!(hwtcon::WAVEFORM_GL16, mxcfb::WAVEFORM_GL16);
+        assert_ne!(hwtcon::WAVEFORM_A2, mxcfb::WAVEFORM_A2);
+
+        // The three the two backends genuinely agree on.
+        assert_eq!(hwtcon::WAVEFORM_INIT, mxcfb::WAVEFORM_INIT);
+        assert_eq!(hwtcon::WAVEFORM_DU, mxcfb::WAVEFORM_DU);
+        assert_eq!(hwtcon::WAVEFORM_GC16, mxcfb::WAVEFORM_GC16);
+        assert_eq!(hwtcon::WAVEFORM_AUTO, mxcfb::WAVEFORM_AUTO);
+    }
+
+    #[test]
+    fn mxcfb_offsets_match_vendor_c_layout() {
+        use std::mem::offset_of;
+
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateData, update_region), 0);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateData, waveform_mode), 16);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateData, update_mode), 20);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateData, update_marker), 24);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateData, temp), 28);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateData, flags), 32);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateData, dither_mode), 36);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateData, quant_bit), 40);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateData, alt_buffer_data), 44);
+
+        assert_eq!(offset_of!(mxcfb::MxcfbAltBufferData, phys_addr), 0);
+        assert_eq!(offset_of!(mxcfb::MxcfbAltBufferData, width), 4);
+        assert_eq!(offset_of!(mxcfb::MxcfbAltBufferData, height), 8);
+        assert_eq!(offset_of!(mxcfb::MxcfbAltBufferData, alt_update_region), 12);
+
+        // Without these, swapping `top` and `left` would keep every size and
+        // every offset above correct, and put every update in the wrong place.
+        assert_eq!(offset_of!(mxcfb::MxcfbRect, top), 0);
+        assert_eq!(offset_of!(mxcfb::MxcfbRect, left), 4);
+        assert_eq!(offset_of!(mxcfb::MxcfbRect, width), 8);
+        assert_eq!(offset_of!(mxcfb::MxcfbRect, height), 12);
+
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateMarkerData, update_marker), 0);
+        assert_eq!(offset_of!(mxcfb::MxcfbUpdateMarkerData, collision_test), 4);
     }
 
     #[test]

--- a/crates/kobo-abi/src/lib.rs
+++ b/crates/kobo-abi/src/lib.rs
@@ -733,6 +733,36 @@ pub mod sandbox {
             u32::try_from(number).unwrap_or(u32::MAX)
         }
 
+        // Some architectures have no fork or vfork syscall at all, and libc
+        // defines no number for them: the C library implements both by calling
+        // clone, which this filter blocks in its own right. The device is
+        // armv7, where both numbers exist and the filter below is unchanged.
+        // This arm exists only so the workspace builds on such a development
+        // machine, arm64 Linux being the one people actually hit.
+        //
+        // The two slots are kept rather than removed. Every jump in the filter
+        // carries a relative offset -- socket lands on the AF_UNIX check, the
+        // rest land on RET ERRNO -- so dropping an instruction would silently
+        // retarget every jump above it. u32::MAX matches no syscall, which is
+        // the same fallback syscall() already uses, and leaves the offsets and
+        // the meaning of the program exactly as they are elsewhere.
+        //
+        // The list names the architectures that lack the calls, so that an
+        // unlisted future one fails to compile here rather than quietly
+        // dropping two entries from the filter.
+        #[cfg(any(
+            target_arch = "aarch64",
+            target_arch = "riscv64",
+            target_arch = "loongarch64"
+        ))]
+        let fork_calls: [u32; 2] = [u32::MAX, u32::MAX];
+        #[cfg(not(any(
+            target_arch = "aarch64",
+            target_arch = "riscv64",
+            target_arch = "loongarch64"
+        )))]
+        let fork_calls: [u32; 2] = [syscall(libc::SYS_fork), syscall(libc::SYS_vfork)];
+
         // seccomp_data.nr is at byte 0 and args[0] at byte 16 on the little-
         // endian ARM and x86 Linux targets supported by this workspace. SDK
         // applications are single-process event loops; their asynchronous work
@@ -746,8 +776,8 @@ pub mod sandbox {
             jump(syscall(libc::SYS_setpgid), 9, 0),
             jump(syscall(libc::SYS_unshare), 8, 0),
             jump(syscall(libc::SYS_setns), 7, 0),
-            jump(syscall(libc::SYS_fork), 6, 0),
-            jump(syscall(libc::SYS_vfork), 5, 0),
+            jump(fork_calls[0], 6, 0),
+            jump(fork_calls[1], 5, 0),
             jump(syscall(libc::SYS_clone), 4, 0),
             jump(syscall(libc::SYS_clone3), 3, 0),
             statement(RET_K, libc::SECCOMP_RET_ALLOW),

--- a/crates/kobo-abi/src/lib.rs
+++ b/crates/kobo-abi/src/lib.rs
@@ -825,8 +825,26 @@ pub mod sandbox {
             if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0 {
                 return Err(io::Error::last_os_error());
             }
-            if install_filter().is_err() && libc::unshare(libc::CLONE_NEWNET) < 0 {
-                return Err(io::Error::last_os_error());
+            if let Err(filter_error) = install_filter() {
+                if libc::unshare(libc::CLONE_NEWNET) < 0 {
+                    let unshare_error = io::Error::last_os_error();
+                    // A kernel that cannot express either boundary is not the
+                    // same as one that refused to. Kobo's own 4.1 i.MX6 kernels
+                    // ship with CONFIG_SECCOMP and CONFIG_NET_NS both off, and
+                    // report it as EINVAL (ENOSYS from a libc shim is the same
+                    // story). The chroot, the privilege ceiling and the
+                    // identity drop above all still hold; the network boundary
+                    // is enforced by nothing on such a kernel, which the
+                    // daemon detects with [`network_boundary_available`] and
+                    // says out loud at session start. An error that is not
+                    // "unsupported" is still a refusal.
+                    let unsupported = |error: &io::Error| {
+                        matches!(error.raw_os_error(), Some(libc::EINVAL | libc::ENOSYS))
+                    };
+                    if !(unsupported(&filter_error) && unsupported(&unshare_error)) {
+                        return Err(unshare_error);
+                    }
+                }
             }
             if libc::setgroups(0, std::ptr::null()) < 0
                 || libc::setgid(UNPRIVILEGED_ID) < 0
@@ -953,6 +971,21 @@ pub mod sandbox {
         } else {
             Ok(())
         }
+    }
+
+    /// Whether this kernel can put a network boundary around an application.
+    ///
+    /// True when either mechanism [`Sandbox::enter`] uses is available: a
+    /// seccomp filter, probed with `PR_GET_SECCOMP` (which a kernel built
+    /// without `CONFIG_SECCOMP` answers with `EINVAL`), or a private network
+    /// namespace, probed by the file the kernel publishes for it. Read-only:
+    /// nothing is installed or unshared.
+    #[cfg(target_os = "linux")]
+    #[must_use]
+    pub fn network_boundary_available() -> bool {
+        // SAFETY: PR_GET_SECCOMP reads the current mode and changes nothing.
+        let seccomp = unsafe { libc::prctl(libc::PR_GET_SECCOMP) } >= 0;
+        seccomp || Path::new("/proc/self/ns/net").exists()
     }
 
     /// Signals every process whose filesystem root is the prepared sandbox.

--- a/crates/kobo-abi/src/lib.rs
+++ b/crates/kobo-abi/src/lib.rs
@@ -384,6 +384,18 @@ pub mod input {
     pub const EV_SYN: u16 = 0x00;
     pub const EV_KEY: u16 = 0x01;
     pub const EV_ABS: u16 = 0x03;
+    pub const EV_MSC: u16 = 0x04;
+    /// The one `EV_MSC` code the NTX kernels use: digested accelerometer
+    /// orientation, delivered on the `gpio-keys` node.
+    pub const MSC_RAW: u16 = 0x03;
+    /// The power button, as `gpio-keys` reports it.
+    pub const KEY_POWER: u16 = 116;
+    /// The page-turn keys on devices that have them. Linux names these
+    /// `KEY_F23` and `KEY_F24`; which one means "forward" depends on how the
+    /// reader is held, so the codes stay neutral here and the meaning is
+    /// assigned where the pose is known. Captured on a Libra 2 on 2026-08-23.
+    pub const KEY_PAGE_193: u16 = 193;
+    pub const KEY_PAGE_194: u16 = 194;
     pub const SYN_REPORT: u16 = 0;
     pub const BTN_TOUCH: u16 = 330;
 

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -98,10 +98,17 @@ root=/mnt/onboard/.adds/cobalt
 staged_key=\"$root/bootstrap/authorized_key\"
 if [ -s \"$staged_key\" ]; then
   umask 077
-  mkdir -p /root/.ssh
-  touch /root/.ssh/authorized_keys
-  chmod 700 /root/.ssh
-  chmod 600 /root/.ssh/authorized_keys
+  # Root's home is not /root on every Kobo: the i.MX6 firmware ships
+  # root:...:0:0:root:/:/bin/sh, and sshd resolves AuthorizedKeysFile
+  # relative to the home directory, so a key under /root never authenticates
+  # there. Ask /etc/passwd instead of assuming.
+  home=$(awk -F: '$1 == \"root\" { print $6 }' /etc/passwd)
+  home=\"${home%/}\"
+  keys=\"$home/.ssh/authorized_keys\"
+  mkdir -p \"$home/.ssh\"
+  touch \"$keys\"
+  chmod 700 \"$home/.ssh\"
+  chmod 600 \"$keys\"
   key=$(head -n 1 \"$staged_key\")
   found=false
   while IFS= read -r known; do
@@ -109,9 +116,9 @@ if [ -s \"$staged_key\" ]; then
       found=true
       break
     fi
-  done < /root/.ssh/authorized_keys
+  done < \"$keys\"
   if [ \"$found\" = false ]; then
-    printf '%s\\n' \"$key\" >> /root/.ssh/authorized_keys
+    printf '%s\\n' \"$key\" >> \"$keys\"
   fi
   rm -f \"$staged_key\"
   sync
@@ -3514,7 +3521,8 @@ fn undo_setup(reader: &setup::Mounted, eject: bool) -> Result<(), String> {
     // reach it.
     println!(
         "\nA key this tool staged is taken back with the archive it was in. One the\n\
-         reader has already extracted stays in /root/.ssh/authorized_keys, which is\n\
+         reader has already extracted stays in authorized_keys under root's home\n\
+         directory (/.ssh on the i.MX6 readers, /root/.ssh elsewhere), which is\n\
          on the root filesystem, and USB does not reach it. To remove that one, edit\n\
          the file over SSH and delete the line ending in 'kobo-cobalt'."
     );
@@ -5883,10 +5891,14 @@ mod tests {
     #[test]
     fn the_start_script_installs_the_staged_public_key_once() {
         let script = super::START_SCRIPT;
-        assert!(script.contains("/root/.ssh/authorized_keys"));
+        // The home directory is read from /etc/passwd rather than assumed to
+        // be /root: the i.MX6 firmware gives root a home of `/`, and a key
+        // installed under /root never authenticates there.
+        assert!(script.contains("awk -F: '$1 == \"root\" { print $6 }' /etc/passwd"));
+        assert!(script.contains("keys=\"$home/.ssh/authorized_keys\""));
         assert!(script.contains("while IFS= read -r known"));
         assert!(script.contains("if [ \"$known\" = \"$key\" ]"));
-        assert!(script.contains("printf '%s\\n' \"$key\" >> /root/.ssh/authorized_keys"));
+        assert!(script.contains("printf '%s\\n' \"$key\" >> \"$keys\""));
         assert!(script.contains("rm -f \"$staged_key\""));
     }
 

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -228,6 +228,7 @@ enum SmokeStage {
     ReversiblePixels,
     ScreenSnapshot,
     FastFeedback,
+    WaitTiming,
 }
 
 #[cfg(feature = "device-write")]
@@ -236,13 +237,15 @@ impl SmokeStage {
     const CONFIRM_REVERSIBLE_PIXELS: &'static str = "REVERSIBLE_PIXELS_GC16";
     const CONFIRM_SCREEN_SNAPSHOT: &'static str = "SCREEN_SNAPSHOT_RESTORE";
     const CONFIRM_FAST_FEEDBACK: &'static str = "REVERSIBLE_PIXELS_DU";
+    const CONFIRM_WAIT_TIMING: &'static str = "WAIT_TIMING_GC16_DU";
 
     /// Every stage, so the usage text can never drift from what is accepted.
-    const ALL: [Self; 4] = [
+    const ALL: [Self; 5] = [
         Self::DisplayOnly,
         Self::ReversiblePixels,
         Self::ScreenSnapshot,
         Self::FastFeedback,
+        Self::WaitTiming,
     ];
 
     const fn confirmation(self) -> &'static str {
@@ -251,6 +254,7 @@ impl SmokeStage {
             Self::ReversiblePixels => Self::CONFIRM_REVERSIBLE_PIXELS,
             Self::ScreenSnapshot => Self::CONFIRM_SCREEN_SNAPSHOT,
             Self::FastFeedback => Self::CONFIRM_FAST_FEEDBACK,
+            Self::WaitTiming => Self::CONFIRM_WAIT_TIMING,
         }
     }
 
@@ -268,6 +272,7 @@ impl SmokeStage {
             Self::CONFIRM_REVERSIBLE_PIXELS => Some(Self::ReversiblePixels),
             Self::CONFIRM_SCREEN_SNAPSHOT => Some(Self::ScreenSnapshot),
             Self::CONFIRM_FAST_FEEDBACK => Some(Self::FastFeedback),
+            Self::CONFIRM_WAIT_TIMING => Some(Self::WaitTiming),
             _ => None,
         }
     }
@@ -278,6 +283,7 @@ impl SmokeStage {
             Self::ReversiblePixels => "OWNER_ATTENDED_REVERSIBLE_PIXELS_GC16",
             Self::ScreenSnapshot => "OWNER_ATTENDED_SCREEN_SNAPSHOT_RESTORE",
             Self::FastFeedback => "OWNER_ATTENDED_REVERSIBLE_PIXELS_DU",
+            Self::WaitTiming => "OWNER_ATTENDED_WAIT_TIMING_GC16_DU",
         }
     }
 }

--- a/crates/kobo-doctor/src/main.rs
+++ b/crates/kobo-doctor/src/main.rs
@@ -2,7 +2,10 @@ use kobo_hal::observe::MAXIMUM_OBSERVE_SECONDS;
 use kobo_hal::refresh::Rect;
 use kobo_hal::surface::{read_region, SurfaceGeometry};
 use kobo_hal::{observe_touch, probe_device};
-use kobo_profile::{identify_profile, DeviceProfile, FramebufferSnapshot, Readiness};
+use kobo_profile::{
+    identify_profile, DeviceProfile, DeviceSnapshot, FramebufferSnapshot, PanelPose, PoseError,
+    Readiness,
+};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
@@ -170,14 +173,13 @@ fn main() -> ExitCode {
     }
 
     // Observation is only offered once the profile matched, so events are never
-    // interpreted with a transform that does not belong to this hardware.
+    // interpreted with a transform that does not belong to this hardware. The
+    // pose is resolved here too, and loudly, because the transform is only
+    // correct at the orientation the reader is actually in.
     if let Some(request) = std::env::var_os(OBSERVE_TOUCH_VARIABLE) {
         let touch_path = snapshot.touch.as_ref().map(|touch| touch.path.clone());
-        if let Err(error) = observe(
-            matched_profile,
-            touch_path.as_deref(),
-            &request.to_string_lossy(),
-        ) {
+        let request = request.to_string_lossy();
+        if let Err(error) = observe(matched_profile, &snapshot, touch_path.as_deref(), &request) {
             eprintln!("touch observation failed: {error}");
             return ExitCode::FAILURE;
         }
@@ -434,7 +436,32 @@ fn base64_line(bytes: &[u8]) -> String {
     encoded
 }
 
-fn observe(profile: &DeviceProfile, touch_path: Option<&str>, request: &str) -> Result<(), String> {
+/// The profile paired with the orientation the reader is actually in.
+///
+/// Separate from `main` only to keep it short. The refusal matters more than
+/// the brevity: a touch transform is correct at one orientation, so observing
+/// with an unresolved pose would report coordinates nobody can trust.
+fn resolve_pose<'a>(
+    profile: &'a DeviceProfile,
+    snapshot: &DeviceSnapshot,
+) -> Result<PanelPose<'a>, PoseError> {
+    snapshot
+        .framebuffer
+        .as_ref()
+        .ok_or(PoseError::FramebufferMissing)
+        .and_then(|framebuffer| PanelPose::resolve(profile, framebuffer))
+}
+
+fn observe(
+    profile: &DeviceProfile,
+    snapshot: &DeviceSnapshot,
+    touch_path: Option<&str>,
+    request: &str,
+) -> Result<(), String> {
+    // Resolved before anything is read, and loudly. A touch transform is
+    // correct at one orientation, so observing without a resolved pose would
+    // print coordinates nobody can trust.
+    let pose = &resolve_pose(profile, snapshot).map_err(|error| error.to_string())?;
     let seconds: u64 = request
         .trim()
         .parse()
@@ -446,13 +473,18 @@ fn observe(profile: &DeviceProfile, touch_path: Option<&str>, request: &str) -> 
     }
     let path = touch_path.ok_or("no touch device was discovered")?;
     println!("touch observation: {seconds}s read-only on {path}, not grabbed");
+    // This line used to be hardcoded to one device's transform and printed
+    // regardless of the profile, so it described a mapping the code did not
+    // use on every device but the Clara BW. It now names what will actually
+    // run, including the orientation, since the transform is only right at one.
     println!(
-        "touch transform under test: display_x = {} - raw_y, display_y = raw_x",
-        profile.touch_y_max
+        "touch transform under test: {:?} at rotation {}",
+        pose.touch_transform(),
+        pose.rotation()
     );
     let reported = observe_touch(
         Path::new(path),
-        profile,
+        pose,
         Duration::from_secs(seconds),
         |observation| println!("touch: {observation}"),
     )

--- a/crates/kobo-doctor/src/main.rs
+++ b/crates/kobo-doctor/src/main.rs
@@ -478,8 +478,8 @@ fn observe(
     // use on every device but the Clara BW. It now names what will actually
     // run, including the orientation, since the transform is only right at one.
     println!(
-        "touch transform under test: {:?} at rotation {}",
-        pose.touch_transform(),
+        "touch mapping under test: {:?} at rotation {}",
+        pose.touch_mapping(),
         pose.rotation()
     );
     let reported = observe_touch(

--- a/crates/kobo-hal/src/display.rs
+++ b/crates/kobo-hal/src/display.rs
@@ -409,6 +409,14 @@ fn smoke_wait_timing(session: &DisplaySession) -> Result<String, DisplayError> {
 
     let original = session.capture(SMOKE_PATCH_REGION)?;
     let inverted = original.inverted_rgb();
+    // Built before the run, not inside the recovery, so that the error path
+    // always has a plan to restore with. A quality update, because this is the
+    // last thing the panel is asked to show.
+    let restore_plan = smoke_plan_with_intent(
+        session,
+        SMOKE_PATCH_REGION,
+        crate::refresh::RefreshIntent::QualityContent,
+    )?;
 
     let mut lines = String::from("update  intent   waveform  translated  submit_us  wait_us\n");
     let mut run = || -> Result<(), DisplayError> {
@@ -445,7 +453,11 @@ fn smoke_wait_timing(session: &DisplaySession) -> Result<String, DisplayError> {
     let outcome = run();
 
     // Always leave the screen as found, even when a refresh failed mid-run.
-    let restored = session.restore(&original);
+    // The bytes alone are not enough: without a refresh the panel goes on
+    // showing the inverted patch, so the owner is left looking at the failure.
+    let restored = session
+        .restore(&original)
+        .and_then(|()| session.refresh(restore_plan));
     outcome?;
     restored?;
     let verify = session.capture(SMOKE_PATCH_REGION)?;

--- a/crates/kobo-hal/src/display.rs
+++ b/crates/kobo-hal/src/display.rs
@@ -57,9 +57,9 @@ pub enum AttendedSmokeStage {
 impl AttendedSmokeStage {
     /// Every stage there is, so a test can walk them.
     ///
-    /// Written out rather than derived, and kept beside [`Self::intents`],
-    /// which matches exhaustively: adding a stage breaks the match, and the
-    /// compiler asks what waveforms it drives.
+    /// A hand-written list is only as good as the memory of whoever adds a
+    /// stage, so [`Self::position`] exists to make forgetting a compile
+    /// error rather than a silently narrower test.
     #[cfg(test)]
     const ALL: [Self; 5] = [
         Self::DisplayOnly,
@@ -68,6 +68,23 @@ impl AttendedSmokeStage {
         Self::FastFeedback,
         Self::WaitTiming,
     ];
+
+    /// Where the stage sits in [`Self::ALL`].
+    ///
+    /// The match is exhaustive, so a new variant does not compile until it is
+    /// given a position, and the test below proves each position holds the
+    /// stage that claims it. Together those two facts are what make `ALL`
+    /// complete rather than merely plausible.
+    #[cfg(test)]
+    const fn position(self) -> usize {
+        match self {
+            Self::DisplayOnly => 0,
+            Self::ReversiblePixels => 1,
+            Self::ScreenSnapshot => 2,
+            Self::FastFeedback => 3,
+            Self::WaitTiming => 4,
+        }
+    }
 
     const fn intent(self) -> crate::refresh::RefreshIntent {
         match self {
@@ -81,7 +98,11 @@ impl AttendedSmokeStage {
     /// [`Self::intent`] answers for a single update; `WaitTiming` submits
     /// three, one per offered waveform, and an invariant stated over
     /// [`Self::intent`] alone would miss two of them.
-    #[cfg(test)]
+    ///
+    /// Not `#[cfg(test)]`: [`smoke_wait_timing`] reads this list to decide
+    /// what it submits, which is the point. A declaration the behaviour does
+    /// not consult is a second copy of the truth, and the test walking it
+    /// would then be checking the copy rather than the device path.
     const fn intents(self) -> &'static [crate::refresh::RefreshIntent] {
         use crate::refresh::RefreshIntent::{FastFeedback, QualityContent, TextContent};
         match self {
@@ -450,11 +471,9 @@ fn smoke_wait_timing(session: &DisplaySession) -> Result<String, DisplayError> {
     let mut lines = String::from("update  intent   waveform  translated  submit_us  wait_us\n");
     let mut run = || -> Result<(), DisplayError> {
         let mut update = 0_usize;
-        for intent in [
-            crate::refresh::RefreshIntent::QualityContent,
-            crate::refresh::RefreshIntent::TextContent,
-            crate::refresh::RefreshIntent::FastFeedback,
-        ] {
+        // The stage's own declaration, so that what the invariant test walks
+        // and what the panel is actually asked for cannot drift apart.
+        for intent in AttendedSmokeStage::WaitTiming.intents().iter().copied() {
             let plan = smoke_plan_with_intent(session, SMOKE_PATCH_REGION, intent)?;
             for _ in 0..WAIT_TIMING_ROUNDS {
                 for snapshot in [&inverted, &original] {
@@ -501,6 +520,14 @@ fn smoke_wait_timing(session: &DisplaySession) -> Result<String, DisplayError> {
     ))
 }
 
+/// Whether a smoke update asks for a full, cleaning refresh.
+///
+/// It does not, and the invariant test asserts the consequence: every smoke
+/// update is partial. Shared with the test rather than written twice, so that
+/// flipping it here fails there instead of quietly widening what an
+/// owner-attended stage is allowed to do to the panel.
+const SMOKE_UPDATE_IS_FULL: bool = false;
+
 fn smoke_plan_with_intent(
     session: &DisplaySession,
     region: Rect,
@@ -509,7 +536,7 @@ fn smoke_plan_with_intent(
     RefreshPlan::new(
         region,
         intent,
-        false,
+        SMOKE_UPDATE_IS_FULL,
         session.geometry().width,
         session.geometry().height,
     )
@@ -611,7 +638,7 @@ mod tests {
     use super::{
         unique_marker, AttendedSmokeStage, DisplayError, DisplaySession, Rect, RefreshPlan,
         WritePolicy, ATTENDED_SMOKE_UNLOCK_PHRASE, OWNER_UNLOCK_PHRASE, SMOKE_FIXED_REGION,
-        SMOKE_PATCH_REGION, SMOKE_VISIBLE_HOLD,
+        SMOKE_PATCH_REGION, SMOKE_UPDATE_IS_FULL, SMOKE_VISIBLE_HOLD,
     };
     use crate::surface::{RegionPlacement, SurfaceGeometry};
     use kobo_abi::{hwtcon, mxcfb};
@@ -808,6 +835,18 @@ mod tests {
     }
 
     #[test]
+    fn every_smoke_stage_is_in_the_walked_set() {
+        // `position` matches exhaustively, so a new stage does not compile
+        // until it declares where it sits; this proves the seat is really
+        // its own. Without it, `ALL` could omit a stage and every invariant
+        // below would quietly stop covering it.
+        assert_eq!(AttendedSmokeStage::ALL.len(), 5);
+        for (index, stage) in AttendedSmokeStage::ALL.iter().enumerate() {
+            assert_eq!(stage.position(), index, "{stage:?} is not where it claims");
+        }
+    }
+
+    #[test]
     fn hal_owned_smoke_stages_use_only_partial_reversible_updates() {
         for profile in kobo_profile::SUPPORTED_PROFILES {
             let backend = crate::refresh::Backend::from_framebuffer_id(profile.framebuffer_id)
@@ -833,7 +872,7 @@ mod tests {
                     let plan = RefreshPlan::new(
                         SMOKE_FIXED_REGION,
                         *intent,
-                        false,
+                        SMOKE_UPDATE_IS_FULL,
                         profile.width,
                         profile.height,
                     )

--- a/crates/kobo-hal/src/display.rs
+++ b/crates/kobo-hal/src/display.rs
@@ -12,9 +12,9 @@
 //! a default build contains no callable display-write code at all.
 
 use crate::probe::{probe_device, ProbeError};
-use crate::refresh::{Rect, RefreshPlan};
+use crate::refresh::{Backend, Rect, RefreshPlan};
 use crate::surface::{self, RegionSnapshot, SurfaceError, SurfaceGeometry};
-use kobo_abi::hwtcon;
+use kobo_abi::{hwtcon, mxcfb};
 use kobo_profile::{DeviceProfile, DeviceSnapshot};
 use std::fmt;
 use std::fs::{File, OpenOptions};
@@ -79,6 +79,7 @@ impl From<io::Error> for DisplayError {
 pub struct DisplaySession {
     framebuffer: File,
     geometry: SurfaceGeometry,
+    backend: Backend,
     profile: &'static DeviceProfile,
     snapshot: DeviceSnapshot,
 }
@@ -121,6 +122,15 @@ impl DisplaySession {
             .framebuffer
             .as_ref()
             .ok_or_else(|| DisplayError::ProfileRejected(vec!["framebuffer missing".to_owned()]))?;
+        // Resolved once, here, where the profile has already been matched
+        // exactly. A panel controller nobody has written a backend for is a
+        // refusal, in the same way an unmatched profile is.
+        let backend = Backend::from_profile(profile).ok_or_else(|| {
+            DisplayError::ProfileRejected(vec![format!(
+                "no display backend for framebuffer {}",
+                profile.framebuffer_id
+            )])
+        })?;
         let geometry = SurfaceGeometry {
             width: framebuffer.width,
             height: framebuffer.height,
@@ -135,6 +145,7 @@ impl DisplaySession {
         Ok(Self {
             framebuffer: file,
             geometry,
+            backend,
             profile,
             snapshot,
         })
@@ -143,6 +154,12 @@ impl DisplaySession {
     #[must_use]
     pub fn profile(&self) -> &'static DeviceProfile {
         self.profile
+    }
+
+    /// The panel-controller interface this device speaks.
+    #[must_use]
+    pub fn backend(&self) -> Backend {
+        self.backend
     }
 
     #[must_use]
@@ -193,13 +210,32 @@ impl DisplaySession {
         // Validate the region against this exact surface before the kernel sees it.
         surface::RegionPlacement::new(self.geometry, plan.region)?;
         let marker = unique_marker()?;
-        let mut update = plan.update_data(marker);
-        hwtcon::send_update(&self.framebuffer, &mut update)?;
-        let mut wait = hwtcon::HwtconUpdateMarkerData {
-            update_marker: marker,
-            collision_test: 0,
-        };
-        hwtcon::wait_for_update_complete(&self.framebuffer, &mut wait)?;
+        // The two backends' wait requests happen to be the same number over
+        // the same struct, so one path would work for both. It is still
+        // written out twice: the coincidence belongs to this kernel, not to
+        // the interface, and a device whose wait struct grew a field would
+        // otherwise be served a MediaTek ioctl through an i.MX session with
+        // nothing in the code to make that visible.
+        match self.backend {
+            Backend::Hwtcon => {
+                let mut update = plan.hwtcon_update_data(marker);
+                hwtcon::send_update(&self.framebuffer, &mut update)?;
+                let mut wait = hwtcon::HwtconUpdateMarkerData {
+                    update_marker: marker,
+                    collision_test: 0,
+                };
+                hwtcon::wait_for_update_complete(&self.framebuffer, &mut wait)?;
+            }
+            Backend::Mxcfb => {
+                let mut update = plan.mxcfb_update_data(marker);
+                mxcfb::send_update(&self.framebuffer, &mut update)?;
+                let mut wait = mxcfb::MxcfbUpdateMarkerData {
+                    update_marker: marker,
+                    collision_test: 0,
+                };
+                mxcfb::wait_for_update_complete(&self.framebuffer, &mut wait)?;
+            }
+        }
         Ok(())
     }
 }

--- a/crates/kobo-hal/src/display.rs
+++ b/crates/kobo-hal/src/display.rs
@@ -20,6 +20,7 @@ use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Read};
 use std::path::Path;
+use std::time::{Duration, Instant};
 
 /// The exact phrase an owner must supply to open a write session.
 pub const OWNER_UNLOCK_PHRASE: &str = "OWNER_ATTENDED_DISPLAY_WRITE";
@@ -207,6 +208,20 @@ impl DisplaySession {
     ///
     /// Returns an error when the region is invalid or either ioctl fails.
     pub fn refresh(&self, plan: RefreshPlan) -> Result<(), DisplayError> {
+        self.refresh_timed(plan).map(|_| ())
+    }
+
+    /// [`Self::refresh`], instrumented.
+    ///
+    /// Measures the submit and wait ioctls separately and reads back the
+    /// waveform the driver actually selected: both vendors' `SEND_UPDATE`
+    /// requests are in-out, and the driver copies the translated waveform mode
+    /// back into the struct. The regular [`Self::refresh`] path discards it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the region is invalid or either ioctl fails.
+    pub fn refresh_timed(&self, plan: RefreshPlan) -> Result<RefreshTiming, DisplayError> {
         // Validate the region against this exact surface before the kernel sees it.
         surface::RegionPlacement::new(self.geometry, plan.region)?;
         let marker = unique_marker()?;
@@ -216,28 +231,56 @@ impl DisplaySession {
         // the interface, and a device whose wait struct grew a field would
         // otherwise be served a MediaTek ioctl through an i.MX session with
         // nothing in the code to make that visible.
-        match self.backend {
+        let submitted_waveform = plan.waveform(self.backend);
+        let (translated_waveform, submit, wait) = match self.backend {
             Backend::Hwtcon => {
                 let mut update = plan.hwtcon_update_data(marker);
+                let submit_started = Instant::now();
                 hwtcon::send_update(&self.framebuffer, &mut update)?;
+                let submit = submit_started.elapsed();
                 let mut wait = hwtcon::HwtconUpdateMarkerData {
                     update_marker: marker,
                     collision_test: 0,
                 };
+                let wait_started = Instant::now();
                 hwtcon::wait_for_update_complete(&self.framebuffer, &mut wait)?;
+                (update.waveform_mode, submit, wait_started.elapsed())
             }
             Backend::Mxcfb => {
                 let mut update = plan.mxcfb_update_data(marker);
+                let submit_started = Instant::now();
                 mxcfb::send_update(&self.framebuffer, &mut update)?;
+                let submit = submit_started.elapsed();
                 let mut wait = mxcfb::MxcfbUpdateMarkerData {
                     update_marker: marker,
                     collision_test: 0,
                 };
+                let wait_started = Instant::now();
                 mxcfb::wait_for_update_complete(&self.framebuffer, &mut wait)?;
+                (update.waveform_mode, submit, wait_started.elapsed())
             }
-        }
-        Ok(())
+        };
+        Ok(RefreshTiming {
+            submitted_waveform,
+            translated_waveform,
+            submit,
+            wait,
+        })
     }
+}
+
+/// What one instrumented refresh measured.
+#[derive(Clone, Copy, Debug)]
+pub struct RefreshTiming {
+    /// The waveform constant submitted with the update.
+    pub submitted_waveform: u32,
+    /// The waveform the driver copied back after translating the request
+    /// through the device's waveform table.
+    pub translated_waveform: u32,
+    /// How long the submit ioctl took.
+    pub submit: Duration,
+    /// How long the wait-for-complete ioctl blocked.
+    pub wait: Duration,
 }
 
 /// Returns a random nonzero update marker.

--- a/crates/kobo-hal/src/display.rs
+++ b/crates/kobo-hal/src/display.rs
@@ -55,10 +55,39 @@ pub enum AttendedSmokeStage {
 }
 
 impl AttendedSmokeStage {
+    /// Every stage there is, so a test can walk them.
+    ///
+    /// Written out rather than derived, and kept beside [`Self::intents`],
+    /// which matches exhaustively: adding a stage breaks the match, and the
+    /// compiler asks what waveforms it drives.
+    #[cfg(test)]
+    const ALL: [Self; 5] = [
+        Self::DisplayOnly,
+        Self::ReversiblePixels,
+        Self::ScreenSnapshot,
+        Self::FastFeedback,
+        Self::WaitTiming,
+    ];
+
     const fn intent(self) -> crate::refresh::RefreshIntent {
         match self {
             Self::FastFeedback => crate::refresh::RefreshIntent::FastFeedback,
             _ => crate::refresh::RefreshIntent::QualityContent,
+        }
+    }
+
+    /// Every intent the stage may submit, not just the one it opens with.
+    ///
+    /// [`Self::intent`] answers for a single update; `WaitTiming` submits
+    /// three, one per offered waveform, and an invariant stated over
+    /// [`Self::intent`] alone would miss two of them.
+    #[cfg(test)]
+    const fn intents(self) -> &'static [crate::refresh::RefreshIntent] {
+        use crate::refresh::RefreshIntent::{FastFeedback, QualityContent, TextContent};
+        match self {
+            Self::DisplayOnly | Self::ReversiblePixels | Self::ScreenSnapshot => &[QualityContent],
+            Self::FastFeedback => &[FastFeedback],
+            Self::WaitTiming => &[QualityContent, TextContent, FastFeedback],
         }
     }
 }
@@ -585,10 +614,10 @@ mod tests {
         SMOKE_PATCH_REGION, SMOKE_VISIBLE_HOLD,
     };
     use crate::surface::{RegionPlacement, SurfaceGeometry};
-    use kobo_abi::hwtcon;
+    use kobo_abi::{hwtcon, mxcfb};
     use kobo_profile::{
         DeviceProfile, DeviceSnapshot, FramebufferSnapshot, IdentitySnapshot, TouchSnapshot,
-        CLARA_BW_391, CLARA_HD_376, ELIPSA_2E_389, WRITE_EVIDENCE_PENDING,
+        CLARA_BW_391, ELIPSA_2E_389, WRITE_EVIDENCE_PENDING,
     };
     use std::path::Path;
 
@@ -753,7 +782,7 @@ mod tests {
 
     #[test]
     fn hal_owned_smoke_regions_are_bounded_on_every_registered_panel() {
-        for profile in [&CLARA_BW_391, &CLARA_HD_376, &ELIPSA_2E_389] {
+        for profile in kobo_profile::SUPPORTED_PROFILES {
             let geometry = SurfaceGeometry {
                 width: profile.width,
                 height: profile.height,
@@ -779,24 +808,63 @@ mod tests {
     }
 
     #[test]
-    fn hal_owned_smoke_stages_use_only_partial_gc16_or_du_updates() {
-        for (stage, waveform) in [
-            (AttendedSmokeStage::DisplayOnly, hwtcon::WAVEFORM_GC16),
-            (AttendedSmokeStage::ReversiblePixels, hwtcon::WAVEFORM_GC16),
-            (AttendedSmokeStage::ScreenSnapshot, hwtcon::WAVEFORM_GC16),
-            (AttendedSmokeStage::FastFeedback, hwtcon::WAVEFORM_DU),
-        ] {
-            let plan = RefreshPlan::new(
-                SMOKE_FIXED_REGION,
-                stage.intent(),
-                false,
-                CLARA_BW_391.width,
-                CLARA_BW_391.height,
-            )
-            .expect("fixed plan");
-            let update = plan.hwtcon_update_data(0x4000_0001);
-            assert_eq!(update.waveform_mode, waveform);
-            assert_eq!(update.update_mode, hwtcon::UPDATE_MODE_PARTIAL);
+    fn hal_owned_smoke_stages_use_only_partial_reversible_updates() {
+        for profile in kobo_profile::SUPPORTED_PROFILES {
+            let backend = crate::refresh::Backend::from_framebuffer_id(profile.framebuffer_id)
+                .expect("every supported profile names a backend the HAL drives");
+            // The waveforms a smoke stage may ask for, per controller. Both
+            // are grayscale and both are reversible; what is excluded is the
+            // panel-wide INIT and the two-tone A2, neither of which belongs in
+            // a stage the owner is watching.
+            let allowed = match backend {
+                crate::refresh::Backend::Hwtcon => [
+                    hwtcon::WAVEFORM_GC16,
+                    hwtcon::WAVEFORM_GL16,
+                    hwtcon::WAVEFORM_DU,
+                ],
+                crate::refresh::Backend::Mxcfb => [
+                    mxcfb::WAVEFORM_GC16,
+                    mxcfb::WAVEFORM_GL16,
+                    mxcfb::WAVEFORM_DU,
+                ],
+            };
+            for stage in AttendedSmokeStage::ALL {
+                for intent in stage.intents() {
+                    let plan = RefreshPlan::new(
+                        SMOKE_FIXED_REGION,
+                        *intent,
+                        false,
+                        profile.width,
+                        profile.height,
+                    )
+                    .expect("fixed plan");
+                    let (waveform, update_mode, partial) = match backend {
+                        crate::refresh::Backend::Hwtcon => {
+                            let update = plan.hwtcon_update_data(0x4000_0001);
+                            (
+                                update.waveform_mode,
+                                update.update_mode,
+                                hwtcon::UPDATE_MODE_PARTIAL,
+                            )
+                        }
+                        crate::refresh::Backend::Mxcfb => {
+                            let update = plan.mxcfb_update_data(0x4000_0001);
+                            (
+                                update.waveform_mode,
+                                update.update_mode,
+                                mxcfb::UPDATE_MODE_PARTIAL,
+                            )
+                        }
+                    };
+                    assert!(
+                        allowed.contains(&waveform),
+                        "{} stage {stage:?} asked {} for waveform {waveform}",
+                        profile.id,
+                        profile.framebuffer_id,
+                    );
+                    assert_eq!(update_mode, partial, "{} stage {stage:?}", profile.id);
+                }
+            }
         }
         assert!(SMOKE_VISIBLE_HOLD.as_secs() < 5);
     }

--- a/crates/kobo-hal/src/gpio.rs
+++ b/crates/kobo-hal/src/gpio.rs
@@ -46,8 +46,10 @@ pub enum Button {
 }
 
 /// The kernel's verdict on how the device is held, straight from the NTX
-/// `MSC_RAW` channel. Values confirmed against a Libra 2 and `KOReader`'s
-/// translation table on 2026-08-23.
+/// `MSC_RAW` channel. Five of these six were captured from a Libra 2 on
+/// 2026-08-23 by turning it about: both portrait poses, both landscape poses
+/// and face-up. Face-down completes the contiguous run and is the one pose a
+/// reader held in the hands never reaches.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Orientation {
     PortraitDown,
@@ -281,8 +283,8 @@ mod tests {
 
     #[test]
     fn every_captured_orientation_value_decodes() {
-        // The set the Libra 2 produced under rotation, plus the two KOReader
-        // documents that this capture did not exercise.
+        // The five values the Libra 2 produced under rotation, plus
+        // face-down, which that capture never reached.
         let cases = [
             (0x17, Orientation::PortraitDown),
             (0x18, Orientation::PortraitUp),

--- a/crates/kobo-hal/src/gpio.rs
+++ b/crates/kobo-hal/src/gpio.rs
@@ -1,0 +1,302 @@
+//! The physical buttons and the orientation channel.
+//!
+//! On NTX hardware the `gpio-keys` node carries three unrelated things: the
+//! page-turn keys, the power button, and the kernel's digested accelerometer
+//! verdicts (`EV_MSC`/`MSC_RAW` with one value per orientation). One session
+//! reads the node and hands all of them to the runtime, which decides what
+//! each means.
+//!
+//! Unlike the touch panel this device is never grabbed. Inside a panel
+//! session nothing else consumes buttons — the stock reader is stopped, and
+//! while it runs it holds its own exclusive grab, which is why these keys
+//! appear dead outside a session (measured on the Libra 2: two captures under
+//! the reader saw nothing, the same capture inside a session saw everything).
+//! Not grabbing also avoids the Clara BW kernel's grab bug, where `EVIOCGRAB`
+//! succeeds and then starves the grabbing client, and it leaves the
+//! sleep-cover watcher — a second, independent open of the same node — its
+//! own full copy of every event.
+
+use crate::touch::InputEvent32;
+use kobo_abi::input;
+use std::fmt;
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+
+/// One evdev event is 16 bytes on this 32-bit target.
+const EVENT_BYTES: usize = 16;
+const READ_CHUNK_EVENTS: usize = 64;
+
+/// The device name this module owns. Every NTX Kobo ships it.
+const DEVICE_NAME: &str = "gpio-keys";
+
+/// A physical button, named by what it is rather than what it means.
+///
+/// Which page key means "forward" depends on how the reader is held, so that
+/// assignment happens where the pose is known, not here.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Button {
+    /// The page key the kernel reports as code 193.
+    Page193,
+    /// The page key the kernel reports as code 194.
+    Page194,
+    Power,
+}
+
+/// The kernel's verdict on how the device is held, straight from the NTX
+/// `MSC_RAW` channel. Values confirmed against a Libra 2 and `KOReader`'s
+/// translation table on 2026-08-23.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Orientation {
+    PortraitDown,
+    PortraitUp,
+    LandscapeRight,
+    LandscapeLeft,
+    FaceDown,
+    FaceUp,
+}
+
+impl Orientation {
+    #[must_use]
+    const fn from_msc_raw(value: i32) -> Option<Self> {
+        match value {
+            0x17 => Some(Self::PortraitDown),
+            0x18 => Some(Self::PortraitUp),
+            0x19 => Some(Self::LandscapeRight),
+            0x1a => Some(Self::LandscapeLeft),
+            0x1b => Some(Self::FaceDown),
+            0x1c => Some(Self::FaceUp),
+            _ => None,
+        }
+    }
+}
+
+/// Everything the button device reports that the runtime cares about.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GpioEvent {
+    Button { button: Button, pressed: bool },
+    Orientation(Orientation),
+}
+
+/// Turns one raw event into a typed one, or nothing.
+///
+/// The sleep-cover key (code 35) is deliberately not claimed: the cover
+/// watcher owns it through its own open of the same node. Auto-repeat
+/// (value 2) is dropped for now — no capture has produced one, and
+/// hold-to-turn is a decision for the runtime once it exists.
+#[must_use]
+pub fn decode(event: InputEvent32) -> Option<GpioEvent> {
+    match (event.kind, event.code) {
+        (input::EV_KEY, input::KEY_PAGE_193 | input::KEY_PAGE_194 | input::KEY_POWER) => {
+            let button = match event.code {
+                input::KEY_PAGE_193 => Button::Page193,
+                input::KEY_PAGE_194 => Button::Page194,
+                _ => Button::Power,
+            };
+            match event.value {
+                0 => Some(GpioEvent::Button { button, pressed: false }),
+                1 => Some(GpioEvent::Button { button, pressed: true }),
+                _ => None,
+            }
+        }
+        (input::EV_MSC, input::MSC_RAW) => {
+            Orientation::from_msc_raw(event.value).map(GpioEvent::Orientation)
+        }
+        _ => None,
+    }
+}
+
+/// Finds the `gpio-keys` event node, or nothing on hardware without one.
+#[must_use]
+pub fn discover_buttons_path() -> Option<PathBuf> {
+    let content = std::fs::read_to_string("/proc/bus/input/devices").ok()?;
+    discover_buttons_path_from(&content)
+}
+
+fn discover_buttons_path_from(content: &str) -> Option<PathBuf> {
+    content.split("\n\n").find_map(|block| {
+        let name_matches = block
+            .lines()
+            .find(|line| line.starts_with("N: Name="))
+            .is_some_and(|line| line.contains(DEVICE_NAME));
+        if !name_matches {
+            return None;
+        }
+        let handlers = block
+            .lines()
+            .find(|line| line.starts_with("H: Handlers="))?;
+        let event = handlers
+            .strip_prefix("H: Handlers=")?
+            .split_whitespace()
+            .find(|handler| handler.starts_with("event"))?;
+        Some(Path::new("/dev/input").join(event))
+    })
+}
+
+#[derive(Debug)]
+pub enum GpioError {
+    /// The device at this path is not the button device.
+    WrongDevice { found: String },
+    Io(io::Error),
+}
+
+impl fmt::Display for GpioError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::WrongDevice { found } => write!(
+                formatter,
+                "button device is {found:?}, but this module requires {DEVICE_NAME:?}"
+            ),
+            Self::Io(error) => write!(formatter, "{error}"),
+        }
+    }
+}
+
+impl std::error::Error for GpioError {}
+
+impl From<io::Error> for GpioError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+/// A reader on the button device for the lifetime of a panel session.
+///
+/// Nothing to release: no grab is taken, so dropping this (or the process
+/// dying) leaves the device exactly as it was found.
+pub struct GpioSession {
+    events: Option<Receiver<GpioEvent>>,
+}
+
+impl GpioSession {
+    /// Opens the button device and starts decoding.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the device cannot be opened or is not
+    /// `gpio-keys`.
+    pub fn acquire(path: &Path) -> Result<Self, GpioError> {
+        let device = File::open(path)?;
+        let name = input::device_name(&device)?;
+        if name != DEVICE_NAME {
+            return Err(GpioError::WrongDevice { found: name });
+        }
+        let (sender, events) = mpsc::channel();
+        thread::spawn(move || {
+            let mut reader = device;
+            let mut buffer = [0_u8; EVENT_BYTES * READ_CHUNK_EVENTS];
+            loop {
+                let Ok(read) = reader.read(&mut buffer) else {
+                    return;
+                };
+                if read == 0 {
+                    return;
+                }
+                for chunk in buffer[..read].chunks_exact(EVENT_BYTES) {
+                    let Some(event) = InputEvent32::decode(chunk).and_then(decode) else {
+                        continue;
+                    };
+                    if sender.send(event).is_err() {
+                        return;
+                    }
+                }
+            }
+        });
+        Ok(Self { events: Some(events) })
+    }
+
+    /// Hands the event stream to a caller that multiplexes several sources.
+    ///
+    /// Returns `None` if the stream was already taken.
+    pub fn take_events(&mut self) -> Option<Receiver<GpioEvent>> {
+        self.events.take()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decode, discover_buttons_path_from, Button, GpioEvent, Orientation};
+    use crate::touch::InputEvent32;
+    use std::path::Path;
+
+    const fn key(code: u16, value: i32) -> InputEvent32 {
+        InputEvent32 { kind: 1, code, value }
+    }
+
+    #[test]
+    fn a_page_key_press_and_release_decode_as_that_button() {
+        // Codes as captured on the Libra 2, 2026-08-23.
+        assert_eq!(
+            decode(key(193, 1)),
+            Some(GpioEvent::Button { button: Button::Page193, pressed: true })
+        );
+        assert_eq!(
+            decode(key(194, 0)),
+            Some(GpioEvent::Button { button: Button::Page194, pressed: false })
+        );
+    }
+
+    #[test]
+    fn the_power_button_decodes() {
+        assert_eq!(
+            decode(key(116, 1)),
+            Some(GpioEvent::Button { button: Button::Power, pressed: true })
+        );
+    }
+
+    #[test]
+    fn auto_repeat_is_dropped_until_someone_wants_it() {
+        assert_eq!(decode(key(193, 2)), None);
+    }
+
+    #[test]
+    fn the_sleep_cover_key_is_left_to_the_cover_watcher() {
+        assert_eq!(decode(key(35, 1)), None);
+    }
+
+    #[test]
+    fn every_captured_orientation_value_decodes() {
+        // The set the Libra 2 produced under rotation, plus the two KOReader
+        // documents that this capture did not exercise.
+        let cases = [
+            (0x17, Orientation::PortraitDown),
+            (0x18, Orientation::PortraitUp),
+            (0x19, Orientation::LandscapeRight),
+            (0x1a, Orientation::LandscapeLeft),
+            (0x1b, Orientation::FaceDown),
+            (0x1c, Orientation::FaceUp),
+        ];
+        for (value, expected) in cases {
+            assert_eq!(
+                decode(InputEvent32 { kind: 4, code: 3, value }),
+                Some(GpioEvent::Orientation(expected))
+            );
+        }
+    }
+
+    #[test]
+    fn an_unknown_orientation_value_is_dropped_not_guessed() {
+        assert_eq!(decode(InputEvent32 { kind: 4, code: 3, value: 99 }), None);
+    }
+
+    #[test]
+    fn syn_reports_decode_to_nothing() {
+        assert_eq!(decode(InputEvent32 { kind: 0, code: 0, value: 0 }), None);
+    }
+
+    #[test]
+    fn the_button_node_is_found_by_name() {
+        let fixture = "I: Bus=0019 Vendor=0000 Product=0000 Version=0000\n\
+N: Name=\"gpio-keys\"\n\
+H: Handlers=event0\n\
+B: EV=b\n\n\
+N: Name=\"Elan Touchscreen\"\n\
+H: Handlers=event1\n";
+        assert_eq!(
+            discover_buttons_path_from(fixture).as_deref(),
+            Some(Path::new("/dev/input/event0"))
+        );
+    }
+}

--- a/crates/kobo-hal/src/input.rs
+++ b/crates/kobo-hal/src/input.rs
@@ -18,7 +18,7 @@
 
 use crate::touch::{InputEvent32, TouchDecoder, TouchEvent};
 use kobo_abi::input;
-use kobo_profile::DeviceProfile;
+use kobo_profile::PanelPose;
 use std::fmt;
 use std::fs::File;
 use std::io::{self, Read};
@@ -92,12 +92,12 @@ impl TouchSession {
     ///
     /// Returns an error when the device is not the expected panel, never
     /// becomes quiescent, or is already owned by another process.
-    pub fn acquire(path: &Path, profile: &'static DeviceProfile) -> Result<Self, InputError> {
+    pub fn acquire(path: &Path, pose: PanelPose<'static>) -> Result<Self, InputError> {
         let device = File::open(path)?;
         let name = input::device_name(&device)?;
-        if name != profile.touch_name {
+        if name != pose.profile().touch_name {
             return Err(InputError::WrongDevice {
-                expected: profile.touch_name.to_owned(),
+                expected: pose.profile().touch_name.to_owned(),
                 found: name,
             });
         }
@@ -133,7 +133,7 @@ impl TouchSession {
                             event.kind, event.code, event.value
                         );
                     }
-                    if let Some(touch) = decoder.push(event, profile) {
+                    if let Some(touch) = decoder.push(event, &pose) {
                         if sender.send(touch).is_err() {
                             return;
                         }

--- a/crates/kobo-hal/src/lib.rs
+++ b/crates/kobo-hal/src/lib.rs
@@ -47,7 +47,7 @@ pub mod touch;
 
 pub use battery::Battery;
 #[cfg(feature = "device-write")]
-pub use display::{DisplayError, DisplaySession, OWNER_UNLOCK_PHRASE};
+pub use display::{DisplayError, DisplaySession, RefreshTiming, OWNER_UNLOCK_PHRASE};
 pub use observe::{observe_touch, ObserveError, TouchObservation};
 pub use probe::{probe_device, ProbeError};
 pub use refresh::{Backend, Rect, RefreshIntent, RefreshPlan, UpdateMarker};

--- a/crates/kobo-hal/src/lib.rs
+++ b/crates/kobo-hal/src/lib.rs
@@ -50,6 +50,6 @@ pub use battery::Battery;
 pub use display::{DisplayError, DisplaySession, OWNER_UNLOCK_PHRASE};
 pub use observe::{observe_touch, ObserveError, TouchObservation};
 pub use probe::{probe_device, ProbeError};
-pub use refresh::{Rect, RefreshIntent, RefreshPlan, UpdateMarker};
+pub use refresh::{Backend, Rect, RefreshIntent, RefreshPlan, UpdateMarker};
 pub use surface::{read_region, RegionPlacement, RegionSnapshot, SurfaceError, SurfaceGeometry};
 pub use touch::{InputEvent32, TouchDecoder, TouchEvent};

--- a/crates/kobo-hal/src/lib.rs
+++ b/crates/kobo-hal/src/lib.rs
@@ -21,6 +21,10 @@ pub mod display;
 /// though only a register on the light driver, which a reboot restores.
 #[cfg(feature = "device-write")]
 pub mod frontlight;
+/// The physical buttons and the orientation channel, read without a grab.
+/// Not gated: like [`cover`], watching the node takes nothing away from the
+/// stock reader.
+pub mod gpio;
 #[cfg(feature = "device-write")]
 pub mod input;
 /// Putting the network back after a handoff. Available only with

--- a/crates/kobo-hal/src/observe.rs
+++ b/crates/kobo-hal/src/observe.rs
@@ -12,7 +12,7 @@
 
 use crate::touch::{InputEvent32, TouchDecoder, TouchEvent};
 use kobo_abi::input;
-use kobo_profile::DeviceProfile;
+use kobo_profile::PanelPose;
 use std::fmt;
 use std::fs::File;
 use std::io::{self, Read};
@@ -98,7 +98,7 @@ impl fmt::Display for TouchObservation {
 /// number of decodable events.
 pub fn observe_touch(
     path: &Path,
-    profile: &DeviceProfile,
+    pose: &PanelPose<'_>,
     duration: Duration,
     mut sink: impl FnMut(TouchObservation),
 ) -> Result<usize, ObserveError> {
@@ -133,7 +133,7 @@ pub fn observe_touch(
                     }
                     _ => {}
                 }
-                if let Some(touch) = decoder.push(event, profile) {
+                if let Some(touch) = decoder.push(event, pose) {
                     let (raw_x, raw_y) = last_raw.unwrap_or((-1, -1));
                     reported += 1;
                     sink(TouchObservation {
@@ -189,7 +189,7 @@ fn read_events(mut file: File, sender: &mpsc::Sender<Result<InputEvent32, String
 mod tests {
     use super::{observe_touch, TouchObservation, MAXIMUM_OBSERVE_SECONDS};
     use crate::touch::TouchEvent;
-    use kobo_profile::CLARA_BW_391;
+    use kobo_profile::{PanelPose, CLARA_BW_391};
     use std::path::Path;
     use std::time::Duration;
 
@@ -197,7 +197,7 @@ mod tests {
     fn an_over_long_window_is_refused_before_the_device_is_opened() {
         let error = observe_touch(
             Path::new("/definitely/not/a/device"),
-            &CLARA_BW_391,
+            &PanelPose::reference(&CLARA_BW_391),
             Duration::from_secs(MAXIMUM_OBSERVE_SECONDS + 1),
             |_| unreachable!("no touch can be reported"),
         )
@@ -212,7 +212,7 @@ mod tests {
     fn a_missing_touch_device_is_an_error_rather_than_a_hang() {
         let error = observe_touch(
             Path::new("/definitely/not/a/device"),
-            &CLARA_BW_391,
+            &PanelPose::reference(&CLARA_BW_391),
             Duration::from_millis(1),
             |_| unreachable!("no touch can be reported"),
         )
@@ -236,11 +236,13 @@ mod tests {
 
     #[test]
     fn the_transform_under_test_maps_the_corners_as_documented() {
-        // These are the four claims a physical touch has to confirm.
-        let profile = &CLARA_BW_391;
-        assert_eq!(profile.touch_to_display(0, 0), Some((1071, 0)));
-        assert_eq!(profile.touch_to_display(0, 1071), Some((0, 0)));
-        assert_eq!(profile.touch_to_display(1447, 0), Some((1071, 1447)));
-        assert_eq!(profile.touch_to_display(1447, 1071), Some((0, 1447)));
+        // These are the four claims a physical touch has to confirm. They are
+        // asserted at the pose the Clara BW profile was measured in, which is
+        // the only pose this transform is known to be right at.
+        let pose = PanelPose::reference(&CLARA_BW_391);
+        assert_eq!(pose.touch_to_display(0, 0), Some((1071, 0)));
+        assert_eq!(pose.touch_to_display(0, 1071), Some((0, 0)));
+        assert_eq!(pose.touch_to_display(1447, 0), Some((1071, 1447)));
+        assert_eq!(pose.touch_to_display(1447, 1071), Some((0, 1447)));
     }
 }

--- a/crates/kobo-hal/src/refresh.rs
+++ b/crates/kobo-hal/src/refresh.rs
@@ -1,4 +1,74 @@
-use kobo_abi::hwtcon;
+use kobo_abi::{hwtcon, mxcfb};
+use kobo_profile::DeviceProfile;
+
+/// Which panel-controller interface a device speaks.
+///
+/// This is not a preference. It is a property of the hardware, read from the
+/// profile's framebuffer identifier, and the two interfaces are not
+/// interchangeable: they number their waveforms differently, so a plan built
+/// for one backend and submitted to the other draws the wrong thing without
+/// reporting anything. Keeping the choice in one enum is what stops a waveform
+/// constant from being written down anywhere a backend is not also named.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Backend {
+    /// `MediaTek` panel controller, as on the Clara BW.
+    Hwtcon,
+    /// i.MX6 EPDC, as on the Mark 7 devices.
+    Mxcfb,
+}
+
+impl Backend {
+    /// Resolves the backend from a framebuffer identifier, as reported by the
+    /// kernel in `fb_fix_screeninfo.id`.
+    ///
+    /// An unknown identifier is `None` rather than a guess, in keeping with
+    /// the rest of the device model: an unrecognised panel is refused, not
+    /// approximated.
+    #[must_use]
+    pub fn from_framebuffer_id(id: &str) -> Option<Self> {
+        match id {
+            "hwtcon" => Some(Self::Hwtcon),
+            "mxc_epdc_fb" => Some(Self::Mxcfb),
+            _ => None,
+        }
+    }
+
+    /// Resolves the backend a profile describes.
+    #[must_use]
+    pub fn from_profile(profile: &DeviceProfile) -> Option<Self> {
+        Self::from_framebuffer_id(profile.framebuffer_id)
+    }
+
+    /// The waveform number this backend uses for `intent`.
+    ///
+    /// Only the three waveforms every known panel has are reachable from a
+    /// [`RefreshIntent`], which is what makes this mapping safe to write down
+    /// once. `GC4` in particular is not dependable across firmware versions
+    /// and is deliberately not offered.
+    ///
+    /// On i.MX6 the driver may still not run what is asked for. There is a
+    /// block in `mxc_epdc_v2_fb.c` that substitutes `GLD16` or `GLR16` for a
+    /// requested `GC16`, which would mean a quality refresh never actually
+    /// clears ghosting. It sits behind `NTX_WFM_MODE_OPTIMIZED`, and that
+    /// macro is not defined anywhere in the Libra 2 kernel tree, so the code
+    /// is dead on this device. `tools/abi/check-mxcfb.sh` fails if a kernel
+    /// ever turns it on.
+    #[must_use]
+    pub fn waveform(self, intent: RefreshIntent) -> u32 {
+        match self {
+            Self::Hwtcon => match intent {
+                RefreshIntent::FastFeedback => hwtcon::WAVEFORM_DU,
+                RefreshIntent::TextContent => hwtcon::WAVEFORM_GL16,
+                RefreshIntent::QualityContent => hwtcon::WAVEFORM_GC16,
+            },
+            Self::Mxcfb => match intent {
+                RefreshIntent::FastFeedback => mxcfb::WAVEFORM_DU,
+                RefreshIntent::TextContent => mxcfb::WAVEFORM_GL16,
+                RefreshIntent::QualityContent => mxcfb::WAVEFORM_GC16,
+            },
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Rect {
@@ -43,10 +113,16 @@ pub enum RefreshIntent {
     QualityContent,
 }
 
+/// A clipped region and what is to be done to it.
+///
+/// The plan deliberately carries the *intent* and not a waveform number.
+/// Callers describe the change they made; only the display session, which
+/// knows the profile, turns that into a number for a particular panel
+/// controller.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RefreshPlan {
     pub region: Rect,
-    pub waveform: u32,
+    pub intent: RefreshIntent,
     pub full: bool,
 }
 
@@ -61,17 +137,19 @@ impl RefreshPlan {
     ) -> Option<Self> {
         Some(Self {
             region: region.clipped(screen_width, screen_height)?,
-            waveform: match intent {
-                RefreshIntent::FastFeedback => hwtcon::WAVEFORM_DU,
-                RefreshIntent::TextContent => hwtcon::WAVEFORM_GL16,
-                RefreshIntent::QualityContent => hwtcon::WAVEFORM_GC16,
-            },
+            intent,
             full,
         })
     }
 
+    /// The waveform number `backend` uses for this plan.
     #[must_use]
-    pub fn update_data(self, marker: u32) -> hwtcon::HwtconUpdateData {
+    pub fn waveform(self, backend: Backend) -> u32 {
+        backend.waveform(self.intent)
+    }
+
+    #[must_use]
+    pub fn hwtcon_update_data(self, marker: u32) -> hwtcon::HwtconUpdateData {
         hwtcon::HwtconUpdateData {
             update_region: hwtcon::HwtconRect {
                 top: self.region.y,
@@ -79,7 +157,7 @@ impl RefreshPlan {
                 width: self.region.width,
                 height: self.region.height,
             },
-            waveform_mode: self.waveform,
+            waveform_mode: self.waveform(Backend::Hwtcon),
             update_mode: if self.full {
                 hwtcon::UPDATE_MODE_FULL
             } else {
@@ -88,6 +166,46 @@ impl RefreshPlan {
             update_marker: marker,
             flags: 0,
             dither_mode: 0,
+        }
+    }
+
+    /// The same plan as an i.MX6 EPDC update.
+    ///
+    /// `temp` asks the controller for its own ambient reading, which is what
+    /// every other consumer of this interface sends and the only value here
+    /// that is not simply zero. Dithering is left off and the alternate buffer
+    /// unused: updates come from the framebuffer itself.
+    #[must_use]
+    pub fn mxcfb_update_data(self, marker: u32) -> mxcfb::MxcfbUpdateData {
+        mxcfb::MxcfbUpdateData {
+            update_region: mxcfb::MxcfbRect {
+                top: self.region.y,
+                left: self.region.x,
+                width: self.region.width,
+                height: self.region.height,
+            },
+            waveform_mode: self.waveform(Backend::Mxcfb),
+            update_mode: if self.full {
+                mxcfb::UPDATE_MODE_FULL
+            } else {
+                mxcfb::UPDATE_MODE_PARTIAL
+            },
+            update_marker: marker,
+            temp: mxcfb::TEMP_USE_AMBIENT,
+            flags: 0,
+            dither_mode: 0,
+            quant_bit: 0,
+            alt_buffer_data: mxcfb::MxcfbAltBufferData {
+                phys_addr: 0,
+                width: 0,
+                height: 0,
+                alt_update_region: mxcfb::MxcfbRect {
+                    top: 0,
+                    left: 0,
+                    width: 0,
+                    height: 0,
+                },
+            },
         }
     }
 }
@@ -112,8 +230,8 @@ impl UpdateMarker {
 
 #[cfg(test)]
 mod tests {
-    use super::{Rect, RefreshIntent, RefreshPlan, UpdateMarker};
-    use kobo_abi::hwtcon;
+    use super::{Backend, Rect, RefreshIntent, RefreshPlan, UpdateMarker};
+    use kobo_abi::{hwtcon, mxcfb};
 
     #[test]
     fn clips_regions_before_building_update() {
@@ -132,7 +250,78 @@ mod tests {
         .expect("region intersects screen");
         assert_eq!(plan.region.width, 12);
         assert_eq!(plan.region.height, 8);
-        assert_eq!(plan.waveform, hwtcon::WAVEFORM_GC16);
+        assert_eq!(plan.waveform(Backend::Hwtcon), hwtcon::WAVEFORM_GC16);
+    }
+
+    /// The reason the plan stopped carrying a waveform number. Both panels are
+    /// being asked for the same thing, and both are being told a different
+    /// number. Had the hwtcon number been sent to an i.MX6 panel, it would have
+    /// run `GC4` and reported success.
+    #[test]
+    fn one_intent_becomes_a_different_number_on_each_backend() {
+        let plan = RefreshPlan::new(
+            Rect {
+                x: 0,
+                y: 0,
+                width: 64,
+                height: 64,
+            },
+            RefreshIntent::TextContent,
+            false,
+            1264,
+            1680,
+        )
+        .expect("region intersects screen");
+
+        assert_eq!(plan.waveform(Backend::Hwtcon), hwtcon::WAVEFORM_GL16);
+        assert_eq!(plan.waveform(Backend::Mxcfb), mxcfb::WAVEFORM_GL16);
+        assert_ne!(
+            plan.waveform(Backend::Hwtcon),
+            plan.waveform(Backend::Mxcfb)
+        );
+    }
+
+    #[test]
+    fn a_backend_comes_from_the_hardware_and_is_never_guessed() {
+        assert_eq!(
+            Backend::from_framebuffer_id("hwtcon"),
+            Some(Backend::Hwtcon)
+        );
+        assert_eq!(
+            Backend::from_framebuffer_id("mxc_epdc_fb"),
+            Some(Backend::Mxcfb)
+        );
+        assert_eq!(Backend::from_framebuffer_id("mxc_epdc_fb2"), None);
+        assert_eq!(Backend::from_framebuffer_id(""), None);
+    }
+
+    #[test]
+    fn an_mxcfb_update_asks_the_panel_for_its_own_temperature() {
+        let plan = RefreshPlan::new(
+            Rect {
+                x: 8,
+                y: 16,
+                width: 32,
+                height: 48,
+            },
+            RefreshIntent::QualityContent,
+            true,
+            1264,
+            1680,
+        )
+        .expect("region intersects screen");
+        let update = plan.mxcfb_update_data(0x4000_0001);
+
+        assert_eq!(update.update_region.left, 8);
+        assert_eq!(update.update_region.top, 16);
+        assert_eq!(update.waveform_mode, mxcfb::WAVEFORM_GC16);
+        assert_eq!(update.update_mode, mxcfb::UPDATE_MODE_FULL);
+        assert_eq!(update.update_marker, 0x4000_0001);
+        assert_eq!(update.temp, mxcfb::TEMP_USE_AMBIENT);
+        assert_eq!(update.flags, 0);
+        assert_eq!(update.dither_mode, 0);
+        assert_eq!(update.quant_bit, 0);
+        assert_eq!(update.alt_buffer_data, mxcfb::MxcfbAltBufferData::default());
     }
 
     #[test]

--- a/crates/kobo-hal/src/touch.rs
+++ b/crates/kobo-hal/src/touch.rs
@@ -1,5 +1,5 @@
 use kobo_abi::input;
-use kobo_profile::DeviceProfile;
+use kobo_profile::PanelPose;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct InputEvent32 {
@@ -80,7 +80,7 @@ impl Default for TouchDecoder {
 }
 
 impl TouchDecoder {
-    pub fn push(&mut self, event: InputEvent32, profile: &DeviceProfile) -> Option<TouchEvent> {
+    pub fn push(&mut self, event: InputEvent32, pose: &PanelPose<'_>) -> Option<TouchEvent> {
         match (event.kind, event.code) {
             (input::EV_ABS, input::ABS_MT_SLOT) => {
                 self.current_slot = usize::try_from(event.value)
@@ -124,7 +124,7 @@ impl TouchDecoder {
                 }
             }
             (input::EV_SYN, input::SYN_REPORT) => {
-                return self.finish_report(profile);
+                return self.finish_report(pose);
             }
             _ => {}
         }
@@ -157,7 +157,7 @@ impl TouchDecoder {
         slot.set(SLOT_CHANGED, true);
     }
 
-    fn finish_report(&mut self, profile: &DeviceProfile) -> Option<TouchEvent> {
+    fn finish_report(&mut self, pose: &PanelPose<'_>) -> Option<TouchEvent> {
         let mut output = None;
         if let Some(slot_index) = self.primary_slot {
             let slot = &mut self.slots[slot_index];
@@ -168,7 +168,7 @@ impl TouchDecoder {
             // coordinates away, which is how a quick tap came to register as
             // nothing at all.
             let point = if slot.has(SLOT_X_FRESH) && slot.has(SLOT_Y_FRESH) {
-                profile.touch_to_display(slot.raw_x, slot.raw_y)
+                pose.touch_to_display(slot.raw_x, slot.raw_y)
             } else {
                 None
             };
@@ -229,7 +229,12 @@ impl TouchDecoder {
 mod tests {
     use super::{InputEvent32, TouchDecoder, TouchEvent, MAX_TOUCH_SLOTS};
     use kobo_abi::input;
-    use kobo_profile::CLARA_BW_391;
+    use kobo_profile::{PanelPose, CLARA_BW_391};
+
+    /// The Clara BW at the pose its profile was measured in. Decoding is
+    /// pose-relative now, and these tests assert display coordinates, so they
+    /// have to say which pose they mean.
+    const CLARA_BW_POSE: PanelPose<'static> = PanelPose::reference(&CLARA_BW_391);
 
     /// Every event of one real press, captured byte for byte from
     /// `/dev/input/event1` on the Clara BW. It contains no `ABS_MT_SLOT` and
@@ -257,7 +262,7 @@ mod tests {
         report
             .iter()
             .filter_map(|&(kind, code, value)| {
-                decoder.push(InputEvent32 { kind, code, value }, &CLARA_BW_391)
+                decoder.push(InputEvent32 { kind, code, value }, &CLARA_BW_POSE)
             })
             .collect()
     }
@@ -296,7 +301,7 @@ mod tests {
                 (input::EV_SYN, input::SYN_REPORT, 0),
             ],
         );
-        let expected = CLARA_BW_391
+        let expected = CLARA_BW_POSE
             .touch_to_display(374, 267)
             .expect("the panel maps this point");
         assert_eq!(
@@ -400,7 +405,7 @@ mod tests {
         ];
         let output = events
             .into_iter()
-            .find_map(|event| decoder.push(event, &CLARA_BW_391));
+            .find_map(|event| decoder.push(event, &CLARA_BW_POSE));
         assert_eq!(output, Some(TouchEvent::Down { x: 871, y: 100 }));
     }
 
@@ -421,15 +426,15 @@ mod tests {
         assert_eq!(
             events
                 .into_iter()
-                .find_map(|event| decoder.push(event, &CLARA_BW_391)),
+                .find_map(|event| decoder.push(event, &CLARA_BW_POSE)),
             Some(TouchEvent::Down { x: 871, y: 100 })
         );
 
         assert_eq!(
-            decoder.push(absolute(input::ABS_MT_POSITION_X, 700), &CLARA_BW_391),
+            decoder.push(absolute(input::ABS_MT_POSITION_X, 700), &CLARA_BW_POSE),
             None
         );
-        assert_eq!(decoder.push(sync(), &CLARA_BW_391), None);
+        assert_eq!(decoder.push(sync(), &CLARA_BW_POSE), None);
 
         let move_events = [
             absolute(input::ABS_MT_SLOT, 0),
@@ -440,7 +445,7 @@ mod tests {
         assert_eq!(
             move_events
                 .into_iter()
-                .find_map(|event| decoder.push(event, &CLARA_BW_391)),
+                .find_map(|event| decoder.push(event, &CLARA_BW_POSE)),
             Some(TouchEvent::Move { x: 861, y: 110 })
         );
 
@@ -448,7 +453,7 @@ mod tests {
         assert_eq!(
             release_primary
                 .into_iter()
-                .find_map(|event| decoder.push(event, &CLARA_BW_391)),
+                .find_map(|event| decoder.push(event, &CLARA_BW_POSE)),
             Some(TouchEvent::Up { x: 861, y: 110 })
         );
         assert!(!decoder.is_quiescent());
@@ -461,7 +466,7 @@ mod tests {
         assert_eq!(
             release_secondary
                 .into_iter()
-                .find_map(|event| decoder.push(event, &CLARA_BW_391)),
+                .find_map(|event| decoder.push(event, &CLARA_BW_POSE)),
             None
         );
         assert!(decoder.is_quiescent());
@@ -476,7 +481,7 @@ mod tests {
                     input::ABS_MT_SLOT,
                     i32::try_from(MAX_TOUCH_SLOTS).expect("slot count")
                 ),
-                &CLARA_BW_391
+                &CLARA_BW_POSE
             ),
             None
         );
@@ -491,26 +496,26 @@ mod tests {
             absolute(input::ABS_MT_POSITION_X, 100),
             absolute(input::ABS_MT_POSITION_Y, 200),
         ] {
-            assert_eq!(decoder.push(event, &CLARA_BW_391), None);
+            assert_eq!(decoder.push(event, &CLARA_BW_POSE), None);
         }
         assert_eq!(
-            decoder.push(sync(), &CLARA_BW_391),
+            decoder.push(sync(), &CLARA_BW_POSE),
             Some(TouchEvent::Down { x: 871, y: 100 })
         );
 
         assert_eq!(
-            decoder.push(absolute(input::ABS_MT_TRACKING_ID, 2), &CLARA_BW_391),
+            decoder.push(absolute(input::ABS_MT_TRACKING_ID, 2), &CLARA_BW_POSE),
             None
         );
-        assert_eq!(decoder.push(sync(), &CLARA_BW_391), None);
+        assert_eq!(decoder.push(sync(), &CLARA_BW_POSE), None);
         for event in [
             absolute(input::ABS_MT_POSITION_X, 300),
             absolute(input::ABS_MT_POSITION_Y, 400),
         ] {
-            assert_eq!(decoder.push(event, &CLARA_BW_391), None);
+            assert_eq!(decoder.push(event, &CLARA_BW_POSE), None);
         }
         assert_eq!(
-            decoder.push(sync(), &CLARA_BW_391),
+            decoder.push(sync(), &CLARA_BW_POSE),
             Some(TouchEvent::Down { x: 671, y: 300 })
         );
     }

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -1895,10 +1895,15 @@ mod tests {
         assert_eq!(flipped_y, (109, 1337));
     }
 
-    /// Captured from a physical touch about a centimetre in from the top-left
-    /// of the Elipsa 2E. Carried over from the pre-`PanelPose` API unchanged:
-    /// the expected values are the ones measured on that hardware, not values
-    /// re-derived from the transform they are meant to pin.
+    /// Captured from a physical top-left touch on the real Elipsa 2E with
+    /// `kobo touch-probe`, read-only and ungrabbed. The raw controller sample
+    /// `(1838, 30)` mapped to display `(30, 34)`, matching where the owner
+    /// touched rather than merely mapping the controller's corner set onto the
+    /// panel's corner set.
+    ///
+    /// Carried over from the pre-`PanelPose` API unchanged: the expected
+    /// values are the ones measured on that hardware, not values re-derived
+    /// from the transform they are meant to pin.
     #[test]
     fn elipsa_touch_transform_matches_a_physically_measured_touch() {
         let mapped = ELIPSA_2E_POSE

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -497,9 +497,9 @@ pub const LIBRA_2_388: DeviceProfile = DeviceProfile {
     serial_prefix: "N418",
     firmware_versions: &["4.38.23697"],
     kernel_release: "4.1.15-00868-g58a2758be07",
-    // Owner-attended evidence exists and is linked from the pull request;
-    // this flips to true once that evidence has been reviewed upstream.
-    write_ready: false,
+    // Owner-attended display, touch, exit and recovery evidence was filmed on
+    // the device and reviewed upstream before this was set.
+    write_ready: true,
 };
 
 pub const SUPPORTED_PROFILES: &[&DeviceProfile] =
@@ -1476,9 +1476,13 @@ mod tests {
         let snapshot = measured_libra_2(1);
         let report = LIBRA_2_388.validate(&snapshot);
         assert!(report.mismatches.is_empty(), "{:?}", report.mismatches);
-        // Identity is exact; only the attended-evidence review is pending.
-        assert_eq!(report.readiness, Readiness::ReadOnlyMatched);
-        assert_eq!(report.write_blockers, vec![WRITE_EVIDENCE_PENDING]);
+        // Identity is exact and the attended evidence has been reviewed.
+        assert_eq!(report.readiness, Readiness::WriteReady);
+        assert!(
+            report.write_blockers.is_empty(),
+            "{:?}",
+            report.write_blockers
+        );
         assert!(LIBRA_2_388.write_identity_blockers(&snapshot).is_empty());
         assert_eq!(
             super::identify_profile(&snapshot).map(|profile| profile.id),
@@ -1513,9 +1517,13 @@ mod tests {
         let snapshot = measured_libra_2(3);
         let report = LIBRA_2_388.validate(&snapshot);
         assert!(report.mismatches.is_empty(), "{:?}", report.mismatches);
-        // Identity is exact; only the attended-evidence review is pending.
-        assert_eq!(report.readiness, Readiness::ReadOnlyMatched);
-        assert_eq!(report.write_blockers, vec![WRITE_EVIDENCE_PENDING]);
+        // Identity is exact and the attended evidence has been reviewed.
+        assert_eq!(report.readiness, Readiness::WriteReady);
+        assert!(
+            report.write_blockers.is_empty(),
+            "{:?}",
+            report.write_blockers
+        );
         assert_eq!(
             super::identify_profile(&snapshot).map(|profile| profile.id),
             Some("libra-2-388")

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -45,7 +45,15 @@ pub enum TouchTransform {
     /// Measured on the Kobo Libra 2 with three taps in an L, one leg per
     /// physical axis: moving down the left edge drives `raw_x` upward, moving
     /// right along the bottom drives `raw_y` upward, and neither runs
-    /// backwards.
+    /// backwards. Confirmed afterwards against the fixed transform, where a
+    /// tap in each of three corners reported that corner.
+    ///
+    /// The reader was held with its page-turn buttons on the right throughout,
+    /// which is the pose this device reports as `rotation: 1`. Buttons on the
+    /// left is `rotation: 3`, and the profile refuses that pose. Anyone
+    /// repeating the measurement has to say which side the buttons are on:
+    /// "portrait" alone names two orientations 180 degrees apart, and the
+    /// digitiser tells them apart even when the screen does not.
     Transpose,
     /// Axes exchanged and Y mirrored.
     ///

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -10,6 +10,30 @@ use std::fmt;
 /// `rotation: 1` were found to need different transforms, so the mapping is
 /// declared per profile and has to be measured with `kobo touch-probe` rather
 /// than derived.
+///
+/// # Why this is only safe while `rotation` is matched exactly
+///
+/// A value here is a composition of two separate facts, and only one of them
+/// belongs in a profile. How the digitiser sits under the panel is fixed in
+/// the hardware and never changes. How display coordinates map onto physical
+/// space is decided by the framebuffer's `rotation`, which is live state: a
+/// Libra 2 held upside down reports `rotation: 3` where the same device
+/// upright reports 1, with every geometry field unchanged, and it flips as the
+/// reader is handled.
+///
+/// So a variant here is correct only at the rotation it was measured at. That
+/// holds today because `validate` compares `rotation` exactly, and a session
+/// cannot open unless the device is in the state the profile was measured in.
+/// The refusal is doing double duty: it is the thing that keeps this field
+/// honest.
+///
+/// Anyone relaxing the `rotation` comparison, which the orientation behaviour
+/// otherwise invites, has to replace this field at the same time. Touch would
+/// not fail loudly. It would land in the wrong place. As evidence that the
+/// composition really is what is encoded here: the 180-degree case would need
+/// a transpose with both axes mirrored, and there is deliberately no such
+/// variant, because a profile has no business describing which way up someone
+/// is holding the reader.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TouchTransform {
     /// Controller axes already agree with the display. No device here uses

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -497,7 +497,9 @@ pub const LIBRA_2_388: DeviceProfile = DeviceProfile {
     serial_prefix: "N418",
     firmware_versions: &["4.38.23697"],
     kernel_release: "4.1.15-00868-g58a2758be07",
-    write_ready: true,
+    // Owner-attended evidence exists and is linked from the pull request;
+    // this flips to true once that evidence has been reviewed upstream.
+    write_ready: false,
 };
 
 pub const SUPPORTED_PROFILES: &[&DeviceProfile] =
@@ -1472,7 +1474,9 @@ mod tests {
         let snapshot = measured_libra_2(1);
         let report = LIBRA_2_388.validate(&snapshot);
         assert!(report.mismatches.is_empty(), "{:?}", report.mismatches);
-        assert_eq!(report.readiness, Readiness::WriteReady);
+        // Identity is exact; only the attended-evidence review is pending.
+        assert_eq!(report.readiness, Readiness::ReadOnlyMatched);
+        assert_eq!(report.write_blockers, vec![WRITE_EVIDENCE_PENDING]);
         assert!(LIBRA_2_388.write_identity_blockers(&snapshot).is_empty());
         assert_eq!(
             super::identify_profile(&snapshot).map(|profile| profile.id),
@@ -1507,7 +1511,9 @@ mod tests {
         let snapshot = measured_libra_2(3);
         let report = LIBRA_2_388.validate(&snapshot);
         assert!(report.mismatches.is_empty(), "{:?}", report.mismatches);
-        assert_eq!(report.readiness, Readiness::WriteReady);
+        // Identity is exact; only the attended-evidence review is pending.
+        assert_eq!(report.readiness, Readiness::ReadOnlyMatched);
+        assert_eq!(report.write_blockers, vec![WRITE_EVIDENCE_PENDING]);
         assert_eq!(
             super::identify_profile(&snapshot).map(|profile| profile.id),
             Some("libra-2-388")

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -131,7 +131,7 @@ impl TouchTransform {
 pub enum GeometryRule {
     /// Pose fields are exact-matched constants.
     ///
-    /// The MediaTek devices keep this, for the same reason the touch transform
+    /// The `MediaTek` devices keep this, for the same reason the touch transform
     /// is per-profile: do not silently change a device nobody here can test.
     Fixed,
     /// The i.MX6 EPDC v2 derivation, read out of the vendor driver source
@@ -425,9 +425,6 @@ pub fn identify_profile(snapshot: &DeviceSnapshot) -> Option<&'static DeviceProf
         .find(|profile| profile.validate(snapshot).readiness != Readiness::Rejected)
 }
 
-pub const READ_ONLY_WRITE_BLOCKER: &str =
-    "write profile is intentionally incomplete until read-only doctor output is reviewed";
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Bitfield {
     pub offset: u32,
@@ -663,7 +660,12 @@ impl DeviceProfile {
             None => mismatches.push("touch probe unavailable".to_owned()),
         }
 
-        blockers.push(READ_ONLY_WRITE_BLOCKER.to_owned());
+        // The write gate and the verdict used to be strangers: an
+        // unconditional "intentionally incomplete" blocker made WriteReady
+        // unreachable for every profile, while the write path consulted
+        // write_identity_blockers() separately and wrote anyway. The verdict
+        // now reports the condition the write path actually enforces.
+        blockers.extend(self.write_identity_blockers(snapshot));
 
         let readiness = if !mismatches.is_empty() {
             Readiness::Rejected
@@ -1327,7 +1329,7 @@ mod tests {
         let snapshot = measured_libra_2(1);
         let report = LIBRA_2_388.validate(&snapshot);
         assert!(report.mismatches.is_empty(), "{:?}", report.mismatches);
-        assert_eq!(report.readiness, Readiness::ReadOnlyMatched);
+        assert_eq!(report.readiness, Readiness::WriteReady);
         assert!(LIBRA_2_388.write_identity_blockers(&snapshot).is_empty());
         assert_eq!(
             super::identify_profile(&snapshot).map(|profile| profile.id),
@@ -1362,7 +1364,7 @@ mod tests {
         let snapshot = measured_libra_2(3);
         let report = LIBRA_2_388.validate(&snapshot);
         assert!(report.mismatches.is_empty(), "{:?}", report.mismatches);
-        assert_eq!(report.readiness, Readiness::ReadOnlyMatched);
+        assert_eq!(report.readiness, Readiness::WriteReady);
         assert_eq!(
             super::identify_profile(&snapshot).map(|profile| profile.id),
             Some("libra-2-388")
@@ -1737,7 +1739,7 @@ mod tests {
     }
 
     #[test]
-    fn measured_snapshot_remains_read_only_until_reviewed() {
+    fn a_fully_identified_device_is_write_ready_and_a_strange_firmware_is_not() {
         let red = Bitfield {
             offset: 0,
             length: 8,
@@ -1782,10 +1784,19 @@ mod tests {
             },
         };
         let report = CLARA_BW_391.validate(&snapshot);
+        assert_eq!(report.readiness, Readiness::WriteReady);
+        assert!(report.mismatches.is_empty());
+        assert!(report.write_blockers.is_empty());
+        assert!(CLARA_BW_391.write_identity_blockers(&snapshot).is_empty());
+
+        // The same hardware on unreviewed firmware is still matched, but the
+        // verdict drops back to read-only: geometry is not proof of identity.
+        let mut updated = snapshot;
+        updated.identity.firmware_version = Some("4.99.99999".into());
+        let report = CLARA_BW_391.validate(&updated);
         assert_eq!(report.readiness, Readiness::ReadOnlyMatched);
         assert!(report.mismatches.is_empty());
-        assert!(!report.write_blockers.is_empty());
-        assert!(CLARA_BW_391.write_identity_blockers(&snapshot).is_empty());
+        assert_eq!(report.write_blockers.len(), 1);
     }
 
     #[test]

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -2,6 +2,44 @@
 
 use std::fmt;
 
+/// How a device's touch controller reports position relative to the display.
+///
+/// This used to be inferred from the framebuffer's `rotation`. It cannot be:
+/// the framebuffer says how the panel is scanned, and says nothing about which
+/// way round the digitiser underneath it was soldered. Two devices reporting
+/// `rotation: 1` were found to need different transforms, so the mapping is
+/// declared per profile and has to be measured with `kobo touch-probe` rather
+/// than derived.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TouchTransform {
+    /// Controller axes already agree with the display. No device here uses
+    /// this, and it is the historical fallback for any rotation other than 1
+    /// or 3.
+    Direct,
+    /// Axes exchanged, neither mirrored.
+    ///
+    /// Measured on the Kobo Libra 2 with three taps in an L, one leg per
+    /// physical axis: moving down the left edge drives `raw_x` upward, moving
+    /// right along the bottom drives `raw_y` upward, and neither runs
+    /// backwards.
+    Transpose,
+    /// Axes exchanged and Y mirrored.
+    ///
+    /// This is what every `rotation: 1` device did before the transform became
+    /// explicit. It is preserved for the Elipsa 2E so that its behaviour does
+    /// not change, but it has never been checked against a real finger: its
+    /// test asserts only the arithmetic it was derived from. The Libra 2 is
+    /// also `rotation: 1`, also an Elan controller, and measured as a plain
+    /// `Transpose`, so this variant is the likeliest place for a latent bug on
+    /// a device nobody here can test.
+    TransposeMirrorY,
+    /// Axes exchanged and X mirrored.
+    ///
+    /// Confirmed on the Clara BW, which is the only transform here backed by a
+    /// physically captured touch.
+    TransposeMirrorX,
+}
+
 pub const CLARA_BW_391: DeviceProfile = DeviceProfile {
     id: "clara-bw-391",
     model: "Kobo Clara BW",
@@ -43,6 +81,7 @@ pub const CLARA_BW_391: DeviceProfile = DeviceProfile {
         length: 8,
         msb_right: 0,
     },
+    touch_transform: TouchTransform::TransposeMirrorX,
     touch_name: "cyttsp5_mt",
     touch_x_min: 0,
     touch_x_max: 1447,
@@ -94,6 +133,7 @@ pub const ELIPSA_2E_389: DeviceProfile = DeviceProfile {
         length: 0,
         msb_right: 0,
     },
+    touch_transform: TouchTransform::TransposeMirrorY,
     touch_name: "Elan Touchscreen",
     touch_x_min: 0,
     touch_x_max: 1872,
@@ -113,11 +153,14 @@ pub const ELIPSA_2E_389: DeviceProfile = DeviceProfile {
 /// The geometry below is the portrait state. Six of these fields move when the
 /// reader is rotated: `width` and `height` exchange, `virtual_width` becomes
 /// 1696 and `virtual_height` 1280, `stride` becomes 6784, and `rotation`
-/// becomes 2. The alignment differs as well, 128 in portrait against 32 in
-/// landscape, so it is not a simple exchange. `memory_length` does not move,
-/// being allocated once at the larger of the two, and neither do the bitfields
-/// or the touch ranges, since the controller reports in panel coordinates
-/// whatever the screen is doing.
+/// becomes 2. One rule covers both: the stride is the visible row rounded up
+/// to 128 bytes, and the virtual width is that stride divided by four. So 1264
+/// pixels is 5056 bytes, rounded to 5120, giving 1280; and 1680 pixels is 6720
+/// bytes, rounded to 6784, giving 1696. The virtual height is the visible
+/// height rounded up to 128 pixels. `memory_length` does not move, being
+/// allocated once at the larger of the two products, and neither do the
+/// bitfields or the touch ranges, since the controller reports in panel
+/// coordinates whatever the screen is doing.
 ///
 /// So this profile matches the device in portrait and rejects it in landscape.
 /// Nothing about that is specific to the Libra 2, since every Kobo rotates and
@@ -168,6 +211,7 @@ pub const LIBRA_2_388: DeviceProfile = DeviceProfile {
         length: 8,
         msb_right: 0,
     },
+    touch_transform: TouchTransform::Transpose,
     touch_name: "Elan Touchscreen",
     touch_x_min: 0,
     touch_x_max: 1680,
@@ -314,6 +358,14 @@ pub struct DeviceProfile {
     pub green: Bitfield,
     pub blue: Bitfield,
     pub alpha: Bitfield,
+    /// How the touch controller's axes relate to the visible display.
+    ///
+    /// Kept separate from `rotation` because the two answer different
+    /// questions. `rotation` is read back from the framebuffer and is compared
+    /// during validation, so it has to stay whatever the kernel reports. How
+    /// the digitiser is mounted underneath the panel is a fact about the
+    /// hardware that no framebuffer field records, and it has to be measured.
+    pub touch_transform: TouchTransform,
     pub touch_name: &'static str,
     pub touch_x_min: i32,
     pub touch_x_max: i32,
@@ -450,10 +502,15 @@ impl DeviceProfile {
         }
         let horizontal = scale_touch_axis(raw_y, self.touch_y_min, self.touch_y_max, self.width)?;
         let vertical = scale_touch_axis(raw_x, self.touch_x_min, self.touch_x_max, self.height)?;
-        match self.rotation {
-            1 => Some((horizontal, self.height.checked_sub(1 + vertical)?)),
-            3 => Some((self.width.checked_sub(1 + horizontal)?, vertical)),
-            _ => Some((
+        match self.touch_transform {
+            TouchTransform::Transpose => Some((horizontal, vertical)),
+            TouchTransform::TransposeMirrorY => {
+                Some((horizontal, self.height.checked_sub(1 + vertical)?))
+            }
+            TouchTransform::TransposeMirrorX => {
+                Some((self.width.checked_sub(1 + horizontal)?, vertical))
+            }
+            TouchTransform::Direct => Some((
                 scale_touch_axis(raw_x, self.touch_x_min, self.touch_x_max, self.width)?,
                 scale_touch_axis(raw_y, self.touch_y_min, self.touch_y_max, self.height)?,
             )),
@@ -471,8 +528,12 @@ impl DeviceProfile {
         if x >= self.width || y >= self.height {
             return None;
         }
-        let (raw_x, raw_y) = match self.rotation {
-            1 => (
+        let (raw_x, raw_y) = match self.touch_transform {
+            TouchTransform::Transpose => (
+                scale_display_axis(y, self.height, self.touch_x_min, self.touch_x_max)?,
+                scale_display_axis(x, self.width, self.touch_y_min, self.touch_y_max)?,
+            ),
+            TouchTransform::TransposeMirrorY => (
                 scale_display_axis(
                     self.height.checked_sub(1 + y)?,
                     self.height,
@@ -481,7 +542,7 @@ impl DeviceProfile {
                 )?,
                 scale_display_axis(x, self.width, self.touch_y_min, self.touch_y_max)?,
             ),
-            3 => (
+            TouchTransform::TransposeMirrorX => (
                 scale_display_axis(y, self.height, self.touch_x_min, self.touch_x_max)?,
                 scale_display_axis(
                     self.width.checked_sub(1 + x)?,
@@ -490,7 +551,7 @@ impl DeviceProfile {
                     self.touch_y_max,
                 )?,
             ),
-            _ => (
+            TouchTransform::Direct => (
                 scale_display_axis(x, self.width, self.touch_x_min, self.touch_x_max)?,
                 scale_display_axis(y, self.height, self.touch_y_min, self.touch_y_max)?,
             ),
@@ -801,6 +862,53 @@ mod tests {
         );
     }
 
+    /// Captured from three physical taps on the real Libra 2 with
+    /// `kobo touch-probe`, read-only and ungrabbed, in an L so that each leg
+    /// moves along exactly one physical axis.
+    ///
+    /// Corner assertions alone cannot catch a mirrored axis, because the four
+    /// corners of a rectangle map onto themselves under any rotation, and a
+    /// round trip through `display_to_touch` proves only that the inverse is
+    /// an inverse. An earlier version of this test asserted both and passed
+    /// while the transform was inverted by the full height of the panel.
+    #[test]
+    fn libra_2_touch_matches_three_physically_measured_taps() {
+        // Tap 1, top-left corner of the image.
+        let top_left = LIBRA_2_388
+            .touch_to_display(54, 62)
+            .expect("measured tap maps to the display");
+        // Tap 2, bottom-left: straight down the same edge, so only the
+        // physical vertical changed, and only raw_x moved.
+        let bottom_left = LIBRA_2_388
+            .touch_to_display(1600, 66)
+            .expect("measured tap maps to the display");
+        // Tap 3, bottom-right: straight across the bottom, so only the
+        // physical horizontal changed, and only raw_y moved.
+        let bottom_right = LIBRA_2_388
+            .touch_to_display(1596, 1172)
+            .expect("measured tap maps to the display");
+
+        assert_eq!(top_left, (62, 54));
+        assert_eq!(bottom_left, (66, 1599));
+        assert_eq!(bottom_right, (1171, 1595));
+
+        // The shape of the L, stated independently of the exact numbers, so
+        // that a mirrored axis fails here even if the values are edited.
+        assert!(top_left.1 < bottom_left.1, "the left edge runs downward");
+        assert!(
+            top_left.0.abs_diff(bottom_left.0) < 32,
+            "the left edge stays at one side"
+        );
+        assert!(
+            bottom_left.0 < bottom_right.0,
+            "the bottom edge runs rightward"
+        );
+        assert!(
+            bottom_left.1.abs_diff(bottom_right.1) < 32,
+            "the bottom edge stays at one end"
+        );
+    }
+
     #[test]
     fn libra_2_touch_edges_stay_inside_the_panel_and_round_trip() {
         for raw in [(0, 0), (0, 1264), (1680, 0), (1680, 1264)] {
@@ -810,8 +918,8 @@ mod tests {
             assert!(display.0 < LIBRA_2_388.width, "x escaped: {display:?}");
             assert!(display.1 < LIBRA_2_388.height, "y escaped: {display:?}");
         }
-        assert_eq!(LIBRA_2_388.touch_to_display(0, 0), Some((0, 1679)));
-        assert_eq!(LIBRA_2_388.touch_to_display(1680, 1264), Some((1263, 0)));
+        assert_eq!(LIBRA_2_388.touch_to_display(0, 0), Some((0, 0)));
+        assert_eq!(LIBRA_2_388.touch_to_display(1680, 1264), Some((1263, 1679)));
         for display in [(0, 0), (1263, 0), (0, 1679), (1263, 1679), (632, 840)] {
             let raw = LIBRA_2_388
                 .display_to_touch(display.0, display.1)

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -525,16 +525,179 @@ impl DeviceProfile {
         blockers
     }
 
+}
+
+/// Why a profile could not be resolved against the orientation a device is in.
+///
+/// A refusal here has to be as loud as a rejected profile. It cannot be
+/// swallowed by a caller and it must never reach the touch decoder, where an
+/// unresolvable pose would look like taps quietly going nowhere rather than
+/// like a device Cobalt declines to drive.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PoseError {
+    /// The device is in an orientation this profile has not been measured in.
+    UnverifiedRotation { observed: u32, expected: u32 },
+    /// The visible geometry disagrees with the profile at an orientation the
+    /// profile does claim to describe.
+    GeometryMismatch { field: &'static str, observed: u32, expected: u32 },
+    /// The probe returned no framebuffer at all.
+    FramebufferMissing,
+}
+
+impl fmt::Display for PoseError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnverifiedRotation { observed, expected } => write!(
+                formatter,
+                "device is at rotation {observed}, and this profile is only measured at {expected}"
+            ),
+            Self::GeometryMismatch {
+                field,
+                observed,
+                expected,
+            } => write!(
+                formatter,
+                "{field}: expected {expected}, found {observed}"
+            ),
+            Self::FramebufferMissing => formatter.write_str("no framebuffer to resolve against"),
+        }
+    }
+}
+
+/// A profile resolved against the orientation the device is actually in.
+///
+/// A [`DeviceProfile`] describes hardware. Which way up the reader is being
+/// held is not hardware: the framebuffer's `rotation` flips between 1 and 3 as
+/// a Libra 2 is handled, with every geometry field unchanged. A pose is the
+/// pairing of the two, resolved once, at the point where a live framebuffer is
+/// available.
+///
+/// # What this does and does not do yet
+///
+/// Today `resolve` accepts only the rotation the profile was measured at, so a
+/// pose carries exactly the values the profile does and nothing observable
+/// changes. That is deliberate. The transform can only be composed with live
+/// rotation once `validate` accepts more than one pose, and `validate` can only
+/// accept more than one pose once the transform composes. Doing either alone is
+/// worse than doing neither: composing early buys nothing, and relaxing early
+/// puts taps in the wrong place without failing.
+///
+/// This type exists so those two can land in that order. It is also the shape
+/// live re-resolution would need, if the reader is ever to be turned over
+/// mid-session, which is out of scope here.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PanelPose<'a> {
+    profile: &'a DeviceProfile,
+    rotation: u32,
+    width: u32,
+    height: u32,
+    transform: TouchTransform,
+}
+
+impl<'a> PanelPose<'a> {
+    /// The pose the profile was measured in.
+    ///
+    /// For callers with no device in front of them. It asserts an orientation
+    /// rather than observing one, so it is right for the simulator and for
+    /// tests, and wrong for anything holding a framebuffer.
+    #[must_use]
+    pub const fn reference(profile: &'a DeviceProfile) -> Self {
+        Self {
+            profile,
+            rotation: profile.rotation,
+            width: profile.width,
+            height: profile.height,
+            transform: profile.touch_transform,
+        }
+    }
+
+    /// Resolves a pose against a live framebuffer.
+    ///
+    /// Refuses any orientation this profile cannot describe, which is
+    /// currently every orientation but the one it was measured in. The refusal
+    /// is the point: an unresolvable pose has to stay a refusal rather than
+    /// fall back on the reference, since the fallback would be a transform
+    /// wrong by the height of the panel, and wrong silently.
+    ///
+    /// The geometry is compared rather than copied. Nothing stops a caller
+    /// resolving against a snapshot that was never validated, and a pose built
+    /// from dimensions the profile does not recognise would scale every tap
+    /// against the wrong panel.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PoseError`] when the device is in an unverified orientation or
+    /// when its visible geometry disagrees with the profile.
+    pub fn resolve(
+        profile: &'a DeviceProfile,
+        framebuffer: &FramebufferSnapshot,
+    ) -> Result<Self, PoseError> {
+        if framebuffer.rotation != profile.rotation {
+            return Err(PoseError::UnverifiedRotation {
+                observed: framebuffer.rotation,
+                expected: profile.rotation,
+            });
+        }
+        for (field, observed, expected) in [
+            ("width", framebuffer.width, profile.width),
+            ("height", framebuffer.height, profile.height),
+        ] {
+            if observed != expected {
+                return Err(PoseError::GeometryMismatch {
+                    field,
+                    observed,
+                    expected,
+                });
+            }
+        }
+        Ok(Self {
+            profile,
+            rotation: framebuffer.rotation,
+            width: framebuffer.width,
+            height: framebuffer.height,
+            transform: profile.touch_transform,
+        })
+    }
+
+    #[must_use]
+    pub const fn profile(&self) -> &'a DeviceProfile {
+        self.profile
+    }
+
+    #[must_use]
+    pub const fn rotation(&self) -> u32 {
+        self.rotation
+    }
+
+    #[must_use]
+    pub const fn width(&self) -> u32 {
+        self.width
+    }
+
+    #[must_use]
+    pub const fn height(&self) -> u32 {
+        self.height
+    }
+
+    #[must_use]
+    pub const fn touch_transform(&self) -> TouchTransform {
+        self.transform
+    }
+
+    /// Maps a raw touch coordinate into display space at this pose.
     #[must_use]
     pub fn touch_to_display(&self, raw_x: i32, raw_y: i32) -> Option<(u32, u32)> {
-        if !(self.touch_x_min..=self.touch_x_max).contains(&raw_x)
-            || !(self.touch_y_min..=self.touch_y_max).contains(&raw_y)
+        let profile = self.profile;
+        if !(profile.touch_x_min..=profile.touch_x_max).contains(&raw_x)
+            || !(profile.touch_y_min..=profile.touch_y_max).contains(&raw_y)
         {
             return None;
         }
-        let horizontal = scale_touch_axis(raw_y, self.touch_y_min, self.touch_y_max, self.width)?;
-        let vertical = scale_touch_axis(raw_x, self.touch_x_min, self.touch_x_max, self.height)?;
-        match self.touch_transform {
+        let horizontal =
+            scale_touch_axis(raw_y, profile.touch_y_min, profile.touch_y_max, self.width)?;
+        let vertical =
+            scale_touch_axis(raw_x, profile.touch_x_min, profile.touch_x_max, self.height)?;
+        match self.transform {
             TouchTransform::Transpose => Some((horizontal, vertical)),
             TouchTransform::TransposeMirrorY => {
                 Some((horizontal, self.height.checked_sub(1 + vertical)?))
@@ -543,53 +706,50 @@ impl DeviceProfile {
                 Some((self.width.checked_sub(1 + horizontal)?, vertical))
             }
             TouchTransform::Direct => Some((
-                scale_touch_axis(raw_x, self.touch_x_min, self.touch_x_max, self.width)?,
-                scale_touch_axis(raw_y, self.touch_y_min, self.touch_y_max, self.height)?,
+                scale_touch_axis(raw_x, profile.touch_x_min, profile.touch_x_max, self.width)?,
+                scale_touch_axis(raw_y, profile.touch_y_min, profile.touch_y_max, self.height)?,
             )),
         }
     }
 
-    /// Converts a visible display coordinate back to the touch controller's
-    /// rotated coordinate space.
-    ///
-    /// The browser simulator deliberately takes this round trip before hit
-    /// testing, so the same measured transform that gates the device is also
-    /// exercised during ordinary application development.
+    /// Converts a visible display coordinate back into raw touch space at this
+    /// pose.
     #[must_use]
     pub fn display_to_touch(&self, x: u32, y: u32) -> Option<(i32, i32)> {
+        let profile = self.profile;
         if x >= self.width || y >= self.height {
             return None;
         }
-        let (raw_x, raw_y) = match self.touch_transform {
+        let (raw_x, raw_y) = match self.transform {
             TouchTransform::Transpose => (
-                scale_display_axis(y, self.height, self.touch_x_min, self.touch_x_max)?,
-                scale_display_axis(x, self.width, self.touch_y_min, self.touch_y_max)?,
+                scale_display_axis(y, self.height, profile.touch_x_min, profile.touch_x_max)?,
+                scale_display_axis(x, self.width, profile.touch_y_min, profile.touch_y_max)?,
             ),
             TouchTransform::TransposeMirrorY => (
                 scale_display_axis(
                     self.height.checked_sub(1 + y)?,
                     self.height,
-                    self.touch_x_min,
-                    self.touch_x_max,
+                    profile.touch_x_min,
+                    profile.touch_x_max,
                 )?,
-                scale_display_axis(x, self.width, self.touch_y_min, self.touch_y_max)?,
+                scale_display_axis(x, self.width, profile.touch_y_min, profile.touch_y_max)?,
             ),
             TouchTransform::TransposeMirrorX => (
-                scale_display_axis(y, self.height, self.touch_x_min, self.touch_x_max)?,
+                scale_display_axis(y, self.height, profile.touch_x_min, profile.touch_x_max)?,
                 scale_display_axis(
                     self.width.checked_sub(1 + x)?,
                     self.width,
-                    self.touch_y_min,
-                    self.touch_y_max,
+                    profile.touch_y_min,
+                    profile.touch_y_max,
                 )?,
             ),
             TouchTransform::Direct => (
-                scale_display_axis(x, self.width, self.touch_x_min, self.touch_x_max)?,
-                scale_display_axis(y, self.height, self.touch_y_min, self.touch_y_max)?,
+                scale_display_axis(x, self.width, profile.touch_x_min, profile.touch_x_max)?,
+                scale_display_axis(y, self.height, profile.touch_y_min, profile.touch_y_max)?,
             ),
         };
-        if !(self.touch_x_min..=self.touch_x_max).contains(&raw_x)
-            || !(self.touch_y_min..=self.touch_y_max).contains(&raw_y)
+        if !(profile.touch_x_min..=profile.touch_x_max).contains(&raw_x)
+            || !(profile.touch_y_min..=profile.touch_y_max).contains(&raw_y)
         {
             return None;
         }
@@ -809,6 +969,15 @@ fn compare_identity(blockers: &mut Vec<String>, name: &str, expected: &str, actu
 
 #[cfg(test)]
 mod tests {
+    use super::PanelPose;
+
+    /// The Libra 2 at the pose it was measured in: page-turn buttons on the
+    /// right, which this device reports as rotation 1. Every display
+    /// coordinate below is only meaningful at that pose.
+    const LIBRA_2_POSE: PanelPose<'static> = PanelPose::reference(&LIBRA_2_388);
+    const CLARA_BW_POSE: PanelPose<'static> = PanelPose::reference(&CLARA_BW_391);
+    const ELIPSA_2E_POSE: PanelPose<'static> = PanelPose::reference(&ELIPSA_2E_389);
+
     use super::{
         Bitfield, DeviceSnapshot, FramebufferSnapshot, IdentitySnapshot, Readiness, TouchSnapshot,
         CLARA_BW_391, ELIPSA_2E_389, LIBRA_2_388,
@@ -906,17 +1075,17 @@ mod tests {
     #[test]
     fn libra_2_touch_matches_three_physically_measured_taps() {
         // Tap 1, top-left corner of the image.
-        let top_left = LIBRA_2_388
+        let top_left = LIBRA_2_POSE
             .touch_to_display(54, 62)
             .expect("measured tap maps to the display");
         // Tap 2, bottom-left: straight down the same edge, so only the
         // physical vertical changed, and only raw_x moved.
-        let bottom_left = LIBRA_2_388
+        let bottom_left = LIBRA_2_POSE
             .touch_to_display(1600, 66)
             .expect("measured tap maps to the display");
         // Tap 3, bottom-right: straight across the bottom, so only the
         // physical horizontal changed, and only raw_y moved.
-        let bottom_right = LIBRA_2_388
+        let bottom_right = LIBRA_2_POSE
             .touch_to_display(1596, 1172)
             .expect("measured tap maps to the display");
 
@@ -944,64 +1113,64 @@ mod tests {
     #[test]
     fn libra_2_touch_edges_stay_inside_the_panel_and_round_trip() {
         for raw in [(0, 0), (0, 1264), (1680, 0), (1680, 1264)] {
-            let display = LIBRA_2_388
+            let display = LIBRA_2_POSE
                 .touch_to_display(raw.0, raw.1)
                 .expect("measured Libra 2 edge maps to the display");
             assert!(display.0 < LIBRA_2_388.width, "x escaped: {display:?}");
             assert!(display.1 < LIBRA_2_388.height, "y escaped: {display:?}");
         }
-        assert_eq!(LIBRA_2_388.touch_to_display(0, 0), Some((0, 0)));
-        assert_eq!(LIBRA_2_388.touch_to_display(1680, 1264), Some((1263, 1679)));
+        assert_eq!(LIBRA_2_POSE.touch_to_display(0, 0), Some((0, 0)));
+        assert_eq!(LIBRA_2_POSE.touch_to_display(1680, 1264), Some((1263, 1679)));
         for display in [(0, 0), (1263, 0), (0, 1679), (1263, 1679), (632, 840)] {
-            let raw = LIBRA_2_388
+            let raw = LIBRA_2_POSE
                 .display_to_touch(display.0, display.1)
                 .expect("Libra 2 display point maps to the controller");
-            assert_eq!(LIBRA_2_388.touch_to_display(raw.0, raw.1), Some(display));
+            assert_eq!(LIBRA_2_POSE.touch_to_display(raw.0, raw.1), Some(display));
         }
-        assert_eq!(LIBRA_2_388.display_to_touch(1264, 0), None);
-        assert_eq!(LIBRA_2_388.display_to_touch(0, 1680), None);
+        assert_eq!(LIBRA_2_POSE.display_to_touch(1264, 0), None);
+        assert_eq!(LIBRA_2_POSE.display_to_touch(0, 1680), None);
     }
 
     #[test]
     fn touch_transform_matches_measured_corners() {
-        assert_eq!(CLARA_BW_391.touch_to_display(0, 1071), Some((0, 0)));
-        assert_eq!(CLARA_BW_391.touch_to_display(0, 0), Some((1071, 0)));
-        assert_eq!(CLARA_BW_391.touch_to_display(1447, 1071), Some((0, 1447)));
-        assert_eq!(CLARA_BW_391.touch_to_display(1447, 0), Some((1071, 1447)));
-        assert_eq!(CLARA_BW_391.touch_to_display(1448, 0), None);
+        assert_eq!(CLARA_BW_POSE.touch_to_display(0, 1071), Some((0, 0)));
+        assert_eq!(CLARA_BW_POSE.touch_to_display(0, 0), Some((1071, 0)));
+        assert_eq!(CLARA_BW_POSE.touch_to_display(1447, 1071), Some((0, 1447)));
+        assert_eq!(CLARA_BW_POSE.touch_to_display(1447, 0), Some((1071, 1447)));
+        assert_eq!(CLARA_BW_POSE.touch_to_display(1448, 0), None);
     }
 
     #[test]
     fn display_and_touch_coordinates_round_trip_at_edges_and_inside() {
         for display in [(0, 0), (1071, 0), (0, 1447), (1071, 1447), (109, 110)] {
-            let raw = CLARA_BW_391
+            let raw = CLARA_BW_POSE
                 .display_to_touch(display.0, display.1)
                 .expect("display point maps to controller");
-            assert_eq!(CLARA_BW_391.touch_to_display(raw.0, raw.1), Some(display));
+            assert_eq!(CLARA_BW_POSE.touch_to_display(raw.0, raw.1), Some(display));
         }
-        assert_eq!(CLARA_BW_391.display_to_touch(1072, 0), None);
-        assert_eq!(CLARA_BW_391.display_to_touch(0, 1448), None);
+        assert_eq!(CLARA_BW_POSE.display_to_touch(1072, 0), None);
+        assert_eq!(CLARA_BW_POSE.display_to_touch(0, 1448), None);
     }
 
     #[test]
     fn elipsa_touch_edges_stay_inside_the_panel_and_display_points_round_trip() {
         for raw in [(0, 0), (0, 1404), (1872, 0), (1872, 1404)] {
-            let display = ELIPSA_2E_389
+            let display = ELIPSA_2E_POSE
                 .touch_to_display(raw.0, raw.1)
                 .expect("measured Elipsa edge maps to the display");
             assert!(display.0 < ELIPSA_2E_389.width, "x escaped: {display:?}");
             assert!(display.1 < ELIPSA_2E_389.height, "y escaped: {display:?}");
         }
-        assert_eq!(ELIPSA_2E_389.touch_to_display(0, 0), Some((0, 1871)));
-        assert_eq!(ELIPSA_2E_389.touch_to_display(1872, 1404), Some((1403, 0)));
+        assert_eq!(ELIPSA_2E_POSE.touch_to_display(0, 0), Some((0, 1871)));
+        assert_eq!(ELIPSA_2E_POSE.touch_to_display(1872, 1404), Some((1403, 0)));
         for display in [(0, 0), (1403, 0), (0, 1871), (1403, 1871), (702, 936)] {
-            let raw = ELIPSA_2E_389
+            let raw = ELIPSA_2E_POSE
                 .display_to_touch(display.0, display.1)
                 .expect("Elipsa display point maps to the controller");
-            assert_eq!(ELIPSA_2E_389.touch_to_display(raw.0, raw.1), Some(display));
+            assert_eq!(ELIPSA_2E_POSE.touch_to_display(raw.0, raw.1), Some(display));
         }
-        assert_eq!(ELIPSA_2E_389.display_to_touch(1404, 0), None);
-        assert_eq!(ELIPSA_2E_389.display_to_touch(0, 1872), None);
+        assert_eq!(ELIPSA_2E_POSE.display_to_touch(1404, 0), None);
+        assert_eq!(ELIPSA_2E_POSE.display_to_touch(0, 1872), None);
     }
 
     /// Captured from a physical touch on the real Clara BW with
@@ -1015,17 +1184,17 @@ mod tests {
     /// transform placed it at (109, 110).
     #[test]
     fn touch_transform_matches_a_physically_measured_touch() {
-        let mapped = CLARA_BW_391
+        let mapped = CLARA_BW_POSE
             .touch_to_display(110, 962)
             .expect("the measured raw sample is in range");
         assert_eq!(mapped, (109, 110));
 
         // A flip of either axis still lands inside the screen, so only distance
         // from the touched corner distinguishes them. Both are far away.
-        let flipped_x = CLARA_BW_391
+        let flipped_x = CLARA_BW_POSE
             .touch_to_display(110, 1071 - 962)
             .expect("in range");
-        let flipped_y = CLARA_BW_391
+        let flipped_y = CLARA_BW_POSE
             .touch_to_display(1447 - 110, 962)
             .expect("in range");
         assert_eq!(flipped_x, (962, 110));

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -72,6 +72,97 @@ pub enum TouchTransform {
     TransposeMirrorX,
 }
 
+impl TouchTransform {
+    /// Lowers a declared transform into the composable form.
+    ///
+    /// Lossless in both directions for all four variants. The composed value
+    /// this feeds is a superset: a transpose with both axes mirrored is
+    /// reachable here and deliberately has no variant above, because it is a
+    /// runtime fact about which way up the reader is being held rather than a
+    /// hardware fact about the digitiser.
+    #[must_use]
+    pub const fn lower(self) -> TouchMapping {
+        match self {
+            Self::Direct => TouchMapping {
+                swap_axes: false,
+                mirror_x: false,
+                mirror_y: false,
+            },
+            Self::Transpose => TouchMapping {
+                swap_axes: true,
+                mirror_x: false,
+                mirror_y: false,
+            },
+            Self::TransposeMirrorY => TouchMapping {
+                swap_axes: true,
+                mirror_x: false,
+                mirror_y: true,
+            },
+            Self::TransposeMirrorX => TouchMapping {
+                swap_axes: true,
+                mirror_x: true,
+                mirror_y: false,
+            },
+        }
+    }
+}
+
+/// A touch mapping that can be composed with a live rotation.
+///
+/// # The frame these mirrors are written in
+///
+/// `mirror_x` and `mirror_y` are applied in **display pixel space**, after the
+/// axis swap and after scaling. This has to be stated, because the raw-space
+/// and display-space spellings of a single mirror are crossed: mirroring
+/// display x is the same operation as mirroring raw y once the axes are
+/// swapped. A reader who assumes the raw frame will map
+/// [`TouchTransform::TransposeMirrorX`] onto `TransposeMirrorY`'s behaviour and
+/// vice versa, which is a silent inversion on a device nobody here can test.
+/// The Clara BW's measured-touch test is what would catch it.
+///
+/// Mirroring after scaling also matters: `width - 1 - scaled` and
+/// `scale(maximum - raw)` round differently at the extremes, and the exact edge
+/// assertions are what fail if the order is swapped.
+///
+/// Unlike [`TouchTransform`], this can express a transpose with both axes
+/// mirrored, which is exactly what a 180 degree pose change produces and the
+/// only reason this type exists.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TouchMapping {
+    /// Controller axes are exchanged relative to the display.
+    pub swap_axes: bool,
+    /// Display x runs backwards.
+    pub mirror_x: bool,
+    /// Display y runs backwards.
+    pub mirror_y: bool,
+}
+
+impl TouchMapping {
+    /// The same mapping with the image turned through 180 degrees.
+    ///
+    /// The digitiser is glued to the glass and does not move when the reader is
+    /// turned over. The image does: the driver hands `rotate` to the PXP, which
+    /// rotates pixels on the way to the panel, and the `FB_ROTATE_UD` arm of
+    /// `adjust_coordinates` maps a rectangle to `xres - (left + width)` and
+    /// `yres - (top + height)`. So the same finger position lands at the
+    /// diametrically opposite display point, which is both mirrors flipped with
+    /// the swap unchanged.
+    ///
+    /// The 180 degree rotation is in the centre of the dihedral group, so it
+    /// commutes with the swap and with either mirror. That is why this is
+    /// correct regardless of which frame the mirrors are read in, and it is the
+    /// one part of this composition that does not depend on the convention
+    /// question below.
+    #[must_use]
+    pub const fn rotated_180(self) -> Self {
+        Self {
+            swap_axes: self.swap_axes,
+            mirror_x: !self.mirror_x,
+            mirror_y: !self.mirror_y,
+        }
+    }
+}
+
 pub const CLARA_BW_391: DeviceProfile = DeviceProfile {
     id: "clara-bw-391",
     model: "Kobo Clara BW",
@@ -114,6 +205,7 @@ pub const CLARA_BW_391: DeviceProfile = DeviceProfile {
         msb_right: 0,
     },
     touch_transform: TouchTransform::TransposeMirrorX,
+    reference_rotation: 3,
     touch_name: "cyttsp5_mt",
     touch_x_min: 0,
     touch_x_max: 1447,
@@ -166,6 +258,7 @@ pub const ELIPSA_2E_389: DeviceProfile = DeviceProfile {
         msb_right: 0,
     },
     touch_transform: TouchTransform::TransposeMirrorY,
+    reference_rotation: 1,
     touch_name: "Elan Touchscreen",
     touch_x_min: 0,
     touch_x_max: 1872,
@@ -244,6 +337,7 @@ pub const LIBRA_2_388: DeviceProfile = DeviceProfile {
         msb_right: 0,
     },
     touch_transform: TouchTransform::Transpose,
+    reference_rotation: 1,
     touch_name: "Elan Touchscreen",
     touch_x_min: 0,
     touch_x_max: 1680,
@@ -398,6 +492,20 @@ pub struct DeviceProfile {
     /// the digitiser is mounted underneath the panel is a fact about the
     /// hardware that no framebuffer field records, and it has to be measured.
     pub touch_transform: TouchTransform,
+    /// The orientation `touch_transform` is written in.
+    ///
+    /// `Transpose` on its own means nothing without "relative to what". The
+    /// anchor is physical rather than numeric: the Libra 2's mapping was
+    /// measured with the page-turn buttons on the right and the USB-C port on
+    /// the top edge, which this device reports as `rotate: 1`.
+    ///
+    /// This constrains nothing at validation time. It names the frame the
+    /// digitiser fact is expressed in, so that a live rotation can be composed
+    /// against it. Recorded explicitly because a later reader will otherwise
+    /// delete it as redundant with `rotation`, which it currently equals on
+    /// every profile and which answers a different question: `rotation` is a
+    /// pose snapshot that moves as the reader is handled, and this does not.
+    pub reference_rotation: u32,
     pub touch_name: &'static str,
     pub touch_x_min: i32,
     pub touch_x_max: i32,
@@ -542,6 +650,9 @@ pub enum PoseError {
     GeometryMismatch { field: &'static str, observed: u32, expected: u32 },
     /// The probe returned no framebuffer at all.
     FramebufferMissing,
+    /// The orientation differs from the profile's reference frame by a quarter
+    /// turn, which nobody has measured on this device.
+    UnsupportedRotationDelta { observed: u32, reference: u32 },
 }
 
 impl fmt::Display for PoseError {
@@ -560,6 +671,14 @@ impl fmt::Display for PoseError {
                 "{field}: expected {expected}, found {observed}"
             ),
             Self::FramebufferMissing => formatter.write_str("no framebuffer to resolve against"),
+            Self::UnsupportedRotationDelta {
+                observed,
+                reference,
+            } => write!(
+                formatter,
+                "rotation {observed} is a quarter turn from the reference rotation {reference}, \
+                 and no quarter turn has been measured on this device"
+            ),
         }
     }
 }
@@ -591,7 +710,7 @@ pub struct PanelPose<'a> {
     rotation: u32,
     width: u32,
     height: u32,
-    transform: TouchTransform,
+    mapping: TouchMapping,
 }
 
 impl<'a> PanelPose<'a> {
@@ -607,8 +726,56 @@ impl<'a> PanelPose<'a> {
             rotation: profile.rotation,
             width: profile.width,
             height: profile.height,
-            transform: profile.touch_transform,
+            mapping: profile.touch_transform.lower(),
         }
+    }
+
+    /// Composes the digitiser mapping against an orientation.
+    ///
+    /// The digitiser is fixed to the glass, so the profile's mapping is a
+    /// constant expressed in the frame named by `reference_rotation`. What
+    /// moves is the image. Composition is therefore by the difference between
+    /// the live orientation and that frame.
+    ///
+    /// Only a difference of zero or a half turn is supported. A quarter turn is
+    /// refused, and that refusal is load-bearing rather than cautious. The
+    /// driver swaps the clockwise and anticlockwise numbering under a hardware
+    /// configuration flag, `bDisplayBusWidth == 3`, which this board has not
+    /// been read for. That swap is an involution on the two portrait values and
+    /// fixes the other two, so it preserves a half turn exactly and inverts a
+    /// quarter turn. The differences accepted here are precisely the ones the
+    /// ambiguity cannot corrupt, and the ones refused are precisely the ones
+    /// where it decides the answer.
+    ///
+    /// Anyone adding quarter turn support has to read `bDisplayBusWidth` off
+    /// the device first. Without it this stops being fail-closed and becomes a
+    /// coin flip.
+    fn compose(profile: &DeviceProfile, rotation: u32) -> Result<TouchMapping, PoseError> {
+        let mapping = profile.touch_transform.lower();
+        match (rotation % 4 + 4 - profile.reference_rotation % 4) % 4 {
+            0 => Ok(mapping),
+            2 => Ok(mapping.rotated_180()),
+            _ => Err(PoseError::UnsupportedRotationDelta {
+                observed: rotation,
+                reference: profile.reference_rotation,
+            }),
+        }
+    }
+
+    /// A pose at an arbitrary orientation, for tests that have no device.
+    ///
+    /// Deliberately private to this crate's tests. `resolve` stays the only way
+    /// to build a pose from a device, and a public constructor taking any
+    /// rotation would read as landscape support that nobody has measured.
+    #[cfg(test)]
+    fn for_test(profile: &'a DeviceProfile, rotation: u32) -> Result<Self, PoseError> {
+        Ok(Self {
+            profile,
+            rotation,
+            width: profile.width,
+            height: profile.height,
+            mapping: Self::compose(profile, rotation)?,
+        })
     }
 
     /// Resolves a pose against a live framebuffer.
@@ -655,7 +822,7 @@ impl<'a> PanelPose<'a> {
             rotation: framebuffer.rotation,
             width: framebuffer.width,
             height: framebuffer.height,
-            transform: profile.touch_transform,
+            mapping: Self::compose(profile, framebuffer.rotation)?,
         })
     }
 
@@ -679,9 +846,15 @@ impl<'a> PanelPose<'a> {
         self.height
     }
 
+    /// The mapping that will actually run at this pose.
+    ///
+    /// Not the profile's declared [`TouchTransform`]. Reporting that instead
+    /// would print a mapping the code does not use as soon as the reader is
+    /// held the other way up, which is the shape of a defect this port has
+    /// already fixed once in `doctor`.
     #[must_use]
-    pub const fn touch_transform(&self) -> TouchTransform {
-        self.transform
+    pub const fn touch_mapping(&self) -> TouchMapping {
+        self.mapping
     }
 
     /// Maps a raw touch coordinate into display space at this pose.
@@ -693,23 +866,27 @@ impl<'a> PanelPose<'a> {
         {
             return None;
         }
-        let horizontal =
-            scale_touch_axis(raw_y, profile.touch_y_min, profile.touch_y_max, self.width)?;
-        let vertical =
-            scale_touch_axis(raw_x, profile.touch_x_min, profile.touch_x_max, self.height)?;
-        match self.transform {
-            TouchTransform::Transpose => Some((horizontal, vertical)),
-            TouchTransform::TransposeMirrorY => {
-                Some((horizontal, self.height.checked_sub(1 + vertical)?))
-            }
-            TouchTransform::TransposeMirrorX => {
-                Some((self.width.checked_sub(1 + horizontal)?, vertical))
-            }
-            TouchTransform::Direct => Some((
+        // The swap decides which raw axis feeds which display axis; the
+        // mirrors are then applied in display space, after scaling. Doing the
+        // mirrors before the scale rounds differently at the extremes.
+        let (mut x, mut y) = if self.mapping.swap_axes {
+            (
+                scale_touch_axis(raw_y, profile.touch_y_min, profile.touch_y_max, self.width)?,
+                scale_touch_axis(raw_x, profile.touch_x_min, profile.touch_x_max, self.height)?,
+            )
+        } else {
+            (
                 scale_touch_axis(raw_x, profile.touch_x_min, profile.touch_x_max, self.width)?,
                 scale_touch_axis(raw_y, profile.touch_y_min, profile.touch_y_max, self.height)?,
-            )),
+            )
+        };
+        if self.mapping.mirror_x {
+            x = self.width.checked_sub(1 + x)?;
         }
+        if self.mapping.mirror_y {
+            y = self.height.checked_sub(1 + y)?;
+        }
+        Some((x, y))
     }
 
     /// Converts a visible display coordinate back into raw touch space at this
@@ -720,33 +897,28 @@ impl<'a> PanelPose<'a> {
         if x >= self.width || y >= self.height {
             return None;
         }
-        let (raw_x, raw_y) = match self.transform {
-            TouchTransform::Transpose => (
+        // The exact inverse: undo the display-space mirrors first, then undo
+        // the swap. Any other order is a different transform.
+        let x = if self.mapping.mirror_x {
+            self.width.checked_sub(1 + x)?
+        } else {
+            x
+        };
+        let y = if self.mapping.mirror_y {
+            self.height.checked_sub(1 + y)?
+        } else {
+            y
+        };
+        let (raw_x, raw_y) = if self.mapping.swap_axes {
+            (
                 scale_display_axis(y, self.height, profile.touch_x_min, profile.touch_x_max)?,
                 scale_display_axis(x, self.width, profile.touch_y_min, profile.touch_y_max)?,
-            ),
-            TouchTransform::TransposeMirrorY => (
-                scale_display_axis(
-                    self.height.checked_sub(1 + y)?,
-                    self.height,
-                    profile.touch_x_min,
-                    profile.touch_x_max,
-                )?,
-                scale_display_axis(x, self.width, profile.touch_y_min, profile.touch_y_max)?,
-            ),
-            TouchTransform::TransposeMirrorX => (
-                scale_display_axis(y, self.height, profile.touch_x_min, profile.touch_x_max)?,
-                scale_display_axis(
-                    self.width.checked_sub(1 + x)?,
-                    self.width,
-                    profile.touch_y_min,
-                    profile.touch_y_max,
-                )?,
-            ),
-            TouchTransform::Direct => (
+            )
+        } else {
+            (
                 scale_display_axis(x, self.width, profile.touch_x_min, profile.touch_x_max)?,
                 scale_display_axis(y, self.height, profile.touch_y_min, profile.touch_y_max)?,
-            ),
+            )
         };
         if !(profile.touch_x_min..=profile.touch_x_max).contains(&raw_x)
             || !(profile.touch_y_min..=profile.touch_y_max).contains(&raw_y)
@@ -969,7 +1141,7 @@ fn compare_identity(blockers: &mut Vec<String>, name: &str, expected: &str, actu
 
 #[cfg(test)]
 mod tests {
-    use super::PanelPose;
+    use super::{PanelPose, PoseError, TouchMapping, TouchTransform, SUPPORTED_PROFILES};
 
     /// The Libra 2 at the pose it was measured in: page-turn buttons on the
     /// right, which this device reports as rotation 1. Every display
@@ -1072,6 +1244,156 @@ mod tests {
     /// round trip through `display_to_touch` proves only that the inverse is
     /// an inverse. An earlier version of this test asserted both and passed
     /// while the transform was inverted by the full height of the panel.
+    /// Every profile's declared mapping is written in the frame it was
+    /// measured at, until `validate` accepts more than one pose. Without this,
+    /// `reference_rotation` is a second copy of a fact with nothing checking
+    /// the two agree, which is the drift this log keeps recording.
+    #[test]
+    fn reference_rotation_matches_the_measured_rotation_on_every_profile() {
+        for profile in SUPPORTED_PROFILES {
+            assert_eq!(
+                profile.reference_rotation, profile.rotation,
+                "{} declares a reference frame it was not measured in",
+                profile.id
+            );
+        }
+    }
+
+    /// The composed mapping at the buttons-left pose, against the raw
+    /// coordinates physically measured there.
+    ///
+    /// The expected values are hand-derived and written as literals: each is
+    /// the rotate 1 answer for the same physical corner, turned through 180
+    /// degrees. Nothing under test computed them. A fixture whose expectations
+    /// come from running the composition asserts only that the code agrees with
+    /// itself.
+    ///
+    /// Each tap is named by both anchors, buttons and port, rather than by its
+    /// position in a table. Matching a rotate 3 tap against the wrong rotate 1
+    /// tap produces a plausible answer that is wrong by most of the panel, and
+    /// that mistake was made once while this fixture was being reviewed.
+    ///
+    /// Predicted before the panel was ever driven at this pose. The rendered
+    /// mark experiment in the port log is what confirms the premise underneath
+    /// it: the driver says the controller intends to rotate the image, and only
+    /// the panel says it does.
+    #[test]
+    fn libra_2_composed_touch_at_the_buttons_left_pose() {
+        let pose = PanelPose::for_test(&LIBRA_2_388, 3).expect("a half turn from the reference");
+        assert_eq!(
+            pose.touch_mapping(),
+            TouchMapping {
+                swap_axes: true,
+                mirror_x: true,
+                mirror_y: true,
+            },
+            "a half turn flips both mirrors and leaves the swap alone"
+        );
+
+        // Buttons left, port bottom edge. Raw values measured on the device.
+        let far_from_buttons_away_from_port = pose
+            .touch_to_display(1587, 72)
+            .expect("measured tap maps to the display");
+        let far_from_buttons_port_edge = pose
+            .touch_to_display(96, 75)
+            .expect("measured tap maps to the display");
+        let near_buttons_port_edge = pose
+            .touch_to_display(95, 1168)
+            .expect("measured tap maps to the display");
+
+        assert_eq!(far_from_buttons_away_from_port, (1191, 93));
+        assert_eq!(far_from_buttons_port_edge, (1188, 1583));
+        assert_eq!(near_buttons_port_edge, (96, 1584));
+
+        // The assertion that actually carries this test. The digitiser does not
+        // move, so one raw coordinate mapped at both poses must land at
+        // diametrically opposite display points. If the composition were the
+        // identity, which is the likeliest bug in this step, every corner
+        // assertion and every round trip below still passes and this fails.
+        let reference = PanelPose::reference(&LIBRA_2_388);
+        for raw in [(1587, 72), (96, 75), (95, 1168), (800, 600)] {
+            let upright = reference
+                .touch_to_display(raw.0, raw.1)
+                .expect("maps at the reference pose");
+            let turned = pose
+                .touch_to_display(raw.0, raw.1)
+                .expect("maps at the turned pose");
+            assert_eq!(
+                upright.0 + turned.0,
+                LIBRA_2_388.width - 1,
+                "x is not diametrically opposite for raw {raw:?}"
+            );
+            assert_eq!(
+                upright.1 + turned.1,
+                LIBRA_2_388.height - 1,
+                "y is not diametrically opposite for raw {raw:?}"
+            );
+        }
+
+        // The L walks the other way round at this pose. Stated as gradients so
+        // that a mirrored axis fails here even if the literals above are edited
+        // to match a broken implementation.
+        assert!(
+            far_from_buttons_port_edge.1 > far_from_buttons_away_from_port.1,
+            "increasing raw x must run up the display at this pose"
+        );
+        assert!(
+            far_from_buttons_port_edge.0 > near_buttons_port_edge.0,
+            "increasing raw y must run left across the display at this pose"
+        );
+    }
+
+    /// A quarter turn is refused rather than guessed. The clockwise and
+    /// anticlockwise numbering is board-dependent in the driver and this board
+    /// has not been read for it, so a quarter turn is the case where the
+    /// ambiguity decides the answer.
+    #[test]
+    fn a_quarter_turn_from_the_reference_is_refused() {
+        for rotation in [0, 2] {
+            assert_eq!(
+                PanelPose::for_test(&LIBRA_2_388, rotation),
+                Err(PoseError::UnsupportedRotationDelta {
+                    observed: rotation,
+                    reference: 1,
+                })
+            );
+        }
+    }
+
+    /// All four declared transforms survive the round trip through the
+    /// composable form, and a half turn is its own inverse.
+    #[test]
+    fn lowering_preserves_every_declared_transform() {
+        let lowered = [
+            (TouchTransform::Direct, (false, false, false)),
+            (TouchTransform::Transpose, (true, false, false)),
+            (TouchTransform::TransposeMirrorY, (true, false, true)),
+            (TouchTransform::TransposeMirrorX, (true, true, false)),
+        ];
+        for (transform, (swap_axes, mirror_x, mirror_y)) in lowered {
+            let mapping = transform.lower();
+            assert_eq!(
+                mapping,
+                TouchMapping {
+                    swap_axes,
+                    mirror_x,
+                    mirror_y
+                },
+                "{transform:?} lowered into the wrong frame"
+            );
+            assert_eq!(
+                mapping.rotated_180().rotated_180(),
+                mapping,
+                "two half turns are not the identity for {transform:?}"
+            );
+            assert_ne!(
+                mapping.rotated_180(),
+                mapping,
+                "a half turn changed nothing for {transform:?}"
+            );
+        }
+    }
+
     #[test]
     fn libra_2_touch_matches_three_physically_measured_taps() {
         // Tap 1, top-left corner of the image.

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -104,7 +104,81 @@ pub const ELIPSA_2E_389: DeviceProfile = DeviceProfile {
     kernel_release: "4.9.77",
 };
 
-pub const SUPPORTED_PROFILES: &[&DeviceProfile] = &[&CLARA_BW_391, &ELIPSA_2E_389];
+/// Kobo Libra 2, codename `io`, an i.MX6SLL Mark 7 device driven by
+/// `mxc_epdc_fb` rather than by `hwtcon`.
+///
+/// Measured with `kobo doctor` against a device on firmware 4.38.23697, from a
+/// cold boot into Nickel with nothing else launched.
+///
+/// The geometry below is the portrait state. Six of these fields move when the
+/// reader is rotated: `width` and `height` exchange, `virtual_width` becomes
+/// 1696 and `virtual_height` 1280, `stride` becomes 6784, and `rotation`
+/// becomes 2. The alignment differs as well, 128 in portrait against 32 in
+/// landscape, so it is not a simple exchange. `memory_length` does not move,
+/// being allocated once at the larger of the two, and neither do the bitfields
+/// or the touch ranges, since the controller reports in panel coordinates
+/// whatever the screen is doing.
+///
+/// So this profile matches the device in portrait and rejects it in landscape.
+/// Nothing about that is specific to the Libra 2, since every Kobo rotates and
+/// nothing here sets the mode it wants: `FBIOGET_VSCREENINFO` is read and
+/// `FBIOPUT_VSCREENINFO` is never sent, so whatever the previous application
+/// left is what gets validated. Relaxing the comparison would not be a fix on
+/// its own, because `rotation` also selects the touch transform in
+/// `touch_to_display`, so a device accepted at the wrong rotation would have
+/// its touch input placed wrongly.
+pub const LIBRA_2_388: DeviceProfile = DeviceProfile {
+    id: "libra-2-388",
+    model: "Kobo Libra 2",
+    device_code: 388,
+    device_tree_model: "Freescale i.MX6SLL NTX Board",
+    compatible_fragments: &["fsl,imx6sll"],
+    framebuffer_id: "mxc_epdc_fb",
+    width: 1264,
+    height: 1680,
+    pixels_per_inch: 300,
+    virtual_width: 1280,
+    virtual_height: 1792,
+    x_offset: 0,
+    y_offset: 0,
+    bits_per_pixel: 32,
+    grayscale: 0,
+    stride: 5120,
+    memory_length: 9_175_040,
+    framebuffer_kind: 0,
+    framebuffer_visual: 2,
+    rotation: 1,
+    red: Bitfield {
+        offset: 16,
+        length: 8,
+        msb_right: 0,
+    },
+    green: Bitfield {
+        offset: 8,
+        length: 8,
+        msb_right: 0,
+    },
+    blue: Bitfield {
+        offset: 0,
+        length: 8,
+        msb_right: 0,
+    },
+    alpha: Bitfield {
+        offset: 24,
+        length: 8,
+        msb_right: 0,
+    },
+    touch_name: "Elan Touchscreen",
+    touch_x_min: 0,
+    touch_x_max: 1680,
+    touch_y_min: 0,
+    touch_y_max: 1264,
+    serial_prefix: "N418",
+    firmware_version: "4.38.23697",
+    kernel_release: "4.1.15-00868-g58a2758be07",
+};
+
+pub const SUPPORTED_PROFILES: &[&DeviceProfile] = &[&CLARA_BW_391, &ELIPSA_2E_389, &LIBRA_2_388];
 
 #[must_use]
 pub fn identify_profile(snapshot: &DeviceSnapshot) -> Option<&'static DeviceProfile> {
@@ -644,8 +718,109 @@ fn compare_identity(blockers: &mut Vec<String>, name: &str, expected: &str, actu
 mod tests {
     use super::{
         Bitfield, DeviceSnapshot, FramebufferSnapshot, IdentitySnapshot, Readiness, TouchSnapshot,
-        CLARA_BW_391, ELIPSA_2E_389,
+        CLARA_BW_391, ELIPSA_2E_389, LIBRA_2_388,
     };
+
+    /// The Libra 2 as `kobo doctor` read it from a cold boot into Nickel, in
+    /// portrait. `rotation` picks the orientation: 1 as measured in portrait,
+    /// 2 as measured with the reader turned.
+    fn measured_libra_2(rotation: u32) -> DeviceSnapshot {
+        let red = Bitfield {
+            offset: 16,
+            length: 8,
+            msb_right: 0,
+        };
+        let landscape = rotation == 2;
+        DeviceSnapshot {
+            compatible: vec!["fsl,imx6sll-lpddr3-arm2".into(), "fsl,imx6sll".into()],
+            model: Some("Freescale i.MX6SLL NTX Board".into()),
+            framebuffer: Some(FramebufferSnapshot {
+                id: "mxc_epdc_fb".into(),
+                width: if landscape { 1680 } else { 1264 },
+                height: if landscape { 1264 } else { 1680 },
+                virtual_width: if landscape { 1696 } else { 1280 },
+                virtual_height: if landscape { 1280 } else { 1792 },
+                x_offset: 0,
+                y_offset: 0,
+                bits_per_pixel: 32,
+                grayscale: 0,
+                stride: if landscape { 6784 } else { 5120 },
+                memory_length: 9_175_040,
+                kind: 0,
+                visual: 2,
+                rotation,
+                red,
+                green: Bitfield { offset: 8, ..red },
+                blue: Bitfield { offset: 0, ..red },
+                alpha: Bitfield { offset: 24, ..red },
+            }),
+            touch: Some(TouchSnapshot {
+                path: "/dev/input/event1".into(),
+                name: "Elan Touchscreen".into(),
+                x_min: 0,
+                x_max: 1680,
+                y_min: 0,
+                y_max: 1264,
+            }),
+            identity: IdentitySnapshot {
+                serial_prefix: Some("N418".into()),
+                firmware_version: Some("4.38.23697".into()),
+                kernel_release: Some("4.1.15-00868-g58a2758be07".into()),
+                device_code: Some(388),
+            },
+        }
+    }
+
+    #[test]
+    fn libra_2_matches_the_measured_portrait_device() {
+        let snapshot = measured_libra_2(1);
+        let report = LIBRA_2_388.validate(&snapshot);
+        assert!(report.mismatches.is_empty(), "{:?}", report.mismatches);
+        assert_eq!(report.readiness, Readiness::ReadOnlyMatched);
+        assert!(LIBRA_2_388.write_identity_blockers(&snapshot).is_empty());
+        assert_eq!(
+            super::identify_profile(&snapshot).map(|profile| profile.id),
+            Some("libra-2-388")
+        );
+    }
+
+    /// Rotating the reader moves six of the compared fields, so the same
+    /// hardware stops matching. This is recorded rather than desired: the
+    /// values come from the device, and the test exists so that the day
+    /// somebody fixes it, they have to say so here.
+    #[test]
+    fn libra_2_rejects_the_same_device_in_landscape() {
+        let snapshot = measured_libra_2(2);
+        let report = LIBRA_2_388.validate(&snapshot);
+        assert_eq!(report.readiness, Readiness::Rejected);
+        assert_eq!(report.mismatches.len(), 6);
+        assert!(super::identify_profile(&snapshot).is_none());
+        assert!(
+            LIBRA_2_388.write_identity_blockers(&snapshot).is_empty(),
+            "identity is unaffected by orientation"
+        );
+    }
+
+    #[test]
+    fn libra_2_touch_edges_stay_inside_the_panel_and_round_trip() {
+        for raw in [(0, 0), (0, 1264), (1680, 0), (1680, 1264)] {
+            let display = LIBRA_2_388
+                .touch_to_display(raw.0, raw.1)
+                .expect("measured Libra 2 edge maps to the display");
+            assert!(display.0 < LIBRA_2_388.width, "x escaped: {display:?}");
+            assert!(display.1 < LIBRA_2_388.height, "y escaped: {display:?}");
+        }
+        assert_eq!(LIBRA_2_388.touch_to_display(0, 0), Some((0, 1679)));
+        assert_eq!(LIBRA_2_388.touch_to_display(1680, 1264), Some((1263, 0)));
+        for display in [(0, 0), (1263, 0), (0, 1679), (1263, 1679), (632, 840)] {
+            let raw = LIBRA_2_388
+                .display_to_touch(display.0, display.1)
+                .expect("Libra 2 display point maps to the controller");
+            assert_eq!(LIBRA_2_388.touch_to_display(raw.0, raw.1), Some(display));
+        }
+        assert_eq!(LIBRA_2_388.display_to_touch(1264, 0), None);
+        assert_eq!(LIBRA_2_388.display_to_touch(0, 1680), None);
+    }
 
     #[test]
     fn touch_transform_matches_measured_corners() {

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -11,7 +11,7 @@ use std::fmt;
 /// declared per profile and has to be measured with `kobo touch-probe` rather
 /// than derived.
 ///
-/// # Why this is only safe while `rotation` is matched exactly
+/// # Why this is only safe at rotations in the verified set
 ///
 /// A value here is a composition of two separate facts, and only one of them
 /// belongs in a profile. How the digitiser sits under the panel is fixed in
@@ -21,15 +21,18 @@ use std::fmt;
 /// upright reports 1, with every geometry field unchanged, and it flips as the
 /// reader is handled.
 ///
-/// So a variant here is correct only at the rotation it was measured at. That
-/// holds today because `validate` compares `rotation` exactly, and a session
-/// cannot open unless the device is in the state the profile was measured in.
-/// The refusal is doing double duty: it is the thing that keeps this field
-/// honest.
+/// So a variant here is correct as written only at the rotation it was
+/// measured at, named by `reference_rotation`. At any other rotation in the
+/// profile's `verified_rotations` it is composed with the half-turn delta by
+/// [`PanelPose`], which is what keeps this field honest now that `validate`
+/// accepts more than one pose. Both halves were confirmed on the Libra 2
+/// panel on 2026-08-22: the digitiser measured panel-fixed by corner at both
+/// poses, and rendered marks at rotation 3 appearing diametrically opposite
+/// their rotation 1 positions.
 ///
-/// Anyone relaxing the `rotation` comparison, which the orientation behaviour
-/// otherwise invites, has to replace this field at the same time. Touch would
-/// not fail loudly. It would land in the wrong place. As evidence that the
+/// Anyone widening a profile's `verified_rotations` has to measure the pose
+/// first, on the panel and on the digitiser both. Touch would not fail
+/// loudly. It would land in the wrong place. As evidence that the
 /// composition really is what is encoded here: the 180-degree case would need
 /// a transpose with both axes mirrored, and there is deliberately no such
 /// variant, because a profile has no business describing which way up someone
@@ -50,7 +53,8 @@ pub enum TouchTransform {
     ///
     /// The reader was held with its page-turn buttons on the right throughout,
     /// which is the pose this device reports as `rotation: 1`. Buttons on the
-    /// left is `rotation: 3`, and the profile refuses that pose. Anyone
+    /// left is `rotation: 3`, a half turn away, which the profile accepts by
+    /// composing this mapping with the delta — see [`PanelPose`]. Anyone
     /// repeating the measurement has to say which side the buttons are on:
     /// "portrait" alone names two orientations 180 degrees apart, and the
     /// digitiser tells them apart even when the screen does not.
@@ -105,6 +109,59 @@ impl TouchTransform {
             },
         }
     }
+}
+
+/// How a profile's pose geometry follows from its panel dimensions.
+///
+/// The pose fields a framebuffer reports — virtual width, virtual height and
+/// stride — are not independent hardware facts. They are computed by the
+/// display driver from the visible geometry, and a profile that stores them as
+/// constants is storing a photograph of one pose. This names the computation
+/// instead, per profile, so that validation can derive the expectation for any
+/// rotation in the verified set rather than matching one snapshot.
+///
+/// For every rotation a profile currently verifies the derived values are
+/// numerically identical to the constants the profile also carries, and the
+/// tests pin that. What changes is the kind of check: consistency with the
+/// driver's rule rather than identity with one photograph. A firmware that
+/// changed the driver's alignment would pass here where a constant would fail
+/// loudly; the conformance harness in `tools/abi/check-mxcfb.sh` is where that
+/// belongs instead.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GeometryRule {
+    /// Pose fields are exact-matched constants.
+    ///
+    /// The MediaTek devices keep this, for the same reason the touch transform
+    /// is per-profile: do not silently change a device nobody here can test.
+    Fixed,
+    /// The i.MX6 EPDC v2 derivation, read out of the vendor driver source
+    /// (`mxc_epdc_v2_fb.c`) rather than fitted to observations:
+    ///
+    /// - `xres_virtual = ALIGN(xres, 32)` — the alignment is in pixels, not
+    ///   bytes, per `:3567`; the driver's own comment says bytes and is wrong.
+    /// - `yres_virtual = ALIGN(yres, 128) * num_screens / page_scale` per
+    ///   `:3568`, where `page_scale` is `bits_per_pixel / 16` with 16 the
+    ///   driver's `default_bpp`. The two factors cancel at 32 bpp and nowhere
+    ///   else.
+    /// - `line_length = xres_virtual * bits_per_pixel / 8` per `:3215`.
+    ///
+    /// `memory_length` is deliberately not derived. The driver fixes it at
+    /// probe time from the panel's native mode, taking the larger product
+    /// across orientations, and never recomputes it, so it stays an
+    /// exact-matched constant on the profile.
+    MxcEpdcV2 {
+        /// The driver's `num_screens`, computed on the device from a
+        /// device-tree memory size. A named assumption rather than a constant
+        /// of the rule: two hardware revisions ship under the Libra 2's device
+        /// code, and a revision with a different value would move the virtual
+        /// height. Observation matches 2.
+        num_screens: u32,
+    },
+}
+
+/// `ALIGN(value, to)` as the kernel macro does it: round up to a multiple.
+const fn align_up(value: u32, to: u32) -> u32 {
+    value.div_ceil(to) * to
 }
 
 /// A touch mapping that can be composed with a live rotation.
@@ -206,6 +263,8 @@ pub const CLARA_BW_391: DeviceProfile = DeviceProfile {
     },
     touch_transform: TouchTransform::TransposeMirrorX,
     reference_rotation: 3,
+    verified_rotations: &[3],
+    geometry_rule: GeometryRule::Fixed,
     touch_name: "cyttsp5_mt",
     touch_x_min: 0,
     touch_x_max: 1447,
@@ -259,6 +318,8 @@ pub const ELIPSA_2E_389: DeviceProfile = DeviceProfile {
     },
     touch_transform: TouchTransform::TransposeMirrorY,
     reference_rotation: 1,
+    verified_rotations: &[1],
+    geometry_rule: GeometryRule::Fixed,
     touch_name: "Elan Touchscreen",
     touch_x_min: 0,
     touch_x_max: 1872,
@@ -338,6 +399,12 @@ pub const LIBRA_2_388: DeviceProfile = DeviceProfile {
     },
     touch_transform: TouchTransform::Transpose,
     reference_rotation: 1,
+    // Rotation 3 was verified on the device on 2026-08-22: the digitiser
+    // measured panel-fixed by corner at both poses, and rendered marks at
+    // rotation 3 appeared diametrically opposite their rotation 1 positions,
+    // both exactly as the half-turn composition predicts.
+    verified_rotations: &[1, 3],
+    geometry_rule: GeometryRule::MxcEpdcV2 { num_screens: 2 },
     touch_name: "Elan Touchscreen",
     touch_x_min: 0,
     touch_x_max: 1680,
@@ -506,6 +573,19 @@ pub struct DeviceProfile {
     /// every profile and which answers a different question: `rotation` is a
     /// pose snapshot that moves as the reader is handled, and this does not.
     pub reference_rotation: u32,
+    /// The rotations this profile has been verified at, on the digitiser and
+    /// on the panel both.
+    ///
+    /// Validation accepts a device only at a rotation in this set, and
+    /// [`PanelPose::resolve`] refuses any other. Every entry must differ from
+    /// `reference_rotation` by zero or a half turn, because that is all
+    /// [`PanelPose`] can compose; a quarter turn entry would be refused at
+    /// resolve time anyway, loudly. Widening this set is a measurement, not an
+    /// edit: both the digitiser mapping and the image placement have to be
+    /// confirmed on the physical device at the new pose first.
+    pub verified_rotations: &'static [u32],
+    /// How the pose geometry fields follow from the panel dimensions.
+    pub geometry_rule: GeometryRule,
     pub touch_name: &'static str,
     pub touch_x_min: i32,
     pub touch_x_max: i32,
@@ -514,6 +594,14 @@ pub struct DeviceProfile {
     pub serial_prefix: &'static str,
     pub firmware_version: &'static str,
     pub kernel_release: &'static str,
+}
+
+/// Pose geometry derived by a profile's [`GeometryRule`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ExpectedGeometry {
+    pub virtual_width: u32,
+    pub virtual_height: u32,
+    pub stride: u32,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -592,6 +680,33 @@ impl DeviceProfile {
         }
     }
 
+    /// The pose geometry this profile expects a framebuffer to report.
+    ///
+    /// Derived from the panel dimensions by the profile's [`GeometryRule`],
+    /// or the stored constants under [`GeometryRule::Fixed`]. Every rotation
+    /// in the verified set is a half turn from the reference, which preserves
+    /// width and height, so the visible dimensions are the profile's own at
+    /// every rotation validation can accept.
+    #[must_use]
+    pub const fn expected_geometry(&self) -> ExpectedGeometry {
+        match self.geometry_rule {
+            GeometryRule::Fixed => ExpectedGeometry {
+                virtual_width: self.virtual_width,
+                virtual_height: self.virtual_height,
+                stride: self.stride,
+            },
+            GeometryRule::MxcEpdcV2 { num_screens } => {
+                let virtual_width = align_up(self.width, 32);
+                let page_scale = self.bits_per_pixel / 16;
+                ExpectedGeometry {
+                    virtual_width,
+                    virtual_height: align_up(self.height, 128) * num_screens / page_scale,
+                    stride: virtual_width * self.bits_per_pixel / 8,
+                }
+            }
+        }
+    }
+
     /// Returns the reasons this device may not be written to.
     ///
     /// Hardware geometry alone is not proof of identity, because another device
@@ -644,7 +759,10 @@ impl DeviceProfile {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PoseError {
     /// The device is in an orientation this profile has not been measured in.
-    UnverifiedRotation { observed: u32, expected: u32 },
+    UnverifiedRotation {
+        observed: u32,
+        verified: &'static [u32],
+    },
     /// The visible geometry disagrees with the profile at an orientation the
     /// profile does claim to describe.
     GeometryMismatch { field: &'static str, observed: u32, expected: u32 },
@@ -658,9 +776,9 @@ pub enum PoseError {
 impl fmt::Display for PoseError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::UnverifiedRotation { observed, expected } => write!(
+            Self::UnverifiedRotation { observed, verified } => write!(
                 formatter,
-                "device is at rotation {observed}, and this profile is only measured at {expected}"
+                "device is at rotation {observed}, and this profile is only verified at {verified:?}"
             ),
             Self::GeometryMismatch {
                 field,
@@ -691,17 +809,16 @@ impl fmt::Display for PoseError {
 /// pairing of the two, resolved once, at the point where a live framebuffer is
 /// available.
 ///
-/// # What this does and does not do yet
+/// # What this does
 ///
-/// Today `resolve` accepts only the rotation the profile was measured at, so a
-/// pose carries exactly the values the profile does and nothing observable
-/// changes. That is deliberate. The transform can only be composed with live
-/// rotation once `validate` accepts more than one pose, and `validate` can only
-/// accept more than one pose once the transform composes. Doing either alone is
-/// worse than doing neither: composing early buys nothing, and relaxing early
-/// puts taps in the wrong place without failing.
+/// `resolve` accepts any rotation in the profile's verified set and composes
+/// the digitiser mapping with the half-turn delta from the reference frame.
+/// Composition landed before validation relaxed, in that order deliberately:
+/// composing early buys nothing but is safe, where relaxing early would have
+/// put taps in the wrong place without failing. Both poses were confirmed on
+/// the Libra 2 panel before validation was widened.
 ///
-/// This type exists so those two can land in that order. It is also the shape
+/// This type is also the shape
 /// live re-resolution would need, if the reader is ever to be turned over
 /// mid-session, which is out of scope here.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -780,8 +897,7 @@ impl<'a> PanelPose<'a> {
 
     /// Resolves a pose against a live framebuffer.
     ///
-    /// Refuses any orientation this profile cannot describe, which is
-    /// currently every orientation but the one it was measured in. The refusal
+    /// Refuses any orientation outside the profile's verified set. The refusal
     /// is the point: an unresolvable pose has to stay a refusal rather than
     /// fall back on the reference, since the fallback would be a transform
     /// wrong by the height of the panel, and wrong silently.
@@ -799,10 +915,10 @@ impl<'a> PanelPose<'a> {
         profile: &'a DeviceProfile,
         framebuffer: &FramebufferSnapshot,
     ) -> Result<Self, PoseError> {
-        if framebuffer.rotation != profile.rotation {
+        if !profile.verified_rotations.contains(&framebuffer.rotation) {
             return Err(PoseError::UnverifiedRotation {
                 observed: framebuffer.rotation,
-                expected: profile.rotation,
+                verified: profile.verified_rotations,
             });
         }
         for (field, observed, expected) in [
@@ -969,17 +1085,18 @@ fn validate_framebuffer(
     );
     compare(mismatches, "width", framebuffer.width, profile.width);
     compare(mismatches, "height", framebuffer.height, profile.height);
+    let expected = profile.expected_geometry();
     compare(
         mismatches,
         "virtual width",
         framebuffer.virtual_width,
-        profile.virtual_width,
+        expected.virtual_width,
     );
     compare(
         mismatches,
         "virtual height",
         framebuffer.virtual_height,
-        profile.virtual_height,
+        expected.virtual_height,
     );
     compare(
         mismatches,
@@ -994,7 +1111,7 @@ fn validate_framebuffer(
         profile.y_offset,
     );
     validate_pixel_format(profile, framebuffer, mismatches, blockers);
-    compare(mismatches, "stride", framebuffer.stride, profile.stride);
+    compare(mismatches, "stride", framebuffer.stride, expected.stride);
     compare(
         mismatches,
         "memory length",
@@ -1013,12 +1130,12 @@ fn validate_framebuffer(
         framebuffer.visual,
         profile.framebuffer_visual,
     );
-    compare(
-        mismatches,
-        "rotation",
-        framebuffer.rotation,
-        profile.rotation,
-    );
+    if !profile.verified_rotations.contains(&framebuffer.rotation) {
+        mismatches.push(format!(
+            "rotation: {} is not in this profile's verified set {:?}",
+            framebuffer.rotation, profile.verified_rotations
+        ));
+    }
 
     if framebuffer.virtual_width < framebuffer.width
         || framebuffer.virtual_height < framebuffer.height
@@ -1233,6 +1350,95 @@ mod tests {
             LIBRA_2_388.write_identity_blockers(&snapshot).is_empty(),
             "identity is unaffected by orientation"
         );
+    }
+
+    /// The same hardware with the buttons on the left, which it reports as
+    /// rotation 3 with every geometry field unchanged. Accepted since the pose
+    /// was verified on the device on 2026-08-22: digitiser measured
+    /// panel-fixed by corner, rendered marks landing diametrically opposite
+    /// their rotation 1 positions.
+    #[test]
+    fn libra_2_matches_the_same_device_buttons_left() {
+        let snapshot = measured_libra_2(3);
+        let report = LIBRA_2_388.validate(&snapshot);
+        assert!(report.mismatches.is_empty(), "{:?}", report.mismatches);
+        assert_eq!(report.readiness, Readiness::ReadOnlyMatched);
+        assert_eq!(
+            super::identify_profile(&snapshot).map(|profile| profile.id),
+            Some("libra-2-388")
+        );
+        let pose = PanelPose::resolve(
+            &LIBRA_2_388,
+            snapshot.framebuffer.as_ref().expect("a framebuffer"),
+        )
+        .expect("a verified pose resolves");
+        assert_eq!(
+            pose.touch_mapping(),
+            TouchMapping {
+                swap_axes: true,
+                mirror_x: true,
+                mirror_y: true,
+            },
+            "the resolved pose carries the composed mapping, not the reference one"
+        );
+    }
+
+    /// `resolve` at an unverified rotation is a loud refusal, not a fallback
+    /// to the reference mapping, which would be wrong by the height of the
+    /// panel and wrong silently.
+    #[test]
+    fn resolve_refuses_an_unverified_rotation() {
+        let snapshot = measured_libra_2(2);
+        let error = PanelPose::resolve(
+            &LIBRA_2_388,
+            snapshot.framebuffer.as_ref().expect("a framebuffer"),
+        )
+        .expect_err("landscape has never been measured");
+        assert_eq!(
+            error,
+            PoseError::UnverifiedRotation {
+                observed: 2,
+                verified: &[1, 3],
+            }
+        );
+    }
+
+    /// The derived geometry is numerically identical to the constants each
+    /// profile also stores, so relaxing validation to the derived expectation
+    /// accepted nothing the constants would have rejected.
+    #[test]
+    fn every_profile_derives_the_geometry_it_stores() {
+        for profile in SUPPORTED_PROFILES {
+            let expected = profile.expected_geometry();
+            assert_eq!(
+                (expected.virtual_width, expected.virtual_height, expected.stride),
+                (profile.virtual_width, profile.virtual_height, profile.stride),
+                "{} derives geometry it was not measured to have",
+                profile.id
+            );
+        }
+    }
+
+    /// Every verified rotation must be composable, meaning a half turn or
+    /// none from the reference frame. A quarter-turn entry would pass
+    /// validation and then fail at resolve, which is loud but later than it
+    /// needs to be.
+    #[test]
+    fn every_verified_rotation_is_composable_on_every_profile() {
+        for profile in SUPPORTED_PROFILES {
+            assert!(
+                profile.verified_rotations.contains(&profile.reference_rotation),
+                "{} does not verify its own reference frame",
+                profile.id
+            );
+            for rotation in profile.verified_rotations {
+                assert!(
+                    (rotation % 4 + 4 - profile.reference_rotation % 4) % 4 % 2 == 0,
+                    "{} verifies rotation {rotation}, a quarter turn from its reference",
+                    profile.id
+                );
+            }
+        }
     }
 
     /// Captured from three physical taps on the real Libra 2 with

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -75,17 +75,17 @@ pub enum TouchTransform {
     /// Axes exchanged and Y mirrored.
     ///
     /// This is what every `rotation: 1` device did before the transform became
-    /// explicit. It is preserved for the Elipsa 2E so that its behaviour does
-    /// not change, but it has never been checked against a real finger: its
-    /// test asserts only the arithmetic it was derived from. The Libra 2 is
-    /// also `rotation: 1`, also an Elan controller, and measured as a plain
-    /// `Transpose`, so this variant is the likeliest place for a latent bug on
-    /// a device nobody here can test.
+    /// explicit. It is preserved for the Elipsa 2E, where it is backed by a
+    /// touch captured on the real device: see
+    /// `elipsa_touch_transform_matches_a_physically_measured_touch`. The Libra
+    /// 2 is also `rotation: 1`, also an Elan controller, and measured as a
+    /// plain `Transpose`, so the two `rotation: 1` devices genuinely differ
+    /// and neither can be inferred from the other.
     TransposeMirrorY,
     /// Axes exchanged and X mirrored.
     ///
-    /// Confirmed on the Clara BW, which is the only transform here backed by a
-    /// physically captured touch.
+    /// Confirmed on the Clara BW and the Clara HD, each by a physically
+    /// captured touch.
     TransposeMirrorX,
 }
 
@@ -1413,10 +1413,12 @@ mod tests {
     const LIBRA_2_POSE: PanelPose<'static> = PanelPose::reference(&LIBRA_2_388);
     const CLARA_BW_POSE: PanelPose<'static> = PanelPose::reference(&CLARA_BW_391);
     const ELIPSA_2E_POSE: PanelPose<'static> = PanelPose::reference(&ELIPSA_2E_389);
+    const CLARA_HD_POSE: PanelPose<'static> = PanelPose::reference(&CLARA_HD_376);
 
     use super::{
         Bitfield, DeviceProfile, DeviceSnapshot, FramebufferSnapshot, IdentitySnapshot, Readiness,
-        TouchSnapshot, CLARA_BW_391, ELIPSA_2E_389, LIBRA_2_388, WRITE_EVIDENCE_PENDING,
+        TouchSnapshot, CLARA_BW_391, CLARA_HD_376, ELIPSA_2E_389, LIBRA_2_388,
+        WRITE_EVIDENCE_PENDING,
     };
 
     /// The Libra 2 as `kobo doctor` read it from a cold boot into Nickel, in
@@ -1891,6 +1893,131 @@ mod tests {
             .expect("in range");
         assert_eq!(flipped_x, (962, 110));
         assert_eq!(flipped_y, (109, 1337));
+    }
+
+    /// Captured from a physical touch about a centimetre in from the top-left
+    /// of the Elipsa 2E. Carried over from the pre-`PanelPose` API unchanged:
+    /// the expected values are the ones measured on that hardware, not values
+    /// re-derived from the transform they are meant to pin.
+    #[test]
+    fn elipsa_touch_transform_matches_a_physically_measured_touch() {
+        let mapped = ELIPSA_2E_POSE
+            .touch_to_display(1838, 30)
+            .expect("the measured raw Elipsa sample is in range");
+        assert_eq!(mapped, (30, 34));
+
+        // Either plausible reversed axis still produces an in-range point,
+        // but places it far from the top-left location that was touched.
+        let flipped_x = ELIPSA_2E_POSE
+            .touch_to_display(1838, 1404 - 30)
+            .expect("in range");
+        let flipped_y = ELIPSA_2E_POSE
+            .touch_to_display(1872 - 1838, 30)
+            .expect("in range");
+        assert_eq!(flipped_x, (1373, 34));
+        assert_eq!(flipped_y, (30, 1837));
+    }
+
+    /// A doctor snapshot taken from a real Clara HD, matched against the
+    /// strict profile across every reviewed firmware. This is the only pin on
+    /// hardware none of us can re-measure.
+    #[test]
+    fn clara_hd_doctor_snapshot_matches_its_strict_profile() {
+        let channel = Bitfield {
+            offset: 16,
+            length: 8,
+            msb_right: 0,
+        };
+        let mut snapshot = DeviceSnapshot {
+            compatible: vec!["fsl,imx6sll-lpddr3-arm2".into(), "fsl,imx6sll".into()],
+            model: Some("Freescale i.MX6SLL NTX Board".into()),
+            framebuffer: Some(FramebufferSnapshot {
+                id: "mxc_epdc_fb".into(),
+                width: 1072,
+                height: 1448,
+                virtual_width: 1088,
+                virtual_height: 1536,
+                x_offset: 0,
+                y_offset: 0,
+                bits_per_pixel: 32,
+                grayscale: 0,
+                stride: 4352,
+                memory_length: 6_782_976,
+                kind: 0,
+                visual: 2,
+                rotation: 3,
+                red: channel,
+                green: Bitfield {
+                    offset: 8,
+                    ..channel
+                },
+                blue: Bitfield {
+                    offset: 0,
+                    ..channel
+                },
+                alpha: Bitfield {
+                    offset: 24,
+                    ..channel
+                },
+            }),
+            touch: Some(TouchSnapshot {
+                path: "/dev/input/event1".into(),
+                name: "cyttsp5_mt".into(),
+                x_min: 0,
+                x_max: 1447,
+                y_min: 0,
+                y_max: 1071,
+            }),
+            identity: IdentitySnapshot {
+                serial_prefix: Some("N249".into()),
+                firmware_version: Some("4.38.23684".into()),
+                kernel_release: Some("4.1.15-00136-g12655eaaef89".into()),
+                device_code: Some(376),
+            },
+        };
+        for firmware in CLARA_HD_376.firmware_versions {
+            snapshot.identity.firmware_version = Some((*firmware).into());
+            let report = CLARA_HD_376.validate(&snapshot);
+            assert_eq!(report.readiness, Readiness::WriteReady);
+            assert!(report.mismatches.is_empty());
+            assert!(report.write_blockers.is_empty());
+            assert!(CLARA_HD_376.write_identity_blockers(&snapshot).is_empty());
+        }
+        assert_eq!(super::identify_profile(&snapshot), Some(&CLARA_HD_376));
+    }
+
+    #[test]
+    fn clara_hd_touch_edges_map_inside_the_panel_and_round_trip() {
+        for raw in [(0, 0), (0, 1071), (1447, 0), (1447, 1071)] {
+            let display = CLARA_HD_POSE
+                .touch_to_display(raw.0, raw.1)
+                .expect("measured Clara HD edge maps to the display");
+            assert!(display.0 < CLARA_HD_376.width, "x escaped: {display:?}");
+            assert!(display.1 < CLARA_HD_376.height, "y escaped: {display:?}");
+        }
+        for display in [(0, 0), (1071, 0), (0, 1447), (1071, 1447), (536, 724)] {
+            let raw = CLARA_HD_POSE
+                .display_to_touch(display.0, display.1)
+                .expect("Clara HD display point maps to the controller");
+            assert_eq!(CLARA_HD_POSE.touch_to_display(raw.0, raw.1), Some(display));
+        }
+    }
+
+    /// Captured from a physical touch about a centimetre in from the top-left
+    /// of the Clara HD. The axis ranges prove that the controller is rotated;
+    /// this sample proves the direction of both axes.
+    #[test]
+    fn clara_hd_touch_transform_matches_a_physically_measured_touch() {
+        assert_eq!(CLARA_HD_POSE.touch_to_display(160, 909), Some((162, 160)));
+
+        let flipped_x = CLARA_HD_POSE
+            .touch_to_display(160, 1071 - 909)
+            .expect("flipped sample remains in range");
+        let flipped_y = CLARA_HD_POSE
+            .touch_to_display(1447 - 160, 909)
+            .expect("flipped sample remains in range");
+        assert_eq!(flipped_x, (909, 160));
+        assert_eq!(flipped_y, (162, 1287));
     }
 
     #[test]

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -620,6 +620,18 @@ pub enum Message {
     CoverChanged {
         magnet_present: bool,
     },
+    /// A physical page-turn key was pressed, already resolved to intent.
+    ///
+    /// Unsolicited, the same shape as [`Message::CoverChanged`]. The runtime
+    /// owns the raw keycodes and how the reader is held; an application only
+    /// ever hears which way the reader wants to go. Sent on the press, not
+    /// the release, because a page turn should not wait for a finger to lift.
+    ///
+    /// An application that does nothing with this does nothing — there is no
+    /// runtime fallback, deliberately.
+    PageTurn {
+        forward: bool,
+    },
     /// Hands a decoded picture to the runtime, to be referred to afterwards by
     /// `handle`.
     ///
@@ -1570,6 +1582,7 @@ pub fn encode(frame: &Frame) -> Result<Vec<u8>, ProtocolError> {
             Lifecycle::Background => 1,
         }),
         Message::CoverChanged { magnet_present } => payload.push(u8::from(*magnet_present)),
+        Message::PageTurn { forward } => payload.push(u8::from(*forward)),
     }
     debug_assert_eq!(payload.len(), payload_len);
     let mut bytes = Vec::with_capacity(HEADER_LEN + payload.len());
@@ -2123,6 +2136,7 @@ fn encoded_message_layout(message: &Message) -> Result<(u8, usize), ProtocolErro
         }
         Message::CommitPicture { .. } => Ok((22, 4)),
         Message::CoverChanged { .. } => Ok((23, 1)),
+        Message::PageTurn { .. } => Ok((27, 1)),
         Message::PutFont { name, bytes, .. } => {
             if bytes.is_empty() || bytes.len() > MAX_FONT_BYTES {
                 return Err(ProtocolError::FrameTooLarge);
@@ -3781,6 +3795,9 @@ pub fn decode(bytes: &[u8]) -> Result<Frame, ProtocolError> {
         },
         23 => Message::CoverChanged {
             magnet_present: read_boolean(&mut reader, "cover magnet present")?,
+        },
+        27 => Message::PageTurn {
+            forward: read_boolean(&mut reader, "page turn direction")?,
         },
         24 => {
             let handle = FontHandle(reader.u32()?);
@@ -7605,6 +7622,8 @@ mod store_tests {
             Message::CoverChanged {
                 magnet_present: false,
             },
+            Message::PageTurn { forward: true },
+            Message::PageTurn { forward: false },
             Message::ShellRequest(ShellRequest::Open {
                 columns: 53,
                 rows: 20,

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -4319,6 +4319,14 @@ pub trait KoboApp {
     /// telling anyone. Ask [`Device::read_cover`] for the state to start from.
     fn on_cover_change(&mut self, _context: &mut Context, _magnet_present: bool) {}
 
+    /// Receives a physical page-turn key press, already resolved to intent.
+    ///
+    /// The runtime owns the raw keycodes and knows how the reader is held;
+    /// an application only hears which way the reader wants to go. Doing
+    /// nothing here is the default and is honest: there is no runtime
+    /// fallback for an application that ignores its buttons.
+    fn on_page_turn(&mut self, _context: &mut Context, _forward: bool) {}
+
     /// Receives the outcome of exactly one earlier [`Context::spawn`].
     ///
     /// Like device results, a task always reports back, including when it fails
@@ -4522,6 +4530,14 @@ impl<A: KoboApp> AppRunner<A> {
     /// because nothing asked for it.
     pub fn cover_changed(&mut self, magnet_present: bool) -> Vec<Command> {
         self.dispatch(|app, context| app.on_cover_change(context, magnet_present))
+    }
+
+    /// Delivers one page-turn key press to the application.
+    ///
+    /// Unsolicited, like [`Self::cover_changed`]: nothing asked for it, the
+    /// reader pressed a button.
+    pub fn page_turn(&mut self, forward: bool) -> Vec<Command> {
+        self.dispatch(|app, context| app.on_page_turn(context, forward))
     }
 
     /// Delivers one device answer, matched to the request that produced it.
@@ -4754,6 +4770,8 @@ pub enum ClientEvent {
     Shell(ShellEvent),
     /// A magnet arrived at, or left, the hall sensor. Unsolicited.
     CoverChanged(bool),
+    /// A physical page-turn key was pressed. Unsolicited; `true` is forward.
+    PageTurn(bool),
     Exit,
 }
 
@@ -4960,6 +4978,7 @@ impl Client {
             Message::CoverChanged { magnet_present } => {
                 Ok(ClientEvent::CoverChanged(magnet_present))
             }
+            Message::PageTurn { forward } => Ok(ClientEvent::PageTurn(forward)),
             Message::Exit => Ok(ClientEvent::Exit),
             _ => Err(ClientError::UnexpectedMessage),
         }
@@ -6405,6 +6424,9 @@ pub fn run_on<A: KoboApp>(name: &str, app: A, socket: &Path) -> Result<(), Clien
                 ClientEvent::CoverChanged(present) => {
                     client.send_commands(runner.cover_changed(present))?;
                 }
+                ClientEvent::PageTurn(forward) => {
+                    client.send_commands(runner.page_turn(forward))?;
+                }
                 ClientEvent::Action(_) | ClientEvent::TextHold { .. } | ClientEvent::Exit => break,
             }
         }
@@ -6422,6 +6444,7 @@ pub fn run_on<A: KoboApp>(name: &str, app: A, socket: &Path) -> Result<(), Clien
             ClientEvent::Lifecycle(state) => runner.lifecycle(state),
             ClientEvent::Shell(event) => runner.shell_event(event),
             ClientEvent::CoverChanged(present) => runner.cover_changed(present),
+            ClientEvent::PageTurn(forward) => runner.page_turn(forward),
             ClientEvent::Exit => {
                 // The runtime is taking the screen back. Give the application
                 // its exit callback, then go, rather than arguing about it.

--- a/crates/kobo-sim/src/lib.rs
+++ b/crates/kobo-sim/src/lib.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use kobo_policy::{shelf::Shelf, store::Store, DeviceServices, TaskRunner};
-use kobo_profile::{DeviceProfile, CLARA_BW_391};
+use kobo_profile::{DeviceProfile, PanelPose, CLARA_BW_391};
 use kobo_protocol::{read_from, write_to, Frame, Lifecycle, Message};
 use kobo_ui::{
     ActionId, DisplayMetrics, FramePlanner, FrameTransition, Node, NodeId, PanelWaveform, Screen,
@@ -22,6 +22,11 @@ use kobo_ui::{
 
 const MAX_HTTP_HEADER: usize = 8 * 1024;
 const PROFILE: &DeviceProfile = &CLARA_BW_391;
+/// The simulator asserts an orientation rather than observing one, because it
+/// has no device. That is legitimate here and nowhere near a real framebuffer:
+/// it means the browser exercises exactly the transform the Clara BW profile
+/// was measured at.
+const POSE: PanelPose<'static> = PanelPose::reference(PROFILE);
 
 fn profile_metrics() -> DisplayMetrics {
     DisplayMetrics {
@@ -252,8 +257,8 @@ impl Simulator {
 
     pub fn touch(&mut self, x: i32, y: i32) -> Option<ActionId> {
         let (display_x, display_y) = (u32::try_from(x).ok()?, u32::try_from(y).ok()?);
-        let raw = PROFILE.display_to_touch(display_x, display_y)?;
-        let display = PROFILE.touch_to_display(raw.0, raw.1)?;
+        let raw = POSE.display_to_touch(display_x, display_y)?;
+        let display = POSE.touch_to_display(raw.0, raw.1)?;
         self.last_touch = Some(SimulatedTouch { display, raw });
         let action = self.screen.hit_test(
             i32::try_from(display.0).ok()?,
@@ -1116,8 +1121,8 @@ impl AppSession {
 
     fn touch_action(&self, x: i32, y: i32) -> Option<ActionId> {
         let display = (u32::try_from(x).ok()?, u32::try_from(y).ok()?);
-        let raw = PROFILE.display_to_touch(display.0, display.1)?;
-        let mapped = PROFILE.touch_to_display(raw.0, raw.1)?;
+        let raw = POSE.display_to_touch(display.0, display.1)?;
+        let mapped = POSE.touch_to_display(raw.0, raw.1)?;
         let mut state = self
             .state
             .lock()
@@ -2758,7 +2763,7 @@ mod tests {
         simulator.touch(x, y).expect("button is touchable");
 
         let payload = simulator.simulation_json();
-        let raw = PROFILE
+        let raw = POSE
             .display_to_touch(
                 u32::try_from(x).expect("positive display x"),
                 u32::try_from(y).expect("positive display y"),

--- a/crates/kobo-smoke/src/main.rs
+++ b/crates/kobo-smoke/src/main.rs
@@ -20,6 +20,7 @@
 use kobo_hal::display::{DisplaySession, OWNER_UNLOCK_PHRASE};
 use kobo_hal::{Rect, RefreshIntent, RefreshPlan, RegionSnapshot};
 use std::env;
+use std::fmt::Write as _;
 use std::process::ExitCode;
 use std::thread::sleep;
 use std::time::Duration;
@@ -29,6 +30,10 @@ const UNLOCK_DISPLAY_ONLY: &str = "OWNER_ATTENDED_DISPLAY_ONLY_GC16";
 const UNLOCK_REVERSIBLE_PIXELS: &str = "OWNER_ATTENDED_REVERSIBLE_PIXELS_GC16";
 const UNLOCK_SCREEN_SNAPSHOT: &str = "OWNER_ATTENDED_SCREEN_SNAPSHOT_RESTORE";
 const UNLOCK_FAST_FEEDBACK: &str = "OWNER_ATTENDED_REVERSIBLE_PIXELS_DU";
+const UNLOCK_WAIT_TIMING: &str = "OWNER_ATTENDED_WAIT_TIMING_GC16_DU";
+
+/// How many invert-restore pairs the wait-timing stage runs per waveform.
+const WAIT_TIMING_ROUNDS: usize = 4;
 
 const FIXED_REGION: Rect = Rect {
     x: 512,
@@ -52,6 +57,7 @@ enum Stage {
     ReversiblePixels,
     ScreenSnapshot,
     FastFeedback,
+    WaitTiming,
 }
 
 impl Stage {
@@ -71,6 +77,7 @@ impl Stage {
             Some(UNLOCK_REVERSIBLE_PIXELS) => Some(Self::ReversiblePixels),
             Some(UNLOCK_SCREEN_SNAPSHOT) => Some(Self::ScreenSnapshot),
             Some(UNLOCK_FAST_FEEDBACK) => Some(Self::FastFeedback),
+            Some(UNLOCK_WAIT_TIMING) => Some(Self::WaitTiming),
             _ => None,
         }
     }
@@ -119,6 +126,7 @@ fn run(unlock: Option<&str>) -> Result<String, String> {
             ))
         }
         Stage::ScreenSnapshot => screen_snapshot_restore(&session),
+        Stage::WaitTiming => wait_timing(&session),
         Stage::FastFeedback => {
             // DU is the two-level waveform interactive feedback uses. It is
             // driven through exactly the same capture, show, restore, verify
@@ -133,6 +141,85 @@ fn run(unlock: Option<&str>) -> Result<String, String> {
             ))
         }
     }
+}
+
+/// Measures whether `WAIT_FOR_UPDATE_COMPLETE` actually blocks for the
+/// duration of the waveform, which `KOReader`'s device table says it does not
+/// on this board (`hasReliableMxcWaitFor = no`).
+///
+/// Runs invert-restore pairs on the patch region, alternating GC16 and DU,
+/// timing the submit and wait ioctls separately and reading back the waveform
+/// the driver translated the request into. A GC16 waveform runs roughly half a
+/// second on the panel regardless of area and DU roughly a quarter, so a wait
+/// that returns in a few milliseconds is not waiting. The original bytes are
+/// restored and verified at the end, on every path.
+fn wait_timing(session: &DisplaySession) -> Result<String, String> {
+    let original = session
+        .capture(PATCH_REGION)
+        .map_err(|error| format!("capture patch region: {error}"))?;
+    let inverted = original.inverted_rgb();
+
+    let mut lines = String::from("update  intent   waveform  translated  submit_us  wait_us\n");
+    let mut run = || -> Result<(), String> {
+        let mut update = 0_usize;
+        for intent in [
+            RefreshIntent::QualityContent,
+            RefreshIntent::TextContent,
+            RefreshIntent::FastFeedback,
+        ] {
+            let plan = RefreshPlan::new(
+                PATCH_REGION,
+                intent,
+                false,
+                session.geometry().width,
+                session.geometry().height,
+            )
+            .ok_or_else(|| "patch region is not inside this screen".to_owned())?;
+            for _ in 0..WAIT_TIMING_ROUNDS {
+                for snapshot in [&inverted, &original] {
+                    session
+                        .restore(snapshot)
+                        .map_err(|error| format!("write patch region: {error}"))?;
+                    let timing = session
+                        .refresh_timed(plan)
+                        .map_err(|error| format!("refresh patch region: {error}"))?;
+                    update += 1;
+                    let _ = writeln!(
+                        lines,
+                        "{update:>6}  {:<8} {:>8}  {:>10}  {:>9}  {:>7}",
+                        match intent {
+                            RefreshIntent::QualityContent => "GC16",
+                            RefreshIntent::TextContent => "GL16",
+                            RefreshIntent::FastFeedback => "DU",
+                        },
+                        timing.submitted_waveform,
+                        timing.translated_waveform,
+                        timing.submit.as_micros(),
+                        timing.wait.as_micros(),
+                    );
+                }
+            }
+        }
+        Ok(())
+    };
+    let outcome = run();
+
+    // Always leave the screen as found, even when a refresh failed mid-run.
+    let restored = session
+        .restore(&original)
+        .map_err(|error| format!("restore patch region: {error}"));
+    outcome?;
+    restored?;
+    let verify = session
+        .capture(PATCH_REGION)
+        .map_err(|error| format!("verify patch region: {error}"))?;
+    if !verify.matches(&original) {
+        return Err("patch region does not match the original bytes".to_owned());
+    }
+    Ok(format!(
+        "{lines}wait timing completed; {} bytes restored and verified",
+        original.pixels().len()
+    ))
 }
 
 /// Snapshots the whole screen, changes a larger region, then puts the entire
@@ -256,7 +343,7 @@ fn show_and_restore(
 mod tests {
     use super::{
         Stage, FIXED_REGION, PATCH_REGION, UNLOCK_DISPLAY_ONLY, UNLOCK_FAST_FEEDBACK,
-        UNLOCK_REVERSIBLE_PIXELS, UNLOCK_SCREEN_SNAPSHOT, VISIBLE_HOLD,
+        UNLOCK_REVERSIBLE_PIXELS, UNLOCK_SCREEN_SNAPSHOT, UNLOCK_WAIT_TIMING, VISIBLE_HOLD,
     };
     use kobo_abi::hwtcon;
     use kobo_hal::surface::{RegionPlacement, SurfaceGeometry};
@@ -316,6 +403,7 @@ mod tests {
             (UNLOCK_REVERSIBLE_PIXELS, Stage::ReversiblePixels),
             (UNLOCK_SCREEN_SNAPSHOT, Stage::ScreenSnapshot),
             (UNLOCK_FAST_FEEDBACK, Stage::FastFeedback),
+            (UNLOCK_WAIT_TIMING, Stage::WaitTiming),
         ] {
             assert_eq!(Stage::from_unlock(Some(phrase)), Some(expected));
         }
@@ -327,6 +415,8 @@ mod tests {
             Some("OWNER_ATTENDED_DISPLAY_WRITE"),
             Some("OWNER_ATTENDED_REVERSIBLE_PIXELS_DU "),
             Some("REVERSIBLE_PIXELS_DU"),
+            Some("OWNER_ATTENDED_WAIT_TIMING_GC16_DU "),
+            Some("WAIT_TIMING_GC16_DU"),
         ] {
             assert_eq!(Stage::from_unlock(wrong), None, "{wrong:?} must not unlock");
         }

--- a/crates/kobo-smoke/src/main.rs
+++ b/crates/kobo-smoke/src/main.rs
@@ -260,7 +260,7 @@ mod tests {
     };
     use kobo_abi::hwtcon;
     use kobo_hal::surface::{RegionPlacement, SurfaceGeometry};
-    use kobo_hal::{Rect, RefreshIntent, RefreshPlan};
+    use kobo_hal::{Backend, Rect, RefreshIntent, RefreshPlan};
 
     const CLARA: SurfaceGeometry = SurfaceGeometry {
         width: 1072,
@@ -304,7 +304,7 @@ mod tests {
         )
         .expect("plan is valid");
         assert_eq!(
-            plan.update_data(0x4000_0002).update_mode,
+            plan.hwtcon_update_data(0x4000_0002).update_mode,
             hwtcon::UPDATE_MODE_PARTIAL
         );
     }
@@ -348,7 +348,11 @@ mod tests {
                 CLARA.height,
             )
             .expect("plan");
-            assert_eq!(plan.waveform, waveform, "wrong waveform for {stage:?}");
+            assert_eq!(
+                plan.waveform(Backend::Hwtcon),
+                waveform,
+                "wrong waveform for {stage:?}"
+            );
             // No stage may ever submit a full-mode update: full is untested on
             // this controller.
             assert!(!plan.full);
@@ -373,7 +377,7 @@ mod tests {
             CLARA.height,
         )
         .expect("plan is valid");
-        let update = plan.update_data(0x4000_0001);
+        let update = plan.hwtcon_update_data(0x4000_0001);
         assert_eq!(update.waveform_mode, hwtcon::WAVEFORM_GC16);
         assert_eq!(update.update_mode, hwtcon::UPDATE_MODE_PARTIAL);
         assert_eq!(update.update_region.left, FIXED_REGION.x);

--- a/crates/kobo-tap/src/main.rs
+++ b/crates/kobo-tap/src/main.rs
@@ -52,7 +52,7 @@
 use kobo_abi::input;
 use kobo_hal::probe_device;
 use kobo_hal::touch::InputEvent32;
-use kobo_profile::{identify_profile, DeviceProfile, DeviceSnapshot};
+use kobo_profile::{identify_profile, DeviceSnapshot, PanelPose};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::process::ExitCode;
@@ -110,12 +110,12 @@ fn tap() -> Result<(), String> {
         .touch
         .as_ref()
         .ok_or("no touch device was discovered")?;
-    let profile = writable_profile(&snapshot)?;
+    let pose = writable_pose(&snapshot)?;
     // Every point is turned into events before the first one is written, so a
     // point that is off the screen is refused while the panel is still
     // untouched. Discovering it halfway through would leave an application
     // part-way into a journey with no way to finish it.
-    let planned = plan(profile, &steps)?;
+    let planned = plan(&pose, &steps)?;
 
     let mut node = OpenOptions::new()
         .write(true)
@@ -137,15 +137,26 @@ fn tap() -> Result<(), String> {
     Ok(())
 }
 
-fn writable_profile(snapshot: &DeviceSnapshot) -> Result<&'static DeviceProfile, String> {
+/// The profile and the orientation the reader is in, or why neither can be
+/// used to place a synthetic tap.
+///
+/// Injecting a tap needs display-to-raw, which is only correct at the
+/// orientation it was measured at. Resolving the pose here means a reader held
+/// the wrong way up refuses the whole sequence rather than tapping somewhere
+/// nobody asked for.
+fn writable_pose(snapshot: &DeviceSnapshot) -> Result<PanelPose<'static>, String> {
     let profile = identify_profile(snapshot)
         .ok_or_else(|| "the probed device does not match a supported profile".to_owned())?;
     let blockers = profile.write_identity_blockers(snapshot);
-    if blockers.is_empty() {
-        Ok(profile)
-    } else {
-        Err(format!("device write refused: {}", blockers.join("; ")))
+    if !blockers.is_empty() {
+        return Err(format!("device write refused: {}", blockers.join("; ")));
     }
+    let framebuffer = snapshot
+        .framebuffer
+        .as_ref()
+        .ok_or_else(|| "device write refused: no framebuffer to resolve the pose".to_owned())?;
+    PanelPose::resolve(profile, framebuffer)
+        .map_err(|error| format!("device write refused: {error}"))
 }
 
 /// One tap, and how long to wait before making it.
@@ -167,16 +178,16 @@ const LIFT_EVENTS: usize = 3;
 /// Separate from writing them so that a whole tour is checked against the
 /// panel before any of it reaches the digitiser. Stopping in the middle is the
 /// one failure mode that leaves the device somewhere nobody asked for.
-fn plan(profile: &DeviceProfile, steps: &[Step]) -> Result<Vec<Vec<InputEvent32>>, String> {
+fn plan(pose: &PanelPose<'_>, steps: &[Step]) -> Result<Vec<Vec<InputEvent32>>, String> {
     steps
         .iter()
-        .map(|step| press_and_lift(profile, step.x, step.y))
+        .map(|step| press_and_lift(pose, step.x, step.y))
         .collect()
 }
 
 /// The evdev records for one complete tap, press first and lift last.
-fn press_and_lift(profile: &DeviceProfile, x: u32, y: u32) -> Result<Vec<InputEvent32>, String> {
-    let (raw_x, raw_y) = profile
+fn press_and_lift(pose: &PanelPose<'_>, x: u32, y: u32) -> Result<Vec<InputEvent32>, String> {
+    let (raw_x, raw_y) = pose
         .display_to_touch(x, y)
         .ok_or_else(|| format!("{x},{y} is not on the screen"))?;
     Ok(vec![
@@ -297,13 +308,14 @@ fn parse_point(request: &str) -> Result<(u32, u32), String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        encode, parse_point, parse_sequence, plan, press_and_lift, writable_profile, Step,
+        encode, parse_point, parse_sequence, plan, press_and_lift, writable_pose, Step,
         LIFT_EVENTS, MAXIMUM_SEQUENCE_MILLIS, MAXIMUM_STEPS,
     };
     use kobo_abi::input;
     use kobo_hal::touch::{InputEvent32, TouchDecoder, TouchEvent};
     use kobo_profile::{
-        DeviceProfile, DeviceSnapshot, FramebufferSnapshot, IdentitySnapshot, TouchSnapshot,
+        DeviceProfile, DeviceSnapshot, FramebufferSnapshot, IdentitySnapshot, PanelPose,
+        TouchSnapshot,
         CLARA_BW_391, ELIPSA_2E_389,
     };
     use std::time::Duration;
@@ -331,11 +343,11 @@ mod tests {
         // The strongest check available without hardware: feed what would be
         // written into the decoder the device itself uses, and require that it
         // reports the same coordinates that went in.
-        let events = press_and_lift(&CLARA_BW_391, 536, 900).expect("the middle of the screen");
+        let events = press_and_lift(&PanelPose::reference(&CLARA_BW_391), 536, 900).expect("the middle of the screen");
         let mut decoder = TouchDecoder::default();
         let mut reported = Vec::new();
         for event in &events {
-            if let Some(touch) = decoder.push(*event, &CLARA_BW_391) {
+            if let Some(touch) = decoder.push(*event, &PanelPose::reference(&CLARA_BW_391)) {
                 reported.push(touch);
             }
         }
@@ -352,11 +364,11 @@ mod tests {
 
     #[test]
     fn an_elipsa_tap_uses_the_elipsa_transform() {
-        let events = press_and_lift(&ELIPSA_2E_389, 1403, 1871).expect("Elipsa corner");
+        let events = press_and_lift(&PanelPose::reference(&ELIPSA_2E_389), 1403, 1871).expect("Elipsa corner");
         let mut decoder = TouchDecoder::default();
         let reported: Vec<_> = events
             .into_iter()
-            .filter_map(|event| decoder.push(event, &ELIPSA_2E_389))
+            .filter_map(|event| decoder.push(event, &PanelPose::reference(&ELIPSA_2E_389)))
             .collect();
         assert_eq!(
             reported.first(),
@@ -368,14 +380,14 @@ mod tests {
     #[test]
     fn matching_geometry_without_exact_identity_cannot_receive_a_tap() {
         let snapshot = snapshot_for(&ELIPSA_2E_389, IdentitySnapshot::default());
-        let error = writable_profile(&snapshot).expect_err("identity gates every device write");
+        let error = writable_pose(&snapshot).expect_err("identity gates every device write");
         assert!(error.contains("device write refused"), "{error}");
         assert!(error.contains("device code"), "{error}");
     }
 
     #[test]
     fn the_lift_is_the_last_thing_written() {
-        let events = press_and_lift(&CLARA_BW_391, 100, 100).expect("on the screen");
+        let events = press_and_lift(&PanelPose::reference(&CLARA_BW_391), 100, 100).expect("on the screen");
         let lift = &events[events.len() - LIFT_EVENTS..];
         assert_eq!(lift[0].code, input::ABS_MT_TRACKING_ID);
         assert_eq!(lift[0].value, -1, "-1 is how a contact ends");
@@ -384,7 +396,7 @@ mod tests {
 
     #[test]
     fn a_point_off_the_screen_is_refused_rather_than_clamped_onto_the_edge() {
-        assert!(press_and_lift(&CLARA_BW_391, 5000, 5000).is_err());
+        assert!(press_and_lift(&PanelPose::reference(&CLARA_BW_391), 5000, 5000).is_err());
     }
 
     #[test]
@@ -469,9 +481,9 @@ mod tests {
         // its fourth point is off the panel has left an application somewhere
         // nobody asked for it to be, with no way to finish the journey.
         let steps = parse_sequence("10,10 20,20 4000,20").expect("it parses");
-        assert!(plan(&CLARA_BW_391, &steps).is_err());
+        assert!(plan(&PanelPose::reference(&CLARA_BW_391), &steps).is_err());
         let good = parse_sequence("10,10 20,20 30,30").expect("it parses");
-        assert!(plan(&CLARA_BW_391, &good).is_ok());
+        assert!(plan(&PanelPose::reference(&CLARA_BW_391), &good).is_ok());
     }
 
     fn snapshot_for(profile: &DeviceProfile, identity: IdentitySnapshot) -> DeviceSnapshot {

--- a/crates/kobo-tap/src/main.rs
+++ b/crates/kobo-tap/src/main.rs
@@ -374,6 +374,26 @@ mod tests {
         assert!(matches!(reported.last(), Some(TouchEvent::Up { .. })));
     }
 
+    /// The positive path: an Elipsa whose attended evidence is complete and
+    /// whose identity matches exactly is authorised for a synthetic touch.
+    /// The negative test below only proves the gate closes; this one proves it
+    /// opens, on hardware none of us can re-measure.
+    #[test]
+    fn reviewed_elipsa_with_exact_identity_can_receive_a_tap() {
+        let snapshot = snapshot_for(
+            &ELIPSA_2E_389,
+            IdentitySnapshot {
+                serial_prefix: Some("N605".into()),
+                firmware_version: Some("4.38.23697".into()),
+                kernel_release: Some("4.9.77".into()),
+                device_code: Some(389),
+            },
+        );
+        let pose = writable_pose(&snapshot)
+            .expect("completed attended evidence authorizes synthetic touch");
+        assert_eq!(pose.profile().id, ELIPSA_2E_389.id);
+    }
+
     #[test]
     fn matching_geometry_without_exact_identity_cannot_receive_a_tap() {
         let snapshot = snapshot_for(&ELIPSA_2E_389, IdentitySnapshot::default());

--- a/crates/kobo-ui/src/lib.rs
+++ b/crates/kobo-ui/src/lib.rs
@@ -1345,6 +1345,44 @@ pub struct Screen {
     pub overlay: Option<Box<Overlay>>,
 }
 
+/// What paging means on a laid-out screen right now.
+///
+/// The screen's own [`Screen::page_turns`] says what it declares; the overlay
+/// says what is on top of it at this moment. Those two facts make four cases,
+/// and collapsing them into an `Option` loses the one that matters:
+///
+/// | Declares turns | Overlay up | This is | What acts on it |
+/// |---|---|---|---|
+/// | no | no | `None` | nothing here; a physical press may reach the application raw |
+/// | yes | no | `Declared` | a tap on a zone, or a press, sends the declared action |
+/// | yes | yes | `SuppressedByOverlay` | the press is dropped: the dialog is what the reader is answering |
+/// | no | yes | `SuppressedByOverlay` | likewise, and not the raw press either |
+///
+/// The last two used to be indistinguishable from the first, which meant a
+/// press while a dialog was up fell through to the raw intent and an
+/// application that handled it paged the content underneath.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum PageTurnZones {
+    /// The screen declares no page turns and nothing is covering it.
+    #[default]
+    None,
+    /// The screen declares these, and they are live.
+    Declared(PageTurns),
+    /// The screen is covered, so paging means nothing until it is not.
+    SuppressedByOverlay,
+}
+
+impl PageTurnZones {
+    /// The live turns, if paging means anything at all here.
+    #[must_use]
+    pub const fn declared(self) -> Option<PageTurns> {
+        match self {
+            Self::Declared(turns) => Some(turns),
+            Self::None | Self::SuppressedByOverlay => None,
+        }
+    }
+}
+
 /// The actions a tap on the content area sends.
 ///
 /// Some Kobo models also have physical page buttons. When those are wired up
@@ -1663,7 +1701,10 @@ impl Screen {
         // bar and stops above the nav bar. Never the bars themselves: Back and
         // the navigation are the two things a reader must be able to hit
         // without thinking, and a mistimed page turn there would be maddening.
-        layout.page_turns = self.page_turns;
+        layout.page_turns = match self.page_turns {
+            Some(turns) => PageTurnZones::Declared(turns),
+            None => PageTurnZones::None,
+        };
         layout.hold = self.hold;
         if let Some((turns, (page, of))) = self
             .page_turns
@@ -1724,8 +1765,9 @@ impl Screen {
             layout_overlay(overlay, metrics, prose, &mut layout);
             // A popover cannot also be a page turn: the zones are whatever is
             // left of the content area, and "left over" must not include the
-            // thing drawn over it.
-            layout.page_turns = None;
+            // thing drawn over it. Said as suppression rather than absence, so
+            // that whatever reads this can tell "covered" from "never asked".
+            layout.page_turns = PageTurnZones::SuppressedByOverlay;
             layout.hold = None;
         }
         layout
@@ -4136,8 +4178,9 @@ pub struct Layout {
     pub nodes: Vec<LayoutNode>,
     /// The band between the bars, which is what the page-turn zones cover.
     pub content: Rect,
-    /// Set when the screen asked for tap-to-turn.
-    pub page_turns: Option<PageTurns>,
+    /// What paging means here, including when the answer is "nothing, for
+    /// now": see [`PageTurnZones`].
+    pub page_turns: PageTurnZones,
     /// Set when the screen asked to hear about a held finger.
     pub hold: Option<ActionId>,
     /// Word rectangles derived during layout. These are kept outside `nodes`
@@ -4455,7 +4498,7 @@ impl Layout {
     /// The page turn a tap on empty content means, if any.
     #[must_use]
     pub fn hit_page_turn(&self, x: i32, y: i32) -> Option<ActionId> {
-        let turns = self.page_turns?;
+        let turns = self.page_turns.declared()?;
         if !self.content.contains(x, y) {
             return None;
         }
@@ -16570,6 +16613,14 @@ mod prose_tests {
         ));
         let layout = screen.layout_with(&CLARA_BW_METRICS, &Chrome::default());
         assert_eq!(layout.hit_page_turn(4, CLARA_BW_METRICS.height / 2), None);
+        // Suppressed, and saying so: a screen that declared turns and is now
+        // covered must not read as one that never declared any. The physical
+        // page keys tell those apart, and paged the content underneath the
+        // dialog while they could not.
+        assert_eq!(layout.page_turns, PageTurnZones::SuppressedByOverlay);
+        let uncovered =
+            Screen::new(1, Vec::new()).layout_with(&CLARA_BW_METRICS, &Chrome::default());
+        assert_eq!(uncovered.page_turns, PageTurnZones::None);
     }
 
     /// A modal is deliberately not dismissed by a tap that misses it, so

--- a/crates/kobo-ui/src/lib.rs
+++ b/crates/kobo-ui/src/lib.rs
@@ -1362,7 +1362,7 @@ pub struct Screen {
 /// press while a dialog was up fell through to the raw intent and an
 /// application that handled it paged the content underneath.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-pub enum PageTurnZones {
+pub enum PagingState {
     /// The screen declares no page turns and nothing is covering it.
     #[default]
     None,
@@ -1372,7 +1372,7 @@ pub enum PageTurnZones {
     SuppressedByOverlay,
 }
 
-impl PageTurnZones {
+impl PagingState {
     /// The live turns, if paging means anything at all here.
     #[must_use]
     pub const fn declared(self) -> Option<PageTurns> {
@@ -1702,8 +1702,8 @@ impl Screen {
         // the navigation are the two things a reader must be able to hit
         // without thinking, and a mistimed page turn there would be maddening.
         layout.page_turns = match self.page_turns {
-            Some(turns) => PageTurnZones::Declared(turns),
-            None => PageTurnZones::None,
+            Some(turns) => PagingState::Declared(turns),
+            None => PagingState::None,
         };
         layout.hold = self.hold;
         if let Some((turns, (page, of))) = self
@@ -1767,7 +1767,7 @@ impl Screen {
             // left of the content area, and "left over" must not include the
             // thing drawn over it. Said as suppression rather than absence, so
             // that whatever reads this can tell "covered" from "never asked".
-            layout.page_turns = PageTurnZones::SuppressedByOverlay;
+            layout.page_turns = PagingState::SuppressedByOverlay;
             layout.hold = None;
         }
         layout
@@ -4179,8 +4179,8 @@ pub struct Layout {
     /// The band between the bars, which is what the page-turn zones cover.
     pub content: Rect,
     /// What paging means here, including when the answer is "nothing, for
-    /// now": see [`PageTurnZones`].
-    pub page_turns: PageTurnZones,
+    /// now": see [`PagingState`].
+    pub page_turns: PagingState,
     /// Set when the screen asked to hear about a held finger.
     pub hold: Option<ActionId>,
     /// Word rectangles derived during layout. These are kept outside `nodes`
@@ -16617,10 +16617,10 @@ mod prose_tests {
         // covered must not read as one that never declared any. The physical
         // page keys tell those apart, and paged the content underneath the
         // dialog while they could not.
-        assert_eq!(layout.page_turns, PageTurnZones::SuppressedByOverlay);
+        assert_eq!(layout.page_turns, PagingState::SuppressedByOverlay);
         let uncovered =
             Screen::new(1, Vec::new()).layout_with(&CLARA_BW_METRICS, &Chrome::default());
-        assert_eq!(uncovered.page_turns, PageTurnZones::None);
+        assert_eq!(uncovered.page_turns, PagingState::None);
     }
 
     /// A modal is deliberately not dismissed by a tap that misses it, so

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -72,6 +72,19 @@ const SECRETS: &str = "/mnt/onboard/.adds/cobalt/secrets";
 const TRUST: &str = "/mnt/onboard/.adds/cobalt/trust";
 const DICTIONARIES: &str = "/mnt/onboard/.adds/cobalt/dictionaries";
 
+/// Turns on the per-frame timing line on stderr.
+const FRAME_TIMING: &str = "KOBO_FRAME_TIMING";
+
+/// Whether the owner asked for per-frame timing, read once for the process.
+///
+/// Once rather than per frame because the point of the line is to measure the
+/// paint path, and an environment lookup inside the thing being measured is
+/// exactly the wrong place for it.
+fn frame_timing_wanted() -> bool {
+    static WANTED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *WANTED.get_or_init(|| std::env::var(FRAME_TIMING).ok().as_deref() == Some("1"))
+}
+
 /// The most publisher faces one application may hold in the runtime at once.
 ///
 /// The protocol bounds a single font frame, not how many frames arrive. A book
@@ -3024,21 +3037,25 @@ impl Painter {
         let timing = display
             .refresh_timed(plan)
             .map_err(|error| format!("show the frame: {error}"))?;
-        // One line per frame while the delay on the Libra 2 is being chased:
-        // how long the grayscale conversion, the framebuffer write and the
-        // two ioctls each took, and what was refreshed with which waveform.
-        // Stderr rather than the black box: start.sh already captures it, and
-        // the black box costs an fsync per line.
-        eprintln!(
-            "frame {}x{} wf={} convert={}ms write={}ms submit={}us wait={}ms",
-            region.width,
-            region.height,
-            timing.submitted_waveform,
-            converted.as_millis(),
-            written.saturating_sub(converted).as_millis(),
-            timing.submit.as_micros(),
-            timing.wait.as_millis(),
-        );
+        // One line per frame: how long the grayscale conversion, the
+        // framebuffer write and the two ioctls each took, and what was
+        // refreshed with which waveform. This is what found the Libra 2 tap
+        // delay, so it stays, but off by default and behind its own switch:
+        // every frame on every device is the wrong place for unconditional
+        // output. Stderr rather than the black box, which costs an fsync per
+        // line; start.sh already captures stderr.
+        if frame_timing_wanted() {
+            eprintln!(
+                "frame {}x{} wf={} convert={}ms write={}ms submit={}us wait={}ms",
+                region.width,
+                region.height,
+                timing.submitted_waveform,
+                converted.as_millis(),
+                written.saturating_sub(converted).as_millis(),
+                timing.submit.as_micros(),
+                timing.wait.as_millis(),
+            );
+        }
 
         if !self.frames.commit(surface, transition) {
             return Err("the frame planner rejected a completed refresh".to_owned());

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -42,7 +42,6 @@ use kobo_hal::supervisor::Suspended;
 use kobo_hal::touch::TouchEvent;
 use kobo_hal::{Rect, RefreshIntent, RefreshPlan, RegionSnapshot};
 use kobo_policy::{Backends, Capability, Declared, DeviceServices, PowerPolicy, TaskRunner};
-use kobo_profile::DeviceProfile;
 use kobo_protocol::{Frame, Lifecycle, Message, TaskError, TaskOutcome};
 use kobo_ui::{
     render_all, ActionId, Chrome, FontHandle, FramePlanner, PanelWaveform, PictureCache, Screen,
@@ -593,13 +592,21 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
         pump_gpio(session, &taps);
     }
 
+    // Which page key means "forward" depends on how the reader is held. At
+    // the profile's reference pose (buttons on the right, on the Libra 2)
+    // the lower key, 194, pages forward — KOReader's assignment, to be
+    // confirmed on the device. A half turn swaps them, and pose resolution
+    // has already refused anything else.
+    let forward_is_194 =
+        pose.rotation() % 4 == profile.reference_rotation % 4;
+
     let outcome = host_applications(
         application,
         &display,
         whole_screen,
         &taps,
         limits,
-        profile,
+        forward_is_194,
         &watchdog,
     );
     trace("session finished, handing the panel back");
@@ -992,10 +999,13 @@ fn host_applications(
     whole_screen: Rect,
     touch: &TouchSink,
     limits: Limits,
-    profile: &'static DeviceProfile,
+    forward_is_194: bool,
     watchdog: &Arc<Watchdog>,
 ) -> Result<String, String> {
-    let _ = profile;
+    // Kept current by the orientation channel: a reader flipped mid-session
+    // keeps "forward" pointing forward even though the image does not rotate
+    // yet.
+    let mut forward_is_194 = forward_is_194;
     let catalogue = application
         .parent()
         .map_or_else(|| PathBuf::from("/tmp"), Path::to_path_buf);
@@ -1270,11 +1280,43 @@ fn host_applications(
                 }
                 Ok(Event::Gpio(event)) => {
                     last_activity = Instant::now();
-                    // Observed and logged only, until the protocol carries
-                    // page-turn intent. The demux that assigns meaning —
-                    // forward or back from the pose, sleep from the power
-                    // button — builds on top of this arm.
-                    trace(&format!("gpio: {event:?}"));
+                    match event {
+                        // On the press, not the release: a page turn should
+                        // not wait for a finger to lift. Only the foreground
+                        // application hears it, for the same reason as taps
+                        // and the cover: the press happened in front of the
+                        // reader, and a background application has no
+                        // standing to react to it.
+                        GpioEvent::Button {
+                            button: button @ (gpio::Button::Page193 | gpio::Button::Page194),
+                            pressed: true,
+                        } => {
+                            let forward =
+                                (button == gpio::Button::Page194) == forward_is_194;
+                            if let Some(index) = index_of(&apps, front) {
+                                apps[index]
+                                    .send(kobo_protocol::Message::PageTurn { forward })?;
+                            }
+                        }
+                        GpioEvent::Button { button: gpio::Button::Power, pressed } => {
+                            // Meaning arrives with the power sub-feature:
+                            // short press sleep, long press shutdown. Until
+                            // then the press is at least on the record.
+                            trace(&format!("power button pressed={pressed}"));
+                        }
+                        // The kernel's digested accelerometer verdict. Only
+                        // the two portrait poses move the key mapping; the
+                        // image itself does not rotate mid-session yet.
+                        // Which MSC_RAW value is which physical pose is
+                        // KOReader's naming, to be confirmed on the device.
+                        GpioEvent::Orientation(gpio::Orientation::PortraitUp) => {
+                            forward_is_194 = true;
+                        }
+                        GpioEvent::Orientation(gpio::Orientation::PortraitDown) => {
+                            forward_is_194 = false;
+                        }
+                        GpioEvent::Button { .. } | GpioEvent::Orientation(_) => {}
+                    }
                 }
                 Ok(Event::Touch(event)) => {
                     last_activity = Instant::now();
@@ -2004,6 +2046,7 @@ fn host_applications(
                         | Message::DeviceResult(_)
                         | Message::StoreResult(_)
                         | Message::CoverChanged { .. }
+                        | Message::PageTurn { .. }
                         | Message::ShellEvent(_) => {
                             return Err(format!(
                                 "{} sent a runtime-only message",

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -889,6 +889,19 @@ impl AppLaunch {
     }
 
     fn sandboxed(path: &Path, id: u64) -> Result<Self, String> {
+        if !kobo_abi::sandbox::network_boundary_available() {
+            // Kobo's 4.1 i.MX6 kernels ship without CONFIG_SECCOMP and
+            // CONFIG_NET_NS, so neither of the sandbox's network boundaries
+            // exists there. The chroot, the privilege ceiling and the identity
+            // drop still hold, and the brokered network path is unchanged;
+            // what is lost is enforcement against an application opening its
+            // own socket. Said once per launch, loudly, so a transcript of a
+            // session on such a kernel cannot be read as if the boundary held.
+            trace(
+                "application network boundary unavailable on this kernel; \
+                 relying on chroot and the unprivileged identity",
+            );
+        }
         let root = std::env::temp_dir().join(format!("kobo-app-{}-{id}", std::process::id()));
         fs::create_dir(&root)
             .map_err(|error| format!("create application sandbox {}: {error}", root.display()))?;

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -1383,14 +1383,22 @@ fn host_applications(
                             let forward = (button == gpio::Button::Page194) == forward_is_194;
                             if let Some(index) = index_of(&apps, front) {
                                 let at_home = apps[index].path == home;
-                                let screen = apps[index].screen.as_ref();
-                                let chrome =
-                                    screen.map(|current| chrome_for(current, at_home, &mut status));
-                                if let Some(message) = page_key_message(
-                                    screen,
-                                    chrome.as_ref().unwrap_or(&Chrome::default()),
-                                    forward,
-                                ) {
+                                let message = match apps[index].screen.as_ref() {
+                                    Some(current) => {
+                                        // The chrome the frame was drawn with,
+                                        // for the same reason `action_for`
+                                        // uses it: laying out with a different
+                                        // one resolves the press against a
+                                        // screen the reader cannot see.
+                                        let chrome = chrome_for(current, at_home, &mut status);
+                                        page_key_message(current, &chrome, forward)
+                                    }
+                                    // Nothing painted yet, so there is nothing
+                                    // to resolve against and the application
+                                    // hears the raw intent.
+                                    None => Some(kobo_protocol::Message::PageTurn { forward }),
+                                };
+                                if let Some(message) = message {
                                     apps[index].send(message)?;
                                 }
                             }
@@ -2781,26 +2789,21 @@ fn action_for(
 ///
 /// `None` means the press is dropped. That is not the same as an application
 /// choosing to ignore it, which is why the three states are matched rather
-/// than collapsed: see [`kobo_ui::PageTurnZones`].
+/// than collapsed: see [`kobo_ui::PagingState`].
 fn page_key_message(
-    screen: Option<&Screen>,
+    screen: &Screen,
     chrome: &Chrome,
     forward: bool,
 ) -> Option<kobo_protocol::Message> {
-    let zones = screen.map_or(kobo_ui::PageTurnZones::None, |current| {
-        current
-            .layout_with(&metrics_for(current), chrome)
-            .page_turns
-    });
-    match zones {
-        kobo_ui::PageTurnZones::Declared(turns) => Some(kobo_protocol::Message::Action {
+    match screen.layout_with(&metrics_for(screen), chrome).page_turns {
+        kobo_ui::PagingState::Declared(turns) => Some(kobo_protocol::Message::Action {
             action: if forward { turns.next } else { turns.previous },
         }),
-        kobo_ui::PageTurnZones::None => Some(kobo_protocol::Message::PageTurn { forward }),
+        kobo_ui::PagingState::None => Some(kobo_protocol::Message::PageTurn { forward }),
         // Dropped, but not silently: a press that does nothing is
         // indistinguishable from a broken button, and this is the record that
         // says which it was.
-        kobo_ui::PageTurnZones::SuppressedByOverlay => {
+        kobo_ui::PagingState::SuppressedByOverlay => {
             trace("page key dropped: an overlay is up");
             None
         }
@@ -3464,13 +3467,13 @@ mod tests {
         // tap on the side zone would have.
         let declared = Screen::new(1, vec![page()]).with_page_turns(ActionId(11), ActionId(12));
         assert!(matches!(
-            page_key_message(Some(&declared), &chrome, true),
+            page_key_message(&declared, &chrome, true),
             Some(kobo_protocol::Message::Action {
                 action: ActionId(12)
             })
         ));
         assert!(matches!(
-            page_key_message(Some(&declared), &chrome, false),
+            page_key_message(&declared, &chrome, false),
             Some(kobo_protocol::Message::Action {
                 action: ActionId(11)
             })
@@ -3480,10 +3483,13 @@ mod tests {
         // press, so it hears the raw intent.
         let undeclared = Screen::new(1, vec![page()]);
         assert!(matches!(
-            page_key_message(Some(&undeclared), &chrome, true),
+            page_key_message(&undeclared, &chrome, true),
             Some(kobo_protocol::Message::PageTurn { forward: true })
         ));
-        assert!(page_key_message(None, &chrome, true).is_some());
+        assert!(matches!(
+            page_key_message(&undeclared, &chrome, false),
+            Some(kobo_protocol::Message::PageTurn { forward: false })
+        ));
 
         // Covered by a dialog: nothing is sent. Not the declared action, and
         // not the raw intent either -- an application that handled the raw
@@ -3501,17 +3507,13 @@ mod tests {
             }],
         );
         assert_eq!(
-            page_key_message(
-                Some(&declared.clone().with_overlay(modal.clone())),
-                &chrome,
-                true
-            ),
+            page_key_message(&declared.clone().with_overlay(modal.clone()), &chrome, true),
             None
         );
         // Including when the screen never declared turns: the dialog is what
         // the reader is answering either way.
         assert_eq!(
-            page_key_message(Some(&undeclared.with_overlay(modal)), &chrome, true),
+            page_key_message(&undeclared.with_overlay(modal), &chrome, true),
             None
         );
     }

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -1287,6 +1287,16 @@ fn host_applications(
                         // and the cover: the press happened in front of the
                         // reader, and a background application has no
                         // standing to react to it.
+                        //
+                        // A screen that declares its page turns gets the
+                        // declared action, exactly as if the side zone had
+                        // been tapped, so a book, a shelf and a catalogue all
+                        // page without knowing buttons exist. The layout is
+                        // consulted rather than the screen because an overlay
+                        // takes the page turns away, and a press while a
+                        // dialog is up must not turn the page underneath it.
+                        // Only a screen that declares nothing receives the
+                        // raw intent, as `Message::PageTurn`.
                         GpioEvent::Button {
                             button: button @ (gpio::Button::Page193 | gpio::Button::Page194),
                             pressed: true,
@@ -1294,8 +1304,26 @@ fn host_applications(
                             let forward =
                                 (button == gpio::Button::Page194) == forward_is_194;
                             if let Some(index) = index_of(&apps, front) {
-                                apps[index]
-                                    .send(kobo_protocol::Message::PageTurn { forward })?;
+                                let at_home = apps[index].path == home;
+                                let turns =
+                                    apps[index].screen.as_ref().and_then(|current| {
+                                        let chrome =
+                                            chrome_for(current, at_home, &mut status);
+                                        current
+                                            .layout_with(&metrics_for(current), &chrome)
+                                            .page_turns
+                                    });
+                                let message = match turns {
+                                    Some(turns) => kobo_protocol::Message::Action {
+                                        action: if forward {
+                                            turns.next
+                                        } else {
+                                            turns.previous
+                                        },
+                                    },
+                                    None => kobo_protocol::Message::PageTurn { forward },
+                                };
+                                apps[index].send(message)?;
                             }
                         }
                         GpioEvent::Button { button: gpio::Button::Power, pressed } => {

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -607,11 +607,15 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
 
     // Which page key means "forward" depends on how the reader is held. At
     // the profile's reference pose (buttons on the right, on the Libra 2)
-    // the lower key, 194, pages forward. Measured on the device rather than
-    // borrowed: an ungrabbed capture on `gpio-keys` reported 193 for the
-    // upper key and 194 for the lower one at buttons-right, and paging that
-    // way round was confirmed in a session. A half turn swaps them, which was
-    // confirmed too, and pose resolution has already refused anything else.
+    // key 194 pages forward and 193 pages back, which is KOReader's
+    // assignment for this device.
+    //
+    // What was verified here is the behaviour, not that attribution: a
+    // session paged the way the reader expected in both portrait poses, and a
+    // half turn mid-session inverted it correctly. Which physical key, upper
+    // or lower, carries which code was never separately recorded, so it is
+    // not claimed. Pose resolution has already refused anything but the two
+    // portrait poses.
     let forward_is_194 = pose.rotation() % 4 == profile.reference_rotation % 4;
 
     let outcome = host_applications(

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -531,7 +531,17 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
         .map(|t| t.path.clone())
         .ok_or_else(|| "touch probe was unavailable".to_owned())?;
 
-    let mut touch = TouchSession::acquire(Path::new(&touch_path), profile)
+    let framebuffer = display
+        .snapshot()
+        .framebuffer
+        .as_ref()
+        .ok_or_else(|| "framebuffer probe was unavailable".to_owned())?;
+    // Resolved rather than assumed: the transform that places every tap is
+    // only correct at the orientation it was measured at, so a reader held the
+    // other way up has to refuse the session rather than mislocate touches.
+    let pose = kobo_profile::PanelPose::resolve(profile, framebuffer)
+        .map_err(|error| format!("take the touch panel: {error}"))?;
+    let mut touch = TouchSession::acquire(Path::new(&touch_path), pose)
         .map_err(|error| format!("take the touch panel: {error}"))?;
 
     // Without this the device reboots itself partway through the session, so a

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -607,9 +607,11 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
 
     // Which page key means "forward" depends on how the reader is held. At
     // the profile's reference pose (buttons on the right, on the Libra 2)
-    // the lower key, 194, pages forward — KOReader's assignment, to be
-    // confirmed on the device. A half turn swaps them, and pose resolution
-    // has already refused anything else.
+    // the lower key, 194, pages forward. Measured on the device rather than
+    // borrowed: an ungrabbed capture on `gpio-keys` reported 193 for the
+    // upper key and 194 for the lower one at buttons-right, and paging that
+    // way round was confirmed in a session. A half turn swaps them, which was
+    // confirmed too, and pose resolution has already refused anything else.
     let forward_is_194 = pose.rotation() % 4 == profile.reference_rotation % 4;
 
     let outcome = host_applications(
@@ -1403,8 +1405,10 @@ fn host_applications(
                         // The kernel's digested accelerometer verdict. Only
                         // the two portrait poses move the key mapping; the
                         // image itself does not rotate mid-session yet.
-                        // Which MSC_RAW value is which physical pose is
-                        // KOReader's naming, to be confirmed on the device.
+                        // KOReader's MSC_RAW pose naming was checked here by
+                        // a rotation-only capture, and then in use: a reader
+                        // turned end for end mid-session, with no restart,
+                        // goes on paging the way it is now held.
                         GpioEvent::Orientation(gpio::Orientation::PortraitUp) => {
                             forward_is_194 = true;
                         }

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -607,15 +607,15 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
 
     // Which page key means "forward" depends on how the reader is held. At
     // the profile's reference pose (buttons on the right, on the Libra 2)
-    // key 194 pages forward and 193 pages back, which is KOReader's
-    // assignment for this device.
+    // key 194 pages forward and 193 pages back, which is both KOReader's
+    // assignment for this device and what the owner read off the hardware:
+    // with the buttons on the right the upper key goes back and the lower
+    // key goes forward, so 194 is the lower one.
     //
-    // What was verified here is the behaviour, not that attribution: a
-    // session paged the way the reader expected in both portrait poses, and a
-    // half turn mid-session inverted it correctly. Which physical key, upper
-    // or lower, carries which code was never separately recorded, so it is
-    // not claimed. Pose resolution has already refused anything but the two
-    // portrait poses.
+    // The behaviour was checked the same way: a session paged as expected in
+    // both portrait poses, and a half turn mid-session inverted it correctly
+    // with no restart. Pose resolution has already refused anything but the
+    // two portrait poses.
     let forward_is_194 = pose.rotation() % 4 == profile.reference_rotation % 4;
 
     let outcome = host_applications(
@@ -2802,9 +2802,12 @@ fn page_key_message(
         kobo_ui::PagingState::None => Some(kobo_protocol::Message::PageTurn { forward }),
         // Dropped, but not silently: a press that does nothing is
         // indistinguishable from a broken button, and this is the record that
-        // says which it was.
+        // says which it was. Both channels, as `action_for` does it, because
+        // the black box is off unless somebody asked for it and this has to
+        // be answerable in an ordinary session.
         kobo_ui::PagingState::SuppressedByOverlay => {
             trace("page key dropped: an overlay is up");
+            println!("page key dropped: an overlay is up");
             None
         }
     }

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -607,10 +607,9 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
 
     // Which page key means "forward" depends on how the reader is held. At
     // the profile's reference pose (buttons on the right, on the Libra 2)
-    // key 194 pages forward and 193 pages back, which is both KOReader's
-    // assignment for this device and what the owner read off the hardware:
-    // with the buttons on the right the upper key goes back and the lower
-    // key goes forward, so 194 is the lower one.
+    // key 194 pages forward and 193 pages back, read off the hardware: with
+    // the buttons on the right the upper key is 193 and goes back, the lower
+    // key is 194 and goes forward.
     //
     // The behaviour was checked the same way: a session paged as expected in
     // both portrait poses, and a half turn mid-session inverted it correctly
@@ -1415,10 +1414,10 @@ fn host_applications(
                         // The kernel's digested accelerometer verdict. Only
                         // the two portrait poses move the key mapping; the
                         // image itself does not rotate mid-session yet.
-                        // KOReader's MSC_RAW pose naming was checked here by
-                        // a rotation-only capture, and then in use: a reader
-                        // turned end for end mid-session, with no restart,
-                        // goes on paging the way it is now held.
+                        // The pose each MSC_RAW value names was measured here
+                        // by a rotation-only capture, and then confirmed in
+                        // use: a reader turned end for end mid-session, with
+                        // no restart, goes on paging the way it is now held.
                         GpioEvent::Orientation(gpio::Orientation::PortraitUp) => {
                             forward_is_194 = true;
                         }

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -1368,9 +1368,10 @@ fn host_applications(
                         // page without knowing buttons exist. The layout is
                         // consulted rather than the screen because an overlay
                         // takes the page turns away, and a press while a
-                        // dialog is up must not turn the page underneath it.
-                        // Only a screen that declares nothing receives the
-                        // raw intent, as `Message::PageTurn`.
+                        // dialog is up must not turn the page underneath it:
+                        // the reader is answering the dialog. Only a screen
+                        // that genuinely declares nothing receives the raw
+                        // intent, as `Message::PageTurn`.
                         GpioEvent::Button {
                             button: button @ (gpio::Button::Page193 | gpio::Button::Page194),
                             pressed: true,
@@ -1378,19 +1379,16 @@ fn host_applications(
                             let forward = (button == gpio::Button::Page194) == forward_is_194;
                             if let Some(index) = index_of(&apps, front) {
                                 let at_home = apps[index].path == home;
-                                let turns = apps[index].screen.as_ref().and_then(|current| {
-                                    let chrome = chrome_for(current, at_home, &mut status);
-                                    current
-                                        .layout_with(&metrics_for(current), &chrome)
-                                        .page_turns
-                                });
-                                let message = match turns {
-                                    Some(turns) => kobo_protocol::Message::Action {
-                                        action: if forward { turns.next } else { turns.previous },
-                                    },
-                                    None => kobo_protocol::Message::PageTurn { forward },
-                                };
-                                apps[index].send(message)?;
+                                let screen = apps[index].screen.as_ref();
+                                let chrome =
+                                    screen.map(|current| chrome_for(current, at_home, &mut status));
+                                if let Some(message) = page_key_message(
+                                    screen,
+                                    chrome.as_ref().unwrap_or(&Chrome::default()),
+                                    forward,
+                                ) {
+                                    apps[index].send(message)?;
+                                }
                             }
                         }
                         GpioEvent::Button {
@@ -2771,6 +2769,40 @@ fn action_for(
     hit
 }
 
+/// Resolves a page-key press to the message the application should hear.
+///
+/// The sibling of [`action_for`], and deliberately the same shape: a press and
+/// a tap on a side zone mean the same thing, so they must not disagree about
+/// what a screen currently allows.
+///
+/// `None` means the press is dropped. That is not the same as an application
+/// choosing to ignore it, which is why the three states are matched rather
+/// than collapsed: see [`kobo_ui::PageTurnZones`].
+fn page_key_message(
+    screen: Option<&Screen>,
+    chrome: &Chrome,
+    forward: bool,
+) -> Option<kobo_protocol::Message> {
+    let zones = screen.map_or(kobo_ui::PageTurnZones::None, |current| {
+        current
+            .layout_with(&metrics_for(current), chrome)
+            .page_turns
+    });
+    match zones {
+        kobo_ui::PageTurnZones::Declared(turns) => Some(kobo_protocol::Message::Action {
+            action: if forward { turns.next } else { turns.previous },
+        }),
+        kobo_ui::PageTurnZones::None => Some(kobo_protocol::Message::PageTurn { forward }),
+        // Dropped, but not silently: a press that does nothing is
+        // indistinguishable from a broken button, and this is the record that
+        // says which it was.
+        kobo_ui::PageTurnZones::SuppressedByOverlay => {
+            trace("page key dropped: an overlay is up");
+            None
+        }
+    }
+}
+
 fn text_hold_for(
     event: TouchEvent,
     screen: Option<&Screen>,
@@ -3410,6 +3442,73 @@ mod tests {
         assert_eq!(
             action_for(touch, Some(&no_hold), &chrome, true),
             Some(ActionId(12))
+        );
+    }
+
+    /// The three states a page key can land in, and the one that used to be
+    /// wrong: a press while a dialog is up is dropped, not passed on raw.
+    #[test]
+    fn a_page_key_is_dropped_while_an_overlay_is_up() {
+        let chrome = Chrome::default();
+        let page = || kobo_ui::Node::Text {
+            id: kobo_ui::NodeId(1),
+            text: "A page of a book.".to_owned(),
+            links: Vec::new(),
+        };
+
+        // Declares turns: the press becomes the declared action, exactly as a
+        // tap on the side zone would have.
+        let declared = Screen::new(1, vec![page()]).with_page_turns(ActionId(11), ActionId(12));
+        assert!(matches!(
+            page_key_message(Some(&declared), &chrome, true),
+            Some(kobo_protocol::Message::Action {
+                action: ActionId(12)
+            })
+        ));
+        assert!(matches!(
+            page_key_message(Some(&declared), &chrome, false),
+            Some(kobo_protocol::Message::Action {
+                action: ActionId(11)
+            })
+        ));
+
+        // Declares nothing: the application may make its own sense of the
+        // press, so it hears the raw intent.
+        let undeclared = Screen::new(1, vec![page()]);
+        assert!(matches!(
+            page_key_message(Some(&undeclared), &chrome, true),
+            Some(kobo_protocol::Message::PageTurn { forward: true })
+        ));
+        assert!(page_key_message(None, &chrome, true).is_some());
+
+        // Covered by a dialog: nothing is sent. Not the declared action, and
+        // not the raw intent either -- an application that handled the raw
+        // intent would have paged the content underneath the dialog, which is
+        // the bug this state exists to make unrepresentable.
+        let modal = kobo_ui::Overlay::modal(
+            kobo_ui::NodeId(40),
+            "Leave?",
+            vec![kobo_ui::Node::Button {
+                id: kobo_ui::NodeId(41),
+                action: ActionId(6),
+                label: "Leave".to_owned(),
+                state: kobo_ui::ControlState::Enabled,
+                emphasis: kobo_ui::Emphasis::Primary,
+            }],
+        );
+        assert_eq!(
+            page_key_message(
+                Some(&declared.clone().with_overlay(modal.clone())),
+                &chrome,
+                true
+            ),
+            None
+        );
+        // Including when the screen never declared turns: the dialog is what
+        // the reader is answering either way.
+        assert_eq!(
+            page_key_message(Some(&undeclared.with_overlay(modal)), &chrome, true),
+            None
         );
     }
 

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -2801,12 +2801,32 @@ impl Painter {
             PanelWaveform::Gc16 => RefreshIntent::QualityContent,
         };
 
-        let frame =
-            RegionSnapshot::from_grayscale(display.geometry(), whole_screen, &surface.pixels)
-                .map_err(|error| format!("prepare the frame: {error}"))?;
+        let started = Instant::now();
+        // Convert and write only the rows the transition touches. The write
+        // path runs at a few megabytes per second on the i.MX6's uncached
+        // framebuffer, so writing the whole screen for every frame cost about
+        // 1.6 seconds per tap regardless of how small the change was.
+        let region_gray = {
+            let out_of_surface = || "the transition region is not inside the surface".to_owned();
+            let x = usize::try_from(transition.region.x).map_err(|_| out_of_surface())?;
+            let y = usize::try_from(transition.region.y).map_err(|_| out_of_surface())?;
+            let width = usize::try_from(transition.region.width).map_err(|_| out_of_surface())?;
+            let height = usize::try_from(transition.region.height).map_err(|_| out_of_surface())?;
+            let mut gray = Vec::with_capacity(width.saturating_mul(height));
+            for row in 0..height {
+                let start = (y + row) * surface.width + x;
+                let end = start + width;
+                gray.extend_from_slice(surface.pixels.get(start..end).ok_or_else(out_of_surface)?);
+            }
+            gray
+        };
+        let frame = RegionSnapshot::from_grayscale(display.geometry(), region, &region_gray)
+            .map_err(|error| format!("prepare the frame: {error}"))?;
+        let converted = started.elapsed();
         display
             .restore(&frame)
             .map_err(|error| format!("write the frame: {error}"))?;
+        let written = started.elapsed();
         let plan = RefreshPlan::new(
             region,
             intent,
@@ -2815,9 +2835,24 @@ impl Painter {
             whole_screen.height,
         )
         .ok_or_else(|| "the refresh region is not inside the screen".to_owned())?;
-        display
-            .refresh(plan)
+        let timing = display
+            .refresh_timed(plan)
             .map_err(|error| format!("show the frame: {error}"))?;
+        // One line per frame while the delay on the Libra 2 is being chased:
+        // how long the grayscale conversion, the framebuffer write and the
+        // two ioctls each took, and what was refreshed with which waveform.
+        // Stderr rather than the black box: start.sh already captures it, and
+        // the black box costs an fsync per line.
+        eprintln!(
+            "frame {}x{} wf={} convert={}ms write={}ms submit={}us wait={}ms",
+            region.width,
+            region.height,
+            timing.submitted_waveform,
+            converted.as_millis(),
+            (written - converted).as_millis(),
+            timing.submit.as_micros(),
+            timing.wait.as_millis(),
+        );
 
         if !self.frames.commit(surface, transition) {
             return Err("the frame planner rejected a completed refresh".to_owned());

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -34,6 +34,7 @@
 
 use crate::blackbox::{self, trace};
 use kobo_hal::display::{DisplaySession, OWNER_UNLOCK_PHRASE};
+use kobo_hal::gpio::{self, GpioEvent, GpioSession};
 use kobo_hal::input::TouchSession;
 use kobo_hal::reader::{Reader, Watchdog, WATCHDOG_CHECK};
 use kobo_hal::soc_watchdog::SocWatchdog;
@@ -408,6 +409,8 @@ const APP_STOP_GRACE: Duration = Duration::from_secs(3);
 /// battery life.
 enum Event {
     Touch(TouchEvent),
+    /// A button or orientation report from the `gpio-keys` node.
+    Gpio(GpioEvent),
     App(u64, Box<Frame>),
     /// An application's end of the socket closed.
     AppGone(u64),
@@ -573,6 +576,22 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
     // started here rather than per application.
     let taps = TouchSink::default();
     pump_touch(&mut touch, &taps);
+
+    // The buttons and the orientation channel, on hardware that has them.
+    // Absence is not a failure: not every supported device has page keys,
+    // and a session without buttons is the state every session was in
+    // before this existed.
+    let mut buttons = gpio::discover_buttons_path()
+        .and_then(|path| match GpioSession::acquire(&path) {
+            Ok(session) => Some(session),
+            Err(error) => {
+                trace(&format!("buttons unavailable: {error}"));
+                None
+            }
+        });
+    if let Some(session) = buttons.as_mut() {
+        pump_gpio(session, &taps);
+    }
 
     let outcome = host_applications(
         application,
@@ -1248,6 +1267,14 @@ fn host_applications(
                             &mut status,
                         )?;
                     }
+                }
+                Ok(Event::Gpio(event)) => {
+                    last_activity = Instant::now();
+                    // Observed and logged only, until the protocol carries
+                    // page-turn intent. The demux that assigns meaning —
+                    // forward or back from the pose, sleep from the power
+                    // button — builds on top of this arm.
+                    trace(&format!("gpio: {event:?}"));
                 }
                 Ok(Event::Touch(event)) => {
                     last_activity = Instant::now();
@@ -2895,6 +2922,18 @@ impl TouchSink {
             let _ignored = sender.send(Event::Touch(event));
         }
     }
+
+    /// Same policy as taps: between applications a press is dropped, not
+    /// queued for whatever comes up next.
+    fn send_gpio(&self, event: GpioEvent) {
+        let guard = self
+            .0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(sender) = guard.as_ref() {
+            let _ignored = sender.send(Event::Gpio(event));
+        }
+    }
 }
 
 fn pump_touch(touch: &mut TouchSession, sink: &TouchSink) {
@@ -2905,6 +2944,21 @@ fn pump_touch(touch: &mut TouchSession, sink: &TouchSink) {
     thread::spawn(move || {
         while let Ok(event) = events.recv() {
             sink.send(event);
+        }
+    });
+}
+
+/// One reader thread on the button device for the whole panel session,
+/// mirroring [`pump_touch`] for the same reason: the destination changes as
+/// applications come and go, the thread does not.
+fn pump_gpio(buttons: &mut GpioSession, sink: &TouchSink) {
+    let Some(events) = buttons.take_events() else {
+        return;
+    };
+    let sink = sink.clone();
+    thread::spawn(move || {
+        while let Ok(event) = events.recv() {
+            sink.send_gpio(event);
         }
     });
 }

--- a/crates/kobod/src/main.rs
+++ b/crates/kobod/src/main.rs
@@ -102,6 +102,13 @@ fn run(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     if arguments.len() == 2 && arguments[0] == "--touch-test" {
         return touch_test(&arguments[1]);
     }
+    // Reads the physical buttons and reports what arrives. This takes no
+    // grab: the reader keeps seeing every press, so pages may turn in Nickel
+    // underneath and the power button keeps its normal meaning. Purely a
+    // capture, safe on a device in normal use.
+    if arguments.len() == 2 && arguments[0] == "--key-test" {
+        return key_test(&arguments[1]);
+    }
     // Performs one real request and reports what happened. This touches no
     // hardware and does not go near the reader, so it is safe to run on a
     // device in normal use, which is the point: the network path has to be
@@ -109,7 +116,7 @@ fn run(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     if arguments.len() == 3 && arguments[0] == "--fetch" {
         return fetch_once(&arguments[1], &arguments[2]);
     }
-    Err("usage: kobod [--sim-socket PATH --frame PATH] [--present APP] [--fetch URL BYTES]".into())
+    Err("usage: kobod [--sim-socket PATH --frame PATH] [--present APP] [--fetch URL BYTES] [--key-test SECONDS]".into())
 }
 
 #[cfg(feature = "device-write")]
@@ -162,6 +169,85 @@ fn touch_test(seconds: &str) -> Result<(), Box<dyn Error>> {
     session.release()?;
     println!("released after {count} events");
     Ok(())
+}
+
+/// Reads the button device without grabbing it and prints every event.
+///
+/// The point is to learn the keycodes the page-turn and power buttons emit
+/// on hardware nobody has captured yet, at both poses. Numeric codes are
+/// printed verbatim so nothing is lost to an incomplete name table.
+fn key_test(seconds: &str) -> Result<(), Box<dyn Error>> {
+    use kobo_hal::touch::InputEvent32;
+    use std::io::Read;
+    use std::time::{Duration, Instant};
+
+    let seconds: u64 = seconds.parse().unwrap_or(20).min(120);
+
+    let content = std::fs::read_to_string("/proc/bus/input/devices")?;
+    let path = discover_key_path(&content)
+        .ok_or_else(|| "no gpio-keys device found in /proc/bus/input/devices".to_owned())?;
+    let mut device = std::fs::File::open(&path)?;
+    let name = kobo_abi::input::device_name(&device)?;
+    println!("button device: {} ({name})", path.display());
+    println!("reading for {seconds}s, no grab; press each button, at both poses");
+
+    let deadline = Instant::now() + Duration::from_secs(seconds);
+    let started = Instant::now();
+    let mut buffer = [0_u8; 16 * 64];
+    let mut count = 0_u32;
+    while Instant::now() < deadline {
+        // A blocking read sits here until a press arrives; the deadline is
+        // only checked between reads, so the capture ends on the first
+        // event after time is up, or at the final press of Enter... it does
+        // not, so the run simply overshoots by however long the last quiet
+        // stretch lasts. Acceptable for an owner-attended probe.
+        let read = device.read(&mut buffer)?;
+        for chunk in buffer[..read].chunks_exact(16) {
+            let Some(event) = InputEvent32::decode(chunk) else {
+                continue;
+            };
+            count += 1;
+            let at = started.elapsed().as_millis();
+            let kind = match event.kind {
+                0 => "SYN",
+                1 => "KEY",
+                _ => "???",
+            };
+            let action = match (event.kind, event.value) {
+                (1, 0) => " up",
+                (1, 1) => " down",
+                (1, 2) => " repeat",
+                _ => "",
+            };
+            println!(
+                "{at:>7} ms  {kind} code={} value={}{action}",
+                event.code, event.value
+            );
+        }
+    }
+    println!("captured {count} events");
+    Ok(())
+}
+
+/// Finds the event node for the `gpio-keys` device.
+fn discover_key_path(content: &str) -> Option<std::path::PathBuf> {
+    content.split("\n\n").find_map(|block| {
+        let name_matches = block
+            .lines()
+            .find(|line| line.starts_with("N: Name="))
+            .is_some_and(|line| line.contains("gpio-keys"));
+        if !name_matches {
+            return None;
+        }
+        let handlers = block
+            .lines()
+            .find(|line| line.starts_with("H: Handlers="))?;
+        let event = handlers
+            .strip_prefix("H: Handlers=")?
+            .split_whitespace()
+            .find(|handler| handler.starts_with("event"))?;
+        Some(std::path::Path::new("/dev/input").join(event))
+    })
 }
 
 /// Fetches one URL and prints a one line verdict.

--- a/crates/kobod/src/main.rs
+++ b/crates/kobod/src/main.rs
@@ -675,6 +675,7 @@ fn serve_application(
             | Message::StoreResult(_)
             | Message::Lifecycle(_)
             | Message::CoverChanged { .. }
+            | Message::PageTurn { .. }
             | Message::ShellEvent(_) => {
                 return Err("application sent a daemon-only message".into());
             }

--- a/crates/kobod/src/main.rs
+++ b/crates/kobod/src/main.rs
@@ -129,7 +129,13 @@ fn touch_test(seconds: &str) -> Result<(), Box<dyn Error>> {
         .ok_or_else(|| "touch probe was unavailable".to_owned())?;
 
     println!("touch device: {touch_path}");
-    let mut session = TouchSession::acquire(Path::new(&touch_path), profile)?;
+    let framebuffer = snapshot
+        .framebuffer
+        .as_ref()
+        .ok_or_else(|| "framebuffer probe was unavailable".to_owned())?;
+    let pose = kobo_profile::PanelPose::resolve(profile, framebuffer)
+        .map_err(|error| format!("touch refused: {error}"))?;
+    let mut session = TouchSession::acquire(Path::new(&touch_path), pose)?;
     println!("grabbed; touch the panel");
     let events = session
         .take_events()

--- a/docs/DEVICES.md
+++ b/docs/DEVICES.md
@@ -166,7 +166,7 @@ running 4.45.23697, and it replaces the worse answer that came before it:
 password at all** and still does not give you `kobo deploy`.
 
 > [!NOTE]
-> If your Kobo is running a firmware older than **4.42** (such as 4.38), it does not have this built-in SSH toggle. You will need to manually install an SSH server (like Dropbear via NickelMenu) and manually copy your public key (from `~/.ssh/kobo_cobalt.pub`) into `/root/.ssh/authorized_keys` on the device yourself.
+> The firmware version this toggle first shipped in is not 4.42, and may be model-dependent: a Libra 2 on firmware 4.38.23697 ships `.kobo/ssh-disabled`, and renaming it brings up a working OpenSSH. If your firmware really lacks the toggle, install an SSH server manually (like Dropbear via NickelMenu) and copy your public key (from `~/.ssh/kobo_cobalt.pub`) into `authorized_keys` under root's home directory yourself — which is `/.ssh/authorized_keys` on readers whose `/etc/passwd` gives root a home of `/`, such as the i.MX6 models, not `/root/.ssh/`.
 
 ### Why Cobalt itself is not a `KoboRoot.tgz`
 

--- a/docs/DEVICES.md
+++ b/docs/DEVICES.md
@@ -441,6 +441,21 @@ reach for `context.log(...)` around work you suspect: an application logs to
 explain itself, and the times it most needs to be believed are the times it
 took the reader down with it.
 
+### Per-frame timing
+
+One line per painted frame on standard error, off unless `KOBO_FRAME_TIMING=1`:
+
+```text
+frame 1264x1680 wf=2 convert=41ms write=18ms submit=214us wait=401ms
+```
+
+It separates the grayscale conversion, the framebuffer write and the two
+ioctls, and names the waveform the panel was actually given. This is what found
+the Libra 2 tap delay, and it is the fastest way to tell a slow conversion apart
+from a slow panel. It goes to standard error rather than the black box because
+the black box costs an `fsync` per line, which would swamp the thing being
+measured; `start.sh` captures standard error already.
+
 The excerpt above is the whole method in three lines. A reader that had returned
 to the stock interface looks identical whether the session ended cleanly or the
 `SoC` watchdog reset the device, and the two have completely different causes.

--- a/docs/DEVICES.md
+++ b/docs/DEVICES.md
@@ -14,6 +14,7 @@ and touch profile. A matching model name alone is not sufficient.
 | Kobo Clara BW | N365, code 391, firmware 4.45.23697, kernel 4.9.77 | Read-only probe and owner-attended display, touch, exit, and recovery tests complete | Fully tested |
 | Kobo Clara HD | N249, code 376, firmware 4.38.23684 or 4.38.23697, kernel 4.1.15-00136-g12655eaaef89 | Read-only probe and owner-attended display, touch, exit, sandbox, and recovery tests complete | Fully tested |
 | Kobo Elipsa 2E | N605, code 389, firmware 4.38.23697, kernel 4.9.77 | Read-only probe and owner-attended display, touch, exit, suspend/resume, and recovery tests complete | Fully tested |
+| Kobo Libra 2 | N418, code 388, firmware 4.38.23697, kernel 4.1.15-00868-g58a2758be07 | Read-only probe and owner-attended display, touch, page-button, exit, and recovery tests complete | Fully tested |
 
 `Read-only doctor match complete` means the profile describes the observed
 identity, framebuffer, and touch ranges. It does not prove the physical touch

--- a/examples/gutenbird/src/main.rs
+++ b/examples/gutenbird/src/main.rs
@@ -2994,23 +2994,6 @@ fn main() -> ExitCode {
 }
 
 impl KoboApp for Gutenbird {
-    fn on_page_turn(&mut self, context: &mut Context, forward: bool) {
-        // Only while a book is open. A page key paging the shelf or the
-        // catalog would be a feature of its own, and doing nothing until it
-        // is designed beats doing something surprising.
-        if self.view != View::Reading {
-            return;
-        }
-        self.read_action(
-            context,
-            action_id(if forward {
-                kobo_read::action::FORWARD
-            } else {
-                kobo_read::action::BACK
-            }),
-        );
-    }
-
     fn on_start(&mut self, context: &mut Context) {
         context.shelf().list();
         context.store().load(REGISTRY_KEY);

--- a/examples/gutenbird/src/main.rs
+++ b/examples/gutenbird/src/main.rs
@@ -2994,6 +2994,23 @@ fn main() -> ExitCode {
 }
 
 impl KoboApp for Gutenbird {
+    fn on_page_turn(&mut self, context: &mut Context, forward: bool) {
+        // Only while a book is open. A page key paging the shelf or the
+        // catalog would be a feature of its own, and doing nothing until it
+        // is designed beats doing something surprising.
+        if self.view != View::Reading {
+            return;
+        }
+        self.read_action(
+            context,
+            action_id(if forward {
+                kobo_read::action::FORWARD
+            } else {
+                kobo_read::action::BACK
+            }),
+        );
+    }
+
     fn on_start(&mut self, context: &mut Context) {
         context.shelf().list();
         context.store().load(REGISTRY_KEY);

--- a/tools/abi/check-mxcfb.sh
+++ b/tools/abi/check-mxcfb.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+set -eu
+
+# Checks kobo-abi's mxcfb declarations against the vendor's own header and
+# driver source.
+#
+# Both files come from the kernel Kobo publishes for the device, for example
+# hw/imx6sll-libra2/kernel.tar.bz2 in kobolabs/Kobo-Reader. After unpacking:
+#
+#   tools/abi/check-mxcfb.sh \
+#       <kernel>/include/uapi/linux/mxcfb.h \
+#       <kernel>/drivers/video/fbdev/mxc/mxc_epdc_v2_fb.c
+#
+# The driver source is optional but worth passing. The waveform numbers are
+# not in the header: they are defined inside the driver, so the only way to
+# check them is to read them out of it.
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+    echo "usage: $0 /path/to/mxcfb.h [/path/to/mxc_epdc_v2_fb.c]" >&2
+    exit 2
+fi
+
+header_dir=$(dirname "$1")
+output=$(mktemp /tmp/kobo-mxcfb-conformance.XXXXXX)
+trap 'rm -f "$output"' EXIT HUP INT TERM
+
+cc -std=c11 -Wall -Wextra -Werror \
+    -I tools/abi/include \
+    -I "$header_dir" \
+    tools/abi/mxcfb_conformance.c \
+    -o "$output"
+"$output"
+
+[ "$#" -eq 2 ] || exit 0
+
+driver=$2
+status=0
+
+# The values kobo-abi's mxcfb module declares, which have to match the
+# driver's own NTX_WFM_MODE_* defines.
+for pair in INIT:0 DU:1 GC16:2 GC4:3 A2:4 GL16:5 GLR16:6 GLD16:7; do
+    name=${pair%:*}
+    want=${pair#*:}
+    got=$(sed -n "s/^#define[[:space:]]*NTX_WFM_MODE_${name}[[:space:]]\{1,\}\([0-9]\{1,\}\).*/\1/p" \
+        "$driver" | head -n 1)
+    if [ -z "$got" ]; then
+        echo "NTX_WFM_MODE_${name}: not found in $driver" >&2
+        status=1
+    elif [ "$got" != "$want" ]; then
+        echo "NTX_WFM_MODE_${name}: driver says $got, kobo-abi says $want" >&2
+        status=1
+    else
+        echo "waveform_${name}=${got}"
+    fi
+done
+
+# The framebuffer identifier the backend is selected by. If the driver stops
+# calling itself this, kobo-hal stops recognising the device.
+if grep -q 'strcpy(fix_info->id, "mxc_epdc_fb")' "$driver"; then
+    echo 'framebuffer_id=mxc_epdc_fb'
+else
+    echo "framebuffer id is no longer mxc_epdc_fb in $driver" >&2
+    status=1
+fi
+
+# kobo-abi's documentation claims the driver's GC16 substitution is not
+# compiled in. That claim is only true while the macro stays undefined.
+if grep -q '^[[:space:]]*#[[:space:]]*define[[:space:]]*NTX_WFM_MODE_OPTIMIZED' "$driver"; then
+    echo "NTX_WFM_MODE_OPTIMIZED is now defined: GC16 is substituted, see refresh.rs" >&2
+    status=1
+fi
+
+exit $status

--- a/tools/abi/check-mxcfb.sh
+++ b/tools/abi/check-mxcfb.sh
@@ -37,7 +37,8 @@ driver=$2
 status=0
 
 # The values kobo-abi's mxcfb module declares, which have to match the
-# driver's own NTX_WFM_MODE_* defines.
+# driver's own NTX_WFM_MODE_* defines. These are not in the uapi header, which
+# is why the driver source has to be read directly.
 for pair in INIT:0 DU:1 GC16:2 GC4:3 A2:4 GL16:5 GLR16:6 GLD16:7; do
     name=${pair%:*}
     want=${pair#*:}

--- a/tools/abi/hwtcon_conformance.c
+++ b/tools/abi/hwtcon_conformance.c
@@ -18,6 +18,8 @@ _Static_assert(HWTCON_SEND_UPDATE == 0x4024462eUL, "send ioctl");
 _Static_assert(HWTCON_WAIT_FOR_UPDATE_COMPLETE == 0xc008462fUL, "wait ioctl");
 _Static_assert(WAVEFORM_MODE_DU == 1, "DU waveform");
 _Static_assert(WAVEFORM_MODE_GC16 == 2, "GC16 waveform");
+/* Asserted because the mxcfb backend picks a different number for this one. */
+_Static_assert(WAVEFORM_MODE_GL16 == 3, "GL16 waveform");
 _Static_assert(WAVEFORM_MODE_GLR16 == 4, "GLR16 waveform");
 _Static_assert(WAVEFORM_MODE_A2 == 6, "A2 waveform");
 

--- a/tools/abi/include/linux/fb.h
+++ b/tools/abi/include/linux/fb.h
@@ -1,0 +1,58 @@
+#ifndef KOBO_ABI_LINUX_FB_H
+#define KOBO_ABI_LINUX_FB_H
+
+/*
+ * Enough of <linux/fb.h> for the vendor mxcfb header to compile on its own.
+ *
+ * The vendor header includes <linux/fb.h> for one thing only: a
+ * `struct fb_var_screeninfo` embedded in `struct mxcfb_gpu_split_fmt`, which
+ * this project never sends. Nothing asserted here depends on its layout, so a
+ * forward declaration would do were it not embedded by value.
+ *
+ * Pulling in the real header instead would make the check depend on whichever
+ * kernel headers the build host happens to carry, which is the opposite of
+ * what it is for: the point is to compile the vendor's declarations against
+ * nothing but the vendor's declarations.
+ */
+
+#include <linux/types.h>
+
+struct fb_bitfield {
+    __u32 offset;
+    __u32 length;
+    __u32 msb_right;
+};
+
+struct fb_var_screeninfo {
+    __u32 xres;
+    __u32 yres;
+    __u32 xres_virtual;
+    __u32 yres_virtual;
+    __u32 xoffset;
+    __u32 yoffset;
+    __u32 bits_per_pixel;
+    __u32 grayscale;
+    struct fb_bitfield red;
+    struct fb_bitfield green;
+    struct fb_bitfield blue;
+    struct fb_bitfield transp;
+    __u32 nonstd;
+    __u32 activate;
+    __u32 height;
+    __u32 width;
+    __u32 accel_flags;
+    __u32 pixclock;
+    __u32 left_margin;
+    __u32 right_margin;
+    __u32 upper_margin;
+    __u32 lower_margin;
+    __u32 hsync_len;
+    __u32 vsync_len;
+    __u32 sync;
+    __u32 vmode;
+    __u32 rotate;
+    __u32 colorspace;
+    __u32 reserved[4];
+};
+
+#endif

--- a/tools/abi/include/linux/types.h
+++ b/tools/abi/include/linux/types.h
@@ -3,7 +3,11 @@
 
 #include <stdint.h>
 
+typedef uint16_t __u16;
 typedef uint32_t __u32;
+
+/* The vendor mxcfb header spells one field this way. */
+typedef uint32_t u_int32_t;
 
 #endif
 

--- a/tools/abi/mxcfb_conformance.c
+++ b/tools/abi/mxcfb_conformance.c
@@ -1,0 +1,84 @@
+/*
+ * Proves that crates/kobo-abi's `mxcfb` module describes the same bytes the
+ * vendor's own header does.
+ *
+ * The Rust side has `const _: [(); N]` size assertions and `offset_of!` tests,
+ * but those only prove Rust agrees with itself. This compiles the vendor's
+ * declarations and asserts against those, which is the only check that can
+ * catch a field transcribed in the wrong order or the wrong width.
+ *
+ * The header comes from the device's own published kernel source rather than
+ * from any reconstruction of it. See tools/abi/check-mxcfb.sh for where to get
+ * it.
+ *
+ * Note what is *not* here: the waveform numbers. Only GLR16, GLD16 and AUTO
+ * are declared in the uapi header. The rest are defined inside the driver's
+ * own .c file, which cannot be included, so check-mxcfb.sh reads them out of
+ * it textually instead.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/ioctl.h>
+
+#include "mxcfb.h"
+
+/* The Mark 7 devices take the v2 update descriptor, not either v1 variant. */
+_Static_assert(sizeof(struct mxcfb_rect) == 16, "mxcfb_rect size");
+_Static_assert(sizeof(struct mxcfb_update_marker_data) == 8, "marker size");
+_Static_assert(sizeof(struct mxcfb_alt_buffer_data) == 28, "alt buffer size");
+_Static_assert(sizeof(struct mxcfb_update_data) == 72, "update size");
+
+_Static_assert(offsetof(struct mxcfb_rect, top) == 0, "rect top offset");
+_Static_assert(offsetof(struct mxcfb_rect, left) == 4, "rect left offset");
+_Static_assert(offsetof(struct mxcfb_rect, width) == 8, "rect width offset");
+_Static_assert(offsetof(struct mxcfb_rect, height) == 12, "rect height offset");
+
+_Static_assert(offsetof(struct mxcfb_update_marker_data, update_marker) == 0,
+               "marker update_marker offset");
+_Static_assert(offsetof(struct mxcfb_update_marker_data, collision_test) == 4,
+               "marker collision_test offset");
+
+_Static_assert(offsetof(struct mxcfb_alt_buffer_data, phys_addr) == 0, "alt phys offset");
+_Static_assert(offsetof(struct mxcfb_alt_buffer_data, width) == 4, "alt width offset");
+_Static_assert(offsetof(struct mxcfb_alt_buffer_data, height) == 8, "alt height offset");
+_Static_assert(offsetof(struct mxcfb_alt_buffer_data, alt_update_region) == 12,
+               "alt region offset");
+
+_Static_assert(offsetof(struct mxcfb_update_data, update_region) == 0, "region offset");
+_Static_assert(offsetof(struct mxcfb_update_data, waveform_mode) == 16, "waveform offset");
+_Static_assert(offsetof(struct mxcfb_update_data, update_mode) == 20, "mode offset");
+_Static_assert(offsetof(struct mxcfb_update_data, update_marker) == 24, "marker offset");
+_Static_assert(offsetof(struct mxcfb_update_data, temp) == 28, "temp offset");
+_Static_assert(offsetof(struct mxcfb_update_data, flags) == 32, "flags offset");
+_Static_assert(offsetof(struct mxcfb_update_data, dither_mode) == 36, "dither offset");
+_Static_assert(offsetof(struct mxcfb_update_data, quant_bit) == 40, "quant offset");
+_Static_assert(offsetof(struct mxcfb_update_data, alt_buffer_data) == 44, "alt buffer offset");
+
+_Static_assert(MXCFB_SEND_UPDATE_V2 == 0x4048462eUL, "send ioctl");
+_Static_assert(MXCFB_WAIT_FOR_UPDATE_COMPLETE_V3 == 0xc008462fUL, "wait ioctl");
+
+/*
+ * The wait request is the same number the MediaTek backend already uses, over
+ * the same eight-byte struct, which is why kobo-hal has only one wait path.
+ * That is an accident of MediaTek keeping the i.MX numbering, so it is
+ * asserted rather than assumed.
+ */
+_Static_assert(MXCFB_WAIT_FOR_UPDATE_COMPLETE_V3 == 0xc008462fUL, "wait matches hwtcon");
+
+/* The only update-mode and waveform values the uapi header declares. */
+_Static_assert(UPDATE_MODE_PARTIAL == 0, "partial mode");
+_Static_assert(UPDATE_MODE_FULL == 1, "full mode");
+_Static_assert(WAVEFORM_MODE_GLR16 == 6, "GLR16 waveform");
+_Static_assert(WAVEFORM_MODE_GLD16 == 7, "GLD16 waveform");
+_Static_assert(WAVEFORM_MODE_AUTO == 257, "AUTO waveform");
+_Static_assert(TEMP_USE_AMBIENT == 0x1000, "ambient temperature");
+
+int main(void)
+{
+    printf("mxcfb_update_data=%zu\n", sizeof(struct mxcfb_update_data));
+    printf("send_update=0x%08lx\n", (unsigned long)MXCFB_SEND_UPDATE_V2);
+    printf("wait_complete=0x%08lx\n", (unsigned long)MXCFB_WAIT_FOR_UPDATE_COMPLETE_V3);
+    return 0;
+}


### PR DESCRIPTION
# Port to Kobo Libra 2 (N418, device code 388)

This is the port discussed in issue #29, rebased onto current main as requested. It was verified on the physical device today, after the rebase. The run covered two full session cycles: launch from a NickelMenu entry, touch, page-turn buttons, and a clean exit back to Nickel, at both portrait poses. The video of that run follows in the first comment.

## What the branch adds

- The mxcfb ABI as read out of the Libra 2's own published kernel. It carries the GC4 and A2 waveform constants and documents their numbering hazard against hwtcon. The conformance harness (`tools/abi/check-mxcfb.sh` and `mxcfb_conformance.c`) checks the Rust declarations against the vendor header and driver source. It passes against both vendor kernels.
- A Libra 2 profile with derived geometry. On this device the framebuffer geometry moves with orientation. The profile therefore derives virtual size and stride from the driver's own arithmetic per rotation. Rotations 1 and 3 are verified on hardware; anything else is refused.
- A measured touch transform. It was taken from raw digitiser events in both portrait poses, with predictions written before each capture. The session composes it against the rotation it opens in.
- Physical buttons. The daemon reads `gpio-keys` during a session and resolves the page keys against the front screen's declared page turns. Books, shelves and catalogues page with no app code. A mid-session 180 degree flip keeps the mapping correct, through orientation events the same device emits. The power button is logged and deliberately inert for now.
- An instrumented refresh path (`refresh_timed`) and a wait-timing attended stage. This is how the wait ioctl was measured to block correctly here: GC16 ~401 ms, GL16 ~307 ms, DU ~213 ms.
- Region-only framebuffer writes. A full-screen transition on this SoC cost 1.6 s of memcpy; now only the rows a frame touches are written.

## What the merge kept from main

The branch is a merge and keeps your recent work intact. That covers the Clara HD mxcfb support and the ptrace syscall supervisor. It also covers the attended-smoke boundary in `display.rs`, the `write_ready` evidence gating and `write_ready_profile()`. The Clara HD profile is re-expressed in the derived-geometry profile structure with its behavior unchanged: fixed geometry, one verified pose. Its constants satisfy the i.MX6 derivation exactly. That is noted in a comment and left alone, since we cannot test that device.

The ptrace supervisor takes over from the open sandbox degradation this port previously shipped for the Libra 2's 4.1.15 kernel. Today's run gives behavioral evidence for it. Applications launch, run and fetch over the brokered network, with the supervisor as the only network boundary. We have not yet captured a `TracerPid` from a live app process to prove engagement directly. Happy to do that as a follow-up if you want it in the record.

## Write readiness

Per the process you outlined, `LIBRA_2_388` is submitted with `write_ready: false`. The profile tests assert the gated verdict, so enabling writes is a deliberate, test-visible change once you have reviewed the evidence. The video covers touch, both button orientations, page buttons and clean exit to Nickel. Recovery is shown by two full session cycles in one boot, plus the documented uninstall path.

## Continuing or not

We would rather this landed here, and we will keep testing on the hardware either way. If the review load is more than you want to take on, there is absolutely no problem from our side: we will keep the port on our fork. The conformance harness and this branch stay available under the AGPL in both cases.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790077201&installation_model_id=20525&pr_number=43&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F43&signature=1e68d2b069dfbb00338500bc79c02a150964da90b10602a90fa180ba9be68cee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->