### PR TITLE
fix: reap Nickel's leftover wpa_supplicant on hand-back where measured

### DIFF
--- a/crates/kobo-hal/src/reader.rs
+++ b/crates/kobo-hal/src/reader.rs
@@ -116,6 +116,12 @@ pub struct Reader {
     arguments: Vec<OsString>,
     environment: BTreeMap<OsString, OsString>,
     working_directory: PathBuf,
+    /// How the process was recognised, so that every later identity check
+    /// asks the same question that found it. A daemon found by its `exe` link
+    /// carries a bare zeroth argument, and re-checking it by argv concludes
+    /// the process has changed identity when it has not moved at all — which
+    /// turns `stop` into a refusal that never sends a signal.
+    identity: Identity,
 }
 
 impl Reader {
@@ -246,6 +252,7 @@ impl Reader {
             arguments,
             environment,
             working_directory,
+            identity,
         })
     }
 
@@ -256,8 +263,12 @@ impl Reader {
     }
 
     fn still_running_in(&self, proc_root: &Path) -> bool {
-        read_argv(proc_root, self.pid)
-            .is_some_and(|argv| argv.first().is_some_and(|first| *first == self.executable))
+        match self.identity {
+            Identity::ZerothArgument => read_argv(proc_root, self.pid)
+                .is_some_and(|argv| argv.first().is_some_and(|first| *first == self.executable)),
+            Identity::Executable => fs::read_link(proc_root.join(self.pid.to_string()).join("exe"))
+                .is_ok_and(|target| target == Path::new(&self.executable)),
+        }
     }
 
     /// Asks the reader to exit, escalating to `SIGKILL` if it will not.
@@ -421,6 +432,9 @@ impl Reader {
             arguments,
             environment,
             working_directory: PathBuf::from(OsString::from_vec(cwd)),
+            // A saved description names the reader, which is always started
+            // with its absolute path as its zeroth argument.
+            identity: Identity::ZerothArgument,
         })
     }
 }
@@ -725,6 +739,31 @@ mod tests {
         // The same pid now belongs to something else entirely.
         fs::write(root.join("360").join("cmdline"), b"/bin/sh\0").expect("rewrite cmdline");
         assert!(!reader.still_running_in(&root));
+        let _ignored = fs::remove_dir_all(&root);
+    }
+
+    /// The defect this pins was found on a device: the supplicant was found
+    /// by its `exe` link, because Nickel starts it with a bare zeroth
+    /// argument, and `stop` then re-checked it by argv, concluded the identity
+    /// had changed, and refused without sending a signal. The identity that
+    /// found a process is the one every later check must use.
+    #[test]
+    fn a_daemon_found_by_its_exe_link_is_still_recognised_by_it() {
+        let root = fake_proc("exe_link", &[(500, "wpa_supplicant", &["-B"])]);
+        // The exe link points at the real binary however the process was
+        // launched; /bin/sh exists on every machine the tests run on.
+        std::os::unix::fs::symlink("/bin/sh", root.join("500").join("exe"))
+            .expect("create exe link");
+        let daemon = Reader::find_matching_in(&root, "/bin/sh", super::Identity::Executable)
+            .expect("daemon found");
+        assert_eq!(daemon.pid(), 500);
+        assert!(
+            daemon.still_running_in(&root),
+            "a daemon that has not moved was declared a different process"
+        );
+        // Once the process is gone the same check must say so.
+        fs::remove_file(root.join("500").join("exe")).expect("remove exe link");
+        assert!(!daemon.still_running_in(&root));
         let _ignored = fs::remove_dir_all(&root);
     }
 

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -288,6 +288,7 @@ pub const CLARA_BW_391: DeviceProfile = DeviceProfile {
     firmware_versions: &["4.45.23697"],
     kernel_release: "4.9.77",
     write_ready: true,
+    reap_nickel_supplicant: false,
 };
 
 /// The Kobo Clara HD, added upstream without i.MX6 hardware to test on.
