### PR TITLE
Stage the firmware's first-login marker with the authorized key

### DIFF
--- a/crates/kobo-cli/src/authorize.rs
+++ b/crates/kobo-cli/src/authorize.rs
@@ -15,8 +15,18 @@
 //! This is the one thing in the CLI that writes to the root filesystem. The
 //! Cobalt payload deliberately cannot: [`crate::package::check`] refuses any
 //! path outside the install folder. So this module is separate, is named for
-//! what it does, ships nothing but this machine's public key, and says so in
-//! the report.
+//! what it does, ships nothing but this machine's public key and the
+//! firmware's own first-login marker, and says so in the report.
+//!
+//! The marker exists because of what the firmware does on the first SSH login.
+//! `sshd_config` forces root through a setup script that runs an interactive
+//! `passwd` until `/.login_pass_set` exists, and only then hands over the
+//! shell. A key authenticates fine, and then the very first non-interactive
+//! `kobo deploy` feeds its script into that `passwd` and fails in a way that
+//! looks like the device is broken (observed on a Libra Colour on 4.45.23697,
+//! Cobalt#49). Root already carries a password hash and access is by key, so
+//! the marker gates only the interactive reset, not authentication; creating
+//! it empty is exactly what the firmware's own `touch ${PASS_SET}` does.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -32,6 +42,10 @@ const AUTHORIZED_KEYS: &[&str] = &["root/.ssh/authorized_keys", ".ssh/authorized
 /// The directories those files live in, with the mode sshd requires.
 const KEY_DIRS: &[(&str, u32)] = &[("root/.ssh", 0o700), (".ssh", 0o700)];
 
+/// The firmware's first-login marker: while it is absent, the forced SSH
+/// setup script runs an interactive `passwd` that eats a piped script.
+const LOGIN_PASS_SET: &str = ".login_pass_set";
+
 /// Every path this module ever stages, for the undo to recognise its own work.
 ///
 /// The directories are listed too, because an archive lists the folders it
@@ -42,6 +56,7 @@ pub const STAGED_MEMBERS: &[&str] = &[
     "root/.ssh/authorized_keys",
     ".ssh",
     ".ssh/authorized_keys",
+    ".login_pass_set",
 ];
 
 /// What the archive is staged as, the single slot the firmware looks at.
@@ -168,10 +183,13 @@ fn entries(public_key: &str) -> Result<(Vec<Folder<'_>>, Vec<File>), String> {
     // both.
     let contents = format!("{line}\n");
     let folders = KEY_DIRS.to_vec();
-    let files = AUTHORIZED_KEYS
+    let mut files: Vec<File> = AUTHORIZED_KEYS
         .iter()
         .map(|path| ((*path).to_owned(), contents.clone().into_bytes(), 0o600))
         .collect();
+    // Empty, and the mode `touch` gives it, because that is byte for byte what
+    // the firmware's own setup script would have created.
+    files.push((LOGIN_PASS_SET.to_owned(), Vec::new(), 0o644));
     Ok((folders, files))
 }
 
@@ -294,10 +312,27 @@ mod tests {
             .filter(|entry| entry.kind == b'0')
             .map(|entry| entry.path.as_str())
             .collect();
-        assert_eq!(files.len(), AUTHORIZED_KEYS.len(), "{listed:?}");
+        // The key at each location, plus the first-login marker.
+        assert_eq!(files.len(), AUTHORIZED_KEYS.len() + 1, "{listed:?}");
         for path in AUTHORIZED_KEYS {
             assert!(files.contains(path), "{path} missing from {files:?}");
         }
+    }
+
+    /// The firmware's first-login `passwd` loop is gated on this file, and a
+    /// piped `kobo deploy` on a fresh reader lands in that loop and fails, so
+    /// the archive creates the marker the way the firmware itself would:
+    /// empty, at the filesystem root, with `touch`'s mode.
+    #[test]
+    fn the_archive_marks_the_first_login_as_done() {
+        let built = archive(SAMPLE).expect("an archive");
+        let listed = list(&built).expect("a readable archive");
+        let marker = listed
+            .iter()
+            .find(|entry| entry.path == super::LOGIN_PASS_SET)
+            .expect("the first-login marker");
+        assert_eq!(marker.size, 0, "the marker must be empty");
+        assert_eq!(marker.mode, 0o644, "was mode {:o}", marker.mode);
     }
 
     #[test]
@@ -329,12 +364,14 @@ mod tests {
     }
 
     #[test]
