### PR TITLE
Mount devpts before starting kobod

### DIFF
--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -128,8 +128,8 @@ fi
 # refused with Failed. A kernel mount, not a write to the root filesystem, and
 # gone again at the next reboot.
 if ! grep -q ' /dev/pts ' /proc/mounts 2>/dev/null; then
-  mkdir -p /dev/pts
-  mount -t devpts devpts /dev/pts -o mode=0620,ptmxmode=0666 || true
+  mkdir -p /dev/pts 2>/dev/null &&
+    mount -t devpts devpts /dev/pts -o mode=0620,ptmxmode=0666 || true
 fi
 KOBO_PRESENT_UNLOCK=OWNER_ATTENDED_PANEL_SESSION \\
   exec \"$root/bin/kobod\" --present \"$root/bin/kobo-launcher\" > /mnt/onboard/kobod.txt 2>&1

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -123,6 +123,14 @@ if [ -s \"$staged_key\" ]; then
   rm -f \"$staged_key\"
   sync
 fi
+# The terminal opens a pty: ptsname names /dev/pts/N and the child opens it.
+# Kobo does not mount devpts, so without this every terminal is refused with
+# Failed. A kernel mount, not a write to the root filesystem, and gone again at
+# the next reboot.
+if ! grep -q ' /dev/pts ' /proc/mounts 2>/dev/null; then
+  mkdir -p /dev/pts
+  mount -t devpts devpts /dev/pts -o mode=0620,ptmxmode=0666 || true
+fi
 KOBO_PRESENT_UNLOCK=OWNER_ATTENDED_PANEL_SESSION \\
   exec \"$root/bin/kobod\" --present \"$root/bin/kobo-launcher\" > /mnt/onboard/kobod.txt 2>&1
 ";

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -124,9 +124,9 @@ if [ -s \"$staged_key\" ]; then
   sync
 fi
 # The terminal opens a pty: ptsname names /dev/pts/N and the child opens it.
-# Kobo does not mount devpts, so without this every terminal is refused with
-# Failed. A kernel mount, not a write to the root filesystem, and gone again at
-# the next reboot.
+# Some Kobo firmware does not mount devpts, so without this every terminal is
+# refused with Failed. A kernel mount, not a write to the root filesystem, and
+# gone again at the next reboot.
 if ! grep -q ' /dev/pts ' /proc/mounts 2>/dev/null; then
   mkdir -p /dev/pts
   mount -t devpts devpts /dev/pts -o mode=0620,ptmxmode=0666 || true


### PR DESCRIPTION
Terminal never opens a shell on my Clara Colour. It draws fine, but every open is refused with `Failed`.

The shell is spawned on a pty: `posix_openpt`, then the child opens whatever `ptsname` returns, which is `/dev/pts/N`. Kobo doesn't mount devpts, so that open fails and the spawn errors out. NickelMenu hits the same thing and mounts it by hand before starting telnetd.

Mounting it in `start.sh` before kobod fixes it. Guarded on `/proc/mounts` so it's a no-op where the firmware already provides it, and it's a kernel mount, so nothing is written to the root filesystem and it's gone at the next reboot.

One thing I'm unsure about: Terminal is listed as hardware tested on the Clara BW and Elipsa 2E, and I don't see how it could work there either. Does that firmware mount devpts already, or is something else mounting it on those readers? If it's the latter this probably belongs somewhere other than `start.sh`.

Filed the report as #55. Device is a Clara Colour (N367, 393) on 4.45.23697, running the profile from #38.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790179469&installation_model_id=20525&pr_number=56&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F56&signature=102bca619db36875952fe6fb6a3fadd063199e942270fa283aa7d4a214cebc53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->