@@ -354,6 +355,7 @@ pub const CLARA_HD_376: DeviceProfile = DeviceProfile {
     firmware_versions: &["4.38.23684", "4.38.23697"],
     kernel_release: "4.1.15-00136-g12655eaaef89",
     write_ready: true,
+    reap_nickel_supplicant: false,
 };
 
 pub const ELIPSA_2E_389: DeviceProfile = DeviceProfile {
@@ -411,6 +413,7 @@ pub const ELIPSA_2E_389: DeviceProfile = DeviceProfile {
     firmware_versions: &["4.38.23697"],
     kernel_release: "4.9.77",
     write_ready: true,
+    reap_nickel_supplicant: false,
 };
 
 /// Kobo Libra 2, codename `io`, an i.MX6SLL Mark 7 device driven by
@@ -500,6 +503,10 @@ pub const LIBRA_2_388: DeviceProfile = DeviceProfile {
     // Owner-attended display, touch, exit and recovery evidence was filmed on
     // the device and reviewed upstream before this was set.
     write_ready: true,
+    // Both halves measured on the device: the two-supplicant collision after
+    // a normal hand-back, and the clean recovery after the leftover one was
+    // killed during a live session.
+    reap_nickel_supplicant: true,
 };
 
 pub const SUPPORTED_PROFILES: &[&DeviceProfile] =
@@ -711,6 +718,24 @@ pub struct DeviceProfile {
     pub kernel_release: &'static str,
     /// True only after owner-attended hardware evidence has been reviewed.
     pub write_ready: bool,
+    /// Whether the hand-back must stop Nickel's leftover `wpa_supplicant`
+    /// before the reader is restarted.
+    ///
+    /// Nickel launches its supplicant detached (`-B`, parented to init), so
+    /// stopping the reader never takes it down and it survives the whole
+    /// Cobalt session. On the Libra 2 the restarted Nickel then starts a
+    /// supplicant of its own, two of them fight over `wlan0`, and Wi-Fi stays
+    /// down until a reboot. Measured on the device: killing the leftover
+    /// supplicant before the hand-back gives a clean recovery, every time,
+    /// and leaving it gives the retry loop, every time.
+    ///
+    /// Per profile rather than unconditional for the usual reason: the
+    /// evidence is from one radio, a Realtek `8723ds` on i.MX6SLL, and the
+    /// `MediaTek` devices share their Wi-Fi stack with Bluetooth and are known
+    /// to behave differently. Do not silently change a device nobody here
+    /// can test; enable this per device once the symptom and the fix are
+    /// observed on it.
+    pub reap_nickel_supplicant: bool,
 }
 
 /// Pose geometry derived by a profile's [`GeometryRule`].
@@ -1487,6 +1512,29 @@ mod tests {
         assert_eq!(
             super::identify_profile(&snapshot).map(|profile| profile.id),
             Some("libra-2-388")
+        );
+    }
+
+    /// The supplicant reap is declared, not guessed. The Libra 2 is the one
+    /// device where both halves were measured: the two-supplicant collision
+    /// after a normal hand-back, and the clean recovery once the leftover one
+    /// was killed. Every other profile keeps its current behaviour until the
+    /// same evidence exists for it, so a change to one of these values is a
+    /// claim about a device and needs the measurement to go with it.
+    #[test]
+    fn the_supplicant_reap_is_declared_only_where_it_was_measured() {
+        let declared = super::SUPPORTED_PROFILES
+            .iter()
+            .map(|profile| (profile.id, profile.reap_nickel_supplicant))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            declared,
+            [
+                ("clara-bw-391", false),
+                ("clara-hd-376", false),
+                ("elipsa-2e-389", false),
+                ("libra-2-388", true),
+            ]
         );
     }
 

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -678,6 +678,29 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
             )
         });
     }
