### PR TITLE
fix: declare the supplicant reap on the Libra Colour profile

### DIFF
--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -597,6 +597,10 @@ pub const LIBRA_COLOUR_390: DeviceProfile = DeviceProfile {
     firmware_versions: &["4.45.23697"],
     kernel_release: "4.9.77",
     write_ready: true,
+    // Off until measured here. The evidence behind the reap is from a Realtek
+    // radio on i.MX6SLL; this is a MediaTek device whose Wi-Fi stack is shared
+    // with Bluetooth and known to behave differently.
+    reap_nickel_supplicant: false,
 };
 
 pub const SUPPORTED_PROFILES: &[&DeviceProfile] = &[
@@ -1629,6 +1633,7 @@ mod tests {
                 ("clara-hd-376", false),
                 ("elipsa-2e-389", false),
                 ("libra-2-388", true),
+                ("libra-colour-390", false),
             ]
         );
     }


### PR DESCRIPTION
Fixes the build break on main after #54 and #49 merged independently.

#49 added `LIBRA_COLOUR_390` before #54 introduced the required `reap_nickel_supplicant` field on `DeviceProfile`, so main stopped compiling once both landed (`E0063: missing field reap_nickel_supplicant` in both the CI and Publish apps workflows).

The field is declared `false` for the Libra Colour: the reap's evidence is from a Realtek radio on i.MX6SLL, and the Libra Colour is a MediaTek device whose shared Wi-Fi/Bluetooth stack is exactly the case #54 says not to change without measurement. `write_ready` is untouched — the device stays enabled. The pinning test now lists all five supported profiles.

Verified locally with `cargo test --workspace --all-targets --all-features`: everything passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790234517&installation_model_id=20525&pr_number=59&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F59&signature=cd266eed26c8b9ebe26275d6d522f252ed7fa875e6587855c960b6e69c9a7702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->