### PR TITLE
Release 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "icon-import"
-version = "0.2.6"
+version = "0.3.0"
 
 [[package]]
 name = "image"
@@ -376,14 +376,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-abi"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "kobo-app-store"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-arxiv"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-audiobook"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-doc",
  "kobo-json",
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-bookview"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-brief"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-chat"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-cli"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-app-store",
  "kobo-image",
@@ -453,14 +453,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-dict"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "unicode-normalization",
 ]
 
 [[package]]
 name = "kobo-doc"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-html",
  "miniz_oxide 0.9.1",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doctor"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -477,14 +477,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-gallery"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-guard"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gutenbird"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-hal"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-abi",
  "kobo-doc",
@@ -516,21 +516,21 @@ dependencies = [
 
 [[package]]
 name = "kobo-handoff"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-hello"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-hn"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-html"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "ratex-layout",
  "ratex-parser",
@@ -550,18 +550,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-image"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "image",
 ]
 
 [[package]]
 name = "kobo-json"
-version = "0.2.6"
+version = "0.3.0"
 
 [[package]]
 name = "kobo-launcher"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-magnet"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-morse"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-net"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "http",
  "httparse",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-opds"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-json",
  "kobo-xml",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-policy"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-abi",
  "kobo-dict",
@@ -614,18 +614,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-profile"
-version = "0.2.6"
+version = "0.3.0"
 
 [[package]]
 name = "kobo-protocol"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-ui",
 ]
 
 [[package]]
 name = "kobo-read"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-rss"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sdk"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-policy",
  "kobo-protocol",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-settings"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-shell"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-abi",
  "kobo-policy",
@@ -676,7 +676,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekick"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekickd"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sim"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-net",
  "kobo-policy",
@@ -706,14 +706,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-smoke"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-store"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sudoku"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tap"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-term"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-ui",
  "vt100",
@@ -746,7 +746,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-terminal"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-policy",
  "kobo-sdk",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-text"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "fontdue",
  "kobo-ui",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tictactoe"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-todo"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -783,18 +783,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-ui"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "kobo-xml"
-version = "0.2.6"
+version = "0.3.0"
 
 [[package]]
 name = "kobod"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "kobo-abi",
  "kobo-app-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.6"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.85.1"
 license = "AGPL-3.0-only"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 <p align="center">
   <a href="https://github.com/BandarLabs/Cobalt/actions/workflows/ci.yml"><img src="https://github.com/BandarLabs/Cobalt/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://github.com/BandarLabs/Cobalt/actions/workflows/apps.yml"><img src="https://github.com/BandarLabs/Cobalt/actions/workflows/apps.yml/badge.svg?branch=main" alt="Publish apps"></a>
-  <a href="https://github.com/BandarLabs/Cobalt/releases/latest"><img src="https://img.shields.io/github/v/release/BandarLabs/Cobalt" alt="Latest release"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/BandarLabs/Cobalt" alt="License"></a>
+  <a href="https://github.com/BandarLabs/Cobalt/releases/latest"><img src="https://img.shields.io/github/v/release/BandarLabs/Cobalt?color=brightgreen" alt="Latest release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/BandarLabs/Cobalt?color=brightgreen" alt="License"></a>
 </p>
 
 Cobalt is an open-source application platform for Kobo. It provides a launcher,

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 <p align="center"><strong>Apps and an SDK for Kobo e-readers.</strong></p>
 
+<p align="center">
+  <a href="https://github.com/BandarLabs/Cobalt/actions/workflows/ci.yml"><img src="https://github.com/BandarLabs/Cobalt/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="https://github.com/BandarLabs/Cobalt/actions/workflows/apps.yml"><img src="https://github.com/BandarLabs/Cobalt/actions/workflows/apps.yml/badge.svg?branch=main" alt="Publish apps"></a>
+  <a href="https://github.com/BandarLabs/Cobalt/releases/latest"><img src="https://img.shields.io/github/v/release/BandarLabs/Cobalt" alt="Latest release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/BandarLabs/Cobalt" alt="License"></a>
+</p>
+
 Cobalt is an open-source application platform for Kobo. It provides a launcher,
 an App Store, a Rust SDK, a runtime with capability isolation, and a Clara BW
 simulator.