-    fn the_archive_writes_nothing_but_the_key() {
+    fn the_archive_writes_nothing_but_the_key_and_the_marker() {
         let built = archive(SAMPLE).expect("an archive");
         for entry in list(&built).expect("a readable archive") {
             assert!(
-                entry.path.starts_with("root/.ssh") || entry.path.starts_with(".ssh"),
-                "{} is outside the ssh folders",
+                entry.path.starts_with("root/.ssh")
+                    || entry.path.starts_with(".ssh")
+                    || entry.path == super::LOGIN_PASS_SET,
+                "{} is outside the ssh folders and is not the first-login marker",
                 entry.path
             );
         }

--- a/crates/kobo-cli/src/harden.rs
+++ b/crates/kobo-cli/src/harden.rs
@@ -159,10 +159,12 @@ pub fn commit_script() -> String {
 /// The script `kobo setup --undo` runs to take the block back out.
 ///
 /// The removal is the bounded sentinel range and nothing else, so an owner's
-/// own edits survive. The restored file is checked with `sshd -t -f` before
-/// it replaces anything, and a check that fails leaves the hardened file in
-/// place and says so: a working key-only server beats a broken permissive
-/// one.
+/// own edits survive. A block that has a beginning but no end, which is what
+/// a hand-applied hardening looks like, is refused rather than guessed at: a
+/// range whose end never matches would run to the end of the file. The
+/// restored file is checked with `sshd -t -f` before it replaces anything,
+/// and a check that fails leaves the hardened file in place and says so: a
+/// working key-only server beats a broken permissive one.
 #[must_use]
 pub fn remove_script() -> String {
     format!(
@@ -172,6 +174,11 @@ pub fn remove_script() -> String {
          if ! grep -q '^{SENTINEL_BEGIN}$' \"$config\"; then\n\
            echo 'hardening=absent'\n\
            exit 0\n\
+         fi\n\
+         if ! grep -q '^{SENTINEL_END}$' \"$config\"; then\n\
+           echo 'the key-only block has no end marker (applied by hand?), so nothing \
+         was removed; delete it from sshd_config yourself' >&2\n\
+           exit 1\n\
          fi\n\
          scratch=/tmp/kobo-unharden.conf\n\
          sed '/^{SENTINEL_BEGIN}$/,/^{SENTINEL_END}$/d' \"$config\" > \"$scratch\"\n\
@@ -326,6 +333,15 @@ mod tests {
     fn the_removal_is_bounded_and_checked_before_it_lands() {
         let script = remove_script();
         assert!(script.contains(&format!("/^{SENTINEL_BEGIN}$/,/^{SENTINEL_END}$/d")));
+        let end_guard = script
+            .find(&format!("grep -q '^{SENTINEL_END}$'"))
+            .expect("refuses a block with no end marker");
+        let ranged = script.find("sed ").expect("the bounded delete");
+        assert!(
+            end_guard < ranged,
+            "a hand-applied block has no end marker, and a range whose end never \
+             matches would delete to the end of the file"
+        );
         let checked = script.find("-t -f \"$scratch\"").expect("checks the file");
         let landed = script
             .find("cat \"$scratch\" > \"$config\"")

--- a/crates/kobo-cli/src/harden.rs
+++ b/crates/kobo-cli/src/harden.rs
@@ -1,0 +1,395 @@
+//! Closing password login for root, once a key is proven to work.
+//!
+//! The firmware's SSH server accepts root by password: its `sshd_config` ends
+//! with `PermitRootLogin yes` and `PermitEmptyPasswords yes` inside a
+//! `Match User root` block, root's credential is a legacy hash in a
+//! world-readable `/etc/passwd`, and there is no `/etc/shadow`. That is the
+//! stock posture; nothing this tool stages changes it either way (observed on
+//! a Libra Colour on 4.45.23697, Cobalt#51). But a setup that has just
+//! installed a key can do better than stock, so it closes the password door
+//! behind itself.
+//!
+//! The order is the whole design, because the one way this could go wrong is
+//! locking the owner out of a reader whose key was never accepted:
+//!
+//! 1. The hardening script travels over a key-authenticated connection, so a
+//!    key that does not work means the door is never touched.
+//! 2. The change is a sentinel-marked block appended to `sshd_config`, gated
+//!    on `sshd -t` and on the effective configuration actually reporting
+//!    `passwordauthentication no`; a failure of either puts the saved copy
+//!    back before the server ever reloads.
+//! 3. The saved copy doubles as a deadline: a watchdog on the device restores
+//!    it after [`REVERT_DELAY`] unless a second, fresh key login removes it
+//!    first. The proof that keys still work is that very login, so a
+//!    hardening nobody could confirm undoes itself.
+//!
+//! Everything here builds the scripts and reads their answers; the connection
+//! itself belongs to the caller, which is `kobo setup`'s wait for the
+//! restarted reader, and to `kobo setup --undo`, which removes the block.
+
+use std::time::Duration;
+
+/// First line of the appended block, and the marker every script looks for.
+///
+/// Exactly the line validated on hardware, kept to the character so a reader
+/// hardened by hand before this existed is recognised as already done.
+pub const SENTINEL_BEGIN: &str = "# cobalt-hardening: key-only SSH for root.";
+
+/// Last line of the appended block, so removal is a bounded range, not a
+/// guess at how many lines the block had.
+pub const SENTINEL_END: &str = "# cobalt-hardening: end.";
+
+/// How long the device waits for the confirming login before it restores
+/// password authentication on its own.
+///
+/// The confirmation normally arrives seconds after the apply, from the same
+/// command. Five minutes is the same patience `kobo setup` has for the
+/// reader itself, and the delay is not a lockout window in either direction:
+/// while it runs, keys already work (the apply arrived over one), and if it
+/// expires, the reader is merely back to stock.
+pub const REVERT_DELAY: Duration = Duration::from_secs(300);
+
+/// Where the block goes: the first of these that exists.
+///
+/// The forced first-login wrapper lives at `/etc/ssh/initial_ssh_setup.sh`,
+/// so `/etc/ssh` is where this firmware keeps its server's files; the bare
+/// `/etc` spelling is the other place OpenSSH is ever built to look. A wrong
+/// choice cannot slip through: the effective-configuration check reads what
+/// `sshd` itself resolves, not what was written.
+const CONFIG_CANDIDATES: &str = "\
+config=/etc/ssh/sshd_config\n\
+[ -f \"$config\" ] || config=/etc/sshd_config\n\
+if [ ! -f \"$config\" ]; then echo 'no sshd_config found' >&2; exit 1; fi\n\
+pending=\"${config}.cobalt-revert\"\n\
+sshd=\"$(command -v sshd || echo /usr/sbin/sshd)\"\n";
+
+/// Reloads the server so the next connection reads the edited file.
+///
+/// A `HUP` to the listener re-executes it against the config on disk and
+/// leaves established sessions alone, including the one running this. The
+/// fallbacks cover a firmware with no pid file and one whose server is
+/// started per-connection, where there is nothing to reload and nothing to
+/// need it.
+const RELOAD: &str = "kill -HUP \"$(cat /var/run/sshd.pid 2>/dev/null)\" 2>/dev/null \
+                      || killall -HUP sshd 2>/dev/null || true\n";
+
+/// The script that closes password login for root, run over a
+/// key-authenticated connection.
+///
+/// Prints exactly one `hardening=` line on success: `applied`, or `already`
+/// for a reader done on an earlier run (which also cancels any revert an
+/// interrupted run left pending, since the block it would guard is present
+/// and this connection proves keys work). Anything else is a refusal, said on
+/// stderr, with the config left as it was found.
+#[must_use]
+pub fn apply_script() -> String {
+    format!(
+        "set -eu\n\
+         {CONFIG_CANDIDATES}\
+         if grep -q '^{SENTINEL_BEGIN}$' \"$config\"; then\n\
+           rm -f \"$pending\"\n\
+           echo 'hardening=already'\n\
+           exit 0\n\
+         fi\n\
+         cp \"$config\" \"$pending\"\n\
+         {{\n\
+           echo ''\n\
+           echo '{SENTINEL_BEGIN}'\n\
+           echo 'Match User root'\n\
+           echo 'PasswordAuthentication no'\n\
+           echo '{SENTINEL_END}'\n\
+         }} >> \"$config\"\n\
+         if ! \"$sshd\" -t 2>/tmp/kobo-harden.err; then\n\
+           mv \"$pending\" \"$config\"\n\
+           echo 'sshd -t refused the hardened config, so it was put back:' >&2\n\
+           cat /tmp/kobo-harden.err >&2\n\
+           exit 1\n\
+         fi\n\
+         effective=\"$(\"$sshd\" -T -C user=root,host=reader,addr=127.0.0.1 2>/dev/null \
+         | grep -i '^passwordauthentication ' || true)\"\n\
+         case \"$effective\" in\n\
+           '') ;;\n\
+           *no) ;;\n\
+           *)\n\
+             mv \"$pending\" \"$config\"\n\
+             echo \"the server still reports $effective, so the block went to the wrong \
+         file and was taken back\" >&2\n\
+             exit 1\n\
+             ;;\n\
+         esac\n\
+         nohup sh -c \"sleep {revert_seconds}; if [ -f '$pending' ]; then \
+         mv '$pending' '$config'; \
+         kill -HUP \\\"\\$(cat /var/run/sshd.pid 2>/dev/null)\\\" 2>/dev/null \
+         || killall -HUP sshd 2>/dev/null || true; fi\" >/dev/null 2>&1 &\n\
+         {RELOAD}\
+         echo 'hardening=applied'\n\
+         exit\n",
+        revert_seconds = REVERT_DELAY.as_secs()
+    )
+}
+
+/// The script the confirming login runs, over a connection opened after the
+/// server reloaded.
+///
+/// The connection is the proof: it authenticated with the key against the
+/// hardened server, so removing the saved copy commits the change and stands
+/// the watchdog down. `already` means an earlier run committed it; `missing`
+/// means the block is gone, which after an apply means the watchdog fired
+/// first and the reader put itself back.
+#[must_use]
+pub fn commit_script() -> String {
+    format!(
+        "set -eu\n\
+         {CONFIG_CANDIDATES}\
+         if ! grep -q '^{SENTINEL_BEGIN}$' \"$config\"; then\n\
+           rm -f \"$pending\"\n\
+           echo 'hardening=missing'\n\
+           exit 0\n\
+         fi\n\
+         if [ -f \"$pending\" ]; then\n\
+           rm -f \"$pending\"\n\
+           echo 'hardening=committed'\n\
+         else\n\
+           echo 'hardening=already'\n\
+         fi\n\
+         exit\n"
+    )
+}
+
+/// The script `kobo setup --undo` runs to take the block back out.
+///
+/// The removal is the bounded sentinel range and nothing else, so an owner's
+/// own edits survive. The restored file is checked with `sshd -t -f` before
+/// it replaces anything, and a check that fails leaves the hardened file in
+/// place and says so: a working key-only server beats a broken permissive
+/// one.
+#[must_use]
+pub fn remove_script() -> String {
+    format!(
+        "set -eu\n\
+         {CONFIG_CANDIDATES}\
+         rm -f \"$pending\"\n\
+         if ! grep -q '^{SENTINEL_BEGIN}$' \"$config\"; then\n\
+           echo 'hardening=absent'\n\
+           exit 0\n\
+         fi\n\
+         scratch=/tmp/kobo-unharden.conf\n\
+         sed '/^{SENTINEL_BEGIN}$/,/^{SENTINEL_END}$/d' \"$config\" > \"$scratch\"\n\
+         if [ ! -s \"$scratch\" ]; then\n\
+           echo 'refusing to install an empty sshd_config' >&2\n\
+           exit 1\n\
+         fi\n\
+         if ! \"$sshd\" -t -f \"$scratch\" 2>/tmp/kobo-unharden.err; then\n\
+           echo 'sshd -t refused the restored config, so the hardened one stays:' >&2\n\
+           cat /tmp/kobo-unharden.err >&2\n\
+           exit 1\n\
+         fi\n\
+         cat \"$scratch\" > \"$config\"\n\
+         rm -f \"$scratch\"\n\
+         {RELOAD}\
+         echo 'hardening=removed'\n\
+         exit\n"
+    )
+}
+
+/// What a script reported, read from its `hardening=` line.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Outcome {
+    /// The block was appended, checked, and the watchdog armed.
+    Applied,
+    /// The block was already there, from this run's retry or an earlier one.
+    Already,
+    /// The confirming login removed the saved copy; the change is permanent.
+    Committed,
+    /// The block is gone: the watchdog fired before the confirmation arrived.
+    Missing,
+    /// There was no block to remove.
+    Absent,
+    /// The block was removed and the server reloaded without it.
+    Removed,
+}
+
+impl Outcome {
+    /// Reads a script's output, ignoring everything that is not the verdict.
+    #[must_use]
+    pub fn parse(output: &str) -> Option<Self> {
+        output
+            .lines()
+            .find_map(|line| match line.trim().strip_prefix("hardening=")? {
+                "applied" => Some(Self::Applied),
+                "already" => Some(Self::Already),
+                "committed" => Some(Self::Committed),
+                "missing" => Some(Self::Missing),
+                "absent" => Some(Self::Absent),
+                "removed" => Some(Self::Removed),
+                _ => None,
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        apply_script, commit_script, remove_script, Outcome, REVERT_DELAY, SENTINEL_BEGIN,
+        SENTINEL_END,
+    };
+
+    /// The block that goes in is the block validated on hardware, between the
+    /// sentinels every other script searches for.
+    #[test]
+    fn the_apply_appends_the_validated_block_between_the_sentinels() {
+        let script = apply_script();
+        let begin = script.find(SENTINEL_BEGIN).expect("the begin sentinel");
+        let matcher = script.find("Match User root").expect("the match line");
+        let closed = script
+            .find("PasswordAuthentication no")
+            .expect("the one directive");
+        let end = script.find(SENTINEL_END).expect("the end sentinel");
+        assert!(begin < matcher && matcher < closed && closed < end);
+    }
+
+    /// The one way this could strand somebody is a broken or misdirected edit
+    /// reaching the live server, so both gates have to sit between the append
+    /// and the reload, and each failure path has to put the saved copy back.
+    #[test]
+    fn the_apply_gates_the_reload_on_both_checks() {
+        let script = apply_script();
+        let saved = script.find("cp \"$config\" \"$pending\"").expect("a copy");
+        let appended = script.find(">> \"$config\"").expect("an append");
+        let syntax = script.find("-t 2>").expect("the sshd -t gate");
+        let effective = script
+            .find("passwordauthentication ")
+            .expect("the effective check");
+        let reload = script.find("kill -HUP").expect("a reload");
+        assert!(saved < appended && appended < syntax && syntax < effective);
+        assert!(effective < reload, "no reload before the checks pass");
+        assert_eq!(
+            script.matches("mv \"$pending\" \"$config\"").count(),
+            2,
+            "each failing gate restores the saved copy"
+        );
+    }
+
+    /// The watchdog is what makes an unconfirmed hardening safe, so it has to
+    /// be armed before the server reloads, survive the session that started
+    /// it, and stand down only when the saved copy is gone.
+    #[test]
+    fn the_apply_arms_the_watchdog_before_the_server_reloads() {
+        let script = apply_script();
+        let watchdog = script.find("nohup sh -c").expect("a watchdog");
+        let sleep = script
+            .find(&format!("sleep {}", REVERT_DELAY.as_secs()))
+            .expect("the deadline");
+        let guarded = script
+            .find("if [ -f '$pending' ]")
+            .expect("gated on the saved copy");
+        let reload = script.find("kill -HUP \"$(cat").expect("the reload");
+        assert!(watchdog < reload, "armed before the reload");
+        assert!(watchdog < sleep && sleep < guarded);
+    }
+
+    /// A rerun must recognise its own block, from this version or one applied
+    /// by hand, and cancel a revert an interrupted run left pending.
+    #[test]
+    fn the_apply_is_idempotent_and_settles_an_interrupted_run() {
+        let script = apply_script();
+        let recognised = script
+            .find(&format!("grep -q '^{SENTINEL_BEGIN}$'"))
+            .expect("looks for its own block");
+        let cancelled = script.find("rm -f \"$pending\"").expect("cancels a revert");
+        let done = script.find("hardening=already").expect("says so");
+        let copy = script.find("cp \"$config\"").expect("the fresh-run copy");
+        assert!(recognised < cancelled && cancelled < done && done < copy);
+    }
+
+    /// The commit is nothing but the removal of the deadline: the connection
+    /// it rode in on is the actual proof.
+    #[test]
+    fn the_commit_stands_the_watchdog_down_and_nothing_else() {
+        let script = commit_script();
+        assert!(script.contains("rm -f \"$pending\""));
+        assert!(script.contains("hardening=committed"));
+        assert!(
+            script.contains("hardening=missing"),
+            "a watchdog that fired first has to be reported, not papered over"
+        );
+        assert!(
+            !script.contains(">> \"$config\"") && !script.contains("kill -HUP"),
+            "the commit writes nothing and reloads nothing"
+        );
+    }
+
+    /// Removal is the sentinel range and only the sentinel range, checked
+    /// before it replaces the live file, so an owner's own edits survive and
+    /// a bad restore never reaches the server.
+    #[test]
+    fn the_removal_is_bounded_and_checked_before_it_lands() {
+        let script = remove_script();
+        assert!(script.contains(&format!("/^{SENTINEL_BEGIN}$/,/^{SENTINEL_END}$/d")));
+        let checked = script.find("-t -f \"$scratch\"").expect("checks the file");
+        let landed = script
+            .find("cat \"$scratch\" > \"$config\"")
+            .expect("replaces in place");
+        let reload = script.find("kill -HUP").expect("reloads");
+        assert!(checked < landed && landed < reload);
+        assert!(script.contains("hardening=absent"), "a rerun has an answer");
+    }
+
+    #[test]
+    fn a_verdict_is_read_from_whatever_else_the_device_printed() {
+        assert_eq!(
+            Outcome::parse("noise\nhardening=applied\n"),
+            Some(Outcome::Applied)
+        );
+        assert_eq!(
+            Outcome::parse("hardening=committed"),
+            Some(Outcome::Committed)
+        );
+        assert_eq!(Outcome::parse("hardening=already"), Some(Outcome::Already));
+        assert_eq!(Outcome::parse("hardening=missing"), Some(Outcome::Missing));
+        assert_eq!(Outcome::parse("hardening=absent"), Some(Outcome::Absent));
+        assert_eq!(Outcome::parse("hardening=removed"), Some(Outcome::Removed));
+        assert_eq!(Outcome::parse("hardening=?\nnothing"), None);
+    }
+
+    /// Every script is piped into a root shell on somebody's reader, so it
+    /// has to parse before it ships. `sh -n` reads the same POSIX grammar
+    /// `BusyBox` ash does, and it is the check that catches a quoting mistake
+    /// in the watchdog's nested quotes at test time instead of on a device.
+    #[test]
+    fn every_script_parses_as_posix_shell() {
+        use std::io::Write as _;
+        for script in [apply_script(), commit_script(), remove_script()] {
+            let mut check = std::process::Command::new("sh")
+                .arg("-n")
+                .stdin(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .expect("a shell to check with");
+            check
+                .stdin
+                .take()
+                .expect("a pipe")
+                .write_all(script.as_bytes())
+                .expect("the script fits in the pipe");
+            let done = check.wait_with_output().expect("the check finishes");
+            assert!(
+                done.status.success(),
+                "sh -n refused:\n{}\n{script}",
+                String::from_utf8_lossy(&done.stderr)
+            );
+        }
+    }
+
+    /// Every script begins by refusing to guess where the config is, and none
+    /// of them ever touches a file outside it, its saved copy, and /tmp.
+    #[test]
+    fn every_script_resolves_the_config_the_same_way() {
+        for script in [apply_script(), commit_script(), remove_script()] {
+            assert!(script.starts_with("set -eu\n"));
+            assert!(script.contains("config=/etc/ssh/sshd_config"));
+            assert!(script.contains("|| config=/etc/sshd_config"));
+            assert!(script.contains("no sshd_config found"));
+        }
+    }
+}

--- a/crates/kobo-cli/src/harden.rs
+++ b/crates/kobo-cli/src/harden.rs
@@ -29,10 +29,18 @@
 
 use std::time::Duration;
 
-/// First line of the appended block, and the marker every script looks for.
+/// What every script greps for to decide whether a block is present.
 ///
-/// Exactly the line validated on hardware, kept to the character so a reader
-/// hardened by hand before this existed is recognised as already done.
+/// A prefix rather than the whole line, because a hardening applied by hand
+/// before this existed carries whatever note its author left on the marker
+/// line (the one this was written against reads "Delete through end of file
+/// to undo."), and failing to recognise it would append a second block.
+pub const SENTINEL_FAMILY: &str = "# cobalt-hardening:";
+
+/// First line of the appended block.
+///
+/// Begins with [`SENTINEL_FAMILY`], and the directive part is exactly the
+/// block validated on hardware.
 pub const SENTINEL_BEGIN: &str = "# cobalt-hardening: key-only SSH for root.";
 
 /// Last line of the appended block, so removal is a bounded range, not a
@@ -86,7 +94,7 @@ pub fn apply_script() -> String {
     format!(
         "set -eu\n\
          {CONFIG_CANDIDATES}\
-         if grep -q '^{SENTINEL_BEGIN}$' \"$config\"; then\n\
+         if grep -q '^{SENTINEL_FAMILY}' \"$config\"; then\n\
            rm -f \"$pending\"\n\
            echo 'hardening=already'\n\
            exit 0\n\
@@ -141,7 +149,7 @@ pub fn commit_script() -> String {
     format!(
         "set -eu\n\
          {CONFIG_CANDIDATES}\
-         if ! grep -q '^{SENTINEL_BEGIN}$' \"$config\"; then\n\
+         if ! grep -q '^{SENTINEL_FAMILY}' \"$config\"; then\n\
            rm -f \"$pending\"\n\
            echo 'hardening=missing'\n\
            exit 0\n\
@@ -171,7 +179,7 @@ pub fn remove_script() -> String {
         "set -eu\n\
          {CONFIG_CANDIDATES}\
          rm -f \"$pending\"\n\
-         if ! grep -q '^{SENTINEL_BEGIN}$' \"$config\"; then\n\
+         if ! grep -q '^{SENTINEL_FAMILY}' \"$config\"; then\n\
            echo 'hardening=absent'\n\
            exit 0\n\
          fi\n\
@@ -238,7 +246,7 @@ impl Outcome {
 mod tests {
     use super::{
         apply_script, commit_script, remove_script, Outcome, REVERT_DELAY, SENTINEL_BEGIN,
-        SENTINEL_END,
+        SENTINEL_END, SENTINEL_FAMILY,
     };
 
     /// The block that goes in is the block validated on hardware, between the
@@ -296,13 +304,17 @@ mod tests {
     }
 
     /// A rerun must recognise its own block, from this version or one applied
-    /// by hand, and cancel a revert an interrupted run left pending.
+    /// by hand with a note added to the marker line, and cancel a revert an
+    /// interrupted run left pending. The prefix is what makes the hand
+    /// variant recognisable, so the begin line has to actually carry it.
     #[test]
     fn the_apply_is_idempotent_and_settles_an_interrupted_run() {
+        assert!(SENTINEL_BEGIN.starts_with(SENTINEL_FAMILY));
+        assert!(SENTINEL_END.starts_with(SENTINEL_FAMILY));
         let script = apply_script();
         let recognised = script
-            .find(&format!("grep -q '^{SENTINEL_BEGIN}$'"))
-            .expect("looks for its own block");
+            .find(&format!("grep -q '^{SENTINEL_FAMILY}'"))
+            .expect("looks for the marker family, not just its own line");
         let cancelled = script.find("rm -f \"$pending\"").expect("cancels a revert");
         let done = script.find("hardening=already").expect("says so");
         let copy = script.find("cp \"$config\"").expect("the fresh-run copy");

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -14,6 +14,7 @@ mod authorize;
 mod connect;
 mod devsession;
 mod drive;
+mod harden;
 mod menu;
 mod package;
 // Only the `device-write` build dispatches to this, but its tests decide what
@@ -2719,7 +2720,30 @@ fn run_remote_shell(
     script: &str,
     timeout: Duration,
 ) -> Result<RemoteShellOutput, String> {
+    run_shell_session(remote_shell_command(remote), script, timeout)
+}
+
+/// The same session, over a connection that has to authenticate afresh.
+///
+/// An owner whose own ssh configuration multiplexes connections would
+/// otherwise have every "new" connection ride the first one's master, which
+/// is fine everywhere except the one login whose entire purpose is to prove
+/// that authenticating still works (see [`harden`]).
+fn run_remote_shell_unshared(
+    remote: &str,
+    script: &str,
+    timeout: Duration,
+) -> Result<RemoteShellOutput, String> {
     let mut command = remote_shell_command(remote);
+    command.args(["-o", "ControlMaster=no", "-o", "ControlPath=none"]);
+    run_shell_session(command, script, timeout)
+}
+
+fn run_shell_session(
+    mut command: Command,
+    script: &str,
+    timeout: Duration,
+) -> Result<RemoteShellOutput, String> {
     command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -3199,7 +3223,11 @@ fn setup_device(arguments: &[String]) -> Result<(), String> {
     );
     if waiting {
         let subnet = subnet.unwrap_or_default();
-        await_reader(&subnet);
+        // Hardening rides the wait because the wait ends in the first
+        // key-authenticated connection. `--no-key` skips it: an owner who
+        // manages keys themselves has not shown this machine's key works, and
+        // closing password login on their behalf could close the only door.
+        await_reader(&subnet, options.authorize_key);
     }
     Ok(())
 }
@@ -3259,7 +3287,13 @@ fn add_menu_entry(volume: &Path, force: bool) -> Result<menu::Menu, String> {
 /// Prints rather than returns, and never fails: everything this command was
 /// asked to do is already on the reader by the time it is called, so a wait
 /// that finds nothing is a wait that found nothing, not a setup that failed.
-fn await_reader(subnet: &str) {
+///
+/// With `harden`, the one reader that appears also has password login for
+/// root closed, because this moment is the first key-authenticated connection
+/// and therefore the first moment it is safe to (see [`harden`]). A wait that
+/// times out or finds several readers hardens nothing: running the setup
+/// again retries it, and recognises a reader already done.
+fn await_reader(subnet: &str, harden: bool) {
     println!(
         "\nWaiting up to {} minutes for the reader to come back on {subnet}.0/24. Ctrl-C to stop.",
         setup::WAIT_LIMIT.as_secs() / 60
@@ -3287,10 +3321,15 @@ fn await_reader(subnet: &str) {
     );
     println!();
     match arrival {
-        setup::Arrival::Found(address) => println!(
-            "The reader is at {address}.\n\n  kobo deploy --device {address}\n\n\
-             That installs over Wi-Fi from here on, with no cable and no restart."
-        ),
+        setup::Arrival::Found(address) => {
+            println!(
+                "The reader is at {address}.\n\n  kobo deploy --device {address}\n\n\
+                 That installs over Wi-Fi from here on, with no cable and no restart."
+            );
+            if harden {
+                harden_root_ssh(&address.to_string());
+            }
+        }
         setup::Arrival::Several(addresses) => {
             let listed = addresses
                 .iter()
@@ -3323,6 +3362,173 @@ fn await_reader(subnet: &str) {
     }
 }
 
+/// Closes password login for root, over the connection that proves keys work.
+///
+/// Prints rather than returns, like the wait it runs inside: the setup itself
+/// succeeded before this began, and every ending here is an ending the reader
+/// survives. The order of the two connections is the safety argument. The
+/// first authenticates with the key and appends the block, gated on `sshd -t`
+/// and armed with a timed revert; the second is a fresh login against the
+/// hardened server, and its success is what commits the change. A second
+/// login that never arrives means the reader restores password login on its
+/// own (see [`harden`]).
+fn harden_root_ssh(host: &str) {
+    let minutes = harden::REVERT_DELAY.as_secs() / 60;
+    println!(
+        "\nThe key works, so password login for root is being switched off \
+         (the firmware\nleaves it on, with the factory credential)."
+    );
+    let remote = format!("root@{host}");
+    let applied = match run_remote_shell(&remote, &harden::apply_script(), SHELL_TIMEOUT) {
+        Ok(output) => output,
+        Err(error) => {
+            println!(
+                "The reader stopped answering before it could be hardened ({error}).\n\
+                 Password login is as the firmware left it; running this setup again\n\
+                 retries."
+            );
+            return;
+        }
+    };
+    if !applied.status.success() {
+        println!(
+            "The reader declined to close password login, and left its configuration\n\
+             as it was: {}\nRunning this setup again retries.",
+            String::from_utf8_lossy(&applied.stderr).trim()
+        );
+        return;
+    }
+    match harden::Outcome::parse(&String::from_utf8_lossy(&applied.stdout)) {
+        Some(harden::Outcome::Already) => {
+            println!("Root's SSH was already key-only; nothing to change.");
+            return;
+        }
+        Some(harden::Outcome::Applied) => {}
+        _ => {
+            println!(
+                "The reader answered something unexpected instead of applying the\n\
+                 change, so nothing further was done: {}",
+                String::from_utf8_lossy(&applied.stdout).trim()
+            );
+            return;
+        }
+    }
+    // A fresh connection, deliberately: proving the still-open session works
+    // would prove nothing about the server as it now stands.
+    let confirmed = run_remote_shell_unshared(&remote, &harden::commit_script(), SHELL_TIMEOUT);
+    match confirmed {
+        Ok(output)
+            if matches!(
+                harden::Outcome::parse(&String::from_utf8_lossy(&output.stdout)),
+                Some(harden::Outcome::Committed | harden::Outcome::Already)
+            ) =>
+        {
+            println!(
+                "Password login for root is off: a fresh key login confirmed the key\n\
+                 still works, which made it permanent. The change is one marked block\n\
+                 in the reader's sshd_config; 'kobo setup --undo' removes it."
+            );
+        }
+        Ok(output)
+            if harden::Outcome::parse(&String::from_utf8_lossy(&output.stdout))
+                == Some(harden::Outcome::Missing) =>
+        {
+            println!(
+                "The reader had already restored password login by the time the\n\
+                 confirming login arrived, so it stands as the firmware left it.\n\
+                 Running this setup again retries."
+            );
+        }
+        _ => {
+            println!(
+                "Password login is off for now, but the confirming key login did not\n\
+                 get through, so the reader will put its configuration back by itself\n\
+                 in {minutes} minutes. Keys keep working throughout; running this setup\n\
+                 again retries."
+            );
+        }
+    }
+}
+
+/// How long `--undo` watches for the reader to rejoin Wi-Fi after ejecting.
+///
+/// Much shorter than a setup's wait, because nothing here involves a restart:
+/// the reader only has to leave USB mode and pick its network back up, which
+/// takes seconds when it is going to happen at all.
+const UNDO_SWEEP_LIMIT: Duration = Duration::from_secs(60);
+
+/// Takes the key-only SSH block back out, if the reader can be found.
+///
+/// Returns one line for the undo's report. USB cannot reach `sshd_config`,
+/// so this looks for the reader over Wi-Fi, and a reader that cannot be
+/// found is reported rather than chased: the same undo has already switched
+/// the SSH server off, so the block it leaves behind configures a server
+/// that no longer runs.
+fn unharden_over_network() -> String {
+    const STAYS: &str = "the key-only SSH block stays in sshd_config, where it is inert \
+                         once the\n    server is off";
+    let Some(subnet) = connect::local_subnet() else {
+        return format!("{STAYS}; this machine has no network to look for the reader on");
+    };
+    let deadline = Instant::now() + UNDO_SWEEP_LIMIT;
+    loop {
+        let mut readers = Vec::new();
+        for address in connect::sweep(&subnet, connect::PROBE_TIMEOUT) {
+            if matches!(identify_device(&address.to_string()), Some(identity) if identity.is_kobo())
+            {
+                readers.push(address);
+            }
+        }
+        match readers[..] {
+            [address] => return unharden_reader(&address.to_string()),
+            [] if Instant::now() < deadline => {
+                thread::sleep(setup::WAIT_INTERVAL);
+            }
+            [] => {
+                return format!(
+                    "{STAYS}. The reader did not rejoin Wi-Fi within a minute; running\n\
+                     \x20   this undo again with it awake and connected removes the block"
+                );
+            }
+            _ => {
+                return format!(
+                    "{STAYS}. More than one reader is on the network, so this will not\n\
+                     \x20   guess; running this undo again with only yours connected \
+                     removes the block"
+                );
+            }
+        }
+    }
+}
+
+/// The removal itself, once exactly one reader has been found.
+fn unharden_reader(host: &str) -> String {
+    let remote = format!("root@{host}");
+    let output = match run_remote_shell(&remote, &harden::remove_script(), SHELL_TIMEOUT) {
+        Ok(output) => output,
+        Err(error) => {
+            return format!(
+                "the key-only SSH block stays: the reader at {host} stopped answering\n\
+                 \x20   ({error})"
+            );
+        }
+    };
+    match harden::Outcome::parse(&String::from_utf8_lossy(&output.stdout)) {
+        Some(harden::Outcome::Removed) => {
+            format!(
+                "password login for root restored: the key-only block was removed from\n\
+                     \x20   the reader's sshd_config at {host}"
+            )
+        }
+        Some(harden::Outcome::Absent) => "there was no key-only SSH block to remove".to_owned(),
+        _ => format!(
+            "the key-only SSH block stays: the reader at {host} declined to remove it\n\
+             \x20   ({})",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ),
+    }
+}
+
 /// What a run would do, without doing any of it.
 ///
 /// A pure function of the options and the reader, so that what `--dry-run`
@@ -3351,6 +3557,9 @@ fn dry_run_plan(options: &SetupOptions, reader: &setup::Mounted) -> String {
              would clear {}\n\
              would remove {} and ask NickelMenu to uninstall itself, unless another\n\
              \x20 mod still has a configuration file beside it\n\
+             would then look for the reader on Wi-Fi and remove the key-only SSH\n\
+             \x20 block from its sshd_config, which USB cannot reach; one that cannot\n\
+             \x20 be found keeps the block, inert once the server is off\n\
              nothing else on the reader is touched",
             reader.volume.display(),
             setup::INSTALL_FOLDER,
@@ -3408,13 +3617,7 @@ fn dry_run_plan(options: &SetupOptions, reader: &setup::Mounted) -> String {
             )
         },
         describe_key_plan(options, would_stage),
-        if options.enable_ssh && options.wait {
-            "wait for the restarted reader to appear on the network"
-        } else if !options.enable_ssh {
-            "stop after ejecting, because SSH was not enabled"
-        } else {
-            "stop, because --no-wait was given"
-        },
+        describe_wait_plan(options),
         match (
             would_stage,
             options.enable_ssh && options.authorize_key,
@@ -3425,6 +3628,23 @@ fn dry_run_plan(options: &SetupOptions, reader: &setup::Mounted) -> String {
             (false, false) => ", nothing extracted as root",
         }
     )
+}
+
+/// The one line of the dry run that covers what happens after the eject.
+fn describe_wait_plan(options: &SetupOptions) -> &'static str {
+    if options.enable_ssh && options.wait && options.authorize_key {
+        "wait for the restarted reader to appear on the network, and close\n\
+         \x20 password login for root over its first key login: a marked block in\n\
+         \x20 sshd_config, gated on sshd -t, which the reader reverts by itself\n\
+         \x20 unless a second, fresh key login confirms keys still work"
+    } else if options.enable_ssh && options.wait {
+        "wait for the restarted reader to appear on the network, leaving\n\
+         \x20 password login as the firmware has it, because --no-key was given"
+    } else if !options.enable_ssh {
+        "stop after ejecting, because SSH was not enabled"
+    } else {
+        "stop, because --no-wait was given"
+    }
 }
 
 /// The one line of the dry run that covers this machine's trust roots.
@@ -3521,6 +3741,19 @@ fn undo_setup(reader: &setup::Mounted, eject: bool) -> Result<(), String> {
             "volume left mounted"
         }
     );
+    // Only a setup that enabled the server can have closed password login, so
+    // an undo that found the server already off has no block to look for, and
+    // an owner who never opted in is not made to watch a network sweep. The
+    // block lives on the root filesystem, which USB cannot reach, so this
+    // goes the way it came: over SSH, once the ejected reader is back on
+    // Wi-Fi.
+    if ssh {
+        println!(
+            "\nIf setting up also closed password login for root, taking that back out\n\
+             needs SSH, so this is watching for the reader to rejoin Wi-Fi:"
+        );
+        println!("  · {}", unharden_over_network());
+    }
     // Said plainly rather than left for somebody to discover. The book
     // partition is all this command can reach over USB, and a key the reader
     // has already extracted lives on the root filesystem, so an undo cannot
@@ -6685,6 +6918,41 @@ mod tests {
             let parsed = parse_setup(&arguments(&["--dry-run", "--enable-ssh", "--no-wait"]))
                 .expect("parse");
             assert!(dry_run_plan(&parsed, &fresh_reader().0).contains("--no-wait was given"));
+        }
+
+        /// The plan has to disclose the hardening before anybody agrees to
+        /// it: enabling SSH with a key ends with password login for root
+        /// closed, and the plan is where that is said first.
+        #[test]
+        fn enabling_ssh_plans_to_close_password_login_for_root() {
+            let parsed = parse_setup(&arguments(&["--enable-ssh", "--dry-run"])).expect("parse");
+            let plan = dry_run_plan(&parsed, &fresh_reader().0);
+            assert!(plan.contains("close"), "{plan}");
+            assert!(plan.contains("password login for root"), "{plan}");
+            assert!(plan.contains("sshd -t"), "{plan}");
+            assert!(plan.contains("fresh key login"), "{plan}");
+        }
+
+        /// Without this machine's key there is no proof a key works, so the
+        /// door has to stay as the firmware left it, and the plan says so.
+        #[test]
+        fn declining_the_key_declines_the_hardening_too() {
+            let parsed =
+                parse_setup(&arguments(&["--enable-ssh", "--no-key", "--dry-run"])).expect("parse");
+            let plan = dry_run_plan(&parsed, &fresh_reader().0);
+            assert!(
+                plan.contains("password login as the firmware has it"),
+                "{plan}"
+            );
+            assert!(!plan.contains("close\n"), "{plan}");
+        }
+
+        #[test]
+        fn an_undo_plans_to_take_the_key_only_block_back_out() {
+            let parsed = parse_setup(&arguments(&["--undo", "--dry-run"])).expect("parse");
+            let plan = dry_run_plan(&parsed, &fresh_reader().0);
+            assert!(plan.contains("key-only SSH"), "{plan}");
+            assert!(plan.contains("sshd_config"), "{plan}");
         }
 
         #[test]

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -3419,9 +3419,9 @@ fn dry_run_plan(options: &SetupOptions, reader: &setup::Mounted) -> String {
             would_stage,
             options.enable_ssh && options.authorize_key,
         ) {
-            (true, true) => ", and nothing extracted as root but NickelMenu's own two files and one authorized_keys",
+            (true, true) => ", and nothing extracted as root but NickelMenu's own two files, one authorized_keys, and the firmware's first-login marker",
             (true, false) => ", and nothing extracted as root but NickelMenu's own two files",
-            (false, true) => ", and nothing extracted as root but one authorized_keys",
+            (false, true) => ", and nothing extracted as root but one authorized_keys and the firmware's first-login marker",
             (false, false) => ", nothing extracted as root",
         }
     )
@@ -6727,7 +6727,10 @@ mod tests {
             assert!(plan.contains("stage NickelMenu"), "{plan}");
             assert!(plan.contains("same .kobo/KoboRoot.tgz"), "{plan}");
             assert!(
-                plan.contains("NickelMenu's own two files and one authorized_keys"),
+                plan.contains(
+                    "NickelMenu's own two files, one authorized_keys, and the firmware's \
+                     first-login marker"
+                ),
                 "{plan}"
             );
         }

--- a/crates/kobo-cli/src/setup.rs
+++ b/crates/kobo-cli/src/setup.rs
@@ -808,24 +808,30 @@ boot. To undo all of it: 'kobo setup --undo'.
 /// What was written, when the reader already had the plugin.
 const KEY_SCOPE: &str = "
 One archive was staged for the firmware to extract as root at the next restart:
-this machine's public key, and nothing else. It becomes root's authorized_keys
-(written to both /root/.ssh and /.ssh, so it is found whether the reader keeps
-root's home at /root or at /), which is the file the reader's SSH server reads
-to decide who may log in. Everything else was written to the book partition. To
-undo all of it: 'kobo setup --undo'.
+this machine's public key, and the firmware's own first-login marker. The key
+becomes root's authorized_keys (written to both /root/.ssh and /.ssh, so it is
+found whether the reader keeps root's home at /root or at /), which is the file
+the reader's SSH server reads to decide who may log in. The marker,
+/.login_pass_set, is an empty file whose absence makes the firmware's SSH
+wrapper demand an interactive password change on the first login, which a
+non-interactive command cannot answer. Everything else was written to the book
+partition. To undo all of it: 'kobo setup --undo'.
 ";
 
 /// What was written, on a reader receiving both. The usual first-time case.
 const PLUGIN_AND_KEY_SCOPE: &str = "
 One archive was staged for the firmware to extract as root at the next restart,
-holding two things, because the firmware extracts one archive and both had to
-travel in it: NickelMenu, checked first to contain nothing but its own plugin
-and its own documentation, and this machine's public key, which becomes root's
-authorized_keys (written to both /root/.ssh and /.ssh, so it is found whether
-root's home is /root or /) and is the file the reader's SSH server reads to
-decide who may log in. Everything else was written to the book partition.
-NickelMenu removes itself if it fails to start, so it cannot leave the reader
-unable to boot. To undo all of it: 'kobo setup --undo'.
+holding three things, because the firmware extracts one archive and all of them
+had to travel in it: NickelMenu, checked first to contain nothing but its own
+plugin and its own documentation; this machine's public key, which becomes
+root's authorized_keys (written to both /root/.ssh and /.ssh, so it is found
+whether root's home is /root or /) and is the file the reader's SSH server
+reads to decide who may log in; and the firmware's own first-login marker,
+/.login_pass_set, an empty file whose absence makes the SSH wrapper demand an
+interactive password change on the first login, which a non-interactive command
+cannot answer. Everything else was written to the book partition. NickelMenu
+removes itself if it fails to start, so it cannot leave the reader unable to
+boot. To undo all of it: 'kobo setup --undo'.
 ";
 
 /// Everything above the step that differs.

--- a/docs/DEVICES.md
+++ b/docs/DEVICES.md
@@ -155,6 +155,17 @@ on port 22 before the wait, and only ones that were not answering and now are
 candidates. It then authenticates with the new dedicated key and asks the same
 read-only identity script every other device command uses.
 
+That first key login is also when the setup closes password login for root.
+The firmware leaves its server accepting root's factory credential; once the
+new key has proven itself, the setup appends a marked key-only block to the
+server's `sshd_config`, gated on `sshd -t` and on the effective configuration
+actually reporting the change. The reader restores its own configuration a few
+minutes later unless a second, fresh key login (made by the same command)
+confirms that keys still work against the hardened server, so a change that
+would have locked anybody out undoes itself. `kobo setup --undo` removes the
+block the way it went in, over SSH, and it is inert either way once the undo
+has switched the server off.
+
 Change alone was not enough. A laptop waking from sleep mid-wait was reported
 as the reader, and a confident wrong address is worse than none. The obvious
 second test was the SSH banner, and it was wrong: this firmware runs

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -177,4 +177,6 @@ cargo run -p kobo-cli -- setup --undo
 
 Or, with no tooling at all, plug the reader in and delete `.adds/cobalt` from
 it. That is the entire uninstall. If you used `--enable-ssh`, `--undo` also
-switches the SSH server back off.
+switches the SSH server back off, and takes the key-only login block back out
+of the server's configuration when it can reach the reader over Wi-Fi (a block
+it cannot reach is inert once the server is off).


### PR DESCRIPTION
Fixes the first-contact failure I hit on a fresh Libra Colour (full diagnosis and correction on #49): the firmware's `sshd_config` forces root through a setup script that runs an interactive `passwd` until `/.login_pass_set` exists. Key authentication succeeds, and then the very first non-interactive `kobo deploy`/`doctor` after `setup --enable-ssh` pipes its script into that `passwd` — the transfer lines are eaten as password input, and the leftovers run as shell commands once the wrapper reaches `exec /bin/sh`. It presents as the base64 body executing line by line (`/bin/sh: f0VMRg…: not found`), which I initially misattributed to the shell.

## The change

`kobo setup --enable-ssh` already stages one archive for the firmware to extract as root, carrying this machine's public key. That archive now also carries `/.login_pass_set`: empty, mode 644, which is byte for byte what the firmware's own `touch ${PASS_SET}` would have created after a successful interactive password change. Root already carries a password hash in `/etc/passwd` and access is by key, so the marker gates only the interactive reset, not authentication — the wrapper goes straight to `exec /bin/sh` on every login, including the first.

- `authorize.rs`: the marker joins `entries()` and `STAGED_MEMBERS`; the module contract ("ships nothing but this machine's public key") is updated to name both things it ships and why.
- `setup.rs`: the `KEY_SCOPE` and `PLUGIN_AND_KEY_SCOPE` reports name the marker and explain it.
- `main.rs`: the dry-run plan's "nothing extracted as root but…" lines include it.
- Tests: the nothing-but-the-key boundary test now admits exactly the marker; a new test pins its path, emptiness, and mode; the plan-string tests updated.

`cargo test -p kobo-cli`: 203 passed. Clippy (pedantic) and rustfmt clean.

## Scope note

This helps every model whose firmware ships the wrapper (the Clara BW on 4.45.23697 has the same script). On firmwares whose `/etc/ssh/initial_ssh_setup.sh` doesn't exist the marker is a single inert empty file at `/`. I considered gating it on the wrapper's presence, but USB setup cannot read the root filesystem to check, and an inert empty file seemed the better trade than a first login that fails interactively — happy to change the approach if you'd rather.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790117203&installation_model_id=20525&pr_number=51&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F51&signature=e770e762ef7ec36a14431b8333b0310290119f59ffb84aee3ba0bdef74fa1948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->