+    // Nickel launches its supplicant detached, so stopping the reader never
+    // took it down and it has been running for the whole session. A restarted
+    // Nickel starts a supplicant of its own on top of it, the two fight over
+    // the interface, and Wi-Fi stays down until a reboot. On the profiles
+    // that declare it, the leftover one is stopped here, after the panel is
+    // given up and before the reader returns, so the new Nickel comes up
+    // alone. This is a reap, not radio configuration: the interface, the
+    // association and the choice to reconnect stay Nickel's.
+    //
+    // Nothing here is fatal. A supplicant that is absent, ambiguous, or will
+    // not die leaves the owner exactly where every session left them before
+    // this existed: reconnecting by hand or rebooting.
+    if profile.reap_nickel_supplicant {
+        match Reader::find_running(kobo_hal::network::SUPPLICANT_EXECUTABLE) {
+            Ok(supplicant) => {
+                trace("stopping the leftover supplicant before the reader returns");
+                if let Err(error) = supplicant.stop(STOP_GRACE) {
+                    trace(&format!("the leftover supplicant would not stop: {error}"));
+                }
+            }
+            Err(error) => trace(&format!("no leftover supplicant to stop: {error}")),
+        }
+    }
     trace("panel and touch released, restarting the reader");
     println!("panel released, restarting the reader");
     let restarted = reader.start(START_GRACE);


### PR DESCRIPTION
Fixes #47.

Nickel launches its supplicant detached, so stopping the reader never takes it down and it survives the whole Cobalt session. The restarted Nickel then starts a supplicant of its own, the two fight over `wlan0`, and Wi-Fi stays down until a reboot. The measurements are in the issue.

The hand-back now stops the leftover supplicant after the panel is released and before the reader is restarted, so the new Nickel comes up alone. This PR does not configure the radio: the interface, the association and the choice to reconnect stay Nickel's. Every failure is non-fatal and traced. A supplicant that is absent, ambiguous, or will not die leaves the owner exactly where every session left them before.

The reap is declared per device profile, in the same spirit as `GeometryRule`. The evidence is from one radio, a Realtek `8723ds` on an i.MX6SLL Libra 2. The MediaTek devices share their Wi-Fi stack with Bluetooth and are known to behave differently, so only the Libra 2 enables it. If your verification on the Clara or the Elipsa shows the same symptom and the same recovery, enabling it there is a one-line profile change with its own evidence. A test pins the declared values, so changing one of them is a claim that needs the measurement to go with it.

Fixing this surfaced a latent defect in `Reader`. A process found by its `exe` link carries a bare zeroth argument. `stop` re-checked identity by argv, concluded the process had changed, and refused without sending a signal. The first on-device run of the reap did exactly that, with the collision following as before. `Reader` now remembers which identity found a process and uses it for every later check. The reader's own argv-based path is unchanged. `Reader::load` keeps the argv identity it always had, and the save format is untouched. A regression test pins the fix. `find_running` had no other live callers, so no existing runtime path changes behaviour.

Verified on the Libra 2 with the same two-second sampling as the issue, times in seconds of uptime, pids from the device:

```
856  nickel=4011  kobod=6566  wpa=4293  wlan0=up    <- session running, leftover supplicant alive
893  nickel=6927  kobod=6566  wpa=-     wlan0=down  <- reaped before Nickel returned
901  nickel=6927  kobod=6566  wpa=7049  wlan0=down  <- Nickel starts its own, and only that one
903  nickel=6927  kobod=6566  wpa=7049  wlan0=up    <- default route back, stable from here
```

About ten seconds of downtime, one supplicant at every sample, and no toggle needed. The trace matches what the issue's negative control produced by hand, with the reap now doing the same job in the hand-back path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790169953&installation_model_id=20525&pr_number=54&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F54&signature=125e268391631fea72cc10787e386780e00ec14513f9b3bedbbde891b175c8e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->