@@ -21,9 +28,10 @@ new app can appear in Store without reinstalling or updating Cobalt.
 
 > [!IMPORTANT]
 > The **Kobo Clara BW N365 (device code 391)**, **Kobo Elipsa 2E N605 (device
-> code 389)**, and **Kobo Clara HD N249 (device code 376)** are fully
-> hardware-tested on the exact firmware and kernel versions in the support
-> matrix. See the
+> code 389)**, **Kobo Clara HD N249 (device code 376)**, **Kobo Libra 2 N418
+> (device code 388)**, and **Kobo Libra Colour N428 (device code 390)** are
+> fully hardware-tested on the exact firmware and kernel versions in the
+> support matrix. See the
 > [device support matrix](docs/DEVICES.md#device-support-matrix) before
 > installing.
 > It is an independent project and is not affiliated with Rakuten Kobo.
@@ -32,9 +40,7 @@ new app can appear in Store without reinstalling or updating Cobalt.
 > **Own an unsupported Kobo? Help test its port.** No coding is required.
 > Read the thread and comment with your exact model, firmware, and whether you
 > can run attended tests:
-> [Libra Colour](https://github.com/BandarLabs/Cobalt/issues/28),
-> [Libra 2](https://github.com/BandarLabs/Cobalt/issues/29),
-> [Clara Colour](https://github.com/BandarLabs/Cobalt/issues/30),
+> [Clara Colour](https://github.com/BandarLabs/Cobalt/issues/30)
 > or [Aura](https://github.com/BandarLabs/Cobalt/issues/32).
 > Start with read-only checks; run panel tests only against the commit named by
 > a maintainer. See

--- a/SDK.md
+++ b/SDK.md
@@ -49,7 +49,7 @@ fn main() {
 ## 0. Your own application, end to end
 
 Before anything else: Cobalt is hardware-tested on the exact Clara BW, Elipsa
-2E, and Clara HD identities in the
+2E, Clara HD, Libra 2, and Libra Colour identities in the
 [device support matrix](docs/DEVICES.md#device-support-matrix). It is
 AGPL-3.0 licensed and comes with no warranty. Every device write is gated on an
 exact hardware match; do not install it on an unlisted identity or firmware.

--- a/crates/kobo-policy/Cargo.toml
+++ b/crates/kobo-policy/Cargo.toml
@@ -9,9 +9,9 @@ repository.workspace = true
 description = "Capability, task, storage, and credential policy for Kobo applications"
 
 [dependencies]
-kobo-abi = { version = "0.2.0", path = "../kobo-abi" }
-kobo-dict = { version = "0.2.2", path = "../kobo-dict" }
-kobo-protocol = { version = "0.2.0", path = "../kobo-protocol" }
+kobo-abi = { version = "0.3.0", path = "../kobo-abi" }
+kobo-dict = { version = "0.3.0", path = "../kobo-dict" }
+kobo-protocol = { version = "0.3.0", path = "../kobo-protocol" }
 
 [lints]
 workspace = true

--- a/crates/kobo-protocol/Cargo.toml
+++ b/crates/kobo-protocol/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 description = "Bounded wire protocol between Kobo applications and the Cobalt runtime"
 
 [dependencies]
-kobo-ui = { version = "0.2.0", path = "../kobo-ui" }
+kobo-ui = { version = "0.3.0", path = "../kobo-ui" }
 
 [lints]
 workspace = true

--- a/crates/kobo-sdk/Cargo.toml
+++ b/crates/kobo-sdk/Cargo.toml
@@ -17,10 +17,10 @@ default = ["text"]
 text = ["dep:kobo-text"]
 
 [dependencies]
-kobo-policy = { version = "0.2.0", path = "../kobo-policy" }
-kobo-protocol = { version = "0.2.0", path = "../kobo-protocol" }
-kobo-text = { version = "0.2.0", path = "../kobo-text", optional = true }
-kobo-ui = { version = "0.2.0", path = "../kobo-ui" }
+kobo-policy = { version = "0.3.0", path = "../kobo-policy" }
+kobo-protocol = { version = "0.3.0", path = "../kobo-protocol" }
+kobo-text = { version = "0.3.0", path = "../kobo-text", optional = true }
+kobo-ui = { version = "0.3.0", path = "../kobo-ui" }
 
 [lints]
 workspace = true

--- a/crates/kobo-text/Cargo.toml
+++ b/crates/kobo-text/Cargo.toml
@@ -10,7 +10,7 @@ description = "Real type for the Kobo application platform"
 
 [dependencies]
 fontdue = "0.9"
-kobo-ui = { version = "0.2.0", path = "../kobo-ui" }
+kobo-ui = { version = "0.3.0", path = "../kobo-ui" }
 unicode-linebreak = "0.1.5"
 unicode-segmentation = "1.12"
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -6,8 +6,10 @@ off. Part of [Cobalt](../README.md).
 
 The procedure below is fully hardware-tested on the **Kobo Clara BW N365
 (device code 391), firmware 4.45.23697**, the **Kobo Elipsa 2E N605 (device
-code 389), firmware 4.38.23697**, and the **Kobo Clara HD N249 (device code
-376), firmware 4.38.23684 or 4.38.23697**. Support remains tied to the exact
+code 389), firmware 4.38.23697**, the **Kobo Clara HD N249 (device code
+376), firmware 4.38.23684 or 4.38.23697**, the **Kobo Libra 2 N418 (device
+code 388), firmware 4.38.23697**, and the **Kobo Libra Colour N428 (device
+code 390), firmware 4.45.23697**. Support remains tied to the exact
 firmware, kernel, framebuffer, touch, and identity combination in the
 [device support matrix](DEVICES.md#device-support-matrix).
 
@@ -103,7 +105,7 @@ you with an unbootable reader.
 
 On this firmware the entry is in the menu at the **bottom right** of the home
 screen. (NickelMenu puts its items in the top-left menu on old firmware and in
-the bottom-right one from 4.23.15505 onward, and all three tested profiles are well
+the bottom-right one from 4.23.15505 onward, and all five tested profiles are well
 past that.) Tap it and choose **Cobalt**.
 
 The launcher appears with Cobalt's built-in applications. Store-only

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -2,8 +2,9 @@
 
 Part of [Cobalt](../README.md).
 
-Cobalt selects a device profile at runtime. The Clara BW, Elipsa 2E, and
-Clara HD profiles are fully hardware-tested at their recorded identity and
+Cobalt selects a device profile at runtime. The Clara BW, Elipsa 2E,
+Clara HD, Libra 2, and Libra Colour profiles are fully hardware-tested at
+their recorded identity and
 firmware boundaries. The current status and exact boundaries are recorded in
 the [device support matrix](DEVICES.md#device-support-matrix).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -578,7 +578,7 @@ kobo dev</code></pre>
     <p class="kicker">Install</p>
     <h2 class="measure">Installing from source.</h2>
     <ol class="steps">
-      <li><strong>Charge a fully supported reader</strong> and connect it over USB. The Clara BW N365, Elipsa 2E N605, and Clara HD N249 are fully tested at the exact versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>.</li>
+      <li><strong>Charge a fully supported reader</strong> and connect it over USB. The Clara BW N365, Elipsa 2E N605, Clara HD N249, Libra 2 N418, and Libra Colour N428 are fully tested at the exact versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>.</li>
       <li><strong>Run the setup:</strong></li>
     </ol>
 <pre><code>git clone https://github.com/BandarLabs/Cobalt.git
@@ -604,7 +604,7 @@ cargo run -p kobo-cli -- setup</code></pre>
       <li><strong>Run it on your own device.</strong> A real, fully supported reader, not just the Clara-sized simulator.</li>
       <li><strong>Open a PR with a gif or photos of it running.</strong> Once reviewed and merged, the publish workflow signs it and it appears in Store. No platform release needed.</li>
     </ol>
-    <p class="measure quiet" style="margin-top:22px">Own an unsupported Kobo? No coding is required to help test it. Join the active <a href="https://github.com/BandarLabs/Cobalt/issues/28">Libra Colour</a>, <a href="https://github.com/BandarLabs/Cobalt/issues/29">Libra 2</a>, <a href="https://github.com/BandarLabs/Cobalt/issues/30">Clara Colour</a>, or <a href="https://github.com/BandarLabs/Cobalt/issues/32">Aura</a> thread and follow the <a href="https://github.com/BandarLabs/Cobalt/blob/main/CONTRIBUTING.md#device-testing">device testing guide</a>. App details are in <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/CONTRIBUTING_APPS.md">docs/CONTRIBUTING_APPS.md</a>.</p>
+    <p class="measure quiet" style="margin-top:22px">Own an unsupported Kobo? No coding is required to help test it. Join the active <a href="https://github.com/BandarLabs/Cobalt/issues/30">Clara Colour</a> or <a href="https://github.com/BandarLabs/Cobalt/issues/32">Aura</a> thread and follow the <a href="https://github.com/BandarLabs/Cobalt/blob/main/CONTRIBUTING.md#device-testing">device testing guide</a>. App details are in <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/CONTRIBUTING_APPS.md">docs/CONTRIBUTING_APPS.md</a>.</p>
   </div>
 </section>
 
@@ -613,7 +613,7 @@ cargo run -p kobo-cli -- setup</code></pre>
     <p class="kicker">Safety</p>
     <h2>Device support and safety.</h2>
     <p>Cobalt does not replace Kobo's boot chain. Normal panel-write entry points require an exact hardware and firmware match, and a reboot returns to the stock reader. The first installation does modify files on the user storage partition, and it is provided without warranty.</p>
-    <p>The Clara BW N365, Elipsa 2E N605, and Clara HD N249 profiles are fully hardware-tested at the exact firmware and kernel versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>. Other identity or firmware combinations remain unsupported until separately verified. Cobalt is an independent project, not affiliated with Rakuten Kobo.</p>
+    <p>The Clara BW N365, Elipsa 2E N605, Clara HD N249, Libra 2 N418, and Libra Colour N428 profiles are fully hardware-tested at the exact firmware and kernel versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>. Other identity or firmware combinations remain unsupported until separately verified. Cobalt is an independent project, not affiliated with Rakuten Kobo.</p>
   </div>
 </section>
 

--- a/docs/sdk.html
+++ b/docs/sdk.html
@@ -273,7 +273,7 @@ footer nav { display: flex; gap: 20px; flex-wrap: wrap; }
 <span class="kw">fn</span> <span class="fn">main</span>() {
     <span class="kw">let</span> _ = kobo_sdk::<span class="fn">run</span>(<span class="str">"counter"</span>, <span class="ty">Counter</span>::<span class="fn">default</span>());
 }</code></pre>
-      <div class="note"><strong>Hardware support.</strong> The Kobo Clara BW N365, device code 391; Kobo Elipsa 2E N605, device code 389; and Kobo Clara HD N249, device code 376 are fully hardware-tested at the exact firmware and kernel versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>.</div>
+      <div class="note"><strong>Hardware support.</strong> The Kobo Clara BW N365, device code 391; Kobo Elipsa 2E N605, device code 389; Kobo Clara HD N249, device code 376; Kobo Libra 2 N418, device code 388; and Kobo Libra Colour N428, device code 390 are fully hardware-tested at the exact firmware and kernel versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>.</div>
     </section>
 
     <section id="application-model">


### PR DESCRIPTION
Bumps the workspace and the four internal crate pins to 0.3.0 so the `v0.3.0` tag passes the release workflow's version check.

Also brings every place the tested device set is stated in line with the device support matrix — README, docs/INSTALL.md, SDK.md, docs/PORTING.md, and the Pages site (`docs/index.html`, `docs/sdk.html`) now name all five: Clara BW, Clara HD, Elipsa 2E, Libra 2, and Libra Colour. The porting call-outs keep only the still-open Clara Colour and Aura threads. README gains CI, Publish apps, latest-release, and license badges, all automatic.

Verified locally with `cargo test --workspace --all-targets --all-features`: everything passes.

Once merged, tagging `v0.3.0` publishes the release; concise notes crediting the device ports go on it after the workflow creates it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790236056&installation_model_id=20525&pr_number=60&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F60&signature=3897cb4834e8770a5f151e49eeed8f8507e386a7c794de88ca18fa571b22e325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->