### PR TITLE
docs: note that setup adds Cobalt to an existing NickelMenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,8 @@ Restart the reader and open **Cobalt** from Kobo's menu. Future applications
 are installed from **Store** over Wi-Fi. Full Cobalt updates remain under
 **Settings**.
 
-Readers running Cobalt `0.1.x` need the `0.2.0` platform update once to add
-Store. After that update, new and updated apps arrive independently through
-the app catalog.
+If you already use NickelMenu, Cobalt is added to it; existing entries are
+left alone.
 
 See [docs/INSTALL.md](docs/INSTALL.md) for the complete walkthrough and
 recovery steps.


### PR DESCRIPTION
The install steps did not say what happens on a reader that already has NickelMenu.

Setup writes only its own `.adds/nm/cobalt` entry, so existing menu items and any config written by hand or by another mod are left alone (`crates/kobo-cli/src/menu.rs:71-77`), and re-extracting the plugin leaves every entry in the config folder alone (`menu.rs:273-281`). This adds one line saying so.

Also drops the `0.1.x` -> `0.2.0` upgrade paragraph.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790151685&installation_model_id=20525&pr_number=52&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F52&signature=63c176506705f58f84c2317b870199662faef875a51ebb44649a655a515e5c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->