### PR TITLE
Add secure paired app installs

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -27,7 +27,11 @@ jobs:
         run: cargo build --locked -p kobo-cli
       - name: Validate the registry
         id: registry
-        run: echo "packages=$(target/debug/kobo app-list --registry apps/catalog.json)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "packages=$(target/debug/kobo app-list --registry apps/catalog.json)" >> "$GITHUB_OUTPUT"
+          node tools/generate-app-pages.mjs
+          git status --porcelain -- docs/apps
+          test -z "$(git status --porcelain -- docs/apps)"
       - name: Save the release tool
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +101,15 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -135,6 +162,12 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -146,6 +179,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
 dependencies = [
  "libm",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -167,6 +209,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,14 +240,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
+ "subtle",
+]
+
+[[package]]
 name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -210,6 +332,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -292,6 +424,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,6 +446,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +465,24 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -717,6 +889,7 @@ version = "0.3.0"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
+ "qrcodegen",
 ]
 
 [[package]]
@@ -796,9 +969,11 @@ version = "0.3.0"
 name = "kobod"
 version = "0.3.0"
 dependencies = [
+ "base64",
  "kobo-abi",
  "kobo-app-store",
  "kobo-hal",
+ "kobo-json",
  "kobo-net",
  "kobo-policy",
  "kobo-profile",
@@ -806,6 +981,10 @@ dependencies = [
  "kobo-shell",
  "kobo-text",
  "kobo-ui",
+ "p256",
+ "ring",
+ "rustls",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -940,6 +1119,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1188,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1221,15 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide 0.8.9",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -1040,6 +1259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
+name = "qrcodegen"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4339fc7a1021c9c1621d87f5e3505f2805c8c105420ba2f2a4df86814590c142"
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,6 +1287,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "ratex-font"
@@ -1212,6 +1440,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,7 +1500,7 @@ version = "8.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
- "sha2",
+ "sha2 0.11.0",
  "walkdir",
 ]
 
@@ -1316,6 +1554,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,13 +1612,24 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1374,6 +1637,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -1411,6 +1684,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
 dependencies = [
  "version_check",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Open **Install links** in Store to link a phone or computer without an
 account. The **Install** button on any
 [Cobalt app page](https://bandarlabs.github.io/Cobalt/#apps) then sends an
 encrypted request to that Kobo. If the reader is offline, reconnect it and
-open Store within 24 hours to continue.
+open Store within 72 hours to continue.
 
 Apps are published automatically when an app PR is merged into `main`.
 Publishing an app does **not** require changing the Cobalt version or creating

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ new app can appear in Store without reinstalling or updating Cobalt.
 ## Features
 
 - Signed Wi-Fi app installation, updates, and removal
+- Shareable app pages with encrypted QR or pairing-code installation
 - Separate Settings-based updates for the Cobalt platform
 - Apps run as separate unprivileged processes
 - Per-app capability checks for network, storage, audio, frontlight, and other
@@ -151,6 +152,12 @@ first `0.2.0` platform install appear as installed, can be removed and
 reinstalled in the same session, and can be updated in place without creating
 a second launcher entry. Platform utilities such as Settings and Terminal are
 shown as installed system apps and cannot be removed.
+
+Open **Install links** in Store to link a phone or computer without an
+account. The **Install** button on any
+[Cobalt app page](https://bandarlabs.github.io/Cobalt/#apps) then sends an
+encrypted request to that Kobo. If the reader is offline, reconnect it and
+open Store within 24 hours to continue.
 
 Apps are published automatically when an app PR is merged into `main`.
 Publishing an app does **not** require changing the Cobalt version or creating

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -372,6 +372,7 @@ fn run(arguments: &[String]) -> Result<(), String> {
         "build" => build_device(arguments.iter().any(|argument| is_device_flag(argument))),
         "doctor" => doctor(&arguments[1..]),
         "devices" => list_devices(&arguments[1..]),
+        "app-link" => app_link_command(&arguments[1..]),
         "session" => dev_session(&arguments[1..]),
         "wait" => wait_for_device(&arguments[1..]),
         "logs" => device_logs(&arguments[1..]),
@@ -1448,6 +1449,7 @@ fn list_devices(arguments: &[String]) -> Result<(), String> {
                 println!("{address}  {}", identity.summary());
                 readers.push(*address);
             }
+
             _ => others += 1,
         }
     }
@@ -1464,6 +1466,42 @@ fn list_devices(arguments: &[String]) -> Result<(), String> {
     };
     println!("use it with --device, for example: kobo doctor --device {first}");
     Ok(())
+}
+
+fn app_link_command(arguments: &[String]) -> Result<(), String> {
+    let (action, host) = parse_app_link(arguments)?;
+    let script = format!(
+        "set -eu\nexec '{}/bin/kobod' --app-link '{action}'\n",
+        connect::INSTALL_DIRECTORY
+    );
+    let output = run_remote_shell(&format!("root@{host}"), &script, REMOTE_COMMAND_TIMEOUT)
+        .map_err(unreachable_device)?;
+    if !output.status.success() {
+        return Err(unreachable_if_ssh_gave_up(
+            remote_shell_error(
+                format!("app-link {action} on {host} exited with {}", output.status),
+                &output.stdout,
+                &output.stderr,
+            ),
+            &output,
+        ));
+    }
+    print!("{}", String::from_utf8_lossy(&output.stdout));
+    Ok(())
+}
+
+fn parse_app_link(arguments: &[String]) -> Result<(&str, &str), String> {
+    const USAGE: &str = "usage: kobo app-link status|unpair --device HOST";
+    let [action, flag, host] = arguments else {
+        return Err(USAGE.to_owned());
+    };
+    if !matches!(action.as_str(), "status" | "unpair")
+        || !is_device_flag(flag)
+        || !valid_device_host(host)
+    {
+        return Err(USAGE.to_owned());
+    }
+    Ok((action, host))
 }
 
 /// Reads a host's identity, or `None` when it is not something we can talk to.
@@ -5241,6 +5279,7 @@ fn print_help() {
            build [--device]       Build host workspace or ARM safe doctor, disabled kobod, and sample app\n\
            doctor [--device IP]   Run read-only device diagnostics\n\
            devices [--subnet A.B.C]  Find every reader on the local network\n\
+           app-link status|unpair --device IP  Inspect or revoke browser pairing\n\
            session --device IP    Keep a device awake and on Wi-Fi while developing\n\
            session --device IP --hold [minutes]  Keep it reachable for unattended testing\n\
            wait --device IP       Block until a device answers again\n\
@@ -6799,6 +6838,40 @@ mod tests {
         fn refuses_unknown_flags() {
             let given = arguments(&["--device", "192.0.2.1", "--forever"]);
             assert!(parse_wait(&given).is_err());
+        }
+    }
+
+    #[test]
+    fn app_link_maintenance_accepts_only_fixed_actions_and_safe_hosts() {
+        let status = vec![
+            "status".to_owned(),
+            "--device".to_owned(),
+            "192.0.2.1".to_owned(),
+        ];
+        assert_eq!(super::parse_app_link(&status), Ok(("status", "192.0.2.1")));
+        let unpair = vec![
+            "unpair".to_owned(),
+            "-s".to_owned(),
+            "reader.local".to_owned(),
+        ];
+        assert_eq!(
+            super::parse_app_link(&unpair),
+            Ok(("unpair", "reader.local"))
+        );
+        for invalid in [
+            vec![
+                "delete".to_owned(),
+                "--device".to_owned(),
+                "reader".to_owned(),
+            ],
+            vec![
+                "status".to_owned(),
+                "--device".to_owned(),
+                "reader;reboot".to_owned(),
+            ],
+            vec!["status".to_owned()],
+        ] {
+            assert!(super::parse_app_link(&invalid).is_err());
         }
     }
 }

--- a/crates/kobo-policy/src/services.rs
+++ b/crates/kobo-policy/src/services.rs
@@ -310,6 +310,10 @@ impl DeviceServices {
             DeviceRequest::LookupWord { word, language } => {
                 self.lookup_word(word, language.as_deref())
             }
+            DeviceRequest::ReadAppLink
+            | DeviceRequest::BeginAppLink
+            | DeviceRequest::PollAppLink
+            | DeviceRequest::DisconnectAppLink => DeviceResult::Denied(DenyReason::Unsupported),
         }
     }
 
@@ -589,7 +593,11 @@ pub fn request_capability(request: &DeviceRequest) -> Option<Capability> {
         | DeviceRequest::RefreshAppCatalog
         | DeviceRequest::InstallApp { .. }
         | DeviceRequest::UninstallApp { .. }
-        | DeviceRequest::LookupWord { .. } => return None,
+        | DeviceRequest::LookupWord { .. }
+        | DeviceRequest::ReadAppLink
+        | DeviceRequest::BeginAppLink
+        | DeviceRequest::PollAppLink
+        | DeviceRequest::DisconnectAppLink => return None,
     })
 }
 

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -124,6 +124,8 @@ pub const MAX_APP_VERSION_LEN: usize = 64;
 /// Capability declarations are drawn as a short list and are also bounded by
 /// the complete capability vocabulary.
 pub const MAX_APP_CAPABILITIES: usize = 16;
+const MAX_APP_LINK_EXPIRES_IN: u32 = 10 * 60;
+const MAX_APP_LINK_BROWSERS: u8 = 8;
 
 /// Human-readable radio identifiers are deliberately shorter than an ordinary
 /// protocol string. They are drawn on one row and are also accepted from local
@@ -1035,6 +1037,39 @@ pub enum DeviceRequest {
         word: String,
         language: Option<String>,
     },
+    /// Report the current browser-link state.
+    ReadAppLink,
+    /// Begin a new browser-link attempt.
+    BeginAppLink,
+    /// Poll for pairing and remote installation progress.
+    PollAppLink,
+    /// Disconnect every paired browser.
+    DisconnectAppLink,
+}
+
+/// Current state of the runtime-owned App Store browser link.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AppLinkState {
+    Unpaired,
+    Pairing {
+        code: String,
+        url: String,
+        expires_in: u32,
+    },
+    Paired {
+        browsers: u8,
+    },
+}
+
+/// Result of processing one remotely requested application installation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RemoteInstallOutcome {
+    None,
+    Installed { id: String },
+    Updated { id: String },
+    AlreadyInstalled { id: String },
+    Included { id: String },
+    Unavailable { id: String },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1181,6 +1216,10 @@ pub enum DeviceResult {
         word: String,
         entries: Vec<DictionaryEntry>,
     },
+    /// Current state of the App Store browser link.
+    AppLink(AppLinkState),
+    /// Outcome of the latest remote installation request.
+    RemoteInstall(RemoteInstallOutcome),
     /// The backend exists, but the requested operation failed.
     Failed(DeviceError),
     /// The request was refused, with the exact reason.
@@ -2279,6 +2318,10 @@ fn encode_device_request(
             push_string(output, word)?;
             push_optional_string(output, language.as_deref())?;
         }
+        DeviceRequest::ReadAppLink => output.push(38),
+        DeviceRequest::BeginAppLink => output.push(39),
+        DeviceRequest::PollAppLink => output.push(40),
+        DeviceRequest::DisconnectAppLink => output.push(41),
     }
     Ok(())
 }
@@ -2529,6 +2572,10 @@ fn decode_device_request(reader: &mut Reader<'_>) -> Result<DeviceRequest, Proto
             validate_lookup(&word, language.as_deref())?;
             Ok(DeviceRequest::LookupWord { word, language })
         }
+        38 => Ok(DeviceRequest::ReadAppLink),
+        39 => Ok(DeviceRequest::BeginAppLink),
+        40 => Ok(DeviceRequest::PollAppLink),
+        41 => Ok(DeviceRequest::DisconnectAppLink),
         _ => Err(ProtocolError::InvalidValue("device request")),
     }
 }
@@ -2700,8 +2747,75 @@ fn encode_device_result(output: &mut Vec<u8>, result: &DeviceResult) -> Result<(
                 push_string(output, &entry.definition)?;
             }
         }
+        DeviceResult::AppLink(state) => {
+            output.push(14);
+            encode_app_link(output, state)?;
+        }
+        DeviceResult::RemoteInstall(outcome) => {
+            output.push(15);
+            encode_remote_install(output, outcome)?;
+        }
     }
     Ok(())
+}
+
+fn valid_app_link_code(code: &str) -> bool {
+    code.len() == 8
+        && code
+            .bytes()
+            .all(|byte| b"23456789ABCDEFGHJKLMNPQRSTUVWXYZ".contains(&byte))
+}
+
+fn encode_app_link(output: &mut Vec<u8>, state: &AppLinkState) -> Result<(), ProtocolError> {
+    match state {
+        AppLinkState::Unpaired => output.push(1),
+        AppLinkState::Pairing {
+            code,
+            url,
+            expires_in,
+        } => {
+            if !valid_app_link_code(code)
+                || !url.starts_with("https://")
+                || url.len() > MAX_URL_LEN
+                || *expires_in > MAX_APP_LINK_EXPIRES_IN
+            {
+                return Err(ProtocolError::InvalidValue("application link"));
+            }
+            output.push(2);
+            push_string(output, code)?;
+            push_string(output, url)?;
+            push_u32(output, *expires_in);
+        }
+        AppLinkState::Paired { browsers } if *browsers <= MAX_APP_LINK_BROWSERS => {
+            output.extend_from_slice(&[3, *browsers]);
+        }
+        AppLinkState::Paired { .. } => {
+            return Err(ProtocolError::InvalidValue("application link"));
+        }
+    }
+    Ok(())
+}
+
+fn encode_remote_install(
+    output: &mut Vec<u8>,
+    outcome: &RemoteInstallOutcome,
+) -> Result<(), ProtocolError> {
+    let (tag, id) = match outcome {
+        RemoteInstallOutcome::None => {
+            output.push(1);
+            return Ok(());
+        }
+        RemoteInstallOutcome::Installed { id } => (2, id),
+        RemoteInstallOutcome::Updated { id } => (3, id),
+        RemoteInstallOutcome::AlreadyInstalled { id } => (4, id),
+        RemoteInstallOutcome::Included { id } => (5, id),
+        RemoteInstallOutcome::Unavailable { id } => (6, id),
+    };
+    if !valid_app_id(id) {
+        return Err(ProtocolError::InvalidValue("application id"));
+    }
+    output.push(tag);
+    push_string(output, id)
 }
 
 fn encode_app_info(output: &mut Vec<u8>, entry: &AppInfo) -> Result<(), ProtocolError> {
@@ -2859,8 +2973,65 @@ fn decode_device_result(reader: &mut Reader<'_>) -> Result<DeviceResult, Protoco
         9 => decode_audio_result(reader),
         12 => decode_apps_result(reader),
         13 => decode_dictionary_result(reader),
+        14 => decode_app_link(reader),
+        15 => decode_remote_install(reader),
         _ => Err(ProtocolError::InvalidValue("device result")),
     }
+}
+
+fn decode_app_link(reader: &mut Reader<'_>) -> Result<DeviceResult, ProtocolError> {
+    let state = match reader.u8()? {
+        1 => AppLinkState::Unpaired,
+        2 => {
+            let code = reader.string()?;
+            let url = reader.string()?;
+            let expires_in = reader.u32()?;
+            if !valid_app_link_code(&code)
+                || !url.starts_with("https://")
+                || url.len() > MAX_URL_LEN
+                || expires_in > MAX_APP_LINK_EXPIRES_IN
+            {
+                return Err(ProtocolError::InvalidValue("application link"));
+            }
+            AppLinkState::Pairing {
+                code,
+                url,
+                expires_in,
+            }
+        }
+        3 => {
+            let browsers = reader.u8()?;
+            if browsers > MAX_APP_LINK_BROWSERS {
+                return Err(ProtocolError::InvalidValue("application link"));
+            }
+            AppLinkState::Paired { browsers }
+        }
+        _ => return Err(ProtocolError::InvalidValue("application link")),
+    };
+    Ok(DeviceResult::AppLink(state))
+}
+
+fn decode_remote_install(reader: &mut Reader<'_>) -> Result<DeviceResult, ProtocolError> {
+    let tag = reader.u8()?;
+    if tag == 1 {
+        return Ok(DeviceResult::RemoteInstall(RemoteInstallOutcome::None));
+    }
+    if !(2..=6).contains(&tag) {
+        return Err(ProtocolError::InvalidValue("remote install outcome"));
+    }
+    let id = reader.string()?;
+    if !valid_app_id(&id) {
+        return Err(ProtocolError::InvalidValue("application id"));
+    }
+    let outcome = match tag {
+        2 => RemoteInstallOutcome::Installed { id },
+        3 => RemoteInstallOutcome::Updated { id },
+        4 => RemoteInstallOutcome::AlreadyInstalled { id },
+        5 => RemoteInstallOutcome::Included { id },
+        6 => RemoteInstallOutcome::Unavailable { id },
+        _ => unreachable!("tag range checked above"),
+    };
+    Ok(DeviceResult::RemoteInstall(outcome))
 }
 
 fn validate_lookup(word: &str, language: Option<&str>) -> Result<(), ProtocolError> {
@@ -6079,6 +6250,10 @@ mod tests {
             DeviceRequest::UninstallApp {
                 id: "word-count".to_owned(),
             },
+            DeviceRequest::ReadAppLink,
+            DeviceRequest::BeginAppLink,
+            DeviceRequest::PollAppLink,
+            DeviceRequest::DisconnectAppLink,
         ];
         for request in requests {
             let frame = Frame {
@@ -6217,6 +6392,43 @@ mod tests {
     }
 
     #[test]
+    fn every_app_link_result_round_trips() {
+        let results = [
+            DeviceResult::AppLink(AppLinkState::Unpaired),
+            DeviceResult::AppLink(AppLinkState::Pairing {
+                code: "2345ABCD".to_owned(),
+                url: "https://store.example/link".to_owned(),
+                expires_in: 600,
+            }),
+            DeviceResult::AppLink(AppLinkState::Paired { browsers: 8 }),
+            DeviceResult::RemoteInstall(RemoteInstallOutcome::None),
+            DeviceResult::RemoteInstall(RemoteInstallOutcome::Installed {
+                id: "word-count".to_owned(),
+            }),
+            DeviceResult::RemoteInstall(RemoteInstallOutcome::Updated {
+                id: "word-count".to_owned(),
+            }),
+            DeviceResult::RemoteInstall(RemoteInstallOutcome::AlreadyInstalled {
+                id: "word-count".to_owned(),
+            }),
+            DeviceResult::RemoteInstall(RemoteInstallOutcome::Included {
+                id: "word-count".to_owned(),
+            }),
+            DeviceResult::RemoteInstall(RemoteInstallOutcome::Unavailable {
+                id: "word-count".to_owned(),
+            }),
+        ];
+        for result in results {
+            let frame = Frame {
+                request_id: 11,
+                message: Message::DeviceResult(result),
+            };
+            let bytes = encode(&frame).expect("encode");
+            assert_eq!(decode(&bytes).expect("decode"), frame);
+        }
+    }
+
+    #[test]
     fn app_requests_and_results_are_bounded_and_validated() {
         let ids = vec![
             String::new(),
@@ -6327,6 +6539,144 @@ mod tests {
         assert_eq!(
             decode(&bad_reason),
             Err(ProtocolError::InvalidValue("deny reason"))
+        );
+    }
+
+    #[test]
+    fn app_link_and_remote_install_payloads_are_bounded_and_validated() {
+        let pairing = |code: String, url: String, expires_in| Frame {
+            request_id: 1,
+            message: Message::DeviceResult(DeviceResult::AppLink(AppLinkState::Pairing {
+                code,
+                url,
+                expires_in,
+            })),
+        };
+        for code in [
+            "2345ABC".to_owned(),
+            "2345ABCDE".to_owned(),
+            "2345ABCI".to_owned(),
+            "2345abcD".to_owned(),
+        ] {
+            assert!(encode(&pairing(code, "https://store.example/link".to_owned(), 60)).is_err());
+        }
+        assert!(encode(&pairing(
+            "2345ABCD".to_owned(),
+            "http://store.example/link".to_owned(),
+            60
+        ))
+        .is_err());
+        assert!(encode(&pairing(
+            "2345ABCD".to_owned(),
+            format!("https://{}", "a".repeat(MAX_URL_LEN)),
+            60
+        ))
+        .is_err());
+        assert!(encode(&pairing(
+            "2345ABCD".to_owned(),
+            "https://store.example/link".to_owned(),
+            601
+        ))
+        .is_err());
+        assert!(encode(&Frame {
+            request_id: 1,
+            message: Message::DeviceResult(DeviceResult::AppLink(AppLinkState::Paired {
+                browsers: 9,
+            })),
+        })
+        .is_err());
+        assert!(encode(&Frame {
+            request_id: 1,
+            message: Message::DeviceResult(DeviceResult::RemoteInstall(
+                RemoteInstallOutcome::Installed {
+                    id: "../store".to_owned(),
+                },
+            )),
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn malformed_app_link_payloads_are_rejected() {
+        let pairing = |code: String, url: String, expires_in| Frame {
+            request_id: 1,
+            message: Message::DeviceResult(DeviceResult::AppLink(AppLinkState::Pairing {
+                code,
+                url,
+                expires_in,
+            })),
+        };
+        let valid_pairing = encode(&pairing(
+            "2345ABCD".to_owned(),
+            "https://store.example/link".to_owned(),
+            600,
+        ))
+        .expect("valid pairing");
+        let mut bad_code = valid_pairing.clone();
+        bad_code[HEADER_LEN + 6] = b'I';
+        assert_eq!(
+            decode(&bad_code),
+            Err(ProtocolError::InvalidValue("application link"))
+        );
+        let mut bad_expiry = valid_pairing;
+        let last = bad_expiry.len() - 1;
+        bad_expiry[last] = 0x59;
+        assert_eq!(
+            decode(&bad_expiry),
+            Err(ProtocolError::InvalidValue("application link"))
+        );
+
+        let mut bad_url = encode(&pairing(
+            "2345ABCD".to_owned(),
+            "https://store.example/link".to_owned(),
+            600,
+        ))
+        .expect("valid pairing");
+        bad_url[HEADER_LEN + 18] = b'x';
+        assert_eq!(
+            decode(&bad_url),
+            Err(ProtocolError::InvalidValue("application link"))
+        );
+
+        let mut bad_browsers = encode(&Frame {
+            request_id: 1,
+            message: Message::DeviceResult(DeviceResult::AppLink(AppLinkState::Paired {
+                browsers: 8,
+            })),
+        })
+        .expect("valid paired state");
+        let last = bad_browsers.len() - 1;
+        bad_browsers[last] = 9;
+        assert_eq!(
+            decode(&bad_browsers),
+            Err(ProtocolError::InvalidValue("application link"))
+        );
+
+        let mut bad_id = encode(&Frame {
+            request_id: 1,
+            message: Message::DeviceResult(DeviceResult::RemoteInstall(
+                RemoteInstallOutcome::Installed {
+                    id: "word-count".to_owned(),
+                },
+            )),
+        })
+        .expect("valid outcome");
+        bad_id[HEADER_LEN + 6] = b'W';
+        assert_eq!(
+            decode(&bad_id),
+            Err(ProtocolError::InvalidValue("application id"))
+        );
+
+        let mut bad_outcome = encode(&Frame {
+            request_id: 1,
+            message: Message::DeviceResult(DeviceResult::RemoteInstall(RemoteInstallOutcome::None)),
+        })
+        .expect("valid empty outcome");
+        let last = bad_outcome.len() - 1;
+        bad_outcome[last] = 7;
+        assert_eq!(
+            decode(&bad_outcome),
+            Err(ProtocolError::InvalidValue("remote install outcome"))
         );
     }
 

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -6,14 +6,15 @@
 //! [`AppRunner::action`] from their platform event loop.
 
 pub use kobo_protocol::{
-    is_valid_key, AppInfo, AudioPlaybackState, AudioSource, BatteryDetail, BluetoothDevice,
-    BluetoothDeviceKind, Credential, DenyReason, DeviceError, DeviceRequest, DeviceResult,
-    DictionaryEntry, Frame, Header, Lifecycle, LogLevel, Message, SecretHeader, ShellError,
-    ShellEvent, ShellRequest, StoreError, StoreRequest, StoreResult, StreamError, Task, TaskError,
-    TaskId, TaskOutcome, WifiNetwork, CACHE_PREFIX, MAX_CACHE_KEYS, MAX_FONT_BYTES, MAX_HEADERS,
-    MAX_HEADER_NAME, MAX_HEADER_VALUE, MAX_INLINE_PICTURE_BYTES, MAX_LOOKUP_WORD_BYTES,
-    MAX_PICTURE_BYTES, MAX_PICTURE_CHUNK_BYTES, MAX_RADIO_DEVICES, MAX_RADIO_NAME, MAX_SHELF_CHUNK,
-    MAX_SHELL_CHUNK, MAX_STORE_KEYS, MAX_STORE_VALUE, MAX_TASK_BYTES, MAX_URL_LEN,
+    is_valid_key, AppInfo, AppLinkState, AudioPlaybackState, AudioSource, BatteryDetail,
+    BluetoothDevice, BluetoothDeviceKind, Credential, DenyReason, DeviceError, DeviceRequest,
+    DeviceResult, DictionaryEntry, Frame, Header, Lifecycle, LogLevel, Message,
+    RemoteInstallOutcome, SecretHeader, ShellError, ShellEvent, ShellRequest, StoreError,
+    StoreRequest, StoreResult, StreamError, Task, TaskError, TaskId, TaskOutcome, WifiNetwork,
+    CACHE_PREFIX, MAX_CACHE_KEYS, MAX_FONT_BYTES, MAX_HEADERS, MAX_HEADER_NAME, MAX_HEADER_VALUE,
+    MAX_INLINE_PICTURE_BYTES, MAX_LOOKUP_WORD_BYTES, MAX_PICTURE_BYTES, MAX_PICTURE_CHUNK_BYTES,
+    MAX_RADIO_DEVICES, MAX_RADIO_NAME, MAX_SHELF_CHUNK, MAX_SHELL_CHUNK, MAX_STORE_KEYS,
+    MAX_STORE_VALUE, MAX_TASK_BYTES, MAX_URL_LEN,
 };
 pub use kobo_ui::QuoteRole;
 pub use kobo_ui::{
@@ -48,13 +49,14 @@ pub use audio::{AudioMetadata, AudioPlayer};
 
 pub mod prelude {
     pub use crate::{
-        action_id, ActionId, AppIcon, AppMetadata, AppRunner, AppShelf, AppShell, AppStore,
-        AudioMetadata, AudioPlaybackState, AudioPlayer, AudioSource, BluetoothDevice,
+        action_id, ActionId, AppIcon, AppLinkState, AppMetadata, AppRunner, AppShelf, AppShell,
+        AppStore, AudioMetadata, AudioPlaybackState, AudioPlayer, AudioSource, BluetoothDevice,
         BluetoothDeviceKind, Capability, Client, ClientEvent, Command, Context, ControlState,
         DenyReason, Device, DeviceError, DeviceRequest, DeviceResult, DialogAction, Failure, Grant,
-        Grants, Heartbeat, KoboApp, Lifecycle, Navigator, Node, NodeId, PowerPolicy, Screen,
-        ScreenBuilder, ShelfDownload, ShelfProgress, ShelfUpload, ShellError, ShellEvent,
-        ShellRequest, StandardState, StoreError, StoreRequest, StoreResult, WifiNetwork,
+        Grants, Heartbeat, KoboApp, Lifecycle, Navigator, Node, NodeId, PowerPolicy,
+        RemoteInstallOutcome, Screen, ScreenBuilder, ShelfDownload, ShelfProgress, ShelfUpload,
+        ShellError, ShellEvent, ShellRequest, StandardState, StoreError, StoreRequest, StoreResult,
+        WifiNetwork,
     };
 }
 
@@ -3439,6 +3441,34 @@ pub struct AppStore<'a> {
 }
 
 impl AppStore<'_> {
+    /// Begins a browser-link pairing attempt.
+    pub fn begin_link(&mut self) {
+        self.context
+            .commands
+            .push(Command::Device(DeviceRequest::BeginAppLink));
+    }
+
+    /// Reads the current browser-link state.
+    pub fn read_link(&mut self) {
+        self.context
+            .commands
+            .push(Command::Device(DeviceRequest::ReadAppLink));
+    }
+
+    /// Polls for pairing and remote installation progress.
+    pub fn poll_link(&mut self) {
+        self.context
+            .commands
+            .push(Command::Device(DeviceRequest::PollAppLink));
+    }
+
+    /// Disconnects every paired browser.
+    pub fn disconnect_link(&mut self) {
+        self.context
+            .commands
+            .push(Command::Device(DeviceRequest::DisconnectAppLink));
+    }
+
     /// Writes a value, replacing whatever was under that key.
     ///
     /// The write is atomic: a reader sees the previous value or the new one and
@@ -5031,6 +5061,27 @@ mod tests {
             .filter(|command| matches!(command, Command::Device(DeviceRequest::Update { .. })))
             .count();
         assert_eq!(queued, 1, "only the well-formed request may be queued");
+    }
+
+    #[test]
+    fn app_store_link_helpers_queue_device_requests() {
+        let mut context = Context::default();
+        {
+            let mut store = context.store();
+            store.begin_link();
+            store.read_link();
+            store.poll_link();
+            store.disconnect_link();
+        }
+        assert_eq!(
+            context.take_commands(),
+            vec![
+                Command::Device(DeviceRequest::BeginAppLink),
+                Command::Device(DeviceRequest::ReadAppLink),
+                Command::Device(DeviceRequest::PollAppLink),
+                Command::Device(DeviceRequest::DisconnectAppLink),
+            ]
+        );
     }
 
     #[test]

--- a/crates/kobod/Cargo.toml
+++ b/crates/kobod/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 kobo-abi = { path = "../kobo-abi" }
 kobo-app-store = { path = "../kobo-app-store" }
 kobo-hal = { path = "../kobo-hal", default-features = false }
+kobo-json = { path = "../kobo-json" }
 kobo-net = { path = "../kobo-net" }
 kobo-policy = { path = "../kobo-policy" }
 kobo-shell = { path = "../kobo-shell" }
@@ -21,6 +22,11 @@ kobo-profile = { path = "../kobo-profile" }
 kobo-protocol = { path = "../kobo-protocol" }
 kobo-text = { path = "../kobo-text" }
 kobo-ui = { path = "../kobo-ui" }
+p256 = { version = "0.13.2", features = ["ecdh"] }
+ring = "0.17"
+base64 = "0.22"
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+webpki-roots = "1"
 
 [lints]
 workspace = true

--- a/crates/kobod/Cargo.toml
+++ b/crates/kobod/Cargo.toml
@@ -22,7 +22,7 @@ kobo-profile = { path = "../kobo-profile" }
 kobo-protocol = { path = "../kobo-protocol" }
 kobo-text = { path = "../kobo-text" }
 kobo-ui = { path = "../kobo-ui" }
-p256 = { version = "0.13.2", features = ["ecdh"] }
+p256 = { version = "0.13.2", features = ["ecdh", "ecdsa"] }
 ring = "0.17"
 base64 = "0.22"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }

--- a/crates/kobod/src/app_link.rs
+++ b/crates/kobod/src/app_link.rs
@@ -1148,7 +1148,9 @@ fn valid_pairing_code(value: &str) -> bool {
 }
 
 fn valid_https_url(value: &str) -> bool {
-    value.starts_with("https://") && value.len() <= kobo_protocol::MAX_URL_LEN
+    value.starts_with("https://")
+        && value.len() <= kobo_protocol::MAX_URL_LEN
+        && !value.chars().any(char::is_control)
 }
 
 fn parse_timestamp(value: &str) -> Option<u64> {
@@ -1621,5 +1623,15 @@ mod tests {
         assert_eq!(parse_timestamp("2026-13-26T12:46:31Z"), None);
         assert_eq!(parse_timestamp("2026-02-29T12:46:31Z"), None);
         assert_eq!(COMMAND_TTL_SECONDS, 86_400);
+    }
+
+    #[test]
+    fn relay_urls_are_https_and_single_line() {
+        assert!(valid_https_url(
+            "https://bandarlabs.github.io/Cobalt/pair/?code=2345ABCD"
+        ));
+        assert!(!valid_https_url("http://example.test/pair"));
+        assert!(!valid_https_url("https://example.test/pair\nforged"));
+        assert!(!valid_https_url("https://example.test/\u{7f}forged"));
     }
 }

--- a/crates/kobod/src/app_link.rs
+++ b/crates/kobod/src/app_link.rs
@@ -1,0 +1,1625 @@
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine as _;
+use kobo_json::{ObjectBuilder, Value};
+use kobo_protocol::{AppLinkState, DeviceError, DeviceResult, RemoteInstallOutcome};
+use p256::ecdh::diffie_hellman;
+use p256::pkcs8::{DecodePublicKey, EncodePublicKey};
+use p256::{PublicKey, SecretKey};
+use ring::{aead, hkdf};
+use std::fmt::Write as _;
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const RELAY_URL: &str = "https://cobalt-install-relay.anandabhishek.workers.dev";
+const STATE_DIRECTORY: &str = "app-link";
+const PRIVATE_KEY_FILE: &str = "device-key";
+const CREDENTIAL_FILE: &str = "credential.json";
+const PENDING_FILE: &str = "pending.json";
+const COMPLETED_FILE: &str = "completed";
+const MAX_RELAY_BODY: u32 = 16 * 1024;
+const MAX_HTTP_RESPONSE: u64 = 48 * 1024;
+const COMMAND_TTL_SECONDS: u64 = 24 * 60 * 60;
+const INSTALL_COMPLETION_TTL_SECONDS: u64 = 15 * 60;
+const CLOCK_SKEW_SECONDS: u64 = 5 * 60;
+const COMPLETED_LIMIT: usize = 64;
+const HKDF_INFO: &[u8] = b"cobalt-app-install-v1";
+static RELAY_TLS_CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
+
+pub fn read(root: &Path) -> Result<DeviceResult, DeviceError> {
+    let mut relay = HttpsRelay::new()?;
+    read_with(root, &mut relay, now())
+}
+
+pub fn begin(root: &Path) -> Result<DeviceResult, DeviceError> {
+    let mut relay = HttpsRelay::new()?;
+    begin_with(root, &mut relay, now(), &device_name())
+}
+
+pub fn poll(root: &Path) -> Result<DeviceResult, DeviceError> {
+    let mut relay = HttpsRelay::new()?;
+    poll_with(
+        root,
+        &mut relay,
+        now(),
+        crate::app_store::prepare_remote_install,
+        crate::app_store::install,
+    )
+}
+
+pub fn disconnect(root: &Path) -> Result<DeviceResult, DeviceError> {
+    let mut relay = HttpsRelay::new()?;
+    disconnect_with(root, &mut relay)
+}
+
+pub fn maintenance(root: &Path, action: &str) -> Result<String, DeviceError> {
+    let result = match action {
+        "status" => read(root)?,
+        "unpair" => disconnect(root)?,
+        _ => return Err(DeviceError::InvalidInput),
+    };
+    match result {
+        DeviceResult::AppLink(AppLinkState::Unpaired) => Ok("unpaired".to_owned()),
+        DeviceResult::AppLink(AppLinkState::Pairing {
+            code, expires_in, ..
+        }) => Ok(format!("pairing {code}, expires in {expires_in}s")),
+        DeviceResult::AppLink(AppLinkState::Paired { browsers }) => {
+            Ok(format!("paired with {browsers} browser(s)"))
+        }
+        _ => Err(DeviceError::Backend),
+    }
+}
+
+fn device_name() -> String {
+    "Kobo reader".to_owned()
+}
+
+fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_secs())
+}
+
+trait Relay {
+    fn send(
+        &mut self,
+        method: &str,
+        path: &str,
+        token: Option<&str>,
+        body: Option<&str>,
+    ) -> Result<Vec<u8>, DeviceError>;
+}
+
+struct HttpsRelay {
+    base: String,
+}
+
+impl HttpsRelay {
+    fn new() -> Result<Self, DeviceError> {
+        let base = std::env::var("KOBO_INSTALL_RELAY_URL").unwrap_or_else(|_| RELAY_URL.to_owned());
+        if !base.starts_with("https://") || base.contains(['\r', '\n']) {
+            return Err(DeviceError::InvalidInput);
+        }
+        Ok(Self {
+            base: base.trim_end_matches('/').to_owned(),
+        })
+    }
+}
+
+impl Relay for HttpsRelay {
+    fn send(
+        &mut self,
+        method: &str,
+        path: &str,
+        token: Option<&str>,
+        body: Option<&str>,
+    ) -> Result<Vec<u8>, DeviceError> {
+        if !matches!(method, "GET" | "POST" | "DELETE")
+            || !path.starts_with('/')
+            || path.contains(['\r', '\n'])
+            || token.is_some_and(|token| !valid_token(token))
+        {
+            return Err(DeviceError::InvalidInput);
+        }
+        let address = kobo_net::parse(&format!("{}{}", self.base, path)).map_err(network_error)?;
+        let config = relay_tls_config()?;
+        let server_name = address
+            .host
+            .clone()
+            .try_into()
+            .map_err(|_| DeviceError::InvalidInput)?;
+        let mut addresses = (address.host.as_str(), address.port)
+            .to_socket_addrs()
+            .map_err(|_| DeviceError::Unreachable)?;
+        let socket = addresses
+            .find_map(|address| TcpStream::connect_timeout(&address, Duration::from_secs(30)).ok())
+            .ok_or(DeviceError::Unreachable)?;
+        socket
+            .set_read_timeout(Some(Duration::from_secs(60)))
+            .and_then(|()| socket.set_write_timeout(Some(Duration::from_secs(60))))
+            .map_err(|_| DeviceError::Unreachable)?;
+        let connection = rustls::ClientConnection::new(config, server_name)
+            .map_err(|_| DeviceError::Unreachable)?;
+        let mut stream = rustls::StreamOwned::new(connection, socket);
+        let body = body.unwrap_or_default().as_bytes();
+        let host = if address.port == 443 {
+            address.host.clone()
+        } else {
+            format!("{}:{}", address.host, address.port)
+        };
+        let mut head = format!(
+            "{method} {} HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\nAccept-Encoding: identity\r\nUser-Agent: kobo-runtime\r\n",
+            address.path
+        );
+        if let Some(token) = token {
+            head.push_str("Authorization: Bearer ");
+            head.push_str(token);
+            head.push_str("\r\n");
+        }
+
+        if method == "POST" {
+            head.push_str("Content-Type: application/json\r\n");
+            write!(head, "Content-Length: {}\r\n", body.len()).map_err(|_| DeviceError::Backend)?;
+        }
+        head.push_str("\r\n");
+        stream
+            .write_all(head.as_bytes())
+            .and_then(|()| stream.write_all(body))
+            .map_err(|_| DeviceError::Unreachable)?;
+        let mut response = Vec::new();
+        stream
+            .take(MAX_HTTP_RESPONSE + 1)
+            .read_to_end(&mut response)
+            .map_err(|_| DeviceError::Unreachable)?;
+        if response.len() as u64 > MAX_HTTP_RESPONSE {
+            return Err(DeviceError::Backend);
+        }
+        match kobo_net::split_response(&response, MAX_RELAY_BODY).map_err(network_error)? {
+            kobo_net::Response::Body(body) => Ok(body.into_owned()),
+            kobo_net::Response::Redirect(_) => Err(DeviceError::Unreachable),
+        }
+    }
+}
+
+fn relay_tls_config() -> Result<Arc<rustls::ClientConfig>, DeviceError> {
+    if let Some(config) = RELAY_TLS_CONFIG.get() {
+        return Ok(Arc::clone(config));
+    }
+    let roots = rustls::RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
+    };
+    let config = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .map_err(|_| DeviceError::Unreachable)?
+    .with_root_certificates(roots)
+    .with_no_client_auth();
+    Ok(Arc::clone(
+        RELAY_TLS_CONFIG.get_or_init(|| Arc::new(config)),
+    ))
+}
+
+fn network_error(error: kobo_protocol::TaskError) -> DeviceError {
+    match error {
+        kobo_protocol::TaskError::Unauthorized => DeviceError::Authentication,
+        kobo_protocol::TaskError::Offline
+        | kobo_protocol::TaskError::Unreachable
+        | kobo_protocol::TaskError::TimedOut => DeviceError::Unreachable,
+        kobo_protocol::TaskError::NotFound => DeviceError::NotFound,
+        kobo_protocol::TaskError::TooLarge
+        | kobo_protocol::TaskError::Denied
+        | kobo_protocol::TaskError::NoCredential => DeviceError::Backend,
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Identity {
+    secret: SecretKey,
+}
+
+impl Identity {
+    fn load_or_create(root: &Path) -> Result<Self, DeviceError> {
+        let directory = state_root(root);
+        fs::create_dir_all(&directory).map_err(|_| DeviceError::Backend)?;
+        set_mode(&directory, 0o700)?;
+        let path = directory.join(PRIVATE_KEY_FILE);
+        match fs::read(&path) {
+            Ok(bytes) => {
+                let secret = SecretKey::from_slice(&bytes).map_err(|_| DeviceError::Integrity)?;
+                Ok(Self { secret })
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let mut bytes = [0_u8; 32];
+                let secret = loop {
+                    File::open("/dev/urandom")
+                        .and_then(|mut random| random.read_exact(&mut bytes))
+                        .map_err(|_| DeviceError::Backend)?;
+                    if let Ok(secret) = SecretKey::from_slice(&bytes) {
+                        break secret;
+                    }
+                };
+                atomic_write(&path, secret.to_bytes().as_ref(), 0o600)?;
+                Ok(Self { secret })
+            }
+            Err(_) => Err(DeviceError::Backend),
+        }
+    }
+
+    fn public_key(&self) -> Result<String, DeviceError> {
+        self.secret
+            .public_key()
+            .to_public_key_der()
+            .map(|document| URL_SAFE_NO_PAD.encode(document.as_bytes()))
+            .map_err(|_| DeviceError::Backend)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Credential {
+    device_id: String,
+    token: String,
+    pairing: Option<Pairing>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Pairing {
+    code: String,
+    url: String,
+    expires_at: u64,
+}
+
+impl Credential {
+    fn load(root: &Path) -> Result<Option<Self>, DeviceError> {
+        let bytes = match fs::read(state_root(root).join(CREDENTIAL_FILE)) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(_) => return Err(DeviceError::Backend),
+        };
+        let value = parse_json(&bytes)?;
+        let version = value.get("version").and_then(Value::as_i64);
+        let device_id = value.get("device_id").and_then(Value::as_str);
+        let token = value.get("device_token").and_then(Value::as_str);
+        if version != Some(1)
+            || !device_id.is_some_and(valid_uuid)
+            || !token.is_some_and(valid_token)
+        {
+            return Err(DeviceError::Integrity);
+        }
+        let pairing = match value.get("pairing") {
+            Some(Value::Null) | None => None,
+            Some(value) => {
+                let code = value.get("code").and_then(Value::as_str);
+                let url = value.get("url").and_then(Value::as_str);
+                let expires_at = value
+                    .get("expires_at")
+                    .and_then(Value::as_str)
+                    .and_then(|value| value.parse::<u64>().ok());
+                if !code.is_some_and(valid_pairing_code)
+                    || !url.is_some_and(valid_https_url)
+                    || expires_at.is_none()
+                {
+                    return Err(DeviceError::Integrity);
+                }
+                Some(Pairing {
+                    code: code.unwrap_or_default().to_owned(),
+                    url: url.unwrap_or_default().to_owned(),
+                    expires_at: expires_at.unwrap_or_default(),
+                })
+            }
+        };
+        Ok(Some(Self {
+            device_id: device_id.unwrap_or_default().to_owned(),
+            token: token.unwrap_or_default().to_owned(),
+            pairing,
+        }))
+    }
+
+    fn save(&self, root: &Path) -> Result<(), DeviceError> {
+        let pairing = self.pairing.as_ref().map_or(Value::Null, |pairing| {
+            ObjectBuilder::new()
+                .set("code", pairing.code.clone())
+                .set("url", pairing.url.clone())
+                .set("expires_at", pairing.expires_at.to_string())
+                .build()
+        });
+        let body = ObjectBuilder::new()
+            .set("version", 1_i32)
+            .set("device_id", self.device_id.clone())
+            .set("device_token", self.token.clone())
+            .set("pairing", pairing)
+            .build()
+            .to_json();
+        atomic_write(
+            &state_root(root).join(CREDENTIAL_FILE),
+            body.as_bytes(),
+            0o600,
+        )
+    }
+}
+
+fn begin_with(
+    root: &Path,
+    relay: &mut impl Relay,
+    now: u64,
+    name: &str,
+) -> Result<DeviceResult, DeviceError> {
+    let identity = Identity::load_or_create(root)?;
+    let mut credential = if let Some(mut credential) = Credential::load(root)? {
+        let path = format!("/v1/devices/{}/pairings", credential.device_id);
+        let response = relay.send("POST", &path, Some(&credential.token), Some("{}"))?;
+        credential.pairing = Some(parse_pairing(&response)?);
+        credential.save(root)?;
+        credential
+    } else {
+        let body = ObjectBuilder::new()
+            .set("device_name", name)
+            .set("device_public_key", identity.public_key()?)
+            .build()
+            .to_json();
+        let response = relay.send("POST", "/v1/pairings", None, Some(&body))?;
+        let value = parse_json(&response)?;
+        let device_id = required_string(&value, "device_id")?;
+        let token = required_string(&value, "device_token")?;
+        if !valid_uuid(&device_id) || !valid_token(&token) {
+            return Err(DeviceError::Integrity);
+        }
+        let pairing = parse_pairing_value(&value)?;
+        let credential = Credential {
+            device_id,
+            token,
+            pairing: Some(pairing),
+        };
+        credential.save(root)?;
+        credential
+    };
+    let state = local_pairing_state(&credential, now).unwrap_or(AppLinkState::Unpaired);
+    if matches!(state, AppLinkState::Unpaired) {
+        credential.pairing = None;
+        credential.save(root)?;
+    }
+    Ok(DeviceResult::AppLink(state))
+}
+
+fn read_with(root: &Path, relay: &mut impl Relay, now: u64) -> Result<DeviceResult, DeviceError> {
+    let Some(mut credential) = Credential::load(root)? else {
+        return Ok(DeviceResult::AppLink(AppLinkState::Unpaired));
+    };
+    let path = format!("/v1/devices/{}/pairing", credential.device_id);
+    let response = relay.send("GET", &path, Some(&credential.token), None)?;
+    let value = parse_json(&response)?;
+    let paired = value
+        .get("paired")
+        .and_then(Value::as_bool)
+        .ok_or(DeviceError::Integrity)?;
+    let browsers = value
+        .get("browser_count")
+        .and_then(Value::as_i64)
+        .and_then(|count| u8::try_from(count).ok())
+        .filter(|count| *count <= 8)
+        .ok_or(DeviceError::Integrity)?;
+    if paired {
+        if browsers == 0 {
+            return Err(DeviceError::Integrity);
+        }
+        if credential.pairing.take().is_some() {
+            credential.save(root)?;
+        }
+        return Ok(DeviceResult::AppLink(AppLinkState::Paired { browsers }));
+    }
+    let state = local_pairing_state(&credential, now).unwrap_or(AppLinkState::Unpaired);
+    if matches!(state, AppLinkState::Unpaired) && credential.pairing.take().is_some() {
+        credential.save(root)?;
+    }
+    Ok(DeviceResult::AppLink(state))
+}
+
+fn poll_with(
+    root: &Path,
+    relay: &mut impl Relay,
+    now: u64,
+    prepare: impl FnOnce(&Path, &str) -> Result<crate::app_store::RemoteInstallPlan, DeviceError>,
+    install: impl FnOnce(&Path, &str) -> Result<(), DeviceError>,
+) -> Result<DeviceResult, DeviceError> {
+    let Some(credential) = Credential::load(root)? else {
+        return Ok(DeviceResult::AppLink(AppLinkState::Unpaired));
+    };
+    if let Some(pending) = Pending::load(root)? {
+        return resume_pending(root, relay, &credential, pending, now, install);
+    }
+    let status = read_with(root, relay, now)?;
+    if !matches!(status, DeviceResult::AppLink(AppLinkState::Paired { .. })) {
+        return Ok(status);
+    }
+    let path = format!("/v1/devices/{}/commands", credential.device_id);
+    let response = relay.send("GET", &path, Some(&credential.token), None)?;
+    let value = parse_json(&response)?;
+    let Some(command) = value.get("command") else {
+        return Err(DeviceError::Integrity);
+    };
+    if matches!(command, Value::Null) {
+        return Ok(DeviceResult::RemoteInstall(RemoteInstallOutcome::None));
+    }
+    process_command(root, relay, &credential, command, now, prepare, install)
+}
+
+fn process_command(
+    root: &Path,
+    relay: &mut impl Relay,
+    credential: &Credential,
+    command: &Value,
+    now: u64,
+    prepare: impl FnOnce(&Path, &str) -> Result<crate::app_store::RemoteInstallPlan, DeviceError>,
+    install: impl FnOnce(&Path, &str) -> Result<(), DeviceError>,
+) -> Result<DeviceResult, DeviceError> {
+    let command_id = required_string(command, "id")?;
+    if !valid_uuid(&command_id) {
+        return Err(DeviceError::Integrity);
+    }
+    if completed(root)?.iter().any(|known| known == &command_id) {
+        return reject_command(
+            root,
+            relay,
+            credential,
+            &command_id,
+            "replayed-command",
+            DeviceError::Integrity,
+        );
+    }
+    let timestamps = required_string(command, "created_at")
+        .and_then(|value| parse_timestamp(&value).ok_or(DeviceError::Integrity))
+        .and_then(|created_at| {
+            required_string(command, "expires_at")
+                .and_then(|value| parse_timestamp(&value).ok_or(DeviceError::Integrity))
+                .map(|expires_at| (created_at, expires_at))
+        });
+    let (created_at, expires_at) = match timestamps {
+        Ok(timestamps) => timestamps,
+        Err(error) => {
+            return reject_command(
+                root,
+                relay,
+                credential,
+                &command_id,
+                "invalid-command",
+                error,
+            );
+        }
+    };
+    if expires_at <= now
+        || expires_at.saturating_sub(created_at) > COMMAND_TTL_SECONDS
+        || created_at > now.saturating_add(CLOCK_SKEW_SECONDS)
+    {
+        return reject_command(
+            root,
+            relay,
+            credential,
+            &command_id,
+            "expired",
+            DeviceError::InvalidInput,
+        );
+    }
+    let Some(envelope) = command.get("envelope") else {
+        return reject_command(
+            root,
+            relay,
+            credential,
+            &command_id,
+            "invalid-command",
+            DeviceError::Integrity,
+        );
+    };
+    let app_id = match decrypt_command(
+        envelope,
+        &Identity::load_or_create(root)?.secret,
+        &credential.device_id,
+    ) {
+        Ok(id) => id,
+        Err(error) => {
+            return reject_command(
+                root,
+                relay,
+                credential,
+                &command_id,
+                "invalid-envelope",
+                error,
+            );
+        }
+    };
+    let plan = match prepare(root, &app_id) {
+        Ok(plan) => plan,
+        Err(error) => {
+            return reject_command(
+                root,
+                relay,
+                credential,
+                &command_id,
+                failure_code(error),
+                error,
+            );
+        }
+    };
+    let pending = Pending {
+        command_id,
+        app_id,
+        expires_at,
+        phase: PendingPhase::Ready {
+            install: plan.install,
+            outcome: plan.outcome,
+        },
+    };
+    pending.save(root)?;
+    resume_pending(root, relay, credential, pending, now, install)
+}
+
+fn resume_pending(
+    root: &Path,
+    relay: &mut impl Relay,
+    credential: &Credential,
+    pending: Pending,
+    now: u64,
+    install: impl FnOnce(&Path, &str) -> Result<(), DeviceError>,
+) -> Result<DeviceResult, DeviceError> {
+    match pending.phase.clone() {
+        PendingPhase::Ready {
+            install: run,
+            outcome,
+        } => {
+            if pending.expires_at <= now {
+                let final_pending = pending.final_failure("expired", DeviceError::InvalidInput);
+                final_pending.save(root)?;
+                return finish_pending(root, relay, credential, &final_pending);
+            }
+            send_ack(relay, credential, &pending.command_id, Ack::Installing)?;
+            let pending = Pending {
+                expires_at: pending
+                    .expires_at
+                    .max(now.saturating_add(INSTALL_COMPLETION_TTL_SECONDS)),
+                ..pending
+            };
+            pending.save(root)?;
+            if matches!(outcome, RemoteInstallOutcome::Unavailable { .. }) {
+                let final_pending = pending.final_outcome_failure("unavailable", outcome.clone());
+                final_pending.save(root)?;
+                return finish_pending(root, relay, credential, &final_pending);
+            }
+            if run {
+                if let Err(error) = install(root, &pending.app_id) {
+                    let final_pending = pending.final_failure(failure_code(error), error);
+                    final_pending.save(root)?;
+                    return finish_pending(root, relay, credential, &final_pending);
+                }
+            }
+            let final_pending = pending.final_success(outcome);
+            final_pending.save(root)?;
+            finish_pending(root, relay, credential, &final_pending)
+        }
+        PendingPhase::Final { .. } => finish_pending(root, relay, credential, &pending),
+    }
+}
+
+fn finish_pending(
+    root: &Path,
+    relay: &mut impl Relay,
+    credential: &Credential,
+    pending: &Pending,
+) -> Result<DeviceResult, DeviceError> {
+    let PendingPhase::Final { ack, report } = pending.phase.clone() else {
+        return Err(DeviceError::Backend);
+    };
+    match send_ack(relay, credential, &pending.command_id, ack) {
+        Ok(()) | Err(DeviceError::NotFound) => {
+            remember_completed(root, &pending.command_id)?;
+            remove_state_file(root, PENDING_FILE)?;
+        }
+        Err(error) => return Err(error),
+    }
+    match report {
+        Report::Outcome(outcome) => Ok(DeviceResult::RemoteInstall(outcome)),
+        Report::Error(error) => Err(error),
+    }
+}
+
+fn reject_command(
+    root: &Path,
+    relay: &mut impl Relay,
+    credential: &Credential,
+    command_id: &str,
+    failure: &str,
+    report: DeviceError,
+) -> Result<DeviceResult, DeviceError> {
+    let pending = Pending {
+        command_id: command_id.to_owned(),
+        app_id: String::new(),
+        expires_at: now(),
+        phase: PendingPhase::Final {
+            ack: Ack::Failed(failure.to_owned()),
+            report: Report::Error(report),
+        },
+    };
+    pending.save(root)?;
+    finish_pending(root, relay, credential, &pending)
+}
+
+fn disconnect_with(root: &Path, relay: &mut impl Relay) -> Result<DeviceResult, DeviceError> {
+    let remote = if let Some(credential) = Credential::load(root)? {
+        let path = format!("/v1/devices/{}", credential.device_id);
+        relay.send("DELETE", &path, Some(&credential.token), None)
+    } else {
+        Ok(Vec::new())
+    };
+    remove_state_file(root, CREDENTIAL_FILE)?;
+    remove_state_file(root, PENDING_FILE)?;
+    remove_state_file(root, COMPLETED_FILE)?;
+    remove_state_file(root, PRIVATE_KEY_FILE)?;
+    match remote {
+        Ok(_)
+        | Err(
+            DeviceError::NotFound
+            | DeviceError::Authentication
+            | DeviceError::TimedOut
+            | DeviceError::Unreachable,
+        ) => {}
+        Err(error) => return Err(error),
+    }
+    Ok(DeviceResult::AppLink(AppLinkState::Unpaired))
+}
+
+fn parse_pairing(response: &[u8]) -> Result<Pairing, DeviceError> {
+    parse_pairing_value(&parse_json(response)?)
+}
+
+fn parse_pairing_value(value: &Value) -> Result<Pairing, DeviceError> {
+    let code = value
+        .get("pairing_code")
+        .or_else(|| value.get("code"))
+        .and_then(Value::as_str)
+        .ok_or(DeviceError::Integrity)?;
+    let url = value
+        .get("pairing_url")
+        .or_else(|| value.get("url"))
+        .and_then(Value::as_str)
+        .ok_or(DeviceError::Integrity)?;
+    let expires_at = required_string(value, "expires_at")
+        .and_then(|value| parse_timestamp(&value).ok_or(DeviceError::Integrity))?;
+    if !valid_pairing_code(code) || !valid_https_url(url) {
+        return Err(DeviceError::Integrity);
+    }
+    Ok(Pairing {
+        code: code.to_owned(),
+        url: url.to_owned(),
+        expires_at,
+    })
+}
+
+fn local_pairing_state(credential: &Credential, now: u64) -> Option<AppLinkState> {
+    let pairing = credential.pairing.as_ref()?;
+    let remaining = pairing.expires_at.checked_sub(now)?;
+    Some(AppLinkState::Pairing {
+        code: pairing.code.clone(),
+        url: pairing.url.clone(),
+        expires_in: u32::try_from(remaining.min(10 * 60)).unwrap_or(10 * 60),
+    })
+}
+
+fn decrypt_command(
+    envelope: &Value,
+    secret: &SecretKey,
+    device_id: &str,
+) -> Result<String, DeviceError> {
+    if required_string(envelope, "algorithm")? != "ECDH-P256-AES-256-GCM" {
+        return Err(DeviceError::Integrity);
+    }
+    let public = decode_bounded(&required_string(envelope, "ephemeral_public_key")?, 91, 91)?;
+    let nonce = decode_bounded(&required_string(envelope, "nonce")?, 12, 12)?;
+    let mut ciphertext = decode_bounded(&required_string(envelope, "ciphertext")?, 17, 768)?;
+    let public = PublicKey::from_public_key_der(&public).map_err(|_| DeviceError::Integrity)?;
+    let shared = diffie_hellman(secret.to_nonzero_scalar(), public.as_affine());
+    let salt = hkdf::Salt::new(hkdf::HKDF_SHA256, &[]);
+    let prk = salt.extract(shared.raw_secret_bytes().as_ref());
+    let info = [HKDF_INFO];
+    let okm = prk
+        .expand(&info, AesKeyLength)
+        .map_err(|_| DeviceError::Integrity)?;
+    let mut key = [0_u8; 32];
+    okm.fill(&mut key).map_err(|_| DeviceError::Integrity)?;
+    let key = aead::UnboundKey::new(&aead::AES_256_GCM, &key)
+        .map(aead::LessSafeKey::new)
+        .map_err(|_| DeviceError::Integrity)?;
+    let nonce: [u8; 12] = nonce.try_into().map_err(|_| DeviceError::Integrity)?;
+    let plaintext = key
+        .open_in_place(
+            aead::Nonce::assume_unique_for_key(nonce),
+            aead::Aad::from(device_id.as_bytes()),
+            &mut ciphertext,
+        )
+        .map_err(|_| DeviceError::Integrity)?;
+    let value = parse_json(plaintext)?;
+    let Value::Object(fields) = &value else {
+        return Err(DeviceError::InvalidInput);
+    };
+    if fields.len() != 2
+        || value.get("version").and_then(Value::as_i64) != Some(1)
+        || value.get("app_id").and_then(Value::as_str).is_none()
+    {
+        return Err(DeviceError::InvalidInput);
+    }
+    let id = value
+        .get("app_id")
+        .and_then(Value::as_str)
+        .ok_or(DeviceError::InvalidInput)?;
+    if !kobo_protocol::valid_app_id(id) {
+        return Err(DeviceError::InvalidInput);
+    }
+    Ok(id.to_owned())
+}
+
+struct AesKeyLength;
+
+impl hkdf::KeyType for AesKeyLength {
+    fn len(&self) -> usize {
+        32
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Pending {
+    command_id: String,
+    app_id: String,
+    expires_at: u64,
+    phase: PendingPhase,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum PendingPhase {
+    Ready {
+        install: bool,
+        outcome: RemoteInstallOutcome,
+    },
+    Final {
+        ack: Ack,
+        report: Report,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum Ack {
+    Installing,
+    Installed(RemoteInstallOutcome),
+    Failed(String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum Report {
+    Outcome(RemoteInstallOutcome),
+    Error(DeviceError),
+}
+
+impl Pending {
+    fn load(root: &Path) -> Result<Option<Self>, DeviceError> {
+        let bytes = match fs::read(state_root(root).join(PENDING_FILE)) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(_) => return Err(DeviceError::Backend),
+        };
+        let value = parse_json(&bytes)?;
+        if value.get("version").and_then(Value::as_i64) != Some(1) {
+            return Err(DeviceError::Integrity);
+        }
+        let command_id = required_string(&value, "command_id")?;
+        let app_id = required_string(&value, "app_id")?;
+        let expires_at = required_string(&value, "expires_at")?
+            .parse::<u64>()
+            .map_err(|_| DeviceError::Integrity)?;
+        if !valid_uuid(&command_id) || (!app_id.is_empty() && !kobo_protocol::valid_app_id(&app_id))
+        {
+            return Err(DeviceError::Integrity);
+        }
+        let phase = match required_string(&value, "phase")?.as_str() {
+            "ready" => PendingPhase::Ready {
+                install: value
+                    .get("install")
+                    .and_then(Value::as_bool)
+                    .ok_or(DeviceError::Integrity)?,
+                outcome: parse_outcome(&value)?,
+            },
+            "final-success" => {
+                let outcome = parse_outcome(&value)?;
+                PendingPhase::Final {
+                    ack: Ack::Installed(outcome.clone()),
+                    report: Report::Outcome(outcome),
+                }
+            }
+            "final-outcome-failure" => {
+                let outcome = parse_outcome(&value)?;
+                PendingPhase::Final {
+                    ack: Ack::Failed(required_string(&value, "failure")?),
+                    report: Report::Outcome(outcome),
+                }
+            }
+            "final-error" => {
+                let error = parse_device_error(&required_string(&value, "error")?)
+                    .ok_or(DeviceError::Integrity)?;
+                PendingPhase::Final {
+                    ack: Ack::Failed(required_string(&value, "failure")?),
+                    report: Report::Error(error),
+                }
+            }
+            _ => return Err(DeviceError::Integrity),
+        };
+        Ok(Some(Self {
+            command_id,
+            app_id,
+            expires_at,
+            phase,
+        }))
+    }
+
+    fn save(&self, root: &Path) -> Result<(), DeviceError> {
+        let mut body = ObjectBuilder::new()
+            .set("version", 1_i32)
+            .set("command_id", self.command_id.clone())
+            .set("app_id", self.app_id.clone())
+            .set("expires_at", self.expires_at.to_string());
+        body = match &self.phase {
+            PendingPhase::Ready { install, outcome } => body
+                .set("phase", "ready")
+                .set("install", *install)
+                .set("outcome", outcome_name(outcome)),
+            PendingPhase::Final {
+                ack: Ack::Installed(outcome),
+                report: Report::Outcome(_),
+            } => body
+                .set("phase", "final-success")
+                .set("outcome", outcome_name(outcome)),
+            PendingPhase::Final {
+                ack: Ack::Failed(failure),
+                report: Report::Outcome(outcome),
+            } => body
+                .set("phase", "final-outcome-failure")
+                .set("failure", failure.clone())
+                .set("outcome", outcome_name(outcome)),
+            PendingPhase::Final {
+                ack: Ack::Failed(failure),
+                report: Report::Error(error),
+            } => body
+                .set("phase", "final-error")
+                .set("failure", failure.clone())
+                .set("error", device_error_name(*error)),
+            PendingPhase::Final { .. } => return Err(DeviceError::Backend),
+        };
+        atomic_write(
+            &state_root(root).join(PENDING_FILE),
+            body.build().to_json().as_bytes(),
+            0o600,
+        )
+    }
+
+    fn final_success(mut self, outcome: RemoteInstallOutcome) -> Self {
+        self.phase = PendingPhase::Final {
+            ack: Ack::Installed(outcome.clone()),
+            report: Report::Outcome(outcome),
+        };
+        self
+    }
+
+    fn final_outcome_failure(mut self, failure: &str, outcome: RemoteInstallOutcome) -> Self {
+        self.phase = PendingPhase::Final {
+            ack: Ack::Failed(failure.to_owned()),
+            report: Report::Outcome(outcome),
+        };
+        self
+    }
+
+    fn final_failure(mut self, failure: &str, error: DeviceError) -> Self {
+        self.phase = PendingPhase::Final {
+            ack: Ack::Failed(failure.to_owned()),
+            report: Report::Error(error),
+        };
+        self
+    }
+}
+
+fn send_ack(
+    relay: &mut impl Relay,
+    credential: &Credential,
+    command_id: &str,
+    ack: Ack,
+) -> Result<(), DeviceError> {
+    let body = match ack {
+        Ack::Installing => ObjectBuilder::new().set("state", "installing").build(),
+        Ack::Installed(outcome) => ObjectBuilder::new()
+            .set("state", "installed")
+            .set(
+                "outcome",
+                relay_outcome(&outcome).ok_or(DeviceError::InvalidInput)?,
+            )
+            .build(),
+        Ack::Failed(failure) => {
+            if failure.is_empty() || failure.len() > 96 {
+                return Err(DeviceError::InvalidInput);
+            }
+            ObjectBuilder::new()
+                .set("state", "failed")
+                .set("failure", failure)
+                .build()
+        }
+    }
+    .to_json();
+    let path = format!(
+        "/v1/devices/{}/commands/{command_id}/ack",
+        credential.device_id
+    );
+    relay
+        .send("POST", &path, Some(&credential.token), Some(&body))
+        .map(|_| ())
+}
+
+fn outcome_name(outcome: &RemoteInstallOutcome) -> String {
+    match outcome {
+        RemoteInstallOutcome::None => "none",
+        RemoteInstallOutcome::Installed { .. } => "installed",
+        RemoteInstallOutcome::Updated { .. } => "updated",
+        RemoteInstallOutcome::AlreadyInstalled { .. } => "already-installed",
+        RemoteInstallOutcome::Included { .. } => "included",
+        RemoteInstallOutcome::Unavailable { .. } => "unavailable",
+    }
+    .to_owned()
+}
+
+fn parse_outcome(value: &Value) -> Result<RemoteInstallOutcome, DeviceError> {
+    let id = required_string(value, "app_id")?;
+    if !kobo_protocol::valid_app_id(&id) {
+        return Err(DeviceError::Integrity);
+    }
+    match required_string(value, "outcome")?.as_str() {
+        "installed" => Ok(RemoteInstallOutcome::Installed { id }),
+        "updated" => Ok(RemoteInstallOutcome::Updated { id }),
+        "already-installed" => Ok(RemoteInstallOutcome::AlreadyInstalled { id }),
+        "included" => Ok(RemoteInstallOutcome::Included { id }),
+        "unavailable" => Ok(RemoteInstallOutcome::Unavailable { id }),
+        _ => Err(DeviceError::Integrity),
+    }
+}
+
+fn relay_outcome(outcome: &RemoteInstallOutcome) -> Option<&'static str> {
+    match outcome {
+        RemoteInstallOutcome::Installed { .. } => Some("installed"),
+        RemoteInstallOutcome::Updated { .. } => Some("updated"),
+        RemoteInstallOutcome::AlreadyInstalled { .. } => Some("already-installed"),
+        RemoteInstallOutcome::Included { .. } => Some("included"),
+        RemoteInstallOutcome::None | RemoteInstallOutcome::Unavailable { .. } => None,
+    }
+}
+
+fn failure_code(error: DeviceError) -> &'static str {
+    match error {
+        DeviceError::NotFound => "not-found",
+        DeviceError::Authentication => "authentication",
+        DeviceError::TimedOut => "timed-out",
+        DeviceError::Unreachable => "unreachable",
+        DeviceError::InvalidInput => "invalid-input",
+        DeviceError::Backend => "backend",
+        DeviceError::Integrity => "integrity",
+    }
+}
+
+fn device_error_name(error: DeviceError) -> &'static str {
+    failure_code(error)
+}
+
+fn parse_device_error(value: &str) -> Option<DeviceError> {
+    Some(match value {
+        "not-found" => DeviceError::NotFound,
+        "authentication" => DeviceError::Authentication,
+        "timed-out" => DeviceError::TimedOut,
+        "unreachable" => DeviceError::Unreachable,
+        "invalid-input" => DeviceError::InvalidInput,
+        "backend" => DeviceError::Backend,
+        "integrity" => DeviceError::Integrity,
+        _ => return None,
+    })
+}
+
+fn completed(root: &Path) -> Result<Vec<String>, DeviceError> {
+    let text = match fs::read_to_string(state_root(root).join(COMPLETED_FILE)) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(_) => return Err(DeviceError::Backend),
+    };
+    let mut ids = Vec::new();
+    for line in text.lines() {
+        if !valid_uuid(line) {
+            return Err(DeviceError::Integrity);
+        }
+        ids.push(line.to_owned());
+    }
+    Ok(ids)
+}
+
+fn remember_completed(root: &Path, command_id: &str) -> Result<(), DeviceError> {
+    let mut ids = completed(root)?;
+    ids.retain(|known| known != command_id);
+    ids.push(command_id.to_owned());
+    if ids.len() > COMPLETED_LIMIT {
+        ids.drain(..ids.len() - COMPLETED_LIMIT);
+    }
+    let mut body = ids.join("\n");
+    body.push('\n');
+    atomic_write(
+        &state_root(root).join(COMPLETED_FILE),
+        body.as_bytes(),
+        0o600,
+    )
+}
+
+fn state_root(root: &Path) -> PathBuf {
+    root.join("state").join(STATE_DIRECTORY)
+}
+
+fn atomic_write(path: &Path, bytes: &[u8], mode: u32) -> Result<(), DeviceError> {
+    let parent = path.parent().ok_or(DeviceError::Backend)?;
+    fs::create_dir_all(parent).map_err(|_| DeviceError::Backend)?;
+    set_mode(parent, 0o700)?;
+    let next = path.with_extension("next");
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(mode)
+        .open(&next)
+        .map_err(|_| DeviceError::Backend)?;
+    file.write_all(bytes)
+        .and_then(|()| file.sync_all())
+        .map_err(|_| DeviceError::Backend)?;
+    fs::set_permissions(&next, fs::Permissions::from_mode(mode))
+        .map_err(|_| DeviceError::Backend)?;
+    fs::rename(&next, path).map_err(|_| DeviceError::Backend)?;
+    File::open(parent)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|_| DeviceError::Backend)
+}
+
+fn remove_state_file(root: &Path, name: &str) -> Result<(), DeviceError> {
+    let path = state_root(root).join(name);
+    match fs::remove_file(path) {
+        Ok(()) => File::open(state_root(root))
+            .and_then(|directory| directory.sync_all())
+            .map_err(|_| DeviceError::Backend),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(_) => Err(DeviceError::Backend),
+    }
+}
+
+fn set_mode(path: &Path, mode: u32) -> Result<(), DeviceError> {
+    fs::set_permissions(path, fs::Permissions::from_mode(mode)).map_err(|_| DeviceError::Backend)
+}
+
+fn parse_json(bytes: &[u8]) -> Result<Value, DeviceError> {
+    let text = std::str::from_utf8(bytes).map_err(|_| DeviceError::Integrity)?;
+    kobo_json::parse(text).map_err(|_| DeviceError::Integrity)
+}
+
+fn required_string(value: &Value, key: &str) -> Result<String, DeviceError> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or(DeviceError::Integrity)
+}
+
+fn decode_bounded(value: &str, minimum: usize, maximum: usize) -> Result<Vec<u8>, DeviceError> {
+    let decoded = URL_SAFE_NO_PAD
+        .decode(value)
+        .map_err(|_| DeviceError::Integrity)?;
+    if !(minimum..=maximum).contains(&decoded.len()) {
+        return Err(DeviceError::Integrity);
+    }
+    Ok(decoded)
+}
+
+fn valid_token(value: &str) -> bool {
+    value.len() == 43
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+}
+
+fn valid_uuid(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() == 36
+        && bytes.iter().enumerate().all(|(index, byte)| match index {
+            8 | 13 | 18 | 23 => *byte == b'-',
+            14 => *byte == b'4',
+            19 => matches!(*byte, b'8' | b'9' | b'a' | b'b'),
+            _ => byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase(),
+        })
+}
+
+fn valid_pairing_code(value: &str) -> bool {
+    value.len() == 8
+        && value
+            .bytes()
+            .all(|byte| b"23456789ABCDEFGHJKLMNPQRSTUVWXYZ".contains(&byte))
+}
+
+fn valid_https_url(value: &str) -> bool {
+    value.starts_with("https://") && value.len() <= kobo_protocol::MAX_URL_LEN
+}
+
+fn parse_timestamp(value: &str) -> Option<u64> {
+    let (date, time) = value.strip_suffix('Z')?.split_once('T')?;
+    let mut date = date.split('-');
+    let year = date.next()?.parse::<i64>().ok()?;
+    let month = date.next()?.parse::<u32>().ok()?;
+    let day = date.next()?.parse::<u32>().ok()?;
+    let leap = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+    let month_days = match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if leap => 29,
+        2 => 28,
+        _ => return None,
+    };
+    if date.next().is_some() || day == 0 || day > month_days {
+        return None;
+    }
+    let time = time.split('.').next()?;
+    let mut time = time.split(':');
+    let hour = time.next()?.parse::<u64>().ok()?;
+    let minute = time.next()?.parse::<u64>().ok()?;
+    let second = time.next()?.parse::<u64>().ok()?;
+    if time.next().is_some() || hour > 23 || minute > 59 || second > 59 {
+        return None;
+    }
+    let year = year - i64::from(month <= 2);
+    let era = year.div_euclid(400);
+    let year_of_era = year - era * 400;
+    let shifted_month = i64::from(month) + if month > 2 { -3 } else { 9 };
+    let day_of_year = (153 * shifted_month + 2) / 5 + i64::from(day) - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    let days = era * 146_097 + day_of_era - 719_468;
+    if days < 0 {
+        return None;
+    }
+    u64::try_from(days)
+        .ok()?
+        .checked_mul(86_400)?
+        .checked_add(hour * 3600 + minute * 60 + second)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use p256::ecdh::EphemeralSecret;
+    use p256::elliptic_curve::rand_core::OsRng;
+    use std::cell::Cell;
+    use std::collections::VecDeque;
+
+    fn root(name: &str) -> PathBuf {
+        let root =
+            std::env::temp_dir().join(format!("cobalt-app-link-{}-{name}", std::process::id()));
+        let _ignored = fs::remove_dir_all(&root);
+        root
+    }
+
+    #[derive(Default)]
+    struct FakeRelay {
+        responses: VecDeque<Result<Vec<u8>, DeviceError>>,
+        requests: Vec<(String, String, Option<String>, Option<String>)>,
+    }
+
+    impl FakeRelay {
+        fn response(mut self, body: &str) -> Self {
+            self.responses.push_back(Ok(body.as_bytes().to_vec()));
+            self
+        }
+
+        fn failure(mut self, error: DeviceError) -> Self {
+            self.responses.push_back(Err(error));
+            self
+        }
+    }
+
+    impl Relay for FakeRelay {
+        fn send(
+            &mut self,
+            method: &str,
+            path: &str,
+            token: Option<&str>,
+            body: Option<&str>,
+        ) -> Result<Vec<u8>, DeviceError> {
+            self.requests.push((
+                method.to_owned(),
+                path.to_owned(),
+                token.map(str::to_owned),
+                body.map(str::to_owned),
+            ));
+            self.responses
+                .pop_front()
+                .unwrap_or(Err(DeviceError::Backend))
+        }
+    }
+
+    fn credential() -> Credential {
+        Credential {
+            device_id: "12345678-1234-4123-8123-123456789abc".to_owned(),
+            token: "A".repeat(43),
+            pairing: None,
+        }
+    }
+
+    fn pairing_response() -> &'static str {
+        r#"{"pairing_code":"2345ABCD","pairing_url":"https://example.test/pair/?code=2345ABCD","expires_at":"2026-08-26T13:00:00.000Z"}"#
+    }
+
+    fn encrypted_envelope(identity: &Identity, device_id: &str, id: &str) -> Value {
+        let ephemeral = EphemeralSecret::random(&mut OsRng);
+        let public = PublicKey::from(&ephemeral);
+        let shared = ephemeral.diffie_hellman(&identity.secret.public_key());
+        let salt = hkdf::Salt::new(hkdf::HKDF_SHA256, &[]);
+        let prk = salt.extract(shared.raw_secret_bytes().as_ref());
+        let info = [HKDF_INFO];
+        let okm = prk.expand(&info, AesKeyLength).expect("expand");
+        let mut bytes = [0_u8; 32];
+        okm.fill(&mut bytes).expect("key");
+        let key = aead::UnboundKey::new(&aead::AES_256_GCM, &bytes)
+            .map(aead::LessSafeKey::new)
+            .expect("AES key");
+        let nonce = [7_u8; 12];
+        let mut plaintext = ObjectBuilder::new()
+            .set("version", 1_i32)
+            .set("app_id", id)
+            .build()
+            .to_json()
+            .into_bytes();
+        key.seal_in_place_append_tag(
+            aead::Nonce::assume_unique_for_key(nonce),
+            aead::Aad::from(device_id.as_bytes()),
+            &mut plaintext,
+        )
+        .expect("encrypt");
+        ObjectBuilder::new()
+            .set("algorithm", "ECDH-P256-AES-256-GCM")
+            .set(
+                "ephemeral_public_key",
+                URL_SAFE_NO_PAD.encode(
+                    public
+                        .to_public_key_der()
+                        .expect("ephemeral public key")
+                        .as_bytes(),
+                ),
+            )
+            .set("nonce", URL_SAFE_NO_PAD.encode(nonce))
+            .set("ciphertext", URL_SAFE_NO_PAD.encode(plaintext))
+            .build()
+    }
+
+    #[test]
+    fn identity_is_persistent_private_and_has_an_uncompressed_public_key() {
+        let root = root("identity");
+        let first = Identity::load_or_create(&root).expect("first identity");
+        let second = Identity::load_or_create(&root).expect("second identity");
+        assert_eq!(first.secret.to_bytes(), second.secret.to_bytes());
+        assert_eq!(
+            URL_SAFE_NO_PAD
+                .decode(first.public_key().expect("encoded public key"))
+                .expect("public key")
+                .len(),
+            91
+        );
+        let mode = fs::metadata(state_root(&root).join(PRIVATE_KEY_FILE))
+            .expect("key metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn first_pairing_registers_once_and_persists_the_opaque_capability() {
+        let root = root("register");
+        let registration = format!(
+            r#"{{"device_id":"{}","device_token":"{}","pairing_code":"2345ABCD","pairing_url":"https://example.test/pair/","expires_at":"2026-08-26T13:00:00.000Z"}}"#,
+            credential().device_id,
+            credential().token
+        );
+        let mut relay = FakeRelay::default().response(&registration);
+        let result = begin_with(&root, &mut relay, 1_777_207_000, "Clara BW").expect("pair");
+        assert!(matches!(
+            result,
+            DeviceResult::AppLink(AppLinkState::Pairing { .. })
+        ));
+        assert_eq!(relay.requests[0].0, "POST");
+        assert_eq!(relay.requests[0].1, "/v1/pairings");
+        assert!(relay.requests[0].2.is_none());
+        let saved = Credential::load(&root)
+            .expect("read credential")
+            .expect("credential");
+        assert_eq!(saved.token, "A".repeat(43));
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn existing_registration_requests_a_new_pairing_without_rotating_identity() {
+        let root = root("repair");
+        credential().save(&root).expect("credential");
+        let identity = Identity::load_or_create(&root).expect("identity");
+        let key = identity.secret.to_bytes();
+        let mut relay = FakeRelay::default().response(pairing_response());
+        begin_with(&root, &mut relay, 1_777_207_000, "reader").expect("pair");
+        assert_eq!(
+            Identity::load_or_create(&root)
+                .expect("same identity")
+                .secret
+                .to_bytes(),
+            key
+        );
+        assert_eq!(
+            relay.requests[0].1,
+            format!("/v1/devices/{}/pairings", credential().device_id)
+        );
+        let token = "A".repeat(43);
+        assert_eq!(relay.requests[0].2.as_deref(), Some(token.as_str()));
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn command_decryption_uses_hkdf_and_device_id_as_aad() {
+        let root = root("decrypt");
+        let identity = Identity::load_or_create(&root).expect("identity");
+        let device_id = credential().device_id;
+        let envelope = encrypted_envelope(&identity, &device_id, "word-count");
+        assert_eq!(
+            decrypt_command(&envelope, &identity.secret, &device_id).expect("decrypt"),
+            "word-count"
+        );
+        assert_eq!(
+            decrypt_command(
+                &envelope,
+                &identity.secret,
+                &credential().device_id.replace('1', "2")
+            ),
+            Err(DeviceError::Integrity)
+        );
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn decrypts_a_fixed_browser_webcrypto_envelope() {
+        // Generated with WebCrypto importKey/deriveBits/deriveKey/encrypt using
+        // fixed P-256 private scalars and a fixed nonce.
+        let private = URL_SAFE_NO_PAD
+            .decode("AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE")
+            .expect("device private key");
+        let secret = SecretKey::from_slice(&private).expect("valid P-256 scalar");
+        let public = URL_SAFE_NO_PAD.encode(
+            secret
+                .public_key()
+                .to_public_key_der()
+                .expect("device public key")
+                .as_bytes(),
+        );
+        assert_eq!(
+            public,
+            "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEb_A7lJJBzh2t1DUZ5pYOCoW0GmmgXDKBA6orzhWUyhY8T3U6Vb8B3FP2wLDH7ueLQMb_fSWpbiKCuYnO9xwUSg"
+        );
+        let envelope = ObjectBuilder::new()
+            .set("algorithm", "ECDH-P256-AES-256-GCM")
+            .set(
+                "ephemeral_public_key",
+                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEVQ9HEAPz35fD31Bqx5f2ch-xoft7j2-D0iRJimXIjiQTYJPXAS5QmnNxXL0LAKPMD_S1wBs_-hlqsfsycDa45g",
+            )
+            .set("nonce", "AAECAwQFBgcICQoL")
+            .set(
+                "ciphertext",
+                "-h-bS-QE5N6219s7MC9U0Om5uE6i7wLT1unUn0jXykNwlfr69mWa5Y6zED2tc4kWaq9u",
+            )
+            .build();
+        assert_eq!(
+            decrypt_command(&envelope, &secret, "12345678-1234-4123-8123-123456789abc"),
+            Ok("word-count".to_owned())
+        );
+    }
+
+    #[test]
+    fn polling_decrypts_prepares_installs_and_acknowledges_in_order() {
+        let root = root("poll");
+        let credential = credential();
+        credential.save(&root).expect("credential");
+        let identity = Identity::load_or_create(&root).expect("identity");
+        let envelope = encrypted_envelope(&identity, &credential.device_id, "word-count");
+        let command = ObjectBuilder::new()
+            .set("id", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+            .set("envelope", envelope)
+            .set("created_at", "2026-08-26T12:46:31.000Z")
+            .set("expires_at", "2026-08-26T12:47:00.000Z")
+            .build();
+        let response = ObjectBuilder::new()
+            .set("command", command)
+            .build()
+            .to_json();
+        let mut relay = FakeRelay::default()
+            .response(r#"{"paired":true,"browser_count":1,"pairing":null}"#)
+            .response(&response)
+            .response("{}")
+            .response("{}");
+        let installs = Cell::new(0);
+        let result = poll_with(
+            &root,
+            &mut relay,
+            1_787_748_392,
+            |_, id| {
+                assert_eq!(id, "word-count");
+                Ok(crate::app_store::RemoteInstallPlan {
+                    outcome: RemoteInstallOutcome::Installed { id: id.to_owned() },
+                    install: true,
+                })
+            },
+            |path, id| {
+                assert_eq!(id, "word-count");
+                assert!(
+                    Pending::load(path)
+                        .expect("pending state")
+                        .expect("installing command")
+                        .expires_at
+                        >= 1_787_748_392 + INSTALL_COMPLETION_TTL_SECONDS
+                );
+                installs.set(installs.get() + 1);
+                Ok(())
+            },
+        )
+        .expect("poll");
+        assert_eq!(installs.get(), 1);
+        assert_eq!(
+            result,
+            DeviceResult::RemoteInstall(RemoteInstallOutcome::Installed {
+                id: "word-count".to_owned()
+            })
+        );
+        assert_eq!(
+            relay
+                .requests
+                .iter()
+                .map(|request| (request.0.as_str(), request.1.as_str()))
+                .collect::<Vec<_>>(),
+            vec![
+                (
+                    "GET",
+                    "/v1/devices/12345678-1234-4123-8123-123456789abc/pairing"
+                ),
+                (
+                    "GET",
+                    "/v1/devices/12345678-1234-4123-8123-123456789abc/commands"
+                ),
+                (
+                    "POST",
+                    "/v1/devices/12345678-1234-4123-8123-123456789abc/commands/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/ack"
+                ),
+                (
+                    "POST",
+                    "/v1/devices/12345678-1234-4123-8123-123456789abc/commands/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/ack"
+                ),
+            ]
+        );
+        assert!(relay.requests[2]
+            .3
+            .as_deref()
+            .is_some_and(|body| { body.contains(r#""state":"installing""#) }));
+        assert!(relay.requests[3].3.as_deref().is_some_and(|body| {
+            body.contains(r#""state":"installed""#) && body.contains(r#""outcome":"installed""#)
+        }));
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn an_expired_command_is_failed_without_decryption_or_installation() {
+        let root = root("expired");
+        credential().save(&root).expect("credential");
+        let response = r#"{"command":{"id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","envelope":{},"created_at":"2026-08-25T12:46:31.000Z","expires_at":"2026-08-26T12:46:31.000Z"}}"#;
+        let mut relay = FakeRelay::default()
+            .response(r#"{"paired":true,"browser_count":1,"pairing":null}"#)
+            .response(response)
+            .response("{}");
+        let result = poll_with(
+            &root,
+            &mut relay,
+            1_787_748_392,
+            |_, _| panic!("expired command must not prepare"),
+            |_, _| panic!("expired command must not install"),
+        );
+        assert_eq!(result, Err(DeviceError::InvalidInput));
+        assert!(relay.requests[2].3.as_deref().is_some_and(|body| {
+            body.contains(r#""state":"failed""#) && body.contains(r#""failure":"expired""#)
+        }));
+        assert!(Pending::load(&root).expect("pending").is_none());
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn final_acknowledgements_survive_restart_and_do_not_repeat_installation() {
+        let root = root("pending");
+        let credential = credential();
+        credential.save(&root).expect("credential");
+        let pending = Pending {
+            command_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa".to_owned(),
+            app_id: "word-count".to_owned(),
+            expires_at: 2_000_000_000,
+            phase: PendingPhase::Final {
+                ack: Ack::Installed(RemoteInstallOutcome::Installed {
+                    id: "word-count".to_owned(),
+                }),
+                report: Report::Outcome(RemoteInstallOutcome::Installed {
+                    id: "word-count".to_owned(),
+                }),
+            },
+        };
+        pending.save(&root).expect("pending");
+        let mut relay = FakeRelay::default().response("{}");
+        let result = poll_with(
+            &root,
+            &mut relay,
+            1_800_000_000,
+            |_, _| panic!("a final acknowledgement must not prepare again"),
+            |_, _| panic!("a final acknowledgement must not install again"),
+        )
+        .expect("retry");
+        assert!(matches!(
+            result,
+            DeviceResult::RemoteInstall(RemoteInstallOutcome::Installed { .. })
+        ));
+        assert!(Pending::load(&root).expect("pending state").is_none());
+        assert_eq!(
+            completed(&root).expect("completed"),
+            vec!["aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"]
+        );
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn disconnect_revokes_the_device_and_removes_every_local_capability() {
+        let root = root("disconnect");
+        Identity::load_or_create(&root).expect("identity");
+        credential().save(&root).expect("credential");
+        fs::write(state_root(&root).join(COMPLETED_FILE), "").expect("journal");
+        let mut relay = FakeRelay::default().response("{}");
+        let result = disconnect_with(&root, &mut relay).expect("disconnect");
+        assert_eq!(result, DeviceResult::AppLink(AppLinkState::Unpaired));
+        assert_eq!(relay.requests[0].0, "DELETE");
+        assert!(Credential::load(&root).expect("credential state").is_none());
+        assert!(!state_root(&root).join(COMPLETED_FILE).exists());
+        assert!(!state_root(&root).join(PRIVATE_KEY_FILE).exists());
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn disconnect_revokes_the_local_identity_while_offline() {
+        let root = root("disconnect-offline");
+        Identity::load_or_create(&root).expect("identity");
+        credential().save(&root).expect("credential");
+        let mut relay = FakeRelay::default().failure(DeviceError::Unreachable);
+        let result = disconnect_with(&root, &mut relay).expect("local disconnect");
+        assert_eq!(result, DeviceResult::AppLink(AppLinkState::Unpaired));
+        assert!(Credential::load(&root).expect("credential state").is_none());
+        assert!(!state_root(&root).join(PRIVATE_KEY_FILE).exists());
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn timestamps_are_strict_and_expiry_is_bounded_to_twenty_four_hours() {
+        assert_eq!(parse_timestamp("1970-01-01T00:00:00.000Z"), Some(0));
+        assert_eq!(
+            parse_timestamp("2026-08-26T12:46:31.167Z"),
+            Some(1_787_748_391)
+        );
+        assert_eq!(parse_timestamp("2026-08-26 12:46:31Z"), None);
+        assert_eq!(parse_timestamp("2026-13-26T12:46:31Z"), None);
+        assert_eq!(parse_timestamp("2026-02-29T12:46:31Z"), None);
+        assert_eq!(COMMAND_TTL_SECONDS, 86_400);
+    }
+}

--- a/crates/kobod/src/app_link.rs
+++ b/crates/kobod/src/app_link.rs
@@ -23,7 +23,7 @@ const PENDING_FILE: &str = "pending.json";
 const COMPLETED_FILE: &str = "completed";
 const MAX_RELAY_BODY: u32 = 16 * 1024;
 const MAX_HTTP_RESPONSE: u64 = 48 * 1024;
-const COMMAND_TTL_SECONDS: u64 = 24 * 60 * 60;
+const COMMAND_TTL_SECONDS: u64 = 72 * 60 * 60;
 const INSTALL_COMPLETION_TTL_SECONDS: u64 = 15 * 60;
 const CLOCK_SKEW_SECONDS: u64 = 5 * 60;
 const COMPLETED_LIMIT: usize = 64;
@@ -1613,7 +1613,7 @@ mod tests {
     }
 
     #[test]
-    fn timestamps_are_strict_and_expiry_is_bounded_to_twenty_four_hours() {
+    fn timestamps_are_strict_and_expiry_is_bounded_to_seventy_two_hours() {
         assert_eq!(parse_timestamp("1970-01-01T00:00:00.000Z"), Some(0));
         assert_eq!(
             parse_timestamp("2026-08-26T12:46:31.167Z"),
@@ -1622,7 +1622,7 @@ mod tests {
         assert_eq!(parse_timestamp("2026-08-26 12:46:31Z"), None);
         assert_eq!(parse_timestamp("2026-13-26T12:46:31Z"), None);
         assert_eq!(parse_timestamp("2026-02-29T12:46:31Z"), None);
-        assert_eq!(COMMAND_TTL_SECONDS, 86_400);
+        assert_eq!(COMMAND_TTL_SECONDS, 259_200);
     }
 
     #[test]

--- a/crates/kobod/src/app_link.rs
+++ b/crates/kobod/src/app_link.rs
@@ -3,9 +3,10 @@ use base64::Engine as _;
 use kobo_json::{ObjectBuilder, Value};
 use kobo_protocol::{AppLinkState, DeviceError, DeviceResult, RemoteInstallOutcome};
 use p256::ecdh::diffie_hellman;
+use p256::ecdsa::signature::Verifier as _;
 use p256::pkcs8::{DecodePublicKey, EncodePublicKey};
 use p256::{PublicKey, SecretKey};
-use ring::{aead, hkdf};
+use ring::{aead, digest, hkdf, hmac};
 use std::fmt::Write as _;
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
@@ -21,13 +22,17 @@ const PRIVATE_KEY_FILE: &str = "device-key";
 const CREDENTIAL_FILE: &str = "credential.json";
 const PENDING_FILE: &str = "pending.json";
 const COMPLETED_FILE: &str = "completed";
+const BROWSERS_FILE: &str = "browsers";
 const MAX_RELAY_BODY: u32 = 16 * 1024;
 const MAX_HTTP_RESPONSE: u64 = 48 * 1024;
 const COMMAND_TTL_SECONDS: u64 = 72 * 60 * 60;
 const INSTALL_COMPLETION_TTL_SECONDS: u64 = 15 * 60;
 const CLOCK_SKEW_SECONDS: u64 = 5 * 60;
 const COMPLETED_LIMIT: usize = 64;
+const PINNED_BROWSER_LIMIT: usize = 8;
 const HKDF_INFO: &[u8] = b"cobalt-app-install-v1";
+const PAIR_PROOF_CONTEXT: &str = "cobalt-pair-proof-v1";
+const INSTALL_SIGNATURE_CONTEXT: &str = "cobalt-install-v2";
 static RELAY_TLS_CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
 
 pub fn read(root: &Path) -> Result<DeviceResult, DeviceError> {
@@ -178,11 +183,29 @@ impl Relay for HttpsRelay {
         if response.len() as u64 > MAX_HTTP_RESPONSE {
             return Err(DeviceError::Backend);
         }
-        match kobo_net::split_response(&response, MAX_RELAY_BODY).map_err(network_error)? {
-            kobo_net::Response::Body(body) => Ok(body.into_owned()),
-            kobo_net::Response::Redirect(_) => Err(DeviceError::Unreachable),
+        match kobo_net::split_response(&response, MAX_RELAY_BODY) {
+            Ok(kobo_net::Response::Body(body)) => Ok(body.into_owned()),
+            Ok(kobo_net::Response::Redirect(_)) => Err(DeviceError::Unreachable),
+            // A relay overload or outage is retryable; only a definite client
+            // error such as 404 may be treated as the relay's final verdict.
+            Err(kobo_protocol::TaskError::NotFound) if transient_status(&response) => {
+                Err(DeviceError::Unreachable)
+            }
+            Err(error) => Err(network_error(error)),
         }
     }
+}
+
+fn transient_status(response: &[u8]) -> bool {
+    let line = response.split(|byte| *byte == b'\r').next().unwrap_or(&[]);
+    let mut parts = line
+        .split(|byte| *byte == b' ')
+        .filter(|part| !part.is_empty());
+    parts
+        .nth(1)
+        .and_then(|code| std::str::from_utf8(code).ok())
+        .and_then(|code| code.parse::<u16>().ok())
+        .is_some_and(|code| matches!(code, 408 | 425 | 429 | 500..=599))
 }
 
 fn relay_tls_config() -> Result<Arc<rustls::ClientConfig>, DeviceError> {
@@ -236,9 +259,7 @@ impl Identity {
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                 let mut bytes = [0_u8; 32];
                 let secret = loop {
-                    File::open("/dev/urandom")
-                        .and_then(|mut random| random.read_exact(&mut bytes))
-                        .map_err(|_| DeviceError::Backend)?;
+                    random_bytes(&mut bytes)?;
                     if let Ok(secret) = SecretKey::from_slice(&bytes) {
                         break secret;
                     }
@@ -257,6 +278,26 @@ impl Identity {
             .map(|document| URL_SAFE_NO_PAD.encode(document.as_bytes()))
             .map_err(|_| DeviceError::Backend)
     }
+
+    /// A short digest of the public key, published only through the QR code
+    /// fragment so a browser can detect a relay substituting its own key.
+    fn public_key_fingerprint(&self) -> Result<String, DeviceError> {
+        let public = self.public_key()?;
+        let digest = digest::digest(&digest::SHA256, public.as_bytes());
+        Ok(URL_SAFE_NO_PAD.encode(&digest.as_ref()[..16]))
+    }
+}
+
+fn random_bytes(bytes: &mut [u8]) -> Result<(), DeviceError> {
+    File::open("/dev/urandom")
+        .and_then(|mut random| random.read_exact(bytes))
+        .map_err(|_| DeviceError::Backend)
+}
+
+fn new_link_secret() -> Result<String, DeviceError> {
+    let mut bytes = [0_u8; 16];
+    random_bytes(&mut bytes)?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -271,6 +312,9 @@ struct Pairing {
     code: String,
     url: String,
     expires_at: u64,
+    /// Shared only through the QR code fragment, never through the relay.
+    /// A browser proves its signing key with an HMAC keyed by this secret.
+    secret: String,
 }
 
 impl Credential {
@@ -295,12 +339,14 @@ impl Credential {
             Some(value) => {
                 let code = value.get("code").and_then(Value::as_str);
                 let url = value.get("url").and_then(Value::as_str);
+                let secret = value.get("secret").and_then(Value::as_str);
                 let expires_at = value
                     .get("expires_at")
                     .and_then(Value::as_str)
                     .and_then(|value| value.parse::<u64>().ok());
                 if !code.is_some_and(valid_pairing_code)
                     || !url.is_some_and(valid_https_url)
+                    || !secret.is_some_and(valid_link_secret)
                     || expires_at.is_none()
                 {
                     return Err(DeviceError::Integrity);
@@ -309,6 +355,7 @@ impl Credential {
                     code: code.unwrap_or_default().to_owned(),
                     url: url.unwrap_or_default().to_owned(),
                     expires_at: expires_at.unwrap_or_default(),
+                    secret: secret.unwrap_or_default().to_owned(),
                 })
             }
         };
@@ -325,6 +372,7 @@ impl Credential {
                 .set("code", pairing.code.clone())
                 .set("url", pairing.url.clone())
                 .set("expires_at", pairing.expires_at.to_string())
+                .set("secret", pairing.secret.clone())
                 .build()
         });
         let body = ObjectBuilder::new()
@@ -352,7 +400,9 @@ fn begin_with(
     let mut credential = if let Some(mut credential) = Credential::load(root)? {
         let path = format!("/v1/devices/{}/pairings", credential.device_id);
         let response = relay.send("POST", &path, Some(&credential.token), Some("{}"))?;
-        credential.pairing = Some(parse_pairing(&response)?);
+        let mut pairing = parse_pairing(&response)?;
+        pairing.secret = new_link_secret()?;
+        credential.pairing = Some(pairing);
         credential.save(root)?;
         credential
     } else {
@@ -372,12 +422,15 @@ fn begin_with(
         let credential = Credential {
             device_id,
             token,
-            pairing: Some(pairing),
+            pairing: Some(Pairing {
+                secret: new_link_secret()?,
+                ..pairing
+            }),
         };
         credential.save(root)?;
         credential
     };
-    let state = local_pairing_state(&credential, now).unwrap_or(AppLinkState::Unpaired);
+    let state = local_pairing_state(&credential, &identity, now).unwrap_or(AppLinkState::Unpaired);
     if matches!(state, AppLinkState::Unpaired) {
         credential.pairing = None;
         credential.save(root)?;
@@ -406,16 +459,146 @@ fn read_with(root: &Path, relay: &mut impl Relay, now: u64) -> Result<DeviceResu
         if browsers == 0 {
             return Err(DeviceError::Integrity);
         }
-        if credential.pairing.take().is_some() {
+        let pairing = credential.pairing.take();
+        sync_browser_pins(root, pairing.as_ref(), &value)?;
+        if pairing.is_some() {
             credential.save(root)?;
         }
         return Ok(DeviceResult::AppLink(AppLinkState::Paired { browsers }));
     }
-    let state = local_pairing_state(&credential, now).unwrap_or(AppLinkState::Unpaired);
+    let identity = Identity::load_or_create(root)?;
+    let state = local_pairing_state(&credential, &identity, now).unwrap_or(AppLinkState::Unpaired);
     if matches!(state, AppLinkState::Unpaired) && credential.pairing.take().is_some() {
         credential.save(root)?;
     }
     Ok(DeviceResult::AppLink(state))
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PinnedBrowser {
+    public_key: String,
+    proven: bool,
+}
+
+/// Pins browser signing keys reported by the relay. A key joins the pinned
+/// set only while a pairing this device created is outstanding: a valid HMAC
+/// proof from the QR fragment secret pins a verified sender, and a single
+/// claim without one is trusted once at pairing time. Keys the relay reports
+/// at any other moment are ignored, so a later-compromised relay cannot add
+/// senders.
+fn sync_browser_pins(
+    root: &Path,
+    pairing: Option<&Pairing>,
+    value: &Value,
+) -> Result<(), DeviceError> {
+    let entries = value
+        .get("browser_keys")
+        .and_then(Value::as_array)
+        .ok_or(DeviceError::Integrity)?;
+    if entries.len() > PINNED_BROWSER_LIMIT {
+        return Err(DeviceError::Integrity);
+    }
+    let mut pinned = load_browsers(root)?;
+    let mut changed = false;
+    let mut unproven_allowance = 1;
+    for entry in entries {
+        let key = entry
+            .get("public_key")
+            .and_then(Value::as_str)
+            .filter(|key| valid_browser_key(key))
+            .ok_or(DeviceError::Integrity)?;
+        if pinned.iter().any(|browser| browser.public_key == key) {
+            continue;
+        }
+        let proof = match entry.get("proof") {
+            None | Some(Value::Null) => None,
+            Some(proof) => Some(
+                proof
+                    .as_str()
+                    .filter(|proof| valid_pair_proof(proof))
+                    .ok_or(DeviceError::Integrity)?,
+            ),
+        };
+        let Some(pairing) = pairing else { continue };
+        let proven = if let Some(proof) = proof {
+            if !verify_pair_proof(&pairing.secret, key, proof) {
+                continue;
+            }
+            true
+        } else {
+            if unproven_allowance == 0 {
+                continue;
+            }
+            unproven_allowance -= 1;
+            false
+        };
+        if pinned.len() >= PINNED_BROWSER_LIMIT {
+            break;
+        }
+        pinned.push(PinnedBrowser {
+            public_key: key.to_owned(),
+            proven,
+        });
+        changed = true;
+    }
+    if changed {
+        save_browsers(root, &pinned)?;
+    }
+    Ok(())
+}
+
+fn verify_pair_proof(secret: &str, browser_key: &str, proof: &str) -> bool {
+    let Ok(secret) = URL_SAFE_NO_PAD.decode(secret) else {
+        return false;
+    };
+    let Ok(proof) = URL_SAFE_NO_PAD.decode(proof) else {
+        return false;
+    };
+    let key = hmac::Key::new(hmac::HMAC_SHA256, &secret);
+    let mut message = Vec::new();
+    message.extend_from_slice(PAIR_PROOF_CONTEXT.as_bytes());
+    message.push(b'\n');
+    message.extend_from_slice(browser_key.as_bytes());
+    hmac::verify(&key, &message, &proof).is_ok()
+}
+
+fn load_browsers(root: &Path) -> Result<Vec<PinnedBrowser>, DeviceError> {
+    let text = match fs::read_to_string(state_root(root).join(BROWSERS_FILE)) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(_) => return Err(DeviceError::Backend),
+    };
+    let mut browsers = Vec::new();
+    for line in text.lines() {
+        let (kind, key) = line.split_once(' ').ok_or(DeviceError::Integrity)?;
+        let proven = match kind {
+            "proven" => true,
+            "tofu" => false,
+            _ => return Err(DeviceError::Integrity),
+        };
+        if !valid_browser_key(key) || browsers.len() >= PINNED_BROWSER_LIMIT {
+            return Err(DeviceError::Integrity);
+        }
+        browsers.push(PinnedBrowser {
+            public_key: key.to_owned(),
+            proven,
+        });
+    }
+    Ok(browsers)
+}
+
+fn save_browsers(root: &Path, browsers: &[PinnedBrowser]) -> Result<(), DeviceError> {
+    let mut body = String::new();
+    for browser in browsers {
+        body.push_str(if browser.proven { "proven " } else { "tofu " });
+        body.push_str(&browser.public_key);
+        body.push('\n');
+    }
+    atomic_write(
+        &state_root(root).join(BROWSERS_FILE),
+        body.as_bytes(),
+        0o600,
+    )
 }
 
 fn poll_with(
@@ -447,6 +630,70 @@ fn poll_with(
     process_command(root, relay, &credential, command, now, prepare, install)
 }
 
+fn validate_command(
+    root: &Path,
+    credential: &Credential,
+    command: &Value,
+    now: u64,
+) -> Result<(InstallRequest, u64), (Option<&'static str>, DeviceError)> {
+    let invalid = |error| (Some("invalid-command"), error);
+    let (created_at, expires_at) = required_string(command, "created_at")
+        .and_then(|value| parse_timestamp(&value).ok_or(DeviceError::Integrity))
+        .and_then(|created_at| {
+            required_string(command, "expires_at")
+                .and_then(|value| parse_timestamp(&value).ok_or(DeviceError::Integrity))
+                .map(|expires_at| (created_at, expires_at))
+        })
+        .map_err(invalid)?;
+    if expires_at <= now
+        || expires_at.saturating_sub(created_at) > COMMAND_TTL_SECONDS
+        || created_at > now.saturating_add(CLOCK_SKEW_SECONDS)
+    {
+        return Err((Some("expired"), DeviceError::InvalidInput));
+    }
+    let envelope = command
+        .get("envelope")
+        .ok_or_else(|| invalid(DeviceError::Integrity))?;
+    let sender = command
+        .get("browser_public_key")
+        .and_then(Value::as_str)
+        .filter(|key| valid_browser_key(key))
+        .ok_or_else(|| invalid(DeviceError::Integrity))?;
+    let signature = command
+        .get("signature")
+        .and_then(Value::as_str)
+        .filter(|signature| valid_install_signature(signature))
+        .ok_or_else(|| invalid(DeviceError::Integrity))?;
+    if !load_browsers(root)
+        .map_err(|error| (None, error))?
+        .iter()
+        .any(|browser| browser.public_key == sender)
+    {
+        return Err((Some("unknown-sender"), DeviceError::Integrity));
+    }
+    if !verify_install_signature(sender, signature, &credential.device_id, envelope) {
+        return Err((Some("invalid-signature"), DeviceError::Integrity));
+    }
+    let identity = Identity::load_or_create(root).map_err(|error| (None, error))?;
+    let request = decrypt_command(envelope, &identity.secret, &credential.device_id)
+        .map_err(|error| (Some("invalid-envelope"), error))?;
+    // Freshness and uniqueness come from inside the sealed request, so the
+    // relay cannot replay an old envelope under a new command identity.
+    if request.requested_at > now.saturating_add(CLOCK_SKEW_SECONDS)
+        || now > request.requested_at.saturating_add(COMMAND_TTL_SECONDS)
+    {
+        return Err((Some("expired"), DeviceError::InvalidInput));
+    }
+    if completed(root)
+        .map_err(|error| (None, error))?
+        .iter()
+        .any(|known| known == &request.request_id)
+    {
+        return Err((Some("replayed-command"), DeviceError::Integrity));
+    }
+    Ok((request, expires_at))
+}
+
 fn process_command(
     root: &Path,
     relay: &mut impl Relay,
@@ -460,76 +707,14 @@ fn process_command(
     if !valid_uuid(&command_id) {
         return Err(DeviceError::Integrity);
     }
-    if completed(root)?.iter().any(|known| known == &command_id) {
-        return reject_command(
-            root,
-            relay,
-            credential,
-            &command_id,
-            "replayed-command",
-            DeviceError::Integrity,
-        );
-    }
-    let timestamps = required_string(command, "created_at")
-        .and_then(|value| parse_timestamp(&value).ok_or(DeviceError::Integrity))
-        .and_then(|created_at| {
-            required_string(command, "expires_at")
-                .and_then(|value| parse_timestamp(&value).ok_or(DeviceError::Integrity))
-                .map(|expires_at| (created_at, expires_at))
-        });
-    let (created_at, expires_at) = match timestamps {
-        Ok(timestamps) => timestamps,
-        Err(error) => {
-            return reject_command(
-                root,
-                relay,
-                credential,
-                &command_id,
-                "invalid-command",
-                error,
-            );
+    let (request, expires_at) = match validate_command(root, credential, command, now) {
+        Ok(validated) => validated,
+        Err((None, error)) => return Err(error),
+        Err((Some(failure), error)) => {
+            return reject_command(root, relay, credential, &command_id, failure, error);
         }
     };
-    if expires_at <= now
-        || expires_at.saturating_sub(created_at) > COMMAND_TTL_SECONDS
-        || created_at > now.saturating_add(CLOCK_SKEW_SECONDS)
-    {
-        return reject_command(
-            root,
-            relay,
-            credential,
-            &command_id,
-            "expired",
-            DeviceError::InvalidInput,
-        );
-    }
-    let Some(envelope) = command.get("envelope") else {
-        return reject_command(
-            root,
-            relay,
-            credential,
-            &command_id,
-            "invalid-command",
-            DeviceError::Integrity,
-        );
-    };
-    let app_id = match decrypt_command(
-        envelope,
-        &Identity::load_or_create(root)?.secret,
-        &credential.device_id,
-    ) {
-        Ok(id) => id,
-        Err(error) => {
-            return reject_command(
-                root,
-                relay,
-                credential,
-                &command_id,
-                "invalid-envelope",
-                error,
-            );
-        }
-    };
+    let app_id = request.app_id;
     let plan = match prepare(root, &app_id) {
         Ok(plan) => plan,
         Err(error) => {
@@ -545,6 +730,7 @@ fn process_command(
     };
     let pending = Pending {
         command_id,
+        request_id: request.request_id,
         app_id,
         expires_at,
         phase: PendingPhase::Ready {
@@ -613,7 +799,9 @@ fn finish_pending(
     };
     match send_ack(relay, credential, &pending.command_id, ack) {
         Ok(()) | Err(DeviceError::NotFound) => {
-            remember_completed(root, &pending.command_id)?;
+            if !pending.request_id.is_empty() {
+                remember_completed(root, &pending.request_id)?;
+            }
             remove_state_file(root, PENDING_FILE)?;
         }
         Err(error) => return Err(error),
@@ -634,6 +822,7 @@ fn reject_command(
 ) -> Result<DeviceResult, DeviceError> {
     let pending = Pending {
         command_id: command_id.to_owned(),
+        request_id: String::new(),
         app_id: String::new(),
         expires_at: now(),
         phase: PendingPhase::Final {
@@ -646,15 +835,19 @@ fn reject_command(
 }
 
 fn disconnect_with(root: &Path, relay: &mut impl Relay) -> Result<DeviceResult, DeviceError> {
-    let remote = if let Some(credential) = Credential::load(root)? {
-        let path = format!("/v1/devices/{}", credential.device_id);
-        relay.send("DELETE", &path, Some(&credential.token), None)
-    } else {
-        Ok(Vec::new())
+    // A missing or unreadable credential cannot authenticate a remote revoke,
+    // but unpairing must still succeed as a guaranteed local reset.
+    let remote = match Credential::load(root) {
+        Ok(Some(credential)) => {
+            let path = format!("/v1/devices/{}", credential.device_id);
+            relay.send("DELETE", &path, Some(&credential.token), None)
+        }
+        Ok(None) | Err(_) => Ok(Vec::new()),
     };
     remove_state_file(root, CREDENTIAL_FILE)?;
     remove_state_file(root, PENDING_FILE)?;
     remove_state_file(root, COMPLETED_FILE)?;
+    remove_state_file(root, BROWSERS_FILE)?;
     remove_state_file(root, PRIVATE_KEY_FILE)?;
     match remote {
         Ok(_)
@@ -693,24 +886,77 @@ fn parse_pairing_value(value: &Value) -> Result<Pairing, DeviceError> {
         code: code.to_owned(),
         url: url.to_owned(),
         expires_at,
+        secret: String::new(),
     })
 }
 
-fn local_pairing_state(credential: &Credential, now: u64) -> Option<AppLinkState> {
+fn local_pairing_state(
+    credential: &Credential,
+    identity: &Identity,
+    now: u64,
+) -> Option<AppLinkState> {
     let pairing = credential.pairing.as_ref()?;
     let remaining = pairing.expires_at.checked_sub(now)?;
+    // The fragment travels inside the QR code only: browsers never send it to
+    // the relay, so it can carry the device key digest and the pairing proof
+    // secret that keep the relay honest.
+    let url = format!(
+        "{}#k={}&s={}",
+        pairing.url,
+        identity.public_key_fingerprint().ok()?,
+        pairing.secret
+    );
     Some(AppLinkState::Pairing {
         code: pairing.code.clone(),
-        url: pairing.url.clone(),
+        url,
         expires_in: u32::try_from(remaining.min(10 * 60)).unwrap_or(10 * 60),
     })
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct InstallRequest {
+    app_id: String,
+    request_id: String,
+    requested_at: u64,
+}
+
+fn verify_install_signature(
+    sender: &str,
+    signature: &str,
+    device_id: &str,
+    envelope: &Value,
+) -> bool {
+    let (Some(ephemeral), Some(nonce), Some(ciphertext)) = (
+        envelope.get("ephemeral_public_key").and_then(Value::as_str),
+        envelope.get("nonce").and_then(Value::as_str),
+        envelope.get("ciphertext").and_then(Value::as_str),
+    ) else {
+        return false;
+    };
+    let Ok(sender) = URL_SAFE_NO_PAD.decode(sender) else {
+        return false;
+    };
+    let Ok(signature) = URL_SAFE_NO_PAD.decode(signature) else {
+        return false;
+    };
+    let Ok(key) = PublicKey::from_public_key_der(&sender) else {
+        return false;
+    };
+    let Ok(signature) = p256::ecdsa::Signature::from_slice(&signature) else {
+        return false;
+    };
+    let message =
+        format!("{INSTALL_SIGNATURE_CONTEXT}\n{device_id}\n{ephemeral}\n{nonce}\n{ciphertext}");
+    p256::ecdsa::VerifyingKey::from(&key)
+        .verify(message.as_bytes(), &signature)
+        .is_ok()
 }
 
 fn decrypt_command(
     envelope: &Value,
     secret: &SecretKey,
     device_id: &str,
-) -> Result<String, DeviceError> {
+) -> Result<InstallRequest, DeviceError> {
     if required_string(envelope, "algorithm")? != "ECDH-P256-AES-256-GCM" {
         return Err(DeviceError::Integrity);
     }
@@ -742,10 +988,7 @@ fn decrypt_command(
     let Value::Object(fields) = &value else {
         return Err(DeviceError::InvalidInput);
     };
-    if fields.len() != 2
-        || value.get("version").and_then(Value::as_i64) != Some(1)
-        || value.get("app_id").and_then(Value::as_str).is_none()
-    {
+    if fields.len() != 4 || value.get("version").and_then(Value::as_i64) != Some(2) {
         return Err(DeviceError::InvalidInput);
     }
     let id = value
@@ -755,7 +998,21 @@ fn decrypt_command(
     if !kobo_protocol::valid_app_id(id) {
         return Err(DeviceError::InvalidInput);
     }
-    Ok(id.to_owned())
+    let request_id = value
+        .get("request_id")
+        .and_then(Value::as_str)
+        .filter(|request_id| valid_request_id(request_id))
+        .ok_or(DeviceError::InvalidInput)?;
+    let requested_at = value
+        .get("requested_at")
+        .and_then(Value::as_i64)
+        .and_then(|requested_at| u64::try_from(requested_at).ok())
+        .ok_or(DeviceError::InvalidInput)?;
+    Ok(InstallRequest {
+        app_id: id.to_owned(),
+        request_id: request_id.to_owned(),
+        requested_at,
+    })
 }
 
 struct AesKeyLength;
@@ -769,6 +1026,7 @@ impl hkdf::KeyType for AesKeyLength {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct Pending {
     command_id: String,
+    request_id: String,
     app_id: String,
     expires_at: u64,
     phase: PendingPhase,
@@ -811,11 +1069,18 @@ impl Pending {
             return Err(DeviceError::Integrity);
         }
         let command_id = required_string(&value, "command_id")?;
+        let request_id = value
+            .get("request_id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
         let app_id = required_string(&value, "app_id")?;
         let expires_at = required_string(&value, "expires_at")?
             .parse::<u64>()
             .map_err(|_| DeviceError::Integrity)?;
-        if !valid_uuid(&command_id) || (!app_id.is_empty() && !kobo_protocol::valid_app_id(&app_id))
+        if !valid_uuid(&command_id)
+            || (!app_id.is_empty() && !kobo_protocol::valid_app_id(&app_id))
+            || (!request_id.is_empty() && !valid_request_id(&request_id))
         {
             return Err(DeviceError::Integrity);
         }
@@ -853,6 +1118,7 @@ impl Pending {
         };
         Ok(Some(Self {
             command_id,
+            request_id,
             app_id,
             expires_at,
             phase,
@@ -863,6 +1129,7 @@ impl Pending {
         let mut body = ObjectBuilder::new()
             .set("version", 1_i32)
             .set("command_id", self.command_id.clone())
+            .set("request_id", self.request_id.clone())
             .set("app_id", self.app_id.clone())
             .set("expires_at", self.expires_at.to_string());
         body = match &self.phase {
@@ -1033,7 +1300,9 @@ fn completed(root: &Path) -> Result<Vec<String>, DeviceError> {
     };
     let mut ids = Vec::new();
     for line in text.lines() {
-        if !valid_uuid(line) {
+        // Uuids are accepted for journals written before entries became
+        // browser-chosen request identifiers.
+        if !valid_request_id(line) && !valid_uuid(line) {
             return Err(DeviceError::Integrity);
         }
         ids.push(line.to_owned());
@@ -1041,10 +1310,10 @@ fn completed(root: &Path) -> Result<Vec<String>, DeviceError> {
     Ok(ids)
 }
 
-fn remember_completed(root: &Path, command_id: &str) -> Result<(), DeviceError> {
+fn remember_completed(root: &Path, request_id: &str) -> Result<(), DeviceError> {
     let mut ids = completed(root)?;
-    ids.retain(|known| known != command_id);
-    ids.push(command_id.to_owned());
+    ids.retain(|known| known != request_id);
+    ids.push(request_id.to_owned());
     if ids.len() > COMPLETED_LIMIT {
         ids.drain(..ids.len() - COMPLETED_LIMIT);
     }
@@ -1123,10 +1392,34 @@ fn decode_bounded(value: &str, minimum: usize, maximum: usize) -> Result<Vec<u8>
 }
 
 fn valid_token(value: &str) -> bool {
-    value.len() == 43
+    valid_base64url(value, 43)
+}
+
+fn valid_base64url(value: &str, length: usize) -> bool {
+    value.len() == length
         && value
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+}
+
+fn valid_link_secret(value: &str) -> bool {
+    valid_base64url(value, 22)
+}
+
+fn valid_request_id(value: &str) -> bool {
+    valid_base64url(value, 22)
+}
+
+fn valid_browser_key(value: &str) -> bool {
+    valid_base64url(value, 122)
+}
+
+fn valid_pair_proof(value: &str) -> bool {
+    valid_base64url(value, 43)
+}
+
+fn valid_install_signature(value: &str) -> bool {
+    valid_base64url(value, 86)
 }
 
 fn valid_uuid(value: &str) -> bool {
@@ -1255,11 +1548,79 @@ mod tests {
         }
     }
 
+    fn pairing() -> Pairing {
+        Pairing {
+            code: "2345ABCD".to_owned(),
+            url: "https://example.test/pair/?code=2345ABCD".to_owned(),
+            expires_at: 2_000_000_000,
+            secret: URL_SAFE_NO_PAD.encode([9_u8; 16]),
+        }
+    }
+
+    fn request_id() -> String {
+        URL_SAFE_NO_PAD.encode([0_u8; 16])
+    }
+
+    fn browser_signing_key() -> p256::ecdsa::SigningKey {
+        p256::ecdsa::SigningKey::from_slice(&[3_u8; 32]).expect("browser key")
+    }
+
+    fn browser_public_key() -> String {
+        URL_SAFE_NO_PAD.encode(
+            browser_signing_key()
+                .verifying_key()
+                .to_public_key_der()
+                .expect("browser public key")
+                .as_bytes(),
+        )
+    }
+
+    fn pin_browser(root: &Path) {
+        save_browsers(
+            root,
+            &[PinnedBrowser {
+                public_key: browser_public_key(),
+                proven: true,
+            }],
+        )
+        .expect("pin browser");
+    }
+
+    fn sign_command(device_id: &str, envelope: &Value) -> String {
+        use p256::ecdsa::signature::Signer as _;
+        let message = format!(
+            "{INSTALL_SIGNATURE_CONTEXT}\n{device_id}\n{}\n{}\n{}",
+            envelope
+                .get("ephemeral_public_key")
+                .and_then(Value::as_str)
+                .expect("ephemeral key"),
+            envelope
+                .get("nonce")
+                .and_then(Value::as_str)
+                .expect("nonce"),
+            envelope
+                .get("ciphertext")
+                .and_then(Value::as_str)
+                .expect("ciphertext"),
+        );
+        let signature: p256::ecdsa::Signature = browser_signing_key().sign(message.as_bytes());
+        URL_SAFE_NO_PAD.encode(signature.to_bytes())
+    }
+
     fn pairing_response() -> &'static str {
         r#"{"pairing_code":"2345ABCD","pairing_url":"https://example.test/pair/?code=2345ABCD","expires_at":"2026-08-26T13:00:00.000Z"}"#
     }
 
-    fn encrypted_envelope(identity: &Identity, device_id: &str, id: &str) -> Value {
+    fn paired_response() -> &'static str {
+        r#"{"paired":true,"browser_count":1,"pairing":null,"browser_keys":[]}"#
+    }
+
+    fn encrypted_envelope(
+        identity: &Identity,
+        device_id: &str,
+        id: &str,
+        requested_at: u64,
+    ) -> Value {
         let ephemeral = EphemeralSecret::random(&mut OsRng);
         let public = PublicKey::from(&ephemeral);
         let shared = ephemeral.diffie_hellman(&identity.secret.public_key());
@@ -1273,12 +1634,11 @@ mod tests {
             .map(aead::LessSafeKey::new)
             .expect("AES key");
         let nonce = [7_u8; 12];
-        let mut plaintext = ObjectBuilder::new()
-            .set("version", 1_i32)
-            .set("app_id", id)
-            .build()
-            .to_json()
-            .into_bytes();
+        let mut plaintext = format!(
+            r#"{{"version":2,"app_id":"{id}","request_id":"{}","requested_at":{requested_at}}}"#,
+            request_id()
+        )
+        .into_bytes();
         key.seal_in_place_append_tag(
             aead::Nonce::assume_unique_for_key(nonce),
             aead::Aad::from(device_id.as_bytes()),
@@ -1376,10 +1736,14 @@ mod tests {
         let root = root("decrypt");
         let identity = Identity::load_or_create(&root).expect("identity");
         let device_id = credential().device_id;
-        let envelope = encrypted_envelope(&identity, &device_id, "word-count");
+        let envelope = encrypted_envelope(&identity, &device_id, "word-count", 1_787_748_392);
         assert_eq!(
             decrypt_command(&envelope, &identity.secret, &device_id).expect("decrypt"),
-            "word-count"
+            InstallRequest {
+                app_id: "word-count".to_owned(),
+                request_id: request_id(),
+                requested_at: 1_787_748_392,
+            }
         );
         assert_eq!(
             decrypt_command(
@@ -1420,12 +1784,16 @@ mod tests {
             .set("nonce", "AAECAwQFBgcICQoL")
             .set(
                 "ciphertext",
-                "-h-bS-QE5N6219s7MC9U0Om5uE6i7wLT1unUn0jXykNwlfr69mWa5Y6zED2tc4kWaq9u",
+                "-h-bS-QE5N6219s4MC9U0Om5uE6i7wLT1unUn0jXykNwlauxLiOWLzQdMzWBsA9HCSZ7wVZyPOK7k0gkTxQjkviE2KpYGhsk7FNeIBEduCw-udeu8P8n2Xiw-IFO3UPRhA5Pny75yV3GRrJ1zzARRpT_Kw",
             )
             .build();
         assert_eq!(
             decrypt_command(&envelope, &secret, "12345678-1234-4123-8123-123456789abc"),
-            Ok("word-count".to_owned())
+            Ok(InstallRequest {
+                app_id: "word-count".to_owned(),
+                request_id: "AAAAAAAAAAAAAAAAAAAAAA".to_owned(),
+                requested_at: 1_787_748_000,
+            })
         );
     }
 
@@ -1434,11 +1802,20 @@ mod tests {
         let root = root("poll");
         let credential = credential();
         credential.save(&root).expect("credential");
+        pin_browser(&root);
         let identity = Identity::load_or_create(&root).expect("identity");
-        let envelope = encrypted_envelope(&identity, &credential.device_id, "word-count");
+        let envelope = encrypted_envelope(
+            &identity,
+            &credential.device_id,
+            "word-count",
+            1_787_748_392,
+        );
+        let signature = sign_command(&credential.device_id, &envelope);
         let command = ObjectBuilder::new()
             .set("id", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
             .set("envelope", envelope)
+            .set("browser_public_key", browser_public_key())
+            .set("signature", signature)
             .set("created_at", "2026-08-26T12:46:31.000Z")
             .set("expires_at", "2026-08-26T12:47:00.000Z")
             .build();
@@ -1447,7 +1824,7 @@ mod tests {
             .build()
             .to_json();
         let mut relay = FakeRelay::default()
-            .response(r#"{"paired":true,"browser_count":1,"pairing":null}"#)
+            .response(paired_response())
             .response(&response)
             .response("{}")
             .response("{}");
@@ -1525,7 +1902,7 @@ mod tests {
         credential().save(&root).expect("credential");
         let response = r#"{"command":{"id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","envelope":{},"created_at":"2026-08-25T12:46:31.000Z","expires_at":"2026-08-26T12:46:31.000Z"}}"#;
         let mut relay = FakeRelay::default()
-            .response(r#"{"paired":true,"browser_count":1,"pairing":null}"#)
+            .response(paired_response())
             .response(response)
             .response("{}");
         let result = poll_with(
@@ -1550,6 +1927,7 @@ mod tests {
         credential.save(&root).expect("credential");
         let pending = Pending {
             command_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa".to_owned(),
+            request_id: request_id(),
             app_id: "word-count".to_owned(),
             expires_at: 2_000_000_000,
             phase: PendingPhase::Final {
@@ -1576,10 +1954,7 @@ mod tests {
             DeviceResult::RemoteInstall(RemoteInstallOutcome::Installed { .. })
         ));
         assert!(Pending::load(&root).expect("pending state").is_none());
-        assert_eq!(
-            completed(&root).expect("completed"),
-            vec!["aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"]
-        );
+        assert_eq!(completed(&root).expect("completed"), vec![request_id()]);
         let _ignored = fs::remove_dir_all(root);
     }
 
@@ -1609,6 +1984,328 @@ mod tests {
         assert_eq!(result, DeviceResult::AppLink(AppLinkState::Unpaired));
         assert!(Credential::load(&root).expect("credential state").is_none());
         assert!(!state_root(&root).join(PRIVATE_KEY_FILE).exists());
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_corrupt_credential_still_unpairs_and_clears_local_state() {
+        let root = root("disconnect-corrupt");
+        Identity::load_or_create(&root).expect("identity");
+        atomic_write(
+            &state_root(&root).join(CREDENTIAL_FILE),
+            b"{not json",
+            0o600,
+        )
+        .expect("corrupt credential");
+        let mut relay = FakeRelay::default();
+        let result = disconnect_with(&root, &mut relay).expect("unpair");
+        assert_eq!(result, DeviceResult::AppLink(AppLinkState::Unpaired));
+        assert!(relay.requests.is_empty());
+        assert!(!state_root(&root).join(CREDENTIAL_FILE).exists());
+        assert!(!state_root(&root).join(PRIVATE_KEY_FILE).exists());
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_relay_outage_during_the_final_acknowledgement_keeps_the_pending_record() {
+        let root = root("ack-outage");
+        credential().save(&root).expect("credential");
+        let pending = Pending {
+            command_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa".to_owned(),
+            request_id: request_id(),
+            app_id: "word-count".to_owned(),
+            expires_at: 2_000_000_000,
+            phase: PendingPhase::Final {
+                ack: Ack::Installed(RemoteInstallOutcome::Installed {
+                    id: "word-count".to_owned(),
+                }),
+                report: Report::Outcome(RemoteInstallOutcome::Installed {
+                    id: "word-count".to_owned(),
+                }),
+            },
+        };
+        pending.save(&root).expect("pending");
+        let mut relay = FakeRelay::default().failure(DeviceError::Unreachable);
+        let result = poll_with(
+            &root,
+            &mut relay,
+            1_800_000_000,
+            |_, _| panic!("a final acknowledgement must not prepare"),
+            |_, _| panic!("a final acknowledgement must not install"),
+        );
+        assert_eq!(result, Err(DeviceError::Unreachable));
+        assert!(Pending::load(&root).expect("pending state").is_some());
+        assert!(completed(&root).expect("completed").is_empty());
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn relay_status_codes_distinguish_outages_from_final_verdicts() {
+        assert!(transient_status(
+            b"HTTP/1.1 500 Internal Server Error\r\n\r\n"
+        ));
+        assert!(transient_status(
+            b"HTTP/1.1 503 Service Unavailable\r\n\r\n"
+        ));
+        assert!(transient_status(b"HTTP/1.1 429 Too Many Requests\r\n\r\n"));
+        assert!(!transient_status(b"HTTP/1.1 404 Not Found\r\n\r\n"));
+        assert!(!transient_status(b"HTTP/1.1 409 Conflict\r\n\r\n"));
+        assert!(!transient_status(b"garbage"));
+    }
+
+    fn pair_proof(secret: &str, key: &str) -> String {
+        let secret = URL_SAFE_NO_PAD.decode(secret).expect("secret");
+        let hmac_key = hmac::Key::new(hmac::HMAC_SHA256, &secret);
+        let mut message = Vec::new();
+        message.extend_from_slice(PAIR_PROOF_CONTEXT.as_bytes());
+        message.push(b'\n');
+        message.extend_from_slice(key.as_bytes());
+        URL_SAFE_NO_PAD.encode(hmac::sign(&hmac_key, &message).as_ref())
+    }
+
+    fn second_browser_key() -> String {
+        URL_SAFE_NO_PAD.encode(
+            p256::ecdsa::SigningKey::from_slice(&[4_u8; 32])
+                .expect("second browser key")
+                .verifying_key()
+                .to_public_key_der()
+                .expect("second public key")
+                .as_bytes(),
+        )
+    }
+
+    #[test]
+    fn browser_keys_pin_only_while_a_device_created_pairing_is_outstanding() {
+        let root = root("pins");
+        let pairing = pairing();
+        let key = browser_public_key();
+        let proven = ObjectBuilder::new()
+            .set(
+                "browser_keys",
+                vec![ObjectBuilder::new()
+                    .set("public_key", key.clone())
+                    .set("proof", pair_proof(&pairing.secret, &key))
+                    .build()],
+            )
+            .build();
+        sync_browser_pins(&root, Some(&pairing), &proven).expect("pin proven");
+        assert_eq!(
+            load_browsers(&root).expect("browsers"),
+            vec![PinnedBrowser {
+                public_key: key.clone(),
+                proven: true,
+            }]
+        );
+        let unproven = ObjectBuilder::new()
+            .set(
+                "browser_keys",
+                vec![ObjectBuilder::new()
+                    .set("public_key", second_browser_key())
+                    .build()],
+            )
+            .build();
+        sync_browser_pins(&root, None, &unproven).expect("ignore without pairing");
+        assert_eq!(load_browsers(&root).expect("browsers").len(), 1);
+        sync_browser_pins(&root, Some(&pairing), &unproven).expect("pin at pairing time");
+        assert_eq!(
+            load_browsers(&root).expect("browsers")[1],
+            PinnedBrowser {
+                public_key: second_browser_key(),
+                proven: false,
+            }
+        );
+        let forged = ObjectBuilder::new()
+            .set(
+                "browser_keys",
+                vec![ObjectBuilder::new()
+                    .set("public_key", "B".repeat(122))
+                    .set(
+                        "proof",
+                        pair_proof(&URL_SAFE_NO_PAD.encode([1_u8; 16]), "B"),
+                    )
+                    .build()],
+            )
+            .build();
+        sync_browser_pins(&root, Some(&pairing), &forged).expect("ignore forged proof");
+        assert_eq!(load_browsers(&root).expect("browsers").len(), 2);
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn commands_from_unknown_senders_are_rejected_without_decryption() {
+        let root = root("unknown-sender");
+        let credential = credential();
+        credential.save(&root).expect("credential");
+        let identity = Identity::load_or_create(&root).expect("identity");
+        let envelope = encrypted_envelope(
+            &identity,
+            &credential.device_id,
+            "word-count",
+            1_787_748_392,
+        );
+        let signature = sign_command(&credential.device_id, &envelope);
+        let command = ObjectBuilder::new()
+            .set("id", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+            .set("envelope", envelope)
+            .set("browser_public_key", browser_public_key())
+            .set("signature", signature)
+            .set("created_at", "2026-08-26T12:46:31.000Z")
+            .set("expires_at", "2026-08-26T12:47:00.000Z")
+            .build();
+        let response = ObjectBuilder::new()
+            .set("command", command)
+            .build()
+            .to_json();
+        let mut relay = FakeRelay::default()
+            .response(paired_response())
+            .response(&response)
+            .response("{}");
+        let result = poll_with(
+            &root,
+            &mut relay,
+            1_787_748_392,
+            |_, _| panic!("an unknown sender must not prepare"),
+            |_, _| panic!("an unknown sender must not install"),
+        );
+        assert_eq!(result, Err(DeviceError::Integrity));
+        assert!(relay.requests[2].3.as_deref().is_some_and(|body| {
+            body.contains(r#""state":"failed""#) && body.contains(r#""failure":"unknown-sender""#)
+        }));
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_tampered_signature_is_rejected_before_decryption() {
+        let root = root("bad-signature");
+        let credential = credential();
+        credential.save(&root).expect("credential");
+        pin_browser(&root);
+        let identity = Identity::load_or_create(&root).expect("identity");
+        let envelope = encrypted_envelope(
+            &identity,
+            &credential.device_id,
+            "word-count",
+            1_787_748_392,
+        );
+        let command = ObjectBuilder::new()
+            .set("id", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+            .set("envelope", envelope)
+            .set("browser_public_key", browser_public_key())
+            .set("signature", "C".repeat(86))
+            .set("created_at", "2026-08-26T12:46:31.000Z")
+            .set("expires_at", "2026-08-26T12:47:00.000Z")
+            .build();
+        let response = ObjectBuilder::new()
+            .set("command", command)
+            .build()
+            .to_json();
+        let mut relay = FakeRelay::default()
+            .response(paired_response())
+            .response(&response)
+            .response("{}");
+        let result = poll_with(
+            &root,
+            &mut relay,
+            1_787_748_392,
+            |_, _| panic!("a forged command must not prepare"),
+            |_, _| panic!("a forged command must not install"),
+        );
+        assert_eq!(result, Err(DeviceError::Integrity));
+        assert!(relay.requests[2]
+            .3
+            .as_deref()
+            .is_some_and(|body| { body.contains(r#""failure":"invalid-signature""#) }));
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_replayed_request_is_rejected_even_under_a_fresh_command_identity() {
+        let root = root("replay");
+        let credential = credential();
+        credential.save(&root).expect("credential");
+        pin_browser(&root);
+        remember_completed(&root, &request_id()).expect("journal");
+        let identity = Identity::load_or_create(&root).expect("identity");
+        let envelope = encrypted_envelope(
+            &identity,
+            &credential.device_id,
+            "word-count",
+            1_787_748_392,
+        );
+        let signature = sign_command(&credential.device_id, &envelope);
+        let command = ObjectBuilder::new()
+            .set("id", "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb")
+            .set("envelope", envelope)
+            .set("browser_public_key", browser_public_key())
+            .set("signature", signature)
+            .set("created_at", "2026-08-26T12:46:31.000Z")
+            .set("expires_at", "2026-08-26T12:47:00.000Z")
+            .build();
+        let response = ObjectBuilder::new()
+            .set("command", command)
+            .build()
+            .to_json();
+        let mut relay = FakeRelay::default()
+            .response(paired_response())
+            .response(&response)
+            .response("{}");
+        let result = poll_with(
+            &root,
+            &mut relay,
+            1_787_748_392,
+            |_, _| panic!("a replayed request must not prepare"),
+            |_, _| panic!("a replayed request must not install"),
+        );
+        assert_eq!(result, Err(DeviceError::Integrity));
+        assert!(relay.requests[2]
+            .3
+            .as_deref()
+            .is_some_and(|body| { body.contains(r#""failure":"replayed-command""#) }));
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_stale_sealed_request_is_rejected_as_expired() {
+        let root = root("stale-request");
+        let credential = credential();
+        credential.save(&root).expect("credential");
+        pin_browser(&root);
+        let identity = Identity::load_or_create(&root).expect("identity");
+        let envelope = encrypted_envelope(
+            &identity,
+            &credential.device_id,
+            "word-count",
+            1_787_748_392 - COMMAND_TTL_SECONDS - 1,
+        );
+        let signature = sign_command(&credential.device_id, &envelope);
+        let command = ObjectBuilder::new()
+            .set("id", "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa")
+            .set("envelope", envelope)
+            .set("browser_public_key", browser_public_key())
+            .set("signature", signature)
+            .set("created_at", "2026-08-26T12:46:31.000Z")
+            .set("expires_at", "2026-08-26T12:47:00.000Z")
+            .build();
+        let response = ObjectBuilder::new()
+            .set("command", command)
+            .build()
+            .to_json();
+        let mut relay = FakeRelay::default()
+            .response(paired_response())
+            .response(&response)
+            .response("{}");
+        let result = poll_with(
+            &root,
+            &mut relay,
+            1_787_748_392,
+            |_, _| panic!("a stale request must not prepare"),
+            |_, _| panic!("a stale request must not install"),
+        );
+        assert_eq!(result, Err(DeviceError::InvalidInput));
+        assert!(relay.requests[2]
+            .3
+            .as_deref()
+            .is_some_and(|body| body.contains(r#""failure":"expired""#)));
         let _ignored = fs::remove_dir_all(root);
     }
 

--- a/crates/kobod/src/app_link.rs
+++ b/crates/kobod/src/app_link.rs
@@ -442,6 +442,14 @@ fn read_with(root: &Path, relay: &mut impl Relay, now: u64) -> Result<DeviceResu
     let Some(mut credential) = Credential::load(root)? else {
         return Ok(DeviceResult::AppLink(AppLinkState::Unpaired));
     };
+    if credential
+        .pairing
+        .as_ref()
+        .is_some_and(|pairing| pairing.expires_at <= now)
+    {
+        credential.pairing = None;
+        credential.save(root)?;
+    }
     let path = format!("/v1/devices/{}/pairing", credential.device_id);
     let response = relay.send("GET", &path, Some(&credential.token), None)?;
     let value = parse_json(&response)?;
@@ -459,10 +467,17 @@ fn read_with(root: &Path, relay: &mut impl Relay, now: u64) -> Result<DeviceResu
         if browsers == 0 {
             return Err(DeviceError::Integrity);
         }
-        let pairing = credential.pairing.take();
-        sync_browser_pins(root, pairing.as_ref(), &value)?;
+        let pairing = credential.pairing.as_ref();
+        let added = sync_browser_pins(root, pairing, &value)?;
         if pairing.is_some() {
+            if added == 0 {
+                return Err(DeviceError::Integrity);
+            }
+            credential.pairing = None;
             credential.save(root)?;
+        }
+        if load_browsers(root)?.is_empty() {
+            return Err(DeviceError::Integrity);
         }
         return Ok(DeviceResult::AppLink(AppLinkState::Paired { browsers }));
     }
@@ -482,15 +497,15 @@ struct PinnedBrowser {
 
 /// Pins browser signing keys reported by the relay. A key joins the pinned
 /// set only while a pairing this device created is outstanding: a valid HMAC
-/// proof from the QR fragment secret pins a verified sender, and a single
-/// claim without one is trusted once at pairing time. Keys the relay reports
-/// at any other moment are ignored, so a later-compromised relay cannot add
-/// senders.
+/// proof from the QR fragment secret pins a verified sender. Manual entry uses
+/// that same secret, so a proofless relay key is never accepted. Keys the relay
+/// reports at any other moment are ignored, so a later-compromised relay cannot
+/// add senders.
 fn sync_browser_pins(
     root: &Path,
     pairing: Option<&Pairing>,
     value: &Value,
-) -> Result<(), DeviceError> {
+) -> Result<usize, DeviceError> {
     let entries = value
         .get("browser_keys")
         .and_then(Value::as_array)
@@ -500,7 +515,7 @@ fn sync_browser_pins(
     }
     let mut pinned = load_browsers(root)?;
     let mut changed = false;
-    let mut unproven_allowance = 1;
+    let mut added = 0;
     for entry in entries {
         let key = entry
             .get("public_key")
@@ -520,31 +535,24 @@ fn sync_browser_pins(
             ),
         };
         let Some(pairing) = pairing else { continue };
-        let proven = if let Some(proof) = proof {
-            if !verify_pair_proof(&pairing.secret, key, proof) {
-                continue;
-            }
-            true
-        } else {
-            if unproven_allowance == 0 {
-                continue;
-            }
-            unproven_allowance -= 1;
-            false
-        };
+        let Some(proof) = proof else { continue };
+        if !verify_pair_proof(&pairing.secret, key, proof) {
+            continue;
+        }
         if pinned.len() >= PINNED_BROWSER_LIMIT {
             break;
         }
         pinned.push(PinnedBrowser {
             public_key: key.to_owned(),
-            proven,
+            proven: true,
         });
         changed = true;
+        added += 1;
     }
     if changed {
         save_browsers(root, &pinned)?;
     }
-    Ok(())
+    Ok(added)
 }
 
 fn verify_pair_proof(secret: &str, browser_key: &str, proof: &str) -> bool {
@@ -1900,6 +1908,7 @@ mod tests {
     fn an_expired_command_is_failed_without_decryption_or_installation() {
         let root = root("expired");
         credential().save(&root).expect("credential");
+        pin_browser(&root);
         let response = r#"{"command":{"id":"aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa","envelope":{},"created_at":"2026-08-25T12:46:31.000Z","expires_at":"2026-08-26T12:46:31.000Z"}}"#;
         let mut relay = FakeRelay::default()
             .response(paired_response())
@@ -2082,13 +2091,21 @@ mod tests {
         let proven = ObjectBuilder::new()
             .set(
                 "browser_keys",
-                vec![ObjectBuilder::new()
-                    .set("public_key", key.clone())
-                    .set("proof", pair_proof(&pairing.secret, &key))
-                    .build()],
+                vec![
+                    ObjectBuilder::new()
+                        .set("public_key", second_browser_key())
+                        .build(),
+                    ObjectBuilder::new()
+                        .set("public_key", key.clone())
+                        .set("proof", pair_proof(&pairing.secret, &key))
+                        .build(),
+                ],
             )
             .build();
-        sync_browser_pins(&root, Some(&pairing), &proven).expect("pin proven");
+        assert_eq!(
+            sync_browser_pins(&root, Some(&pairing), &proven).expect("pin proven"),
+            1
+        );
         assert_eq!(
             load_browsers(&root).expect("browsers"),
             vec![PinnedBrowser {
@@ -2106,14 +2123,11 @@ mod tests {
             .build();
         sync_browser_pins(&root, None, &unproven).expect("ignore without pairing");
         assert_eq!(load_browsers(&root).expect("browsers").len(), 1);
-        sync_browser_pins(&root, Some(&pairing), &unproven).expect("pin at pairing time");
         assert_eq!(
-            load_browsers(&root).expect("browsers")[1],
-            PinnedBrowser {
-                public_key: second_browser_key(),
-                proven: false,
-            }
+            sync_browser_pins(&root, Some(&pairing), &unproven).expect("reject proofless pairing"),
+            0
         );
+        assert_eq!(load_browsers(&root).expect("browsers").len(), 1);
         let forged = ObjectBuilder::new()
             .set(
                 "browser_keys",
@@ -2127,7 +2141,68 @@ mod tests {
             )
             .build();
         sync_browser_pins(&root, Some(&pairing), &forged).expect("ignore forged proof");
-        assert_eq!(load_browsers(&root).expect("browsers").len(), 2);
+        assert_eq!(load_browsers(&root).expect("browsers").len(), 1);
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn pairing_remains_open_when_no_browser_key_can_be_pinned() {
+        let root = root("empty-pins");
+        let credential = Credential {
+            pairing: Some(pairing()),
+            ..credential()
+        };
+        credential.save(&root).expect("credential");
+        let mut relay = FakeRelay::default().response(paired_response());
+
+        assert_eq!(
+            read_with(&root, &mut relay, 1_787_748_392),
+            Err(DeviceError::Integrity)
+        );
+        assert!(Credential::load(&root)
+            .expect("credential state")
+            .expect("credential")
+            .pairing
+            .is_some());
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn expired_pairing_cannot_pin_a_browser_key() {
+        let root = root("expired-pairing");
+        let pairing = pairing();
+        let key = browser_public_key();
+        Credential {
+            pairing: Some(pairing.clone()),
+            ..credential()
+        }
+        .save(&root)
+        .expect("credential");
+        let response = ObjectBuilder::new()
+            .set("paired", true)
+            .set("browser_count", 1)
+            .set("pairing", Value::Null)
+            .set(
+                "browser_keys",
+                vec![ObjectBuilder::new()
+                    .set("public_key", key.clone())
+                    .set("proof", pair_proof(&pairing.secret, &key))
+                    .build()],
+            )
+            .build()
+            .to_json();
+        let mut relay = FakeRelay::default().response(&response);
+
+        assert_eq!(
+            read_with(&root, &mut relay, pairing.expires_at),
+            Err(DeviceError::Integrity)
+        );
+        assert!(Credential::load(&root)
+            .expect("credential state")
+            .expect("credential")
+            .pairing
+            .is_none());
+        assert!(load_browsers(&root).expect("browsers").is_empty());
         let _ignored = fs::remove_dir_all(root);
     }
 
@@ -2136,6 +2211,14 @@ mod tests {
         let root = root("unknown-sender");
         let credential = credential();
         credential.save(&root).expect("credential");
+        save_browsers(
+            &root,
+            &[PinnedBrowser {
+                public_key: second_browser_key(),
+                proven: true,
+            }],
+        )
+        .expect("pin other browser");
         let identity = Identity::load_or_create(&root).expect("identity");
         let envelope = encrypted_envelope(
             &identity,

--- a/crates/kobod/src/app_store.rs
+++ b/crates/kobod/src/app_store.rs
@@ -3,7 +3,7 @@
 use kobo_app_store::{
     parse_public_bundle, verify, Catalog, DetachedSignature, Ed25519PublicKey, Manifest,
 };
-use kobo_protocol::{AppInfo, DeviceError};
+use kobo_protocol::{AppInfo, DeviceError, RemoteInstallOutcome};
 use kobo_ui::Glyph;
 use std::collections::BTreeSet;
 use std::fs;
@@ -182,7 +182,11 @@ pub fn catalog(root: &Path) -> Result<Vec<AppInfo>, DeviceError> {
 
 pub fn installed(root: &Path) -> Result<Vec<AppInfo>, DeviceError> {
     let key = public_key()?;
-    let mut entries = installed_manifests(root, &key)?
+    installed_with_key(root, &key)
+}
+
+fn installed_with_key(root: &Path, key: &Ed25519PublicKey) -> Result<Vec<AppInfo>, DeviceError> {
+    let mut entries = installed_manifests(root, key)?
         .into_iter()
         .map(|manifest| manifest_info(&manifest, Some(manifest.version())))
         .collect::<Result<Vec<_>, _>>()?;
@@ -202,6 +206,79 @@ pub fn installed(root: &Path) -> Result<Vec<AppInfo>, DeviceError> {
 pub fn install(root: &Path, id: &str) -> Result<(), DeviceError> {
     install_with(root, id, &public_key()?, |url, maximum| {
         kobo_net::fetch(url, maximum).map_err(network_error)
+    })
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RemoteInstallPlan {
+    pub outcome: RemoteInstallOutcome,
+    pub install: bool,
+}
+
+pub fn prepare_remote_install(root: &Path, id: &str) -> Result<RemoteInstallPlan, DeviceError> {
+    let key = public_key()?;
+    prepare_remote_install_with(root, id, &key, |url, maximum| {
+        kobo_net::fetch(url, maximum).map_err(network_error)
+    })
+}
+
+fn prepare_remote_install_with(
+    root: &Path,
+    id: &str,
+    key: &Ed25519PublicKey,
+    mut fetch: impl FnMut(&str, u32) -> Result<Vec<u8>, DeviceError>,
+) -> Result<RemoteInstallPlan, DeviceError> {
+    if !kobo_protocol::valid_app_id(id) || kobo_app_store::is_public_reserved_app_id(id) {
+        return Err(DeviceError::InvalidInput);
+    }
+    let json = fetch(CATALOG_URL, CATALOG_LIMIT)?;
+    let signature = fetch(CATALOG_SIGNATURE_URL, SIGNATURE_LIMIT)?;
+    let catalog = verify_catalog(&json, &signature, key)?;
+    write_catalog_cache(root, &json, &signature)?;
+    let Some(entry) = catalog
+        .entries()
+        .iter()
+        .find(|entry| entry.manifest().id() == id)
+    else {
+        return Ok(RemoteInstallPlan {
+            outcome: RemoteInstallOutcome::Unavailable { id: id.to_owned() },
+            install: false,
+        });
+    };
+    if !kobo_app_store::cobalt_version_at_least(
+        env!("CARGO_PKG_VERSION"),
+        entry.manifest().minimum_cobalt_version(),
+    ) {
+        return Ok(RemoteInstallPlan {
+            outcome: RemoteInstallOutcome::Unavailable { id: id.to_owned() },
+            install: false,
+        });
+    }
+
+    let installed = installed_with_key(root, key)?;
+    let current = installed.iter().find(|candidate| candidate.id == id);
+    if current.and_then(|candidate| candidate.installed_version.as_deref())
+        == Some(entry.manifest().version())
+    {
+        let included = managed_builtin(id).is_some()
+            && builtin_is_installed(root, id)?
+            && !safe_directory(&apps_root(root).join(id))?;
+        return Ok(RemoteInstallPlan {
+            outcome: if included {
+                RemoteInstallOutcome::Included { id: id.to_owned() }
+            } else {
+                RemoteInstallOutcome::AlreadyInstalled { id: id.to_owned() }
+            },
+            install: false,
+        });
+    }
+    Ok(RemoteInstallPlan {
+        outcome: if current.is_some() {
+            RemoteInstallOutcome::Updated { id: id.to_owned() }
+        } else {
+            RemoteInstallOutcome::Installed { id: id.to_owned() }
+        },
+        install: true,
     })
 }
 
@@ -379,9 +456,9 @@ fn read_catalog_directory(
 fn catalog_info(
     root: &Path,
     catalog: &Catalog,
-    _key: &Ed25519PublicKey,
+    key: &Ed25519PublicKey,
 ) -> Result<Vec<AppInfo>, DeviceError> {
-    let installed = installed(root)?;
+    let installed = installed_with_key(root, key)?;
     let mut entries = catalog
         .entries()
         .iter()
@@ -1025,6 +1102,124 @@ mod tests {
         assert!(!apps_root(&root)
             .join(format!("word-count.{UNINSTALLED_SUFFIX}"))
             .exists());
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn remote_install_plans_distinguish_new_updated_current_and_included_apps() {
+        let root = root();
+        let seed = [9_u8; 32];
+        let key = derive_public_key(&seed).expect("key");
+        let (json, signature, package) = release(&seed);
+        let plan = prepare_remote_install_with(&root, "word-count", &key, |url, _| {
+            if url == CATALOG_URL {
+                Ok(json.clone())
+            } else {
+                Ok(signature.clone())
+            }
+        })
+        .expect("new plan");
+        assert_eq!(
+            plan,
+            RemoteInstallPlan {
+                outcome: RemoteInstallOutcome::Installed {
+                    id: "word-count".to_owned()
+                },
+                install: true
+            }
+        );
+        install_with(&root, "word-count", &key, |_, _| Ok(package.clone())).expect("install");
+        let plan = prepare_remote_install_with(&root, "word-count", &key, |url, _| {
+            if url == CATALOG_URL {
+                Ok(json.clone())
+            } else {
+                Ok(signature.clone())
+            }
+        })
+        .expect("current plan");
+        assert_eq!(
+            plan.outcome,
+            RemoteInstallOutcome::AlreadyInstalled {
+                id: "word-count".to_owned()
+            }
+        );
+        assert!(!plan.install);
+
+        let (updated_json, updated_signature, _) = release_for(&seed, "word-count", "1.1.0");
+        let plan = prepare_remote_install_with(&root, "word-count", &key, |url, _| {
+            if url == CATALOG_URL {
+                Ok(updated_json.clone())
+            } else {
+                Ok(updated_signature.clone())
+            }
+        })
+        .expect("update plan");
+        assert_eq!(
+            plan.outcome,
+            RemoteInstallOutcome::Updated {
+                id: "word-count".to_owned()
+            }
+        );
+        assert!(plan.install);
+
+        let included_root = root.with_extension("included");
+        let _ignored = fs::remove_dir_all(&included_root);
+        fs::create_dir_all(included_root.join("bin")).expect("built-in directory");
+        fs::write(builtin_binary(&included_root, "todo"), b"built-in todo").expect("built-in Todo");
+        let (included_json, included_signature, _) = release_for(&seed, "todo", "1.0.0");
+        let plan = prepare_remote_install_with(&included_root, "todo", &key, |url, _| {
+            if url == CATALOG_URL {
+                Ok(included_json.clone())
+            } else {
+                Ok(included_signature.clone())
+            }
+        })
+        .expect("included plan");
+        assert_eq!(
+            plan.outcome,
+            RemoteInstallOutcome::Included {
+                id: "todo".to_owned()
+            }
+        );
+        assert!(!plan.install);
+        let _ignored = fs::remove_dir_all(root);
+        let _ignored = fs::remove_dir_all(included_root);
+    }
+
+    #[test]
+    fn an_installed_app_absent_from_the_signed_catalog_is_unavailable() {
+        let root = root();
+        let seed = [9_u8; 32];
+        let key = derive_public_key(&seed).expect("key");
+        let (json, signature, package) = release(&seed);
+        refresh_with(&root, &key, |url, _| {
+            if url == CATALOG_URL {
+                Ok(json.clone())
+            } else {
+                Ok(signature.clone())
+            }
+        })
+        .expect("refresh");
+        install_with(&root, "word-count", &key, |_, _| Ok(package.clone())).expect("install");
+
+        let (other_json, other_signature, _) = release_for(&seed, "notes", "1.0.0");
+        let plan = prepare_remote_install_with(&root, "word-count", &key, |url, _| {
+            if url == CATALOG_URL {
+                Ok(other_json.clone())
+            } else {
+                Ok(other_signature.clone())
+            }
+        })
+        .expect("unavailable plan");
+        assert_eq!(
+            plan.outcome,
+            RemoteInstallOutcome::Unavailable {
+                id: "word-count".to_owned()
+            }
+        );
+        assert!(!plan.install);
+        let installed = installed_with_key(&root, &key).expect("installed app remains");
+        assert!(installed.iter().any(|app| app.id == "word-count"));
         let _ignored = fs::remove_dir_all(root);
     }
 

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -2035,6 +2035,29 @@ fn host_applications(
                                         }
                                         app_store_done(result)
                                     }
+                                    kobo_protocol::DeviceRequest::ReadAppLink => app_link_result(
+                                        crate::app_link::read(Path::new(COBALT_ROOT)),
+                                    ),
+                                    kobo_protocol::DeviceRequest::BeginAppLink => app_link_result(
+                                        crate::app_link::begin(Path::new(COBALT_ROOT)),
+                                    ),
+                                    kobo_protocol::DeviceRequest::PollAppLink => {
+                                        let result = crate::app_link::poll(Path::new(COBALT_ROOT));
+                                        if let Ok(kobo_protocol::DeviceResult::RemoteInstall(
+                                            outcome,
+                                        )) = &result
+                                        {
+                                            if let Some(id) = remote_installed_id(outcome) {
+                                                stop_named_application(&mut apps, id);
+                                            }
+                                        }
+                                        app_link_result(result)
+                                    }
+                                    kobo_protocol::DeviceRequest::DisconnectAppLink => {
+                                        app_link_result(crate::app_link::disconnect(Path::new(
+                                            COBALT_ROOT,
+                                        )))
+                                    }
                                     _ => services.handle(request.clone()),
                                 }
                             };
@@ -2344,8 +2367,29 @@ fn system_request_allowed(app: &str, request: &kobo_protocol::DeviceRequest) -> 
         kobo_protocol::DeviceRequest::ReadAppCatalog
         | kobo_protocol::DeviceRequest::RefreshAppCatalog
         | kobo_protocol::DeviceRequest::InstallApp { .. }
-        | kobo_protocol::DeviceRequest::UninstallApp { .. } => app == "store",
+        | kobo_protocol::DeviceRequest::UninstallApp { .. }
+        | kobo_protocol::DeviceRequest::ReadAppLink
+        | kobo_protocol::DeviceRequest::BeginAppLink
+        | kobo_protocol::DeviceRequest::PollAppLink
+        | kobo_protocol::DeviceRequest::DisconnectAppLink => app == "store",
         _ => true,
+    }
+}
+
+fn app_link_result(
+    result: Result<kobo_protocol::DeviceResult, kobo_protocol::DeviceError>,
+) -> kobo_protocol::DeviceResult {
+    result.unwrap_or_else(kobo_protocol::DeviceResult::Failed)
+}
+
+fn remote_installed_id(outcome: &kobo_protocol::RemoteInstallOutcome) -> Option<&str> {
+    match outcome {
+        kobo_protocol::RemoteInstallOutcome::Installed { id }
+        | kobo_protocol::RemoteInstallOutcome::Updated { id } => Some(id),
+        kobo_protocol::RemoteInstallOutcome::None
+        | kobo_protocol::RemoteInstallOutcome::AlreadyInstalled { .. }
+        | kobo_protocol::RemoteInstallOutcome::Included { .. }
+        | kobo_protocol::RemoteInstallOutcome::Unavailable { .. } => None,
     }
 }
 
@@ -3767,5 +3811,15 @@ mod hosting_tests {
             "launcher",
             &DeviceRequest::RefreshAppCatalog
         ));
+        for request in [
+            DeviceRequest::ReadAppLink,
+            DeviceRequest::BeginAppLink,
+            DeviceRequest::PollAppLink,
+            DeviceRequest::DisconnectAppLink,
+        ] {
+            assert!(super::system_request_allowed("store", &request));
+            assert!(!super::system_request_allowed("settings", &request));
+            assert!(!super::system_request_allowed("todo", &request));
+        }
     }
 }

--- a/crates/kobod/src/main.rs
+++ b/crates/kobod/src/main.rs
@@ -58,6 +58,7 @@ fn remember_device_profile(profile: &kobo_profile::DeviceProfile) -> Result<(), 
 
 use std::process::ExitCode;
 
+mod app_link;
 mod app_store;
 #[cfg(feature = "device-write")]
 mod blackbox;
@@ -116,7 +117,15 @@ fn run(arguments: &[String]) -> Result<(), Box<dyn Error>> {
     if arguments.len() == 3 && arguments[0] == "--fetch" {
         return fetch_once(&arguments[1], &arguments[2]);
     }
-    Err("usage: kobod [--sim-socket PATH --frame PATH] [--present APP] [--fetch URL BYTES] [--key-test SECONDS]".into())
+    if arguments.len() == 2 && arguments[0] == "--app-link" {
+        println!(
+            "{}",
+            app_link::maintenance(Path::new("/mnt/onboard/.adds/cobalt"), &arguments[1])
+                .map_err(|error| format!("app link: {error}"))?
+        );
+        return Ok(());
+    }
+    Err("usage: kobod [--sim-socket PATH --frame PATH] [--present APP] [--fetch URL BYTES] [--key-test SECONDS] [--app-link status|unpair]".into())
 }
 
 #[cfg(feature = "device-write")]

--- a/docs/APP_STORE.md
+++ b/docs/APP_STORE.md
@@ -11,6 +11,34 @@ Installed readers use the fixed app channel:
 - `https://github.com/BandarLabs/Cobalt/releases/download/app-catalog/cobalt-app-catalog.json`
 - `https://github.com/BandarLabs/Cobalt/releases/download/app-catalog/cobalt-app-catalog.json.sig`
 
+## Install links
+
+Each catalog app also has a shareable page at
+`https://bandarlabs.github.io/Cobalt/apps/<app-id>/`. A reader can link a
+browser without creating an account:
+
+1. Open **App Store** on the Kobo and select **Install links**.
+2. Scan the QR code, or open the displayed address and enter its eight-character
+   pairing code.
+3. Choose **Install** on an app page.
+
+The browser encrypts the app identity for that Kobo before sending it. The
+relay cannot read the request, and it never receives package URLs or signing
+keys. `kobod` resolves the identity through the signed catalog and performs the
+same package verification as an install started on the device.
+
+Install requests wait for up to 24 hours. If the Kobo is offline, open Cobalt
+App Store after reconnecting to process the queue. The result distinguishes a
+new install, an update, an app already at the current version, an app included
+with Cobalt, and an app unavailable from the current catalog.
+
+Use **Disconnect all** on the Kobo to revoke every linked browser. With SSH
+enabled, the host maintenance command can do the same:
+
+```sh
+kobo app-link unpair --device <reader-address>
+```
+
 ## Registry
 
 Store apps are workspace packages declared in `apps/catalog.json`. The

--- a/docs/APP_STORE.md
+++ b/docs/APP_STORE.md
@@ -27,6 +27,15 @@ relay cannot read the request, and it never receives package URLs or signing
 keys. `kobod` resolves the identity through the signed catalog and performs the
 same package verification as an install started on the device.
 
+The relay is not trusted with installs. During pairing the browser registers
+its own signing key, and the Kobo pins that key only while its pairing window
+is open. The QR link carries the device key fingerprint and a pairing secret
+in the URL fragment, which never reaches the relay, so a QR-scanned browser
+proves it saw the device screen and detects a substituted device key. Every
+install request is signed by a pinned browser key and seals a unique request
+identifier and timestamp inside the encrypted envelope, so the relay cannot
+mint, alter, or replay install commands.
+
 Install requests wait for up to 72 hours. If the Kobo is offline, open Cobalt
 App Store after reconnecting to process the queue. The result distinguishes a
 new install, an update, an app already at the current version, an app included

--- a/docs/APP_STORE.md
+++ b/docs/APP_STORE.md
@@ -27,7 +27,7 @@ relay cannot read the request, and it never receives package URLs or signing
 keys. `kobod` resolves the identity through the signed catalog and performs the
 same package verification as an install started on the device.
 
-Install requests wait for up to 24 hours. If the Kobo is offline, open Cobalt
+Install requests wait for up to 72 hours. If the Kobo is offline, open Cobalt
 App Store after reconnecting to process the queue. The result distinguishes a
 new install, an update, an app already at the current version, an app included
 with Cobalt, and an app unavailable from the current catalog.

--- a/docs/APP_STORE.md
+++ b/docs/APP_STORE.md
@@ -18,8 +18,8 @@ Each catalog app also has a shareable page at
 browser without creating an account:
 
 1. Open **App Store** on the Kobo and select **Install links**.
-2. Scan the QR code, or open the displayed address and enter its eight-character
-   pairing code.
+2. Scan the QR code, or open the displayed address and enter its pairing code
+   and verification key.
 3. Choose **Install** on an app page.
 
 The browser encrypts the app identity for that Kobo before sending it. The
@@ -30,9 +30,10 @@ same package verification as an install started on the device.
 The relay is not trusted with installs. During pairing the browser registers
 its own signing key, and the Kobo pins that key only while its pairing window
 is open. The QR link carries the device key fingerprint and a pairing secret
-in the URL fragment, which never reaches the relay, so a QR-scanned browser
-proves it saw the device screen and detects a substituted device key. Every
-install request is signed by a pinned browser key and seals a unique request
+in the URL fragment, which never reaches the relay. Manual entry uses the same
+values through the displayed verification key. Both paths prove the browser
+saw the device screen and detect a substituted device key. Every later install
+request is signed by the pinned browser key and seals a unique request
 identifier and timestamp inside the encrypted envelope, so the relay cannot
 mint, alter, or replay install commands.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -127,7 +127,7 @@ For app links shared on the web, open **Install links** in App Store and scan
 the QR code or enter its eight-character code in the browser. This links the
 browser without an account. Future app-page installs use Wi-Fi and do not need
 the USB cable. If the Kobo is offline, reconnect it and open App Store within
-24 hours to continue.
+72 hours to continue.
 
 For the `0.2.0` release, **Sudoku** is the end-to-end Store test: it is not in
 the USB package. Seeing it in Store, installing it, and then seeing it appear

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -123,6 +123,12 @@ over Wi-Fi.
 Each app can be installed, updated or removed independently. Installed apps
 appear in the launcher without rebooting.
 
+For app links shared on the web, open **Install links** in App Store and scan
+the QR code or enter its eight-character code in the browser. This links the
+browser without an account. Future app-page installs use Wi-Fi and do not need
+the USB cable. If the Kobo is offline, reconnect it and open App Store within
+24 hours to continue.
+
 For the `0.2.0` release, **Sudoku** is the end-to-end Store test: it is not in
 the USB package. Seeing it in Store, installing it, and then seeing it appear
 in the launcher proves that catalog refresh, package verification, installation

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -124,10 +124,10 @@ Each app can be installed, updated or removed independently. Installed apps
 appear in the launcher without rebooting.
 
 For app links shared on the web, open **Install links** in App Store and scan
-the QR code or enter its eight-character code in the browser. This links the
-browser without an account. Future app-page installs use Wi-Fi and do not need
-the USB cable. If the Kobo is offline, reconnect it and open App Store within
-72 hours to continue.
+the QR code, or enter its pairing code and verification key in the browser.
+This links the browser without an account. Future app-page installs use Wi-Fi
+and do not need the USB cable. If the Kobo is offline, reconnect it and open
+App Store within 72 hours to continue.
 
 For the `0.2.0` release, **Sudoku** is the end-to-end Store test: it is not in
 the USB package. Seeing it in Store, installing it, and then seeing it appear

--- a/docs/apps/arxiv/index.html
+++ b/docs/apps/arxiv/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>arXiv for Cobalt</title>
+<meta name="description" content="Browse, search and keep preprints, and read the ones with a rendering.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/arxiv/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="arXiv for Cobalt">
+<meta property="og:description" content="Browse, search and keep preprints, and read the ones with a rendering.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/arxiv/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="arXiv for Cobalt">
+<meta name="twitter:description" content="Browse, search and keep preprints, and read the ones with a rendering.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap" data-app-id="arxiv">
+  <p class="eyebrow">Kobo app</p>
+  <h1>arXiv</h1>
+  <p class="summary">Browse, search and keep preprints, and read the ones with a rendering.</p>
+  <div class="meta"><span>Version 1.3.0</span><span>network</span></div>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">First-time setup</p>
+    <h2>New to Cobalt? Set it up once.</h2>
+    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
+      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
+    </ol>
+    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
+  </section>
+  <section class="panel" id="pair-panel">
+    <p class="eyebrow">Already using Cobalt?</p>
+    <h2>Link your Kobo</h2>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel" id="install-panel" hidden>
+    <h2>Install on <span id="device-name">your Kobo</span></h2>
+    <p>Cobalt verifies the signed catalog and app package before changing the installed copy.</p>
+    <div class="actions">
+      <button type="button" id="install">Install arXiv</button>
+      <button type="button" id="forget" class="secondary">Forget this Kobo</button>
+    </div>
+    <p class="status" id="install-status" role="status" aria-live="polite"></p>
+  </section>
+</main>
+<script src="../install.js" defer></script>
+</body>
+</html>

--- a/docs/apps/arxiv/index.html
+++ b/docs/apps/arxiv/index.html
@@ -25,20 +25,9 @@
   <h1>arXiv</h1>
   <p class="summary">Browse, search and keep preprints, and read the ones with a rendering.</p>
   <div class="meta"><span>Version 1.3.0</span><span>network</span></div>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">First-time setup</p>
-    <h2>New to Cobalt? Set it up once.</h2>
-    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
-      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
-    </ol>
-    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
-  </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Already using Cobalt?</p>
-    <h2>Link your Kobo</h2>
+    <p class="eyebrow">Install with Cobalt</p>
+    <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
     <form id="pair-form">
       <div class="field">
@@ -49,6 +38,17 @@
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
     <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">Cobalt not installed?</p>
+    <h2>Set up Cobalt first</h2>
+    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
+      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
+    </ol>
+    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/arxiv/index.html
+++ b/docs/apps/arxiv/index.html
@@ -28,11 +28,15 @@
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
-    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>

--- a/docs/apps/audiobook/index.html
+++ b/docs/apps/audiobook/index.html
@@ -28,11 +28,15 @@
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
-    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>

--- a/docs/apps/audiobook/index.html
+++ b/docs/apps/audiobook/index.html
@@ -25,20 +25,9 @@
   <h1>Audiobook Studio</h1>
   <p class="summary">Research, narrate and play an original audiobook about any topic.</p>
   <div class="meta"><span>Version 1.0.0</span><span>network, audio, bluetooth-audio, bluetooth-control</span></div>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">First-time setup</p>
-    <h2>New to Cobalt? Set it up once.</h2>
-    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
-      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
-    </ol>
-    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
-  </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Already using Cobalt?</p>
-    <h2>Link your Kobo</h2>
+    <p class="eyebrow">Install with Cobalt</p>
+    <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
     <form id="pair-form">
       <div class="field">
@@ -49,6 +38,17 @@
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
     <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">Cobalt not installed?</p>
+    <h2>Set up Cobalt first</h2>
+    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
+      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
+    </ol>
+    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/audiobook/index.html
+++ b/docs/apps/audiobook/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Audiobook Studio for Cobalt</title>
+<meta name="description" content="Research, narrate and play an original audiobook about any topic.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/audiobook/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Audiobook Studio for Cobalt">
+<meta property="og:description" content="Research, narrate and play an original audiobook about any topic.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/audiobook/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Audiobook Studio for Cobalt">
+<meta name="twitter:description" content="Research, narrate and play an original audiobook about any topic.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap" data-app-id="audiobook">
+  <p class="eyebrow">Kobo app</p>
+  <h1>Audiobook Studio</h1>
+  <p class="summary">Research, narrate and play an original audiobook about any topic.</p>
+  <div class="meta"><span>Version 1.0.0</span><span>network, audio, bluetooth-audio, bluetooth-control</span></div>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">First-time setup</p>
+    <h2>New to Cobalt? Set it up once.</h2>
+    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
+      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
+    </ol>
+    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
+  </section>
+  <section class="panel" id="pair-panel">
+    <p class="eyebrow">Already using Cobalt?</p>
+    <h2>Link your Kobo</h2>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel" id="install-panel" hidden>
+    <h2>Install on <span id="device-name">your Kobo</span></h2>
+    <p>Cobalt verifies the signed catalog and app package before changing the installed copy.</p>
+    <div class="actions">
+      <button type="button" id="install">Install Audiobook Studio</button>
+      <button type="button" id="forget" class="secondary">Forget this Kobo</button>
+    </div>
+    <p class="status" id="install-status" role="status" aria-live="polite"></p>
+  </section>
+</main>
+<script src="../install.js" defer></script>
+</body>
+</html>

--- a/docs/apps/brief/index.html
+++ b/docs/apps/brief/index.html
@@ -28,11 +28,15 @@
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
-    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>

--- a/docs/apps/brief/index.html
+++ b/docs/apps/brief/index.html
@@ -25,20 +25,9 @@
   <h1>Daily Brief</h1>
   <p class="summary">Collects the day's stories while you read something else.</p>
   <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">First-time setup</p>
-    <h2>New to Cobalt? Set it up once.</h2>
-    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
-      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
-    </ol>
-    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
-  </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Already using Cobalt?</p>
-    <h2>Link your Kobo</h2>
+    <p class="eyebrow">Install with Cobalt</p>
+    <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
     <form id="pair-form">
       <div class="field">
@@ -49,6 +38,17 @@
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
     <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">Cobalt not installed?</p>
+    <h2>Set up Cobalt first</h2>
+    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
+      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
+    </ol>
+    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/brief/index.html
+++ b/docs/apps/brief/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Daily Brief for Cobalt</title>
+<meta name="description" content="Collects the day's stories while you read something else.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/brief/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Daily Brief for Cobalt">
+<meta property="og:description" content="Collects the day's stories while you read something else.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/brief/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Daily Brief for Cobalt">
+<meta name="twitter:description" content="Collects the day's stories while you read something else.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap" data-app-id="brief">
+  <p class="eyebrow">Kobo app</p>
+  <h1>Daily Brief</h1>
+  <p class="summary">Collects the day's stories while you read something else.</p>
+  <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">First-time setup</p>
+    <h2>New to Cobalt? Set it up once.</h2>
+    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
+      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
+    </ol>
+    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
+  </section>
+  <section class="panel" id="pair-panel">
+    <p class="eyebrow">Already using Cobalt?</p>
+    <h2>Link your Kobo</h2>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel" id="install-panel" hidden>
+    <h2>Install on <span id="device-name">your Kobo</span></h2>
+    <p>Cobalt verifies the signed catalog and app package before changing the installed copy.</p>
+    <div class="actions">
+      <button type="button" id="install">Install Daily Brief</button>
+      <button type="button" id="forget" class="secondary">Forget this Kobo</button>
+    </div>
+    <p class="status" id="install-status" role="status" aria-live="polite"></p>
+  </section>
+</main>
+<script src="../install.js" defer></script>
+</body>
+</html>

--- a/docs/apps/chat/index.html
+++ b/docs/apps/chat/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>AI Command Center for Cobalt</title>
+<meta name="description" content="Ask a question and tap the answer, rather than typing one.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/chat/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="AI Command Center for Cobalt">
+<meta property="og:description" content="Ask a question and tap the answer, rather than typing one.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/chat/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="AI Command Center for Cobalt">
+<meta name="twitter:description" content="Ask a question and tap the answer, rather than typing one.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap" data-app-id="chat">
+  <p class="eyebrow">Kobo app</p>
+  <h1>AI Command Center</h1>
+  <p class="summary">Ask a question and tap the answer, rather than typing one.</p>
+  <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">First-time setup</p>
+    <h2>New to Cobalt? Set it up once.</h2>
+    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
+      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
+    </ol>
+    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
+  </section>
+  <section class="panel" id="pair-panel">
+    <p class="eyebrow">Already using Cobalt?</p>
+    <h2>Link your Kobo</h2>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel" id="install-panel" hidden>
+    <h2>Install on <span id="device-name">your Kobo</span></h2>
+    <p>Cobalt verifies the signed catalog and app package before changing the installed copy.</p>
+    <div class="actions">
+      <button type="button" id="install">Install AI Command Center</button>
+      <button type="button" id="forget" class="secondary">Forget this Kobo</button>
+    </div>
+    <p class="status" id="install-status" role="status" aria-live="polite"></p>
+  </section>
+</main>
+<script src="../install.js" defer></script>
+</body>
+</html>

--- a/docs/apps/chat/index.html
+++ b/docs/apps/chat/index.html
@@ -28,11 +28,15 @@
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
-    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>

--- a/docs/apps/chat/index.html
+++ b/docs/apps/chat/index.html
@@ -25,20 +25,9 @@
   <h1>AI Command Center</h1>
   <p class="summary">Ask a question and tap the answer, rather than typing one.</p>
   <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">First-time setup</p>
-    <h2>New to Cobalt? Set it up once.</h2>
-    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
-      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
-    </ol>
-    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
-  </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Already using Cobalt?</p>
-    <h2>Link your Kobo</h2>
+    <p class="eyebrow">Install with Cobalt</p>
+    <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
     <form id="pair-form">
       <div class="field">
@@ -49,6 +38,17 @@
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
     <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">Cobalt not installed?</p>
+    <h2>Set up Cobalt first</h2>
+    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
+      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
+    </ol>
+    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/gallery/index.html
+++ b/docs/apps/gallery/index.html
@@ -25,20 +25,9 @@
   <h1>Components</h1>
   <p class="summary">Every UI primitive on real hardware, for checking by eye.</p>
   <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">First-time setup</p>
-    <h2>New to Cobalt? Set it up once.</h2>
-    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
-      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
-    </ol>
-    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
-  </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Already using Cobalt?</p>
-    <h2>Link your Kobo</h2>
+    <p class="eyebrow">Install with Cobalt</p>
+    <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
     <form id="pair-form">
       <div class="field">
@@ -49,6 +38,17 @@
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
     <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">Cobalt not installed?</p>
+    <h2>Set up Cobalt first</h2>
+    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
+      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
+    </ol>
+    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/gallery/index.html
+++ b/docs/apps/gallery/index.html
@@ -28,11 +28,15 @@
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
-    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>

--- a/docs/apps/gallery/index.html
+++ b/docs/apps/gallery/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Components for Cobalt</title>
+<meta name="description" content="Every UI primitive on real hardware, for checking by eye.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/gallery/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Components for Cobalt">
+<meta property="og:description" content="Every UI primitive on real hardware, for checking by eye.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/gallery/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Components for Cobalt">
+<meta name="twitter:description" content="Every UI primitive on real hardware, for checking by eye.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap" data-app-id="gallery">
+  <p class="eyebrow">Kobo app</p>
+  <h1>Components</h1>
+  <p class="summary">Every UI primitive on real hardware, for checking by eye.</p>
+  <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">First-time setup</p>
+    <h2>New to Cobalt? Set it up once.</h2>
+    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
+      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
+    </ol>
+    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
+  </section>
+  <section class="panel" id="pair-panel">
+    <p class="eyebrow">Already using Cobalt?</p>
+    <h2>Link your Kobo</h2>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel" id="install-panel" hidden>
+    <h2>Install on <span id="device-name">your Kobo</span></h2>
+    <p>Cobalt verifies the signed catalog and app package before changing the installed copy.</p>
+    <div class="actions">
+      <button type="button" id="install">Install Components</button>
+      <button type="button" id="forget" class="secondary">Forget this Kobo</button>
+    </div>
+    <p class="status" id="install-status" role="status" aria-live="polite"></p>
+  </section>
+</main>
+<script src="../install.js" defer></script>
+</body>
+</html>

--- a/docs/apps/gutenbird/index.html
+++ b/docs/apps/gutenbird/index.html
@@ -25,20 +25,9 @@
   <h1>Gutenbird</h1>
   <p class="summary">Sixty thousand free books from Project Gutenberg.</p>
   <div class="meta"><span>Version 1.0.0</span><span>network, frontlight-control</span></div>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">First-time setup</p>
-    <h2>New to Cobalt? Set it up once.</h2>
-    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
-      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
-    </ol>
-    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
-  </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Already using Cobalt?</p>
-    <h2>Link your Kobo</h2>
+    <p class="eyebrow">Install with Cobalt</p>
+    <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
     <form id="pair-form">
       <div class="field">
@@ -49,6 +38,17 @@
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
     <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">Cobalt not installed?</p>
+    <h2>Set up Cobalt first</h2>
+    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
+      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
+    </ol>
+    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/gutenbird/index.html
+++ b/docs/apps/gutenbird/index.html
@@ -28,11 +28,15 @@
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
-    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>

--- a/docs/apps/gutenbird/index.html
+++ b/docs/apps/gutenbird/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Gutenbird for Cobalt</title>
+<meta name="description" content="Sixty thousand free books from Project Gutenberg.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/gutenbird/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Gutenbird for Cobalt">
+<meta property="og:description" content="Sixty thousand free books from Project Gutenberg.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/gutenbird/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Gutenbird for Cobalt">
+<meta name="twitter:description" content="Sixty thousand free books from Project Gutenberg.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap" data-app-id="gutenbird">
+  <p class="eyebrow">Kobo app</p>
+  <h1>Gutenbird</h1>
+  <p class="summary">Sixty thousand free books from Project Gutenberg.</p>
+  <div class="meta"><span>Version 1.0.0</span><span>network, frontlight-control</span></div>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">First-time setup</p>
+    <h2>New to Cobalt? Set it up once.</h2>
+    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
+      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
+    </ol>
+    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
+  </section>
+  <section class="panel" id="pair-panel">
+    <p class="eyebrow">Already using Cobalt?</p>
+    <h2>Link your Kobo</h2>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel" id="install-panel" hidden>
+    <h2>Install on <span id="device-name">your Kobo</span></h2>
+    <p>Cobalt verifies the signed catalog and app package before changing the installed copy.</p>
+    <div class="actions">
+      <button type="button" id="install">Install Gutenbird</button>
+      <button type="button" id="forget" class="secondary">Forget this Kobo</button>
+    </div>
+    <p class="status" id="install-status" role="status" aria-live="polite"></p>
+  </section>
+</main>
+<script src="../install.js" defer></script>
+</body>
+</html>

--- a/docs/apps/hn/index.html
+++ b/docs/apps/hn/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Hacker News for Cobalt</title>
+<meta name="description" content="Top, New, Ask and Show, with whole comment threads.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/hn/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Hacker News for Cobalt">
+<meta property="og:description" content="Top, New, Ask and Show, with whole comment threads.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/hn/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Hacker News for Cobalt">
+<meta name="twitter:description" content="Top, New, Ask and Show, with whole comment threads.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap" data-app-id="hn">
+  <p class="eyebrow">Kobo app</p>
+  <h1>Hacker News</h1>
+  <p class="summary">Top, New, Ask and Show, with whole comment threads.</p>
+  <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">First-time setup</p>
+    <h2>New to Cobalt? Set it up once.</h2>
+    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
+      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
+    </ol>
+    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
+  </section>
+  <section class="panel" id="pair-panel">
+    <p class="eyebrow">Already using Cobalt?</p>
+    <h2>Link your Kobo</h2>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel" id="install-panel" hidden>
+    <h2>Install on <span id="device-name">your Kobo</span></h2>
+    <p>Cobalt verifies the signed catalog and app package before changing the installed copy.</p>
+    <div class="actions">
+      <button type="button" id="install">Install Hacker News</button>
+      <button type="button" id="forget" class="secondary">Forget this Kobo</button>
+    </div>
+    <p class="status" id="install-status" role="status" aria-live="polite"></p>
+  </section>
+</main>
+<script src="../install.js" defer></script>
+</body>
+</html>

--- a/docs/apps/hn/index.html
+++ b/docs/apps/hn/index.html
@@ -28,11 +28,15 @@
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
-    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>

--- a/docs/apps/hn/index.html
+++ b/docs/apps/hn/index.html
@@ -25,20 +25,9 @@
   <h1>Hacker News</h1>
   <p class="summary">Top, New, Ask and Show, with whole comment threads.</p>
   <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">First-time setup</p>
-    <h2>New to Cobalt? Set it up once.</h2>
-    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
-      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
-    </ol>
-    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
-  </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Already using Cobalt?</p>
-    <h2>Link your Kobo</h2>
+    <p class="eyebrow">Install with Cobalt</p>
+    <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
     <form id="pair-form">
       <div class="field">
@@ -49,6 +38,17 @@
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
     <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">Cobalt not installed?</p>
+    <h2>Set up Cobalt first</h2>
+    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
+      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
+    </ol>
+    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/install.css
+++ b/docs/apps/install.css
@@ -111,6 +111,8 @@ button.secondary:hover { border-color: var(--ink); background: var(--paper-deep)
   text-decoration: none;
 }
 .button-link:hover { background: var(--blue-dark); text-decoration: none; }
+.button-link.secondary { border-color: #918878; background: transparent; color: var(--ink); }
+.button-link.secondary:hover { border-color: var(--ink); background: #fff; }
 .actions { display: flex; flex-wrap: wrap; gap: 10px; }
 .status {
   min-height: 1.55em;

--- a/docs/apps/install.css
+++ b/docs/apps/install.css
@@ -1,0 +1,136 @@
+:root {
+  --paper: #f6f2ea;
+  --paper-deep: #eee8db;
+  --ink: #1b1813;
+  --muted: #625b50;
+  --rule: #d7cebc;
+  --blue: #1a41a8;
+  --blue-dark: #143283;
+  --success: #176b43;
+  --warning: #8a5a00;
+  --danger: #9c2f27;
+  --serif: Charter, "Iowan Old Style", Palatino, Georgia, serif;
+  --sans: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  border-top: 5px solid var(--blue);
+  background: var(--paper);
+  color: var(--ink);
+  font: 17px/1.55 var(--sans);
+}
+
+a { color: var(--blue); }
+a:hover { text-decoration-thickness: 2px; text-underline-offset: 3px; }
+
+.wrap { width: min(720px, calc(100% - 32px)); margin: 0 auto; }
+
+header {
+  border-bottom: 1px solid var(--rule);
+  padding: 18px 0;
+}
+
+header .wrap { display: flex; justify-content: space-between; align-items: center; gap: 24px; }
+.brand { color: var(--ink); font: 700 21px/1 var(--serif); text-decoration: none; }
+.back { font-size: 14px; }
+
+main { padding: 64px 0 80px; }
+.eyebrow {
+  margin: 0 0 12px;
+  color: var(--blue);
+  font: 600 12px/1.2 var(--sans);
+  letter-spacing: .13em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font: 700 clamp(38px, 8vw, 58px)/1.05 var(--serif);
+  letter-spacing: -.02em;
+}
+
+.summary { max-width: 38em; margin: 18px 0 0; color: var(--muted); font-size: 19px; }
+.meta { display: flex; flex-wrap: wrap; gap: 8px 22px; margin: 22px 0 38px; color: var(--muted); font-size: 14px; }
+
+.panel {
+  border: 1px solid var(--rule);
+  background: #fff;
+  padding: clamp(22px, 5vw, 34px);
+  box-shadow: 0 8px 28px rgb(27 24 19 / .07);
+}
+
+.panel + .panel { margin-top: 22px; }
+.setup { background: var(--paper-deep); }
+.setup ol { margin: 20px 0 24px; padding-left: 22px; color: var(--muted); }
+.setup li + li { margin-top: 8px; }
+.panel h2 { margin: 0 0 8px; font: 700 26px/1.2 var(--serif); }
+.panel p { margin: 0 0 22px; color: var(--muted); }
+.field { display: grid; gap: 8px; margin-bottom: 16px; }
+label { font-weight: 650; font-size: 14px; }
+input {
+  width: 100%;
+  min-height: 48px;
+  border: 1px solid #918878;
+  border-radius: 4px;
+  padding: 10px 13px;
+  background: #fff;
+  color: var(--ink);
+  font: 600 20px/1 var(--sans);
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+button {
+  min-height: 48px;
+  border: 1px solid var(--blue);
+  border-radius: 4px;
+  padding: 11px 18px;
+  background: var(--blue);
+  color: #fff;
+  cursor: pointer;
+  font: 650 16px/1.2 var(--sans);
+}
+
+button:hover { background: var(--blue-dark); }
+button:focus-visible, input:focus-visible, a:focus-visible { outline: 3px solid #e0a500; outline-offset: 3px; }
+button:disabled { cursor: wait; opacity: .62; }
+button.secondary { border-color: #918878; background: transparent; color: var(--ink); }
+button.secondary:hover { border-color: var(--ink); background: var(--paper-deep); }
+.button-link {
+  display: inline-block;
+  min-height: 48px;
+  border: 1px solid var(--blue);
+  border-radius: 4px;
+  padding: 11px 18px;
+  background: var(--blue);
+  color: #fff;
+  font-weight: 650;
+  text-decoration: none;
+}
+.button-link:hover { background: var(--blue-dark); text-decoration: none; }
+.actions { display: flex; flex-wrap: wrap; gap: 10px; }
+.status {
+  min-height: 1.55em;
+  margin: 20px 0 0 !important;
+  color: var(--ink) !important;
+  font-weight: 600;
+}
+.status[data-tone="success"] { color: var(--success) !important; }
+.status[data-tone="warning"] { color: var(--warning) !important; }
+.status[data-tone="error"] { color: var(--danger) !important; }
+.privacy { margin-top: 22px !important; font-size: 13px; }
+[hidden] { display: none !important; }
+
+@media (max-width: 540px) {
+  main { padding-top: 42px; }
+  header .wrap { align-items: baseline; }
+  .panel { box-shadow: none; }
+  .actions button { width: 100%; }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  button { transition: background-color 150ms ease, opacity 150ms ease; }
+}

--- a/docs/apps/install.css
+++ b/docs/apps/install.css
@@ -69,6 +69,8 @@ h1 {
 .panel h2 { margin: 0 0 8px; font: 700 26px/1.2 var(--serif); }
 .panel p { margin: 0 0 22px; color: var(--muted); }
 .field { display: grid; gap: 8px; margin-bottom: 16px; }
+#pair-form { width: min(100%, 460px); margin-inline: auto; }
+#pair-form button { width: 100%; }
 label { font-weight: 650; font-size: 14px; }
 input {
   width: 100%;
@@ -82,6 +84,8 @@ input {
   letter-spacing: .12em;
   text-transform: uppercase;
 }
+#pair-code { text-align: center; font-size: 30px; letter-spacing: .2em; }
+input.secret { font-size: 16px; letter-spacing: .03em; text-transform: none; }
 
 button {
   min-height: 48px;

--- a/docs/apps/install.js
+++ b/docs/apps/install.js
@@ -10,6 +10,8 @@ const pairPanel = document.querySelector("#pair-panel");
 const installPanel = document.querySelector("#install-panel");
 const pairForm = document.querySelector("#pair-form");
 const pairCode = document.querySelector("#pair-code");
+const pairSecret = document.querySelector("#pair-secret");
+const pairSecretField = document.querySelector("#pair-secret-field");
 const pairStatus = document.querySelector("#pair-status");
 const installStatus = document.querySelector("#install-status");
 const installButton = document.querySelector("#install");
@@ -18,9 +20,18 @@ const deviceName = document.querySelector("#device-name");
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const APP_ID = /^[a-z][a-z0-9-]{0,31}$/;
 const BASE64URL = /^[A-Za-z0-9_-]+$/;
+const COMMAND_TTL_MS = 72 * 60 * 60 * 1000;
+const INSTALL_COMPLETION_TTL_MS = 15 * 60 * 1000;
+const CLOCK_SKEW_MS = 5 * 60 * 1000;
 
 function validString(value, length) {
   return typeof value === "string" && value.length === length && BASE64URL.test(value);
+}
+
+function timestamp(value) {
+  if (typeof value !== "string") return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value ? parsed : null;
 }
 
 function normalizedPending(value) {
@@ -33,7 +44,7 @@ function normalizedPending(value) {
     && pending
     && typeof pending === "object"
     && UUID.test(pending.commandId)
-    && typeof pending.expiresAt === "string"
+    && timestamp(pending.expiresAt) !== null
   ));
 }
 
@@ -172,6 +183,19 @@ function fragmentParams() {
   return new URLSearchParams(location.hash.slice(1));
 }
 
+function pairingCredentials() {
+  const fragment = fragmentParams();
+  const fingerprint = fragment.get("k");
+  const secret = fragment.get("s");
+  if (validString(fingerprint, 22) && validString(secret, 22)) {
+    return { fingerprint, secret };
+  }
+  const parts = pairSecret.value.trim().split(".");
+  return parts.length === 2 && validString(parts[0], 22) && validString(parts[1], 22)
+    ? { fingerprint: parts[0], secret: parts[1] }
+    : null;
+}
+
 async function generateBrowserKey() {
   const pair = await crypto.subtle.generateKey(
     { name: "ECDSA", namedCurve: "P-256" },
@@ -272,7 +296,7 @@ async function envelopeFor(value) {
 async function queueInstall(value) {
   const envelope = await envelopeFor(value);
   const signature = await signInstall(value, envelope);
-  return json(await fetch(`${RELAY}/v1/devices/${value.deviceId}/installs`, {
+  const queued = await json(await fetch(`${RELAY}/v1/devices/${value.deviceId}/installs`, {
     method: "POST",
     headers: {
       authorization: `Bearer ${value.browserToken}`,
@@ -280,12 +304,59 @@ async function queueInstall(value) {
     },
     body: JSON.stringify({ envelope, signature })
   }));
+  const expiresAt = timestamp(queued?.expires_at);
+  if (
+    !queued
+    || typeof queued !== "object"
+    || Array.isArray(queued)
+    || !UUID.test(queued.command_id)
+    || queued.state !== "queued"
+    || typeof queued.device_online !== "boolean"
+    || expiresAt === null
+    || expiresAt < Date.now() - CLOCK_SKEW_MS
+    || expiresAt > Date.now() + COMMAND_TTL_MS + CLOCK_SKEW_MS
+  ) {
+    throw new Error("The install service returned an invalid queue response.");
+  }
+  return queued;
 }
 
 async function installState(value, commandId) {
-  return json(await fetch(`${RELAY}/v1/devices/${value.deviceId}/installs/${commandId}`, {
+  const state = await json(await fetch(`${RELAY}/v1/devices/${value.deviceId}/installs/${commandId}`, {
     headers: { authorization: `Bearer ${value.browserToken}` }
   }));
+  const active = state?.state === "queued" || state?.state === "installing";
+  const installed = state?.state === "installed";
+  const failed = state?.state === "failed";
+  const validOutcome = ["installed", "updated", "already-installed", "included"].includes(state?.outcome);
+  const validFailure = typeof state?.failure === "string"
+    && state.failure.length > 0
+    && state.failure.length <= 96
+    && !/[\u0000-\u001f\u007f]/.test(state.failure);
+  const createdAt = timestamp(state?.created_at);
+  const updatedAt = timestamp(state?.updated_at);
+  const expiresAt = timestamp(state?.expires_at);
+  if (
+    !state
+    || typeof state !== "object"
+    || Array.isArray(state)
+    || state.command_id !== commandId
+    || typeof state.device_online !== "boolean"
+    || createdAt === null
+    || updatedAt === null
+    || expiresAt === null
+    || updatedAt < createdAt
+    || updatedAt > Date.now() + CLOCK_SKEW_MS
+    || expiresAt < createdAt
+    || expiresAt > createdAt + COMMAND_TTL_MS + INSTALL_COMPLETION_TTL_MS
+    || !(active || installed || failed)
+    || (active && (state.outcome !== null || state.failure !== null))
+    || (installed && (!validOutcome || state.failure !== null))
+    || (failed && (state.outcome !== null || !validFailure))
+  ) {
+    throw new Error("The install service returned an invalid status response.");
+  }
+  return state;
 }
 
 function resultMessage(state) {
@@ -315,10 +386,21 @@ function resultMessage(state) {
   return { tone: "", text: state.state === "installing" ? "Installing on your Kobo…" : "Sent to your Kobo…" };
 }
 
-async function watch(value, commandId) {
+async function watch(value, commandId, expiresAt) {
+  let deadline = timestamp(expiresAt);
   for (;;) {
+    if (deadline === null || Date.now() >= deadline) {
+      clearPending(value, commandId);
+      setStatus(installStatus, "The install request expired. Send it again.", "warning");
+      return;
+    }
     try {
       const state = await installState(value, commandId);
+      deadline = timestamp(state.expires_at);
+      if (state.expires_at !== expiresAt) {
+        expiresAt = state.expires_at;
+        savePending(value, { appId, commandId, expiresAt });
+      }
       const message = resultMessage(state);
       setStatus(installStatus, message.text, message.tone);
       if (state.state === "installed" || state.state === "failed") {
@@ -333,6 +415,7 @@ async function watch(value, commandId) {
         throw error;
       }
       if (error.status === 401 || error.status === 403) throw error;
+      if (!(error instanceof ApiError) && !(error instanceof TypeError)) throw error;
       setStatus(installStatus, "Status is temporarily unavailable. The request remains queued.", "warning");
       await new Promise(resolve => setTimeout(resolve, 30000));
     }
@@ -346,16 +429,19 @@ pairForm.addEventListener("submit", async event => {
     setStatus(pairStatus, "Enter the 8-character code shown on your Kobo.", "error");
     return;
   }
+  const credentials = pairingCredentials();
+  if (!credentials) {
+    setStatus(pairStatus, "Enter the verification key shown on your Kobo.", "error");
+    return;
+  }
   const button = pairForm.querySelector("button");
   button.disabled = true;
   setStatus(pairStatus, "Linking…");
   try {
-    const fragment = fragmentParams();
-    const secret = fragment.get("s");
     const browserKey = await generateBrowserKey();
     const claimed = await claim(code, {
       browser_public_key: browserKey.publicKey,
-      ...secret && { proof: await pairProof(secret, browserKey.publicKey) }
+      proof: await pairProof(credentials.secret, browserKey.publicKey)
     });
     if (
       typeof claimed.device_name !== "string"
@@ -364,8 +450,7 @@ pairForm.addEventListener("submit", async event => {
     ) {
       throw new Error("The install service returned an invalid pairing response.");
     }
-    const expected = fragment.get("k");
-    if (expected && !(await deviceKeyMatchesFragment(claimed.device_public_key, expected))) {
+    if (!(await deviceKeyMatchesFragment(claimed.device_public_key, credentials.fingerprint))) {
       throw new Error("The install service returned a key that does not match your Kobo. Nothing was linked.");
     }
     const value = connectionValue({
@@ -402,7 +487,7 @@ installButton.addEventListener("click", async () => {
   if (pending) {
     installButton.disabled = true;
     try {
-      await watch(value, pending.commandId);
+      await watch(value, pending.commandId, pending.expiresAt);
     } finally {
       installButton.disabled = false;
     }
@@ -420,7 +505,7 @@ installButton.addEventListener("click", async () => {
     savePending(value, pending);
     const message = resultMessage(queued);
     setStatus(installStatus, message.text, message.tone);
-    await watch(value, queued.command_id);
+    await watch(value, queued.command_id, queued.expires_at);
   } catch (error) {
     if (error.status === 401 || error.status === 403) {
       const latest = connection();
@@ -457,12 +542,16 @@ forgetButton.addEventListener("click", () => {
 
 const queryCode = new URLSearchParams(location.search).get("code");
 if (queryCode) pairCode.value = queryCode.toUpperCase();
+if (pairingCredentials()) {
+  pairSecret.required = false;
+  pairSecretField.hidden = true;
+}
 const saved = connection();
 showConnection(saved);
 const pending = pendingFor(saved);
 if (saved && pending) {
   installButton.disabled = true;
-  watch(saved, pending.commandId)
+  watch(saved, pending.commandId, pending.expiresAt)
     .catch(error => {
       if (error.status === 401 || error.status === 403) {
         const latest = connection();

--- a/docs/apps/install.js
+++ b/docs/apps/install.js
@@ -37,6 +37,15 @@ function normalizedPending(value) {
   ));
 }
 
+function validPrivateJwk(value) {
+  return Boolean(value)
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && value.kty === "EC"
+    && value.crv === "P-256"
+    && typeof value.d === "string";
+}
+
 function connectionValue(value) {
   if (
     !value
@@ -45,6 +54,8 @@ function connectionValue(value) {
     || !UUID.test(value.deviceId)
     || !validString(value.browserToken, 43)
     || !validString(value.publicKey, 122)
+    || !validString(value.browserPublicKey, 122)
+    || !validPrivateJwk(value.browserPrivateKey)
   ) {
     return null;
   }
@@ -52,6 +63,8 @@ function connectionValue(value) {
     deviceId: value.deviceId,
     browserToken: value.browserToken,
     publicKey: value.publicKey,
+    browserPublicKey: value.browserPublicKey,
+    browserPrivateKey: value.browserPrivateKey,
     deviceName: typeof value.deviceName === "string" && value.deviceName.length <= 64
       ? value.deviceName || "Kobo reader"
       : "Kobo reader",
@@ -147,12 +160,62 @@ async function json(response) {
   return body;
 }
 
-async function claim(code) {
+async function claim(code, body) {
   return json(await fetch(`${RELAY}/v1/pairings/${encodeURIComponent(code)}/claim`, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: "{}"
+    body: JSON.stringify(body)
   }));
+}
+
+function fragmentParams() {
+  return new URLSearchParams(location.hash.slice(1));
+}
+
+async function generateBrowserKey() {
+  const pair = await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign"]
+  );
+  return {
+    publicKey: base64Url(await crypto.subtle.exportKey("spki", pair.publicKey)),
+    privateKey: await crypto.subtle.exportKey("jwk", pair.privateKey)
+  };
+}
+
+async function deviceKeyMatchesFragment(publicKey, expected) {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(publicKey));
+  return base64Url(new Uint8Array(digest).slice(0, 16)) === expected;
+}
+
+async function pairProof(secret, browserPublicKey) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    fromBase64Url(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  return base64Url(await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(`cobalt-pair-proof-v1\n${browserPublicKey}`)
+  ));
+}
+
+async function signInstall(value, envelope) {
+  const key = await crypto.subtle.importKey(
+    "jwk",
+    value.browserPrivateKey,
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign"]
+  );
+  const message = encoder.encode(
+    `cobalt-install-v2\n${value.deviceId}\n${envelope.ephemeral_public_key}\n${envelope.nonce}\n${envelope.ciphertext}`
+  );
+  return base64Url(await crypto.subtle.sign({ name: "ECDSA", hash: "SHA-256" }, key, message));
 }
 
 async function envelopeFor(value) {
@@ -187,7 +250,12 @@ async function envelopeFor(value) {
     ["encrypt"]
   );
   const nonce = crypto.getRandomValues(new Uint8Array(12));
-  const plaintext = encoder.encode(JSON.stringify({ version: 1, app_id: appId }));
+  const plaintext = encoder.encode(JSON.stringify({
+    version: 2,
+    app_id: appId,
+    request_id: base64Url(crypto.getRandomValues(new Uint8Array(16))),
+    requested_at: Math.floor(Date.now() / 1000)
+  }));
   const ciphertext = await crypto.subtle.encrypt(
     { name: "AES-GCM", iv: nonce, additionalData: encoder.encode(value.deviceId) },
     key,
@@ -203,13 +271,14 @@ async function envelopeFor(value) {
 
 async function queueInstall(value) {
   const envelope = await envelopeFor(value);
+  const signature = await signInstall(value, envelope);
   return json(await fetch(`${RELAY}/v1/devices/${value.deviceId}/installs`, {
     method: "POST",
     headers: {
       authorization: `Bearer ${value.browserToken}`,
       "content-type": "application/json"
     },
-    body: JSON.stringify({ envelope })
+    body: JSON.stringify({ envelope, signature })
   }));
 }
 
@@ -281,7 +350,13 @@ pairForm.addEventListener("submit", async event => {
   button.disabled = true;
   setStatus(pairStatus, "Linking…");
   try {
-    const claimed = await claim(code);
+    const fragment = fragmentParams();
+    const secret = fragment.get("s");
+    const browserKey = await generateBrowserKey();
+    const claimed = await claim(code, {
+      browser_public_key: browserKey.publicKey,
+      ...secret && { proof: await pairProof(secret, browserKey.publicKey) }
+    });
     if (
       typeof claimed.device_name !== "string"
       || claimed.device_name.length === 0
@@ -289,10 +364,16 @@ pairForm.addEventListener("submit", async event => {
     ) {
       throw new Error("The install service returned an invalid pairing response.");
     }
+    const expected = fragment.get("k");
+    if (expected && !(await deviceKeyMatchesFragment(claimed.device_public_key, expected))) {
+      throw new Error("The install service returned a key that does not match your Kobo. Nothing was linked.");
+    }
     const value = connectionValue({
       deviceId: claimed.device_id,
       browserToken: claimed.browser_token,
       publicKey: claimed.device_public_key,
+      browserPublicKey: browserKey.publicKey,
+      browserPrivateKey: browserKey.privateKey,
       deviceName: claimed.device_name
     });
     if (!value || typeof claimed.device_online !== "boolean") {

--- a/docs/apps/install.js
+++ b/docs/apps/install.js
@@ -15,11 +15,53 @@ const installStatus = document.querySelector("#install-status");
 const installButton = document.querySelector("#install");
 const forgetButton = document.querySelector("#forget");
 const deviceName = document.querySelector("#device-name");
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const APP_ID = /^[a-z][a-z0-9-]{0,31}$/;
+const BASE64URL = /^[A-Za-z0-9_-]+$/;
+
+function validString(value, length) {
+  return typeof value === "string" && value.length === length && BASE64URL.test(value);
+}
+
+function normalizedPending(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const entries = value.appId ? [[value.appId, value]] : Object.entries(value);
+  return Object.fromEntries(entries.filter(([id, pending]) =>
+    APP_ID.test(id)
+    && !id.endsWith("-")
+    && !id.includes("--")
+    && pending
+    && typeof pending === "object"
+    && UUID.test(pending.commandId)
+    && typeof pending.expiresAt === "string"
+  ));
+}
+
+function connectionValue(value) {
+  if (
+    !value
+    || typeof value !== "object"
+    || Array.isArray(value)
+    || !UUID.test(value.deviceId)
+    || !validString(value.browserToken, 43)
+    || !validString(value.publicKey, 122)
+  ) {
+    return null;
+  }
+  return {
+    deviceId: value.deviceId,
+    browserToken: value.browserToken,
+    publicKey: value.publicKey,
+    deviceName: typeof value.deviceName === "string" && value.deviceName.length <= 64
+      ? value.deviceName || "Kobo reader"
+      : "Kobo reader",
+    pending: normalizedPending(value.pending)
+  };
+}
 
 function connection() {
   try {
-    const value = JSON.parse(localStorage.getItem(STORAGE_KEY));
-    return value?.deviceId && value?.browserToken && value?.publicKey ? value : null;
+    return connectionValue(JSON.parse(localStorage.getItem(STORAGE_KEY)));
   } catch {
     return null;
   }
@@ -240,12 +282,22 @@ pairForm.addEventListener("submit", async event => {
   setStatus(pairStatus, "Linking…");
   try {
     const claimed = await claim(code);
-    const value = {
+    if (
+      typeof claimed.device_name !== "string"
+      || claimed.device_name.length === 0
+      || claimed.device_name.length > 64
+    ) {
+      throw new Error("The install service returned an invalid pairing response.");
+    }
+    const value = connectionValue({
       deviceId: claimed.device_id,
       browserToken: claimed.browser_token,
       publicKey: claimed.device_public_key,
       deviceName: claimed.device_name
-    };
+    });
+    if (!value || typeof claimed.device_online !== "boolean") {
+      throw new Error("The install service returned an invalid pairing response.");
+    }
     saveConnection(value);
     showConnection(value);
     installPanel.querySelector("h2").tabIndex = -1;

--- a/docs/apps/install.js
+++ b/docs/apps/install.js
@@ -1,0 +1,348 @@
+"use strict";
+
+const RELAY = "https://cobalt-install-relay.anandabhishek.workers.dev";
+const STORAGE_KEY = "cobalt.install-link.v1";
+const encoder = new TextEncoder();
+const app = document.querySelector("main");
+const appId = app.dataset.appId;
+const setupPanel = document.querySelector("#setup-panel");
+const pairPanel = document.querySelector("#pair-panel");
+const installPanel = document.querySelector("#install-panel");
+const pairForm = document.querySelector("#pair-form");
+const pairCode = document.querySelector("#pair-code");
+const pairStatus = document.querySelector("#pair-status");
+const installStatus = document.querySelector("#install-status");
+const installButton = document.querySelector("#install");
+const forgetButton = document.querySelector("#forget");
+const deviceName = document.querySelector("#device-name");
+
+function connection() {
+  try {
+    const value = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    return value?.deviceId && value?.browserToken && value?.publicKey ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function setStatus(element, message, tone = "") {
+  if (element.textContent === message && element.dataset.tone === tone) return;
+  element.textContent = message;
+  element.dataset.tone = tone;
+}
+
+function showConnection(value) {
+  setupPanel.hidden = Boolean(value);
+  pairPanel.hidden = Boolean(value);
+  installPanel.hidden = !value;
+  if (value) deviceName.textContent = value.deviceName;
+}
+
+function saveConnection(value) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+}
+
+function pendingFor(value) {
+  if (!value?.pending) return null;
+  if (value.pending.appId) {
+    return value.pending.appId === appId ? value.pending : null;
+  }
+  return value.pending[appId] || null;
+}
+
+function savePending(value, pending) {
+  const latest = connection();
+  if (latest && latest.deviceId !== value.deviceId) return value;
+  const target = latest?.deviceId === value.deviceId ? latest : value;
+  if (target.pending?.appId) target.pending = {};
+  target.pending ||= {};
+  target.pending[appId] = pending;
+  saveConnection(target);
+  return target;
+}
+
+function clearPending(value, commandId) {
+  const latest = connection();
+  if (latest && latest.deviceId !== value.deviceId) return;
+  const target = latest?.deviceId === value.deviceId ? latest : value;
+  if (target.pending?.appId) {
+    if (target.pending.commandId === commandId) delete target.pending;
+  } else if (target.pending?.[appId]?.commandId === commandId) {
+    delete target.pending[appId];
+  }
+  saveConnection(target);
+}
+
+function base64Url(bytes) {
+  let binary = "";
+  for (const byte of new Uint8Array(bytes)) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function fromBase64Url(value) {
+  const padded = value.replaceAll("-", "+").replaceAll("_", "/").padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const binary = atob(padded);
+  return Uint8Array.from(binary, character => character.charCodeAt(0));
+}
+
+class ApiError extends Error {
+  constructor(message, status, code) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+async function json(response) {
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new ApiError(
+      body.error?.message || "The service could not complete this request.",
+      response.status,
+      body.error?.code
+    );
+  }
+  return body;
+}
+
+async function claim(code) {
+  return json(await fetch(`${RELAY}/v1/pairings/${encodeURIComponent(code)}/claim`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{}"
+  }));
+}
+
+async function envelopeFor(value) {
+  const deviceKey = await crypto.subtle.importKey(
+    "spki",
+    fromBase64Url(value.publicKey),
+    { name: "ECDH", namedCurve: "P-256" },
+    false,
+    []
+  );
+  const ephemeral = await crypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" },
+    true,
+    ["deriveBits"]
+  );
+  const shared = await crypto.subtle.deriveBits(
+    { name: "ECDH", public: deviceKey },
+    ephemeral.privateKey,
+    256
+  );
+  const material = await crypto.subtle.importKey("raw", shared, "HKDF", false, ["deriveKey"]);
+  const key = await crypto.subtle.deriveKey(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: new Uint8Array(),
+      info: encoder.encode("cobalt-app-install-v1")
+    },
+    material,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt"]
+  );
+  const nonce = crypto.getRandomValues(new Uint8Array(12));
+  const plaintext = encoder.encode(JSON.stringify({ version: 1, app_id: appId }));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: nonce, additionalData: encoder.encode(value.deviceId) },
+    key,
+    plaintext
+  );
+  return {
+    algorithm: "ECDH-P256-AES-256-GCM",
+    ephemeral_public_key: base64Url(await crypto.subtle.exportKey("spki", ephemeral.publicKey)),
+    nonce: base64Url(nonce),
+    ciphertext: base64Url(ciphertext)
+  };
+}
+
+async function queueInstall(value) {
+  const envelope = await envelopeFor(value);
+  return json(await fetch(`${RELAY}/v1/devices/${value.deviceId}/installs`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${value.browserToken}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({ envelope })
+  }));
+}
+
+async function installState(value, commandId) {
+  return json(await fetch(`${RELAY}/v1/devices/${value.deviceId}/installs/${commandId}`, {
+    headers: { authorization: `Bearer ${value.browserToken}` }
+  }));
+}
+
+function resultMessage(state) {
+  if (state.state === "installed") {
+    return {
+      tone: "success",
+      text: {
+        installed: "Installed on your Kobo.",
+        updated: "Updated on your Kobo.",
+        "already-installed": "Already installed and up to date.",
+        included: "This app is included with Cobalt."
+      }[state.outcome] || "Completed on your Kobo."
+    };
+  }
+  if (state.state === "failed") {
+    if (state.failure === "expired") {
+      return { tone: "warning", text: "The install request expired. Send it again." };
+    }
+    if (state.failure === "unavailable") {
+      return { tone: "warning", text: "This app is not available in the current catalog. Nothing changed." };
+    }
+    return { tone: "error", text: "The install could not be completed. Open App Store on your Kobo and try again." };
+  }
+  if (!state.device_online) {
+    return { tone: "warning", text: "Waiting for your Kobo — open Cobalt App Store to continue." };
+  }
+  return { tone: "", text: state.state === "installing" ? "Installing on your Kobo…" : "Sent to your Kobo…" };
+}
+
+async function watch(value, commandId) {
+  for (;;) {
+    try {
+      const state = await installState(value, commandId);
+      const message = resultMessage(state);
+      setStatus(installStatus, message.text, message.tone);
+      if (state.state === "installed" || state.state === "failed") {
+        clearPending(value, commandId);
+        return;
+      }
+      const delay = state.device_online ? 3000 : 30000;
+      await new Promise(resolve => setTimeout(resolve, delay));
+    } catch (error) {
+      if (error.status === 404) {
+        clearPending(value, commandId);
+        throw error;
+      }
+      if (error.status === 401 || error.status === 403) throw error;
+      setStatus(installStatus, "Status is temporarily unavailable. The request remains queued.", "warning");
+      await new Promise(resolve => setTimeout(resolve, 30000));
+    }
+  }
+}
+
+pairForm.addEventListener("submit", async event => {
+  event.preventDefault();
+  const code = pairCode.value.replace(/[^A-Z0-9]/gi, "").toUpperCase();
+  if (code.length !== 8) {
+    setStatus(pairStatus, "Enter the 8-character code shown on your Kobo.", "error");
+    return;
+  }
+  const button = pairForm.querySelector("button");
+  button.disabled = true;
+  setStatus(pairStatus, "Linking…");
+  try {
+    const claimed = await claim(code);
+    const value = {
+      deviceId: claimed.device_id,
+      browserToken: claimed.browser_token,
+      publicKey: claimed.device_public_key,
+      deviceName: claimed.device_name
+    };
+    saveConnection(value);
+    showConnection(value);
+    installPanel.querySelector("h2").tabIndex = -1;
+    installPanel.querySelector("h2").focus();
+    setStatus(
+      installStatus,
+      claimed.device_online ? "Ready to install." : "Linked. Open Cobalt App Store on your Kobo to receive installs.",
+      claimed.device_online ? "success" : "warning"
+    );
+  } catch (error) {
+    setStatus(pairStatus, error.message, "error");
+  } finally {
+    button.disabled = false;
+  }
+});
+
+installButton.addEventListener("click", async () => {
+  const value = connection();
+  if (!value) return showConnection(null);
+  const pending = pendingFor(value);
+  if (pending) {
+    installButton.disabled = true;
+    try {
+      await watch(value, pending.commandId);
+    } finally {
+      installButton.disabled = false;
+    }
+    return;
+  }
+  installButton.disabled = true;
+  setStatus(installStatus, "Preparing encrypted request…");
+  try {
+    const queued = await queueInstall(value);
+    const pending = {
+      appId,
+      commandId: queued.command_id,
+      expiresAt: queued.expires_at
+    };
+    savePending(value, pending);
+    const message = resultMessage(queued);
+    setStatus(installStatus, message.text, message.tone);
+    await watch(value, queued.command_id);
+  } catch (error) {
+    if (error.status === 401 || error.status === 403) {
+      const latest = connection();
+      if (!latest || latest.deviceId === value.deviceId) {
+        localStorage.removeItem(STORAGE_KEY);
+        showConnection(null);
+        setStatus(pairStatus, "This browser is no longer linked. Link it again to continue.", "warning");
+      }
+    } else if (error.code === "device_not_found") {
+      const latest = connection();
+      if (!latest || latest.deviceId === value.deviceId) {
+        localStorage.removeItem(STORAGE_KEY);
+        showConnection(null);
+        setStatus(pairStatus, "This Kobo link is no longer available. Link it again to continue.", "warning");
+      }
+    } else if (error.status === 404) {
+      setStatus(installStatus, "The install request expired. Send it again.", "warning");
+    } else if (error instanceof TypeError) {
+      setStatus(installStatus, "The install service could not be reached. Check your connection and try again.", "error");
+    } else {
+      setStatus(installStatus, error.message, "error");
+    }
+  } finally {
+    installButton.disabled = false;
+  }
+});
+
+forgetButton.addEventListener("click", () => {
+  localStorage.removeItem(STORAGE_KEY);
+  pairCode.value = "";
+  setStatus(pairStatus, "This browser is no longer linked.");
+  showConnection(null);
+});
+
+const queryCode = new URLSearchParams(location.search).get("code");
+if (queryCode) pairCode.value = queryCode.toUpperCase();
+const saved = connection();
+showConnection(saved);
+const pending = pendingFor(saved);
+if (saved && pending) {
+  installButton.disabled = true;
+  watch(saved, pending.commandId)
+    .catch(error => {
+      if (error.status === 401 || error.status === 403) {
+        const latest = connection();
+        if (!latest || latest.deviceId === saved.deviceId) {
+          localStorage.removeItem(STORAGE_KEY);
+          showConnection(null);
+          setStatus(pairStatus, "This browser is no longer linked. Link it again to continue.", "warning");
+        }
+      } else if (error.status === 404) {
+        setStatus(installStatus, "The install request expired. Send it again.", "warning");
+      } else {
+        setStatus(installStatus, error.message, "error");
+      }
+    })
+    .finally(() => { installButton.disabled = false; });
+}

--- a/docs/apps/magnet/index.html
+++ b/docs/apps/magnet/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Magnet for Cobalt</title>
+<meta name="description" content="Find the hall sensor behind the bezel and watch it answer.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/magnet/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Magnet for Cobalt">
+<meta property="og:description" content="Find the hall sensor behind the bezel and watch it answer.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/magnet/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Magnet for Cobalt">
+<meta name="twitter:description" content="Find the hall sensor behind the bezel and watch it answer.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap" data-app-id="magnet">
+  <p class="eyebrow">Kobo app</p>
+  <h1>Magnet</h1>
+  <p class="summary">Find the hall sensor behind the bezel and watch it answer.</p>
+  <div class="meta"><span>Version 1.0.0</span><span>cover-sensor</span></div>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">First-time setup</p>
+    <h2>New to Cobalt? Set it up once.</h2>
+    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
+      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
+    </ol>
+    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
+  </section>
+  <section class="panel" id="pair-panel">
+    <p class="eyebrow">Already using Cobalt?</p>
+    <h2>Link your Kobo</h2>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel" id="install-panel" hidden>
+    <h2>Install on <span id="device-name">your Kobo</span></h2>
+    <p>Cobalt verifies the signed catalog and app package before changing the installed copy.</p>
+    <div class="actions">
+      <button type="button" id="install">Install Magnet</button>
+      <button type="button" id="forget" class="secondary">Forget this Kobo</button>
+    </div>
+    <p class="status" id="install-status" role="status" aria-live="polite"></p>
+  </section>
+</main>
+<script src="../install.js" defer></script>
+</body>
+</html>

--- a/docs/apps/magnet/index.html
+++ b/docs/apps/magnet/index.html
@@ -28,11 +28,15 @@
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
-    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>

--- a/docs/apps/magnet/index.html
+++ b/docs/apps/magnet/index.html
@@ -25,20 +25,9 @@
   <h1>Magnet</h1>
   <p class="summary">Find the hall sensor behind the bezel and watch it answer.</p>
   <div class="meta"><span>Version 1.0.0</span><span>cover-sensor</span></div>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">First-time setup</p>
-    <h2>New to Cobalt? Set it up once.</h2>
-    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
-      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
-    </ol>
-    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
-  </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Already using Cobalt?</p>
-    <h2>Link your Kobo</h2>
+    <p class="eyebrow">Install with Cobalt</p>
+    <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
     <form id="pair-form">
       <div class="field">
@@ -49,6 +38,17 @@
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
     <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">Cobalt not installed?</p>
+    <h2>Set up Cobalt first</h2>
+    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
+      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
+    </ol>
+    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/morse/index.html
+++ b/docs/apps/morse/index.html
@@ -25,20 +25,9 @@
   <h1>Morse</h1>
   <p class="summary">Sends a typed message in Morse on the front light, a letter at a time.</p>
   <div class="meta"><span>Version 1.0.2</span><span>frontlight-control, keep-awake</span></div>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">First-time setup</p>
-    <h2>New to Cobalt? Set it up once.</h2>
-    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
-      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
-    </ol>
-    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
-  </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Already using Cobalt?</p>
-    <h2>Link your Kobo</h2>
+    <p class="eyebrow">Install with Cobalt</p>
+    <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
     <form id="pair-form">
       <div class="field">
@@ -49,6 +38,17 @@
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
     <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">Cobalt not installed?</p>
+    <h2>Set up Cobalt first</h2>
+    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
+      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
+    </ol>
+    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/morse/index.html
+++ b/docs/apps/morse/index.html
@@ -28,11 +28,15 @@
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
-    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>

--- a/docs/apps/morse/index.html
+++ b/docs/apps/morse/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Morse for Cobalt</title>
+<meta name="description" content="Sends a typed message in Morse on the front light, a letter at a time.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/morse/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Morse for Cobalt">
+<meta property="og:description" content="Sends a typed message in Morse on the front light, a letter at a time.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/morse/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Morse for Cobalt">
+<meta name="twitter:description" content="Sends a typed message in Morse on the front light, a letter at a time.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap" data-app-id="morse">
+  <p class="eyebrow">Kobo app</p>
+  <h1>Morse</h1>
+  <p class="summary">Sends a typed message in Morse on the front light, a letter at a time.</p>
+  <div class="meta"><span>Version 1.0.2</span><span>frontlight-control, keep-awake</span></div>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">First-time setup</p>
+    <h2>New to Cobalt? Set it up once.</h2>
+    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
+      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
+    </ol>
+    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
+  </section>
+  <section class="panel" id="pair-panel">
+    <p class="eyebrow">Already using Cobalt?</p>
+    <h2>Link your Kobo</h2>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel" id="install-panel" hidden>
+    <h2>Install on <span id="device-name">your Kobo</span></h2>
+    <p>Cobalt verifies the signed catalog and app package before changing the installed copy.</p>
+    <div class="actions">
+      <button type="button" id="install">Install Morse</button>
+      <button type="button" id="forget" class="secondary">Forget this Kobo</button>
+    </div>
+    <p class="status" id="install-status" role="status" aria-live="polite"></p>
+  </section>
+</main>
+<script src="../install.js" defer></script>
+</body>
+</html>

--- a/docs/apps/rss/index.html
+++ b/docs/apps/rss/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Feeds for Cobalt</title>
+<meta name="description" content="Follow a site by name and read its articles, not its layout.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/rss/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Feeds for Cobalt">
+<meta property="og:description" content="Follow a site by name and read its articles, not its layout.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/rss/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Feeds for Cobalt">
+<meta name="twitter:description" content="Follow a site by name and read its articles, not its layout.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap" data-app-id="rss">
+  <p class="eyebrow">Kobo app</p>
+  <h1>Feeds</h1>
+  <p class="summary">Follow a site by name and read its articles, not its layout.</p>
+  <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">First-time setup</p>
+    <h2>New to Cobalt? Set it up once.</h2>
+    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
+      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
+    </ol>
+    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
+  </section>
+  <section class="panel" id="pair-panel">
+    <p class="eyebrow">Already using Cobalt?</p>
+    <h2>Link your Kobo</h2>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel" id="install-panel" hidden>
+    <h2>Install on <span id="device-name">your Kobo</span></h2>
+    <p>Cobalt verifies the signed catalog and app package before changing the installed copy.</p>
+    <div class="actions">
+      <button type="button" id="install">Install Feeds</button>
+      <button type="button" id="forget" class="secondary">Forget this Kobo</button>
+    </div>
+    <p class="status" id="install-status" role="status" aria-live="polite"></p>
+  </section>
+</main>
+<script src="../install.js" defer></script>
+</body>
+</html>

--- a/docs/apps/rss/index.html
+++ b/docs/apps/rss/index.html
@@ -25,20 +25,9 @@
   <h1>Feeds</h1>
   <p class="summary">Follow a site by name and read its articles, not its layout.</p>
   <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">First-time setup</p>
-    <h2>New to Cobalt? Set it up once.</h2>
-    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
-      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
-    </ol>
-    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
-  </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Already using Cobalt?</p>
-    <h2>Link your Kobo</h2>
+    <p class="eyebrow">Install with Cobalt</p>
+    <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
     <form id="pair-form">
       <div class="field">
@@ -49,6 +38,17 @@
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
     <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">Cobalt not installed?</p>
+    <h2>Set up Cobalt first</h2>
+    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
+      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
+    </ol>
+    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/rss/index.html
+++ b/docs/apps/rss/index.html
@@ -28,11 +28,15 @@
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
-    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>

--- a/docs/apps/sidekick/index.html
+++ b/docs/apps/sidekick/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sidekick for Cobalt</title>
+<meta name="description" content="Approve or deny what your coding agents ask to run, from here.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/sidekick/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Sidekick for Cobalt">
+<meta property="og:description" content="Approve or deny what your coding agents ask to run, from here.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/sidekick/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Sidekick for Cobalt">
+<meta name="twitter:description" content="Approve or deny what your coding agents ask to run, from here.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap" data-app-id="sidekick">
+  <p class="eyebrow">Kobo app</p>
+  <h1>Sidekick</h1>
+  <p class="summary">Approve or deny what your coding agents ask to run, from here.</p>
+  <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">First-time setup</p>
+    <h2>New to Cobalt? Set it up once.</h2>
+    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
+      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
+    </ol>
+    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
+  </section>
+  <section class="panel" id="pair-panel">
+    <p class="eyebrow">Already using Cobalt?</p>
+    <h2>Link your Kobo</h2>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel" id="install-panel" hidden>
+    <h2>Install on <span id="device-name">your Kobo</span></h2>
+    <p>Cobalt verifies the signed catalog and app package before changing the installed copy.</p>
+    <div class="actions">
+      <button type="button" id="install">Install Sidekick</button>
+      <button type="button" id="forget" class="secondary">Forget this Kobo</button>
+    </div>
+    <p class="status" id="install-status" role="status" aria-live="polite"></p>
+  </section>
+</main>
+<script src="../install.js" defer></script>
+</body>
+</html>

--- a/docs/apps/sidekick/index.html
+++ b/docs/apps/sidekick/index.html
@@ -25,20 +25,9 @@
   <h1>Sidekick</h1>
   <p class="summary">Approve or deny what your coding agents ask to run, from here.</p>
   <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">First-time setup</p>
-    <h2>New to Cobalt? Set it up once.</h2>
-    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
-      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
-    </ol>
-    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
-  </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Already using Cobalt?</p>
-    <h2>Link your Kobo</h2>
+    <p class="eyebrow">Install with Cobalt</p>
+    <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
     <form id="pair-form">
       <div class="field">
@@ -49,6 +38,17 @@
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
     <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">Cobalt not installed?</p>
+    <h2>Set up Cobalt first</h2>
+    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
+      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
+    </ol>
+    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/sidekick/index.html
+++ b/docs/apps/sidekick/index.html
@@ -28,11 +28,15 @@
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
-    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>

--- a/docs/apps/sudoku/index.html
+++ b/docs/apps/sudoku/index.html
@@ -25,20 +25,9 @@
   <h1>Sudoku</h1>
   <p class="summary">A crisp touch-first Sudoku built for the e-ink panel.</p>
   <div class="meta"><span>Version 1.0.1</span><span>No additional permissions</span></div>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">First-time setup</p>
-    <h2>New to Cobalt? Set it up once.</h2>
-    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
-      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
-    </ol>
-    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
-  </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Already using Cobalt?</p>
-    <h2>Link your Kobo</h2>
+    <p class="eyebrow">Install with Cobalt</p>
+    <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
     <form id="pair-form">
       <div class="field">
@@ -49,6 +38,17 @@
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
     <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">Cobalt not installed?</p>
+    <h2>Set up Cobalt first</h2>
+    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
+      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
+    </ol>
+    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/sudoku/index.html
+++ b/docs/apps/sudoku/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Sudoku for Cobalt</title>
+<meta name="description" content="A crisp touch-first Sudoku built for the e-ink panel.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/sudoku/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Sudoku for Cobalt">
+<meta property="og:description" content="A crisp touch-first Sudoku built for the e-ink panel.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/sudoku/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Sudoku for Cobalt">
+<meta name="twitter:description" content="A crisp touch-first Sudoku built for the e-ink panel.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap" data-app-id="sudoku">
+  <p class="eyebrow">Kobo app</p>
+  <h1>Sudoku</h1>
+  <p class="summary">A crisp touch-first Sudoku built for the e-ink panel.</p>
+  <div class="meta"><span>Version 1.0.1</span><span>No additional permissions</span></div>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">First-time setup</p>
+    <h2>New to Cobalt? Set it up once.</h2>
+    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
+      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
+    </ol>
+    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
+  </section>
+  <section class="panel" id="pair-panel">
+    <p class="eyebrow">Already using Cobalt?</p>
+    <h2>Link your Kobo</h2>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel" id="install-panel" hidden>
+    <h2>Install on <span id="device-name">your Kobo</span></h2>
+    <p>Cobalt verifies the signed catalog and app package before changing the installed copy.</p>
+    <div class="actions">
+      <button type="button" id="install">Install Sudoku</button>
+      <button type="button" id="forget" class="secondary">Forget this Kobo</button>
+    </div>
+    <p class="status" id="install-status" role="status" aria-live="polite"></p>
+  </section>
+</main>
+<script src="../install.js" defer></script>
+</body>
+</html>

--- a/docs/apps/sudoku/index.html
+++ b/docs/apps/sudoku/index.html
@@ -28,11 +28,15 @@
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
-    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>

--- a/docs/apps/tictactoe/index.html
+++ b/docs/apps/tictactoe/index.html
@@ -25,20 +25,9 @@
   <h1>Tic-tac-toe</h1>
   <p class="summary">Two players, one panel. Nought goes first.</p>
   <div class="meta"><span>Version 1.0.0</span><span>No additional permissions</span></div>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">First-time setup</p>
-    <h2>New to Cobalt? Set it up once.</h2>
-    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
-      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
-    </ol>
-    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
-  </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Already using Cobalt?</p>
-    <h2>Link your Kobo</h2>
+    <p class="eyebrow">Install with Cobalt</p>
+    <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
     <form id="pair-form">
       <div class="field">
@@ -49,6 +38,17 @@
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
     <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">Cobalt not installed?</p>
+    <h2>Set up Cobalt first</h2>
+    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
+      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
+    </ol>
+    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/tictactoe/index.html
+++ b/docs/apps/tictactoe/index.html
@@ -28,11 +28,15 @@
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
-    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>

--- a/docs/apps/tictactoe/index.html
+++ b/docs/apps/tictactoe/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Tic-tac-toe for Cobalt</title>
+<meta name="description" content="Two players, one panel. Nought goes first.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/tictactoe/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Tic-tac-toe for Cobalt">
+<meta property="og:description" content="Two players, one panel. Nought goes first.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/tictactoe/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Tic-tac-toe for Cobalt">
+<meta name="twitter:description" content="Two players, one panel. Nought goes first.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap" data-app-id="tictactoe">
+  <p class="eyebrow">Kobo app</p>
+  <h1>Tic-tac-toe</h1>
+  <p class="summary">Two players, one panel. Nought goes first.</p>
+  <div class="meta"><span>Version 1.0.0</span><span>No additional permissions</span></div>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">First-time setup</p>
+    <h2>New to Cobalt? Set it up once.</h2>
+    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
+      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
+    </ol>
+    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
+  </section>
+  <section class="panel" id="pair-panel">
+    <p class="eyebrow">Already using Cobalt?</p>
+    <h2>Link your Kobo</h2>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel" id="install-panel" hidden>
+    <h2>Install on <span id="device-name">your Kobo</span></h2>
+    <p>Cobalt verifies the signed catalog and app package before changing the installed copy.</p>
+    <div class="actions">
+      <button type="button" id="install">Install Tic-tac-toe</button>
+      <button type="button" id="forget" class="secondary">Forget this Kobo</button>
+    </div>
+    <p class="status" id="install-status" role="status" aria-live="polite"></p>
+  </section>
+</main>
+<script src="../install.js" defer></script>
+</body>
+</html>

--- a/docs/apps/todo/index.html
+++ b/docs/apps/todo/index.html
@@ -25,20 +25,9 @@
   <h1>Todo</h1>
   <p class="summary">A list that remembers itself. Tap an item to finish it.</p>
   <div class="meta"><span>Version 1.0.0</span><span>No additional permissions</span></div>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">First-time setup</p>
-    <h2>New to Cobalt? Set it up once.</h2>
-    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
-      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
-    </ol>
-    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
-  </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Already using Cobalt?</p>
-    <h2>Link your Kobo</h2>
+    <p class="eyebrow">Install with Cobalt</p>
+    <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
     <form id="pair-form">
       <div class="field">
@@ -49,6 +38,17 @@
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
     <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">Cobalt not installed?</p>
+    <h2>Set up Cobalt first</h2>
+    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
+      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
+    </ol>
+    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/todo/index.html
+++ b/docs/apps/todo/index.html
@@ -28,11 +28,15 @@
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
-    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>

--- a/docs/apps/todo/index.html
+++ b/docs/apps/todo/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Todo for Cobalt</title>
+<meta name="description" content="A list that remembers itself. Tap an item to finish it.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/todo/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Todo for Cobalt">
+<meta property="og:description" content="A list that remembers itself. Tap an item to finish it.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/todo/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Todo for Cobalt">
+<meta name="twitter:description" content="A list that remembers itself. Tap an item to finish it.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap" data-app-id="todo">
+  <p class="eyebrow">Kobo app</p>
+  <h1>Todo</h1>
+  <p class="summary">A list that remembers itself. Tap an item to finish it.</p>
+  <div class="meta"><span>Version 1.0.0</span><span>No additional permissions</span></div>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">First-time setup</p>
+    <h2>New to Cobalt? Set it up once.</h2>
+    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
+      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
+    </ol>
+    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
+  </section>
+  <section class="panel" id="pair-panel">
+    <p class="eyebrow">Already using Cobalt?</p>
+    <h2>Link your Kobo</h2>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel" id="install-panel" hidden>
+    <h2>Install on <span id="device-name">your Kobo</span></h2>
+    <p>Cobalt verifies the signed catalog and app package before changing the installed copy.</p>
+    <div class="actions">
+      <button type="button" id="install">Install Todo</button>
+      <button type="button" id="forget" class="secondary">Forget this Kobo</button>
+    </div>
+    <p class="status" id="install-status" role="status" aria-live="polite"></p>
+  </section>
+</main>
+<script src="../install.js" defer></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -371,7 +371,7 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
   <div class="wrap">
     <p class="kicker">Apps</p>
     <h2 class="measure">The apps.</h2>
-    <p class="measure quiet">Every screenshot below is a capture from a Kobo Clara BW. Store apps version independently of the platform; the rest ship with the platform install.</p>
+    <p class="measure quiet">Every screenshot below is a capture from a Kobo Clara BW. Open an app to set up Cobalt or install it on a linked reader. Cobalt is installed once over USB; later apps arrive over Wi-Fi.</p>
     <div class="apps-grid">
       <div class="app">
         <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/examples/launcher/README.md"><img src="media/site/apps/launcher.png" width="1072" height="1448" loading="lazy" alt="Cobalt launcher app grid on e-ink"></a>
@@ -384,53 +384,53 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
         <p>Installs, updates, removes and reinstalls signed apps over Wi-Fi.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/tree/main/apps/arxiv"><img src="media/site/apps/arxiv.png" width="1072" height="1448" loading="lazy" alt="Newest machine learning preprints listed in the arXiv app on a Kobo"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/tree/main/apps/arxiv">arXiv</a></h3>
+        <a class="shot" href="apps/arxiv/"><img src="media/site/apps/arxiv.png" width="1072" height="1448" loading="lazy" alt="Newest machine learning preprints listed in the arXiv app on a Kobo"></a>
+        <h3><a href="apps/arxiv/">arXiv</a></h3>
         <p>Browses a subject's newest preprints and reads the full text on the panel.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/tree/main/apps/sudoku"><img src="media/site/apps/sudoku.png" width="1072" height="1448" loading="lazy" alt="A complete 81-cell Sudoku game on a Kobo Clara BW"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/tree/main/apps/sudoku">Sudoku</a></h3>
+        <a class="shot" href="apps/sudoku/"><img src="media/site/apps/sudoku.png" width="1072" height="1448" loading="lazy" alt="A complete 81-cell Sudoku game on a Kobo Clara BW"></a>
+        <h3><a href="apps/sudoku/">Sudoku</a></h3>
         <p>Store-only by design: installing it proves delivery of an app the USB package never contained.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/tree/main/apps/morse"><img src="media/site/apps/morse.png" width="1072" height="1448" loading="lazy" alt="The letter S filling the Kobo panel while the front light sends it in Morse"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/tree/main/apps/morse">Morse</a></h3>
+        <a class="shot" href="apps/morse/"><img src="media/site/apps/morse.png" width="1072" height="1448" loading="lazy" alt="The letter S filling the Kobo panel while the front light sends it in Morse"></a>
+        <h3><a href="apps/morse/">Morse</a></h3>
         <p>Sends a typed message in Morse on the front light, one letter across the whole panel.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/examples/audiobook/README.md"><img src="media/site/apps/audiobook.png" width="1072" height="1448" loading="lazy" alt="An audiobook player with cover art, position and transport controls on e-ink"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/examples/audiobook/README.md">Audiobook Studio</a></h3>
+        <a class="shot" href="apps/audiobook/"><img src="media/site/apps/audiobook.png" width="1072" height="1448" loading="lazy" alt="An audiobook player with cover art, position and transport controls on e-ink"></a>
+        <h3><a href="apps/audiobook/">Audiobook Studio</a></h3>
         <p>Researches, writes, narrates and plays an original audiobook.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/examples/gutenbird/README.md"><img src="media/site/apps/gutenbird.png" width="1072" height="1448" loading="lazy" alt="A shelf of book covers from an OPDS catalogue on a Kobo"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/examples/gutenbird/README.md">Gutenbird</a></h3>
+        <a class="shot" href="apps/gutenbird/"><img src="media/site/apps/gutenbird.png" width="1072" height="1448" loading="lazy" alt="A shelf of book covers from an OPDS catalogue on a Kobo"></a>
+        <h3><a href="apps/gutenbird/">Gutenbird</a></h3>
         <p>Reads any OPDS library: Project Gutenberg, Standard Ebooks, Open Library, or yours.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/examples/hn/README.md"><img src="media/site/apps/hackernews.png" width="1072" height="1448" loading="lazy" alt="A ranked list of Hacker News stories on a Kobo e-reader"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/examples/hn/README.md">Hacker News</a></h3>
+        <a class="shot" href="apps/hn/"><img src="media/site/apps/hackernews.png" width="1072" height="1448" loading="lazy" alt="A ranked list of Hacker News stories on a Kobo e-reader"></a>
+        <h3><a href="apps/hn/">Hacker News</a></h3>
         <p>Top, New, Ask and Show stories with complete comment threads.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/examples/rss/README.md"><img src="media/site/apps/feeds.png" width="1072" height="1448" loading="lazy" alt="Subscribed feeds and articles in the Feeds app"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/examples/rss/README.md">Feeds</a></h3>
+        <a class="shot" href="apps/rss/"><img src="media/site/apps/feeds.png" width="1072" height="1448" loading="lazy" alt="Subscribed feeds and articles in the Feeds app"></a>
+        <h3><a href="apps/rss/">Feeds</a></h3>
         <p>Discovers a site's feed and presents its articles without the site's layout.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/examples/brief/README.md"><img src="media/site/apps/brief.png" width="1072" height="1448" loading="lazy" alt="A numbered daily news brief on e-ink"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/examples/brief/README.md">Daily Brief</a></h3>
+        <a class="shot" href="apps/brief/"><img src="media/site/apps/brief.png" width="1072" height="1448" loading="lazy" alt="A numbered daily news brief on e-ink"></a>
+        <h3><a href="apps/brief/">Daily Brief</a></h3>
         <p>Collects the day's stories in the background while you use another app.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/examples/chat/README.md"><img src="media/site/apps/chat.png" width="1072" height="1448" loading="lazy" alt="An AI answer displayed as readable text on the Kobo panel"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/examples/chat/README.md">AI Command Center</a></h3>
+        <a class="shot" href="apps/chat/"><img src="media/site/apps/chat.png" width="1072" height="1448" loading="lazy" alt="An AI answer displayed as readable text on the Kobo panel"></a>
+        <h3><a href="apps/chat/">AI Command Center</a></h3>
         <p>Asks a question and turns the answer into touch-friendly reading.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/examples/sidekick/README.md"><img src="media/site/apps/sidekick.png" width="1072" height="1448" loading="lazy" alt="A coding agent request with tappable responses in Sidekick"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/examples/sidekick/README.md">Sidekick</a></h3>
+        <a class="shot" href="apps/sidekick/"><img src="media/site/apps/sidekick.png" width="1072" height="1448" loading="lazy" alt="A coding agent request with tappable responses in Sidekick"></a>
+        <h3><a href="apps/sidekick/">Sidekick</a></h3>
         <p>Approve or deny requests from coding agents, away from the keyboard.</p>
       </div>
       <div class="app">
@@ -439,8 +439,8 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
         <p>A panel-native shell with keys that send input immediately.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/examples/gallery/README.md"><img src="media/site/apps/components.png" width="1072" height="1448" loading="lazy" alt="Cobalt typography and UI components on e-ink"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/examples/gallery/README.md">Components</a></h3>
+        <a class="shot" href="apps/gallery/"><img src="media/site/apps/components.png" width="1072" height="1448" loading="lazy" alt="Cobalt typography and UI components on e-ink"></a>
+        <h3><a href="apps/gallery/">Components</a></h3>
         <p>The UI toolkit's controls, layouts, typography and states, on the panel.</p>
       </div>
       <div class="app">
@@ -449,18 +449,18 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
         <p>Connectivity, hardware, and platform updates, kept separate from Store.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/examples/todo/README.md"><img src="media/site/apps/todo.png" width="1072" height="1448" loading="lazy" alt="A persistent to-do list with completed items"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/examples/todo/README.md">Todo</a></h3>
+        <a class="shot" href="apps/todo/"><img src="media/site/apps/todo.png" width="1072" height="1448" loading="lazy" alt="A persistent to-do list with completed items"></a>
+        <h3><a href="apps/todo/">Todo</a></h3>
         <p>A persistent list with touch entry and completed-item states.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/examples/tictactoe/README.md"><img src="media/site/apps/tictactoe.png" width="1072" height="1448" loading="lazy" alt="A completed game of tic-tac-toe on e-ink"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/examples/tictactoe/README.md">Tic-tac-toe</a></h3>
+        <a class="shot" href="apps/tictactoe/"><img src="media/site/apps/tictactoe.png" width="1072" height="1448" loading="lazy" alt="A completed game of tic-tac-toe on e-ink"></a>
+        <h3><a href="apps/tictactoe/">Tic-tac-toe</a></h3>
         <p>Two players, partial refreshes for individual cells.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/examples/magnet/README.md"><img src="media/site/apps/magnet.png" width="1072" height="1448" loading="lazy" alt="The Kobo hall sensor responding to a magnet"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/examples/magnet/README.md">Magnet</a></h3>
+        <a class="shot" href="apps/magnet/"><img src="media/site/apps/magnet.png" width="1072" height="1448" loading="lazy" alt="The Kobo hall sensor responding to a magnet"></a>
+        <h3><a href="apps/magnet/">Magnet</a></h3>
         <p>Locates the hall sensor behind the bezel and reports its changes.</p>
       </div>
     </div>

--- a/docs/pair/index.html
+++ b/docs/pair/index.html
@@ -15,12 +15,16 @@
   <h1>Link your Kobo</h1>
   <p class="summary">Pair this browser once, then install signed apps from any Cobalt app page.</p>
   <section class="panel">
-    <h2>Confirm the pairing code</h2>
-    <p>The code must match the one shown in Cobalt App Store on your Kobo.</p>
+    <h2>Confirm your Kobo</h2>
+    <p>Enter the pairing code and verification key shown in Cobalt App Store. QR scans fill these securely for you.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>

--- a/docs/pair/index.html
+++ b/docs/pair/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Link your Kobo to Cobalt apps</title>
+<meta name="description" content="Link this browser to your Kobo to install signed Cobalt apps.">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../apps/install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../">Cobalt</a><a class="back" href="../#apps">All apps</a></div></header>
+<main class="wrap">
+  <p class="eyebrow">Install links</p>
+  <h1>Link your Kobo</h1>
+  <p class="summary">Pair this browser once, then install signed apps from any Cobalt app page.</p>
+  <section class="panel">
+    <h2>Confirm the pairing code</h2>
+    <p>The code must match the one shown in Cobalt App Store on your Kobo.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <div class="actions" id="continue" hidden><a href="../#apps">Choose an app</a></div>
+    <p class="privacy">No account is required. Install requests are encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+</main>
+<script src="pair.js" defer></script>
+</body>
+</html>

--- a/docs/pair/pair.js
+++ b/docs/pair/pair.js
@@ -37,6 +37,56 @@ function pairingValue(value) {
   };
 }
 
+function fragmentParams() {
+  return new URLSearchParams(location.hash.slice(1));
+}
+
+const encoder = new TextEncoder();
+
+function base64Url(bytes) {
+  let binary = "";
+  for (const byte of new Uint8Array(bytes)) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function fromBase64Url(value) {
+  const padded = value.replaceAll("-", "+").replaceAll("_", "/").padEnd(Math.ceil(value.length / 4) * 4, "=");
+  const binary = atob(padded);
+  return Uint8Array.from(binary, character => character.charCodeAt(0));
+}
+
+async function generateBrowserKey() {
+  const pair = await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign"]
+  );
+  return {
+    publicKey: base64Url(await crypto.subtle.exportKey("spki", pair.publicKey)),
+    privateKey: await crypto.subtle.exportKey("jwk", pair.privateKey)
+  };
+}
+
+async function deviceKeyMatchesFragment(publicKey, expected) {
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(publicKey));
+  return base64Url(new Uint8Array(digest).slice(0, 16)) === expected;
+}
+
+async function pairProof(secret, browserPublicKey) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    fromBase64Url(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  return base64Url(await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(`cobalt-pair-proof-v1\n${browserPublicKey}`)
+  ));
+}
+
 function setStatus(message, tone = "") {
   if (status.textContent === message && status.dataset.tone === tone) return;
   status.textContent = message;
@@ -62,18 +112,30 @@ form.addEventListener("submit", async event => {
   button.disabled = true;
   setStatus("Linking…");
   try {
+    const fragment = fragmentParams();
+    const secret = fragment.get("s");
+    const browserKey = await generateBrowserKey();
     const claimed = pairingValue(await responseJson(await fetch(
       `${RELAY}/v1/pairings/${encodeURIComponent(code)}/claim`,
       {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: "{}"
+        body: JSON.stringify({
+          browser_public_key: browserKey.publicKey,
+          ...secret && { proof: await pairProof(secret, browserKey.publicKey) }
+        })
       }
     )));
+    const expected = fragment.get("k");
+    if (expected && !(await deviceKeyMatchesFragment(claimed.publicKey, expected))) {
+      throw new Error("The install service returned a key that does not match your Kobo. Nothing was linked.");
+    }
     localStorage.setItem(STORAGE_KEY, JSON.stringify({
       deviceId: claimed.deviceId,
       browserToken: claimed.browserToken,
       publicKey: claimed.publicKey,
+      browserPublicKey: browserKey.publicKey,
+      browserPrivateKey: browserKey.privateKey,
       deviceName: claimed.deviceName
     }));
     form.hidden = true;

--- a/docs/pair/pair.js
+++ b/docs/pair/pair.js
@@ -1,0 +1,67 @@
+"use strict";
+
+const RELAY = "https://cobalt-install-relay.anandabhishek.workers.dev";
+const STORAGE_KEY = "cobalt.install-link.v1";
+const form = document.querySelector("#pair-form");
+const input = document.querySelector("#pair-code");
+const status = document.querySelector("#pair-status");
+const next = document.querySelector("#continue");
+
+function setStatus(message, tone = "") {
+  if (status.textContent === message && status.dataset.tone === tone) return;
+  status.textContent = message;
+  status.dataset.tone = tone;
+}
+
+async function responseJson(response) {
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(body.error?.message || "The service could not complete this request.");
+  }
+  return body;
+}
+
+form.addEventListener("submit", async event => {
+  event.preventDefault();
+  const code = input.value.replace(/[^A-Z0-9]/gi, "").toUpperCase();
+  if (code.length !== 8) {
+    setStatus("Enter the 8-character code shown on your Kobo.", "error");
+    return;
+  }
+  const button = form.querySelector("button");
+  button.disabled = true;
+  setStatus("Linking…");
+  try {
+    const claimed = await responseJson(await fetch(
+      `${RELAY}/v1/pairings/${encodeURIComponent(code)}/claim`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}"
+      }
+    ));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      deviceId: claimed.device_id,
+      browserToken: claimed.browser_token,
+      publicKey: claimed.device_public_key,
+      deviceName: claimed.device_name
+    }));
+    form.hidden = true;
+    next.hidden = false;
+    next.tabIndex = -1;
+    next.focus();
+    setStatus(
+      claimed.device_online
+        ? `${claimed.device_name} is linked.`
+        : `${claimed.device_name} is linked. Open Cobalt App Store on your Kobo to receive installs.`,
+      claimed.device_online ? "success" : "warning"
+    );
+  } catch (error) {
+    setStatus(error.message, "error");
+  } finally {
+    button.disabled = false;
+  }
+});
+
+const code = new URLSearchParams(location.search).get("code");
+if (code) input.value = code.toUpperCase();

--- a/docs/pair/pair.js
+++ b/docs/pair/pair.js
@@ -4,6 +4,8 @@ const RELAY = "https://cobalt-install-relay.anandabhishek.workers.dev";
 const STORAGE_KEY = "cobalt.install-link.v1";
 const form = document.querySelector("#pair-form");
 const input = document.querySelector("#pair-code");
+const secretInput = document.querySelector("#pair-secret");
+const secretField = document.querySelector("#pair-secret-field");
 const status = document.querySelector("#pair-status");
 const next = document.querySelector("#continue");
 const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
@@ -39,6 +41,19 @@ function pairingValue(value) {
 
 function fragmentParams() {
   return new URLSearchParams(location.hash.slice(1));
+}
+
+function pairingCredentials() {
+  const fragment = fragmentParams();
+  const fingerprint = fragment.get("k");
+  const secret = fragment.get("s");
+  if (validString(fingerprint, 22) && validString(secret, 22)) {
+    return { fingerprint, secret };
+  }
+  const parts = secretInput.value.trim().split(".");
+  return parts.length === 2 && validString(parts[0], 22) && validString(parts[1], 22)
+    ? { fingerprint: parts[0], secret: parts[1] }
+    : null;
 }
 
 const encoder = new TextEncoder();
@@ -108,12 +123,15 @@ form.addEventListener("submit", async event => {
     setStatus("Enter the 8-character code shown on your Kobo.", "error");
     return;
   }
+  const credentials = pairingCredentials();
+  if (!credentials) {
+    setStatus("Enter the verification key shown on your Kobo.", "error");
+    return;
+  }
   const button = form.querySelector("button");
   button.disabled = true;
   setStatus("Linking…");
   try {
-    const fragment = fragmentParams();
-    const secret = fragment.get("s");
     const browserKey = await generateBrowserKey();
     const claimed = pairingValue(await responseJson(await fetch(
       `${RELAY}/v1/pairings/${encodeURIComponent(code)}/claim`,
@@ -122,12 +140,11 @@ form.addEventListener("submit", async event => {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           browser_public_key: browserKey.publicKey,
-          ...secret && { proof: await pairProof(secret, browserKey.publicKey) }
+          proof: await pairProof(credentials.secret, browserKey.publicKey)
         })
       }
     )));
-    const expected = fragment.get("k");
-    if (expected && !(await deviceKeyMatchesFragment(claimed.publicKey, expected))) {
+    if (!(await deviceKeyMatchesFragment(claimed.publicKey, credentials.fingerprint))) {
       throw new Error("The install service returned a key that does not match your Kobo. Nothing was linked.");
     }
     localStorage.setItem(STORAGE_KEY, JSON.stringify({
@@ -157,3 +174,7 @@ form.addEventListener("submit", async event => {
 
 const code = new URLSearchParams(location.search).get("code");
 if (code) input.value = code.toUpperCase();
+if (pairingCredentials()) {
+  secretInput.required = false;
+  secretField.hidden = true;
+}

--- a/docs/pair/pair.js
+++ b/docs/pair/pair.js
@@ -6,6 +6,36 @@ const form = document.querySelector("#pair-form");
 const input = document.querySelector("#pair-code");
 const status = document.querySelector("#pair-status");
 const next = document.querySelector("#continue");
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const BASE64URL = /^[A-Za-z0-9_-]+$/;
+
+function validString(value, length) {
+  return typeof value === "string" && value.length === length && BASE64URL.test(value);
+}
+
+function pairingValue(value) {
+  if (
+    !value
+    || typeof value !== "object"
+    || Array.isArray(value)
+    || !UUID.test(value.device_id)
+    || !validString(value.browser_token, 43)
+    || !validString(value.device_public_key, 122)
+    || typeof value.device_online !== "boolean"
+    || typeof value.device_name !== "string"
+    || value.device_name.length === 0
+    || value.device_name.length > 64
+  ) {
+    throw new Error("The install service returned an invalid pairing response.");
+  }
+  return {
+    deviceId: value.device_id,
+    browserToken: value.browser_token,
+    publicKey: value.device_public_key,
+    deviceName: value.device_name,
+    deviceOnline: value.device_online
+  };
+}
 
 function setStatus(message, tone = "") {
   if (status.textContent === message && status.dataset.tone === tone) return;
@@ -32,29 +62,29 @@ form.addEventListener("submit", async event => {
   button.disabled = true;
   setStatus("Linking…");
   try {
-    const claimed = await responseJson(await fetch(
+    const claimed = pairingValue(await responseJson(await fetch(
       `${RELAY}/v1/pairings/${encodeURIComponent(code)}/claim`,
       {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: "{}"
       }
-    ));
+    )));
     localStorage.setItem(STORAGE_KEY, JSON.stringify({
-      deviceId: claimed.device_id,
-      browserToken: claimed.browser_token,
-      publicKey: claimed.device_public_key,
-      deviceName: claimed.device_name
+      deviceId: claimed.deviceId,
+      browserToken: claimed.browserToken,
+      publicKey: claimed.publicKey,
+      deviceName: claimed.deviceName
     }));
     form.hidden = true;
     next.hidden = false;
     next.tabIndex = -1;
     next.focus();
     setStatus(
-      claimed.device_online
-        ? `${claimed.device_name} is linked.`
-        : `${claimed.device_name} is linked. Open Cobalt App Store on your Kobo to receive installs.`,
-      claimed.device_online ? "success" : "warning"
+      claimed.deviceOnline
+        ? `${claimed.deviceName} is linked.`
+        : `${claimed.deviceName} is linked. Open Cobalt App Store on your Kobo to receive installs.`,
+      claimed.deviceOnline ? "success" : "warning"
     );
   } catch (error) {
     setStatus(error.message, "error");

--- a/examples/settings/src/main.rs
+++ b/examples/settings/src/main.rs
@@ -15,6 +15,7 @@ const BATTERY: &str = "battery";
 const UPDATE: &str = "update";
 const CHECK: &str = "check";
 const INSTALL: &str = "install";
+const CLOSE: &str = "close";
 const TOGGLE: &str = "toggle";
 const RESCAN: &str = "rescan";
 const MORE: &str = "more";
@@ -274,41 +275,55 @@ impl Settings {
     fn update(&self) -> Screen {
         let mut screen = ScreenBuilder::new("settings-update")
             .top_bar("Software update")
-            .owns_back(true)
-            .section_with_value("Installed", VERSION);
+            .owns_back(true);
         match &self.update {
             UpdateFlow::Idle => {
                 screen = screen
+                    .section_with_value("Installed", VERSION)
                     .text("Checking asks GitHub for the newest published release. Nothing is downloaded until you choose to install it.")
                     .button(CHECK, "Check for updates");
             }
             UpdateFlow::Checking | UpdateFlow::Digest { .. } => {
-                screen = screen.text("Checking for the newest release.");
+                screen = screen
+                    .section_with_value("Installed", VERSION)
+                    .text("Checking for the newest release.");
             }
             UpdateFlow::UpToDate { latest } => {
                 screen = screen
+                    .section_with_value("Installed", VERSION)
                     .text(format!("{latest} is the newest published release, and it is what this reader is running."))
                     .button(CHECK, "Check again");
             }
             UpdateFlow::Ready { version, .. } => {
                 screen = screen
-                    .text(
-                        "The download is checked against its published digest before anything is replaced, and the release you are running now is kept for one step back.",
+                    .banner(
+                        kobo_sdk::BannerLevel::Info,
+                        format!("Cobalt {version} is available."),
                     )
-                    .button(INSTALL, format!("Update to {version}"));
+                    .facts([("Installed", VERSION), ("Available", version.as_str())])
+                    .text(
+                        "The package is verified before installation. The current release is kept for rollback.",
+                    )
+                    .primary_button(INSTALL, "Install update");
             }
             UpdateFlow::Installing { version } => {
-                screen = screen.text(format!(
-                    "Installing {version}. Keep the reader awake; this screen will change when it is done."
-                ));
+                screen = screen.section_with_value("Installing", version).text(
+                    "Keep the reader awake. This screen will change when installation is complete.",
+                );
             }
             UpdateFlow::Installed { version } => {
-                screen = screen.text(format!(
-                    "Updated to {version}. Close Cobalt and open it again from the menu to run the new release."
-                ));
+                screen = screen
+                    .facts([("Installed", version)])
+                    .splash(
+                        Some(Glyph::Check),
+                        "Update complete",
+                        "Close Cobalt, then reopen it from the menu.",
+                    )
+                    .primary_button(CLOSE, "Close Cobalt");
             }
             UpdateFlow::Failed(reason) => {
                 screen = screen
+                    .section_with_value("Installed", VERSION)
                     .banner(kobo_sdk::BannerLevel::Attention, reason.clone())
                     .button(CHECK, "Try again");
             }
@@ -806,6 +821,9 @@ impl KoboApp for Settings {
             self.show(context);
         } else if action == action_id(INSTALL) {
             self.install_update(context);
+        } else if action == action_id(CLOSE) && matches!(self.update, UpdateFlow::Installed { .. })
+        {
+            context.exit();
         } else if action == action_id(TOGGLE) {
             match self.view {
                 View::Bluetooth => context
@@ -939,7 +957,9 @@ impl KoboApp for Settings {
             | DeviceResult::Cover { .. }
             | DeviceResult::Audio { .. }
             | DeviceResult::Dictionary { .. }
-            | DeviceResult::Apps { .. } => {}
+            | DeviceResult::Apps { .. }
+            | DeviceResult::AppLink(_)
+            | DeviceResult::RemoteInstall(_) => {}
         }
         self.show(context);
     }
@@ -1140,8 +1160,8 @@ fn main() -> ExitCode {
 mod tests {
     use super::{RadioState, Settings, DEVICE_ACTIONS, MORE, NETWORK_ACTIONS, PREVIOUS, RESCAN};
     use kobo_sdk::{
-        action_id, BatteryDetail, BluetoothDevice, BluetoothDeviceKind, Chrome, WifiNetwork,
-        CLARA_BW_METRICS,
+        action_id, BannerLevel, BatteryDetail, BluetoothDevice, BluetoothDeviceKind, Chrome,
+        Emphasis, Glyph, Node, WifiNetwork, CLARA_BW_METRICS,
     };
 
     fn bluetooth_device(index: usize) -> BluetoothDevice {
@@ -1524,5 +1544,75 @@ mod tests {
             layout.rect_of_action(action_id(super::CHECK)).is_none(),
             "a check that is already running must not be restartable"
         );
+    }
+
+    #[test]
+    fn an_available_update_has_a_clear_status_versions_and_primary_action() {
+        let screen = Settings {
+            view: super::View::Update,
+            update: super::UpdateFlow::Ready {
+                version: "9.9.9".to_owned(),
+                url: "https://example.test/KoboRoot.tgz".to_owned(),
+                sha256: "a".repeat(64),
+            },
+            ..Settings::default()
+        }
+        .update();
+
+        assert!(screen.nodes.iter().any(|node| matches!(
+            node,
+            Node::Banner {
+                level: BannerLevel::Info,
+                text,
+                ..
+            } if text == "Cobalt 9.9.9 is available."
+        )));
+        assert!(screen.nodes.iter().any(|node| matches!(
+            node,
+            Node::Facts { entries, .. }
+                if entries == &[("Installed".to_owned(), super::VERSION.to_owned()),
+                    ("Available".to_owned(), "9.9.9".to_owned())]
+        )));
+        assert!(screen.nodes.iter().any(|node| matches!(
+            node,
+            Node::Button {
+                action,
+                label,
+                emphasis: Emphasis::Primary,
+                ..
+            } if *action == action_id(super::INSTALL) && label == "Install update"
+        )));
+    }
+
+    #[test]
+    fn a_completed_update_has_a_checkmark_and_a_primary_way_to_close() {
+        let screen = Settings {
+            view: super::View::Update,
+            update: super::UpdateFlow::Installed {
+                version: "9.9.9".to_owned(),
+            },
+            ..Settings::default()
+        }
+        .update();
+
+        assert!(screen.nodes.iter().any(|node| matches!(
+            node,
+            Node::Splash {
+                glyph: Some(Glyph::Check),
+                title,
+                summary,
+                ..
+            } if title == "Update complete"
+                && summary == "Close Cobalt, then reopen it from the menu."
+        )));
+        assert!(screen.nodes.iter().any(|node| matches!(
+            node,
+            Node::Button {
+                action,
+                label,
+                emphasis: Emphasis::Primary,
+                ..
+            } if *action == action_id(super::CLOSE) && label == "Close Cobalt"
+        )));
     }
 }

--- a/examples/store/Cargo.toml
+++ b/examples/store/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 kobo-sdk = { path = "../../crates/kobo-sdk" }
+qrcodegen = "1.8"
 
 [dev-dependencies]
 kobo-ui = { path = "../../crates/kobo-ui" }

--- a/examples/store/src/main.rs
+++ b/examples/store/src/main.rs
@@ -196,7 +196,11 @@ impl Store {
                 screen
                     .facts([
                         ("Pairing code", code.clone()),
-                        ("Address", url.clone()),
+                        (
+                            "Address",
+                            url.split_once('#')
+                                .map_or_else(|| url.clone(), |(base, _)| base.to_owned()),
+                        ),
                         (
                             "Expires",
                             format!("in {minutes} minute{}", if minutes == 1 { "" } else { "s" }),

--- a/examples/store/src/main.rs
+++ b/examples/store/src/main.rs
@@ -5,15 +5,23 @@
 //! it never receives a package URL or chooses an installation path.
 
 use kobo_sdk::{
-    action_id, ActionId, AppInfo, Context, DenyReason, DeviceRequest, DeviceResult, Glyph, KoboApp,
-    RowLead, Screen, ScreenBuilder,
+    action_id, ActionId, AppInfo, AppLinkState, Context, DenyReason, DeviceRequest, DeviceResult,
+    Glyph, Heartbeat, KoboApp, PictureHandle, RemoteInstallOutcome, RowLead, Screen, ScreenBuilder,
+    TaskId, TaskOutcome, TilePicture,
 };
+use qrcodegen::{QrCode, QrCodeEcc};
 use std::process::ExitCode;
 
 const PAGE_SIZE: usize = 5;
 const REFRESH: &str = "refresh";
+const APP_LINK: &str = "app-link";
+const BEGIN_LINK: &str = "begin-link";
+const DISCONNECT_LINK: &str = "disconnect-link";
 const PREVIOUS: &str = "previous";
 const NEXT: &str = "next";
+const QR_HANDLE: PictureHandle = PictureHandle(1);
+const QR_SCALE: u32 = 7;
+const QR_QUIET_ZONE: i32 = 4;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 enum View {
@@ -24,9 +32,9 @@ enum View {
         id: String,
         action: &'static str,
     },
+    AppLink,
 }
 
-#[derive(Default)]
 struct Store {
     entries: Vec<AppInfo>,
     view: View,
@@ -34,6 +42,29 @@ struct Store {
     refreshing: bool,
     refresh_after_cache: bool,
     notice: Option<String>,
+    app_link: AppLinkState,
+    link_poll: Heartbeat,
+    link_request_pending: bool,
+    pairing_qr: Option<TilePicture>,
+    pairing_qr_url: Option<String>,
+}
+
+impl Default for Store {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            view: View::Catalog,
+            page: 0,
+            refreshing: false,
+            refresh_after_cache: false,
+            notice: None,
+            app_link: AppLinkState::Unpaired,
+            link_poll: Heartbeat::every(5),
+            link_request_pending: false,
+            pairing_qr: None,
+            pairing_qr_url: None,
+        }
+    }
 }
 
 impl Store {
@@ -42,6 +73,7 @@ impl Store {
             View::Catalog => self.catalog(),
             View::Detail(id) => self.detail(&id),
             View::Working { id, action } => self.working(&id, action),
+            View::AppLink => self.app_link(),
         };
         context.set_screen(screen);
     }
@@ -51,7 +83,8 @@ impl Store {
         self.page = self.page.min(pages - 1);
         let mut screen = ScreenBuilder::new("store-catalog")
             .top_bar("App Store")
-            .top_bar_glyph(REFRESH, "Refresh", Glyph::Refresh);
+            .top_bar_glyph(REFRESH, "Refresh", Glyph::Refresh)
+            .top_bar_glyph(APP_LINK, "Install links", Glyph::Globe);
         if let Some(notice) = &self.notice {
             screen = screen.banner(kobo_sdk::BannerLevel::Attention, notice.clone());
         }
@@ -114,6 +147,153 @@ impl Store {
             };
         }
         screen.build()
+    }
+
+    fn app_link(&self) -> Screen {
+        let mut screen = ScreenBuilder::new("store-app-link")
+            .top_bar("Install links")
+            .owns_back(true);
+        if let Some(notice) = &self.notice {
+            screen = screen.banner(kobo_sdk::BannerLevel::Attention, notice.clone());
+        }
+        match &self.app_link {
+            AppLinkState::Unpaired => screen
+                .splash(
+                    Some(Glyph::Globe),
+                    "Link this Kobo",
+                    "Link a browser to install apps from Cobalt app pages. Requests are encrypted for this Kobo.",
+                )
+                .bottom_action_marked(
+                    if self.notice.is_some() {
+                        DISCONNECT_LINK
+                    } else {
+                        BEGIN_LINK
+                    },
+                    if self.notice.is_some() {
+                        "Reset link"
+                    } else {
+                        "Link browser"
+                    },
+                    if self.notice.is_some() {
+                        Glyph::Refresh
+                    } else {
+                        Glyph::Key
+                    },
+                )
+                .build(),
+            AppLinkState::Pairing {
+                code,
+                url,
+                expires_in,
+            } => {
+                let minutes = (*expires_in).div_ceil(60);
+                let mut screen = screen
+                    .heading("Scan or enter the code")
+                    .text("Scan the code with your phone, or open the address below and enter the pairing code.");
+                if let Some(picture) = self.pairing_qr {
+                    screen = screen.picture(picture, 58);
+                }
+                screen
+                    .facts([
+                        ("Pairing code", code.clone()),
+                        ("Address", url.clone()),
+                        (
+                            "Expires",
+                            format!("in {minutes} minute{}", if minutes == 1 { "" } else { "s" }),
+                        ),
+                    ])
+                    .bottom_action_marked(DISCONNECT_LINK, "Cancel", Glyph::Close)
+                    .build()
+            }
+            AppLinkState::Paired { browsers } => screen
+                .splash(
+                    Some(Glyph::Check),
+                    "Browser linked",
+                    "Install requests are checked while App Store is open. Requests sent while this Kobo is offline remain queued for up to 24 hours.",
+                )
+                .facts([(
+                    "Linked browsers",
+                    format!("{browsers}"),
+                )])
+                .bottom_action_marked(DISCONNECT_LINK, "Disconnect all", Glyph::Trash)
+                .build(),
+        }
+    }
+
+    fn update_link_state(&mut self, context: &mut Context, state: AppLinkState) {
+        self.link_request_pending = false;
+        match &state {
+            AppLinkState::Pairing { url, .. } if self.pairing_qr_url.as_deref() != Some(url) => {
+                self.pairing_qr = qr_picture(context, url);
+                self.pairing_qr_url = Some(url.clone());
+            }
+            AppLinkState::Pairing { .. } => {}
+            _ if self.pairing_qr.take().is_some() => {
+                context.drop_picture(QR_HANDLE);
+                self.pairing_qr_url = None;
+            }
+            _ => {}
+        }
+        self.app_link = state;
+        if matches!(
+            self.app_link,
+            AppLinkState::Pairing { .. } | AppLinkState::Paired { .. }
+        ) {
+            self.link_poll.start(context);
+        } else {
+            self.link_poll.stop(context);
+        }
+    }
+
+    fn poll_link(&mut self, context: &mut Context) {
+        if !self.link_request_pending {
+            self.link_request_pending = true;
+            context.store().poll_link();
+        }
+    }
+
+    fn handle_link_result(
+        &mut self,
+        context: &mut Context,
+        request: &DeviceRequest,
+        result: &DeviceResult,
+    ) -> bool {
+        if !matches!(
+            request,
+            DeviceRequest::ReadAppLink
+                | DeviceRequest::BeginAppLink
+                | DeviceRequest::PollAppLink
+                | DeviceRequest::DisconnectAppLink
+        ) {
+            return false;
+        }
+        match result {
+            DeviceResult::AppLink(state) => {
+                self.notice = None;
+                self.update_link_state(context, state.clone());
+                if *request == DeviceRequest::ReadAppLink
+                    && matches!(self.app_link, AppLinkState::Paired { .. })
+                {
+                    self.poll_link(context);
+                }
+            }
+            DeviceResult::RemoteInstall(outcome) if *request == DeviceRequest::PollAppLink => {
+                self.link_request_pending = false;
+                self.notice = remote_install_notice(outcome, &self.entries);
+                if !matches!(outcome, RemoteInstallOutcome::None) {
+                    context.applications().cached_catalog();
+                }
+            }
+            DeviceResult::Failed(error) => {
+                self.link_request_pending = false;
+                self.notice = Some(format!(
+                    "Install links are unavailable: {}. Connect Wi-Fi and try again.",
+                    error.describe()
+                ));
+            }
+            _ => return false,
+        }
+        true
     }
 
     fn detail(&self, id: &str) -> Screen {
@@ -241,12 +421,30 @@ impl KoboApp for Store {
         self.refresh_after_cache = true;
         self.show(context);
         context.applications().cached_catalog();
+        context.store().read_link();
     }
 
     fn on_action(&mut self, context: &mut Context, action: ActionId) {
         if action == ActionId::BACK {
             self.view = View::Catalog;
             self.show(context);
+            return;
+        }
+        if action == action_id(APP_LINK) {
+            self.view = View::AppLink;
+            self.notice = None;
+            self.show(context);
+            context.store().read_link();
+            return;
+        }
+        if action == action_id(BEGIN_LINK) {
+            self.link_request_pending = true;
+            context.store().begin_link();
+            return;
+        }
+        if action == action_id(DISCONNECT_LINK) {
+            self.link_request_pending = true;
+            context.store().disconnect_link();
             return;
         }
         if action == action_id(REFRESH) {
@@ -296,11 +494,15 @@ impl KoboApp for Store {
         request: DeviceRequest,
         result: DeviceResult,
     ) {
+        if self.handle_link_result(context, &request, &result) {
+            self.show(context);
+            return;
+        }
         let mut refresh_after_paint = false;
         match (request, result) {
             (DeviceRequest::ReadAppCatalog, DeviceResult::Apps { entries }) => {
                 self.replace_entries(entries);
-                if !matches!(self.view, View::Working { .. }) {
+                if !matches!(self.view, View::Working { .. } | View::AppLink) {
                     self.view = View::Catalog;
                 }
                 refresh_after_paint = self.refresh_after_cache;
@@ -309,7 +511,7 @@ impl KoboApp for Store {
             (DeviceRequest::RefreshAppCatalog, DeviceResult::Apps { entries }) => {
                 self.replace_entries(entries);
                 self.refreshing = false;
-                if !matches!(self.view, View::Working { .. }) {
+                if !matches!(self.view, View::Working { .. } | View::AppLink) {
                     self.notice = None;
                     self.view = View::Catalog;
                 }
@@ -347,7 +549,7 @@ impl KoboApp for Store {
                     "The catalog could not be refreshed: {}. The last verified list is still shown.",
                     error.describe()
                 ));
-                if !matches!(self.view, View::Working { .. }) {
+                if !matches!(self.view, View::Working { .. } | View::AppLink) {
                     self.view = View::Catalog;
                 }
             }
@@ -363,6 +565,7 @@ impl KoboApp for Store {
                 self.view = View::Catalog;
             }
             (_, DeviceResult::Denied(reason)) => {
+                self.link_request_pending = false;
                 self.refreshing = false;
                 self.notice = Some(denied(reason).to_owned());
                 self.view = View::Catalog;
@@ -373,6 +576,71 @@ impl KoboApp for Store {
         if refresh_after_paint {
             context.applications().refresh_catalog();
         }
+    }
+
+    fn on_task(&mut self, context: &mut Context, task: TaskId, outcome: TaskOutcome) {
+        if self.link_poll.on_task(context, task, &outcome) {
+            if matches!(
+                self.app_link,
+                AppLinkState::Pairing { .. } | AppLinkState::Paired { .. }
+            ) {
+                self.poll_link(context);
+            } else {
+                self.link_poll.stop(context);
+            }
+        }
+    }
+
+    fn on_background(&mut self, context: &mut Context) {
+        self.link_poll.stop(context);
+    }
+
+    fn on_foreground(&mut self, context: &mut Context) {
+        context.store().read_link();
+    }
+}
+
+fn qr_picture(context: &mut Context, value: &str) -> Option<TilePicture> {
+    let qr = QrCode::encode_text(value, QrCodeEcc::Medium).ok()?;
+    let side_modules = qr.size() + QR_QUIET_ZONE * 2;
+    let side = u32::try_from(side_modules).ok()?.checked_mul(QR_SCALE)?;
+    let mut grey = vec![255; usize::try_from(side.checked_mul(side)?).ok()?];
+    for y in 0..side {
+        for x in 0..side {
+            let module_x = i32::try_from(x / QR_SCALE).ok()? - QR_QUIET_ZONE;
+            let module_y = i32::try_from(y / QR_SCALE).ok()? - QR_QUIET_ZONE;
+            if qr.get_module(module_x, module_y) {
+                let offset = usize::try_from(y.checked_mul(side)?.checked_add(x)?).ok()?;
+                grey[offset] = 0;
+            }
+        }
+    }
+    context.put_picture(QR_HANDLE, side, side, grey)
+}
+
+fn remote_install_notice(outcome: &RemoteInstallOutcome, entries: &[AppInfo]) -> Option<String> {
+    let name = |id: &str| {
+        entries
+            .iter()
+            .find(|entry| entry.id == id)
+            .map_or_else(|| id.to_owned(), |entry| entry.title.clone())
+    };
+    match outcome {
+        RemoteInstallOutcome::None => None,
+        RemoteInstallOutcome::Installed { id } => {
+            Some(format!("{} installed successfully.", name(id)))
+        }
+        RemoteInstallOutcome::Updated { id } => Some(format!("{} updated successfully.", name(id))),
+        RemoteInstallOutcome::AlreadyInstalled { id } => {
+            Some(format!("{} is already installed and up to date.", name(id)))
+        }
+        RemoteInstallOutcome::Included { id } => {
+            Some(format!("{} is included with Cobalt.", name(id)))
+        }
+        RemoteInstallOutcome::Unavailable { id } => Some(format!(
+            "{} is not available in the current catalog. Nothing changed.",
+            name(id)
+        )),
     }
 }
 
@@ -459,7 +727,10 @@ mod tests {
                 _ => None,
             })
             .collect::<Vec<_>>();
-        assert_eq!(requests, vec![&DeviceRequest::ReadAppCatalog]);
+        assert_eq!(
+            requests,
+            vec![&DeviceRequest::ReadAppCatalog, &DeviceRequest::ReadAppLink]
+        );
         let commands = runner.device_result(DeviceResult::Apps {
             entries: vec![app("notes", None)],
         });
@@ -478,6 +749,7 @@ mod tests {
             paint < refresh,
             "network refresh started before cached content painted"
         );
+        runner.device_result(DeviceResult::AppLink(AppLinkState::Unpaired));
         runner.device_result(DeviceResult::Apps {
             entries: vec![app("notes", None)],
         });
@@ -491,6 +763,7 @@ mod tests {
         runner.device_result(DeviceResult::Apps {
             entries: vec![app("notes", None)],
         });
+        runner.device_result(DeviceResult::AppLink(AppLinkState::Unpaired));
         runner.device_result(DeviceResult::Apps {
             entries: vec![app("notes", None)],
         });
@@ -512,6 +785,7 @@ mod tests {
         runner.device_result(DeviceResult::Apps {
             entries: vec![app("sudoku", None)],
         });
+        runner.device_result(DeviceResult::AppLink(AppLinkState::Unpaired));
         runner.device_result(DeviceResult::Apps {
             entries: vec![app("sudoku", None)],
         });
@@ -542,6 +816,7 @@ mod tests {
         runner.device_result(DeviceResult::Apps {
             entries: vec![app("sudoku", Some("1.0.0"))],
         });
+        runner.device_result(DeviceResult::AppLink(AppLinkState::Unpaired));
         runner.device_result(DeviceResult::Apps {
             entries: vec![app("sudoku", Some("1.0.0"))],
         });
@@ -561,6 +836,7 @@ mod tests {
         runner.device_result(DeviceResult::Apps {
             entries: vec![app("notes", None)],
         });
+        runner.device_result(DeviceResult::AppLink(AppLinkState::Unpaired));
         runner.action(action_id(&app_action("notes")));
         runner.action(action_id(&install_action("notes")));
         runner.device_result(DeviceResult::Apps {
@@ -598,6 +874,7 @@ mod tests {
                 .map(|index| app(&format!("app-{index}"), Some("1.1.0")))
                 .collect(),
         });
+        runner.device_result(DeviceResult::AppLink(AppLinkState::Unpaired));
         let commands = runner.device_result(DeviceResult::Apps {
             entries: (0..14)
                 .map(|index| app(&format!("app-{index}"), Some("1.1.0")))
@@ -606,6 +883,58 @@ mod tests {
         assert!(commands
             .iter()
             .any(|command| matches!(command, Command::SetScreen(_))));
+    }
+
+    #[test]
+    fn pairing_state_draws_a_qr_code_and_starts_polling() {
+        let mut runner = AppRunner::new(Store::default());
+        runner.start();
+        runner.device_result(DeviceResult::Apps {
+            entries: vec![app("sudoku", None)],
+        });
+        let commands = runner.device_result(DeviceResult::AppLink(AppLinkState::Pairing {
+            code: "23456789".to_owned(),
+            url: "https://bandarlabs.github.io/Cobalt/pair/?code=23456789".to_owned(),
+            expires_in: 600,
+        }));
+        assert!(commands
+            .iter()
+            .any(|command| matches!(command, Command::PutPicture { .. })));
+        assert!(runner.app().link_poll.is_running());
+    }
+
+    #[test]
+    fn remote_install_outcomes_use_state_specific_messages() {
+        assert_eq!(
+            remote_install_notice(
+                &RemoteInstallOutcome::AlreadyInstalled {
+                    id: "sudoku".to_owned()
+                },
+                &[app("sudoku", Some("1.1.0"))]
+            )
+            .as_deref(),
+            Some("sudoku app is already installed and up to date.")
+        );
+        assert_eq!(
+            remote_install_notice(
+                &RemoteInstallOutcome::Included {
+                    id: "settings".to_owned()
+                },
+                &[]
+            )
+            .as_deref(),
+            Some("settings is included with Cobalt.")
+        );
+        assert_eq!(
+            remote_install_notice(
+                &RemoteInstallOutcome::Unavailable {
+                    id: "removed-app".to_owned()
+                },
+                &[]
+            )
+            .as_deref(),
+            Some("removed-app is not available in the current catalog. Nothing changed.")
+        );
     }
 
     #[test]

--- a/examples/store/src/main.rs
+++ b/examples/store/src/main.rs
@@ -187,15 +187,21 @@ impl Store {
                 expires_in,
             } => {
                 let minutes = (*expires_in).div_ceil(60);
-                let mut screen = screen
-                    .heading("Scan or enter the code")
-                    .text("Scan the code with your phone, or open the address below and enter the pairing code.");
+                let verification = pairing_verification(url).unwrap_or_else(|| "Unavailable".into());
+                let mut screen = screen.heading("Link this browser").text(
+                    "Scan the QR code. To pair manually, open the address below and enter both values.",
+                );
                 if let Some(picture) = self.pairing_qr {
                     screen = screen.picture(picture, 58);
                 }
                 screen
+                    .section("Enter manually")
+                    .splash(
+                        None,
+                        format!("{} {}", &code[..4], &code[4..]),
+                        format!("Verification key\n{verification}"),
+                    )
                     .facts([
-                        ("Pairing code", code.clone()),
                         (
                             "Address",
                             url.split_once('#')
@@ -213,7 +219,7 @@ impl Store {
                 .splash(
                     Some(Glyph::Check),
                     "Browser linked",
-                    "Install requests are checked while App Store is open. Requests sent while this Kobo is offline remain queued for up to 24 hours.",
+                    "Install requests are checked while App Store is open. Requests sent while this Kobo is offline remain queued for up to 72 hours.",
                 )
                 .facts([(
                     "Linked browsers",
@@ -622,6 +628,21 @@ fn qr_picture(context: &mut Context, value: &str) -> Option<TilePicture> {
     context.put_picture(QR_HANDLE, side, side, grey)
 }
 
+fn pairing_verification(url: &str) -> Option<String> {
+    let fragment = url.split_once('#')?.1;
+    let mut fingerprint = None;
+    let mut secret = None;
+    for entry in fragment.split('&') {
+        let (name, value) = entry.split_once('=')?;
+        match name {
+            "k" if value.len() == 22 => fingerprint = Some(value),
+            "s" if value.len() == 22 => secret = Some(value),
+            _ => {}
+        }
+    }
+    Some(format!("{}.{}", fingerprint?, secret?))
+}
+
 fn remote_install_notice(outcome: &RemoteInstallOutcome, entries: &[AppInfo]) -> Option<String> {
     let name = |id: &str| {
         entries
@@ -898,13 +919,34 @@ mod tests {
         });
         let commands = runner.device_result(DeviceResult::AppLink(AppLinkState::Pairing {
             code: "23456789".to_owned(),
-            url: "https://bandarlabs.github.io/Cobalt/pair/?code=23456789".to_owned(),
+            url: format!(
+                "https://bandarlabs.github.io/Cobalt/pair/?code=23456789#k={}&s={}",
+                "A".repeat(22),
+                "B".repeat(22)
+            ),
             expires_in: 600,
         }));
         assert!(commands
             .iter()
             .any(|command| matches!(command, Command::PutPicture { .. })));
         assert!(runner.app().link_poll.is_running());
+        let screen = runner.app().app_link();
+        let display = format!("{screen:?}");
+        assert!(display.contains("2345 6789"));
+        assert!(display.contains(&format!("{}.{}", "A".repeat(22), "B".repeat(22))));
+    }
+
+    #[test]
+    fn manual_pairing_verification_combines_the_fragment_values() {
+        assert_eq!(
+            pairing_verification(&format!(
+                "https://example.test/pair#k={}&s={}",
+                "A".repeat(22),
+                "B".repeat(22)
+            )),
+            Some(format!("{}.{}", "A".repeat(22), "B".repeat(22)))
+        );
+        assert_eq!(pairing_verification("https://example.test/pair"), None);
     }
 
     #[test]

--- a/tools/generate-app-pages.mjs
+++ b/tools/generate-app-pages.mjs
@@ -67,20 +67,9 @@ for (const app of catalog.apps) {
   <h1>${name}</h1>
   <p class="summary">${summary}</p>
   <div class="meta"><span>Version ${escape(app.version)}</span><span>${capabilities}</span></div>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">First-time setup</p>
-    <h2>New to Cobalt? Set it up once.</h2>
-    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
-      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
-    </ol>
-    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
-  </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Already using Cobalt?</p>
-    <h2>Link your Kobo</h2>
+    <p class="eyebrow">Install with Cobalt</p>
+    <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
     <form id="pair-form">
       <div class="field">
@@ -91,6 +80,17 @@ for (const app of catalog.apps) {
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
     <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">Cobalt not installed?</p>
+    <h2>Set up Cobalt first</h2>
+    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
+      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
+    </ol>
+    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/tools/generate-app-pages.mjs
+++ b/tools/generate-app-pages.mjs
@@ -1,0 +1,119 @@
+import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const catalog = JSON.parse(readFileSync(resolve(root, "apps/catalog.json"), "utf8"));
+const appsRoot = resolve(root, "docs/apps");
+for (const app of catalog.apps) {
+  if (
+    typeof app.id !== "string"
+    || app.id.length === 0
+    || app.id.length > 32
+    || !/^[a-z][a-z0-9-]*$/.test(app.id)
+    || app.id.endsWith("-")
+    || app.id.includes("--")
+  ) {
+    throw new Error(`invalid app id: ${String(app.id)}`);
+  }
+}
+const appIds = new Set(catalog.apps.map(app => app.id));
+
+mkdirSync(appsRoot, { recursive: true });
+for (const entry of readdirSync(appsRoot, { withFileTypes: true })) {
+  if (entry.isDirectory() && !appIds.has(entry.name)) {
+    rmSync(resolve(appsRoot, entry.name), { recursive: true });
+  }
+}
+
+const escape = value => value
+  .replaceAll("&", "&amp;")
+  .replaceAll("<", "&lt;")
+  .replaceAll(">", "&gt;")
+  .replaceAll('"', "&quot;");
+
+for (const app of catalog.apps) {
+  const id = escape(app.id);
+  const name = escape(app.display_name);
+  const summary = escape(app.summary);
+  const capabilities = app.capabilities.length
+    ? app.capabilities.map(escape).join(", ")
+    : "No additional permissions";
+  const canonical = `https://bandarlabs.github.io/Cobalt/apps/${id}/`;
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${name} for Cobalt</title>
+<meta name="description" content="${summary}">
+<link rel="canonical" href="${canonical}">
+<meta property="og:type" content="website">
+<meta property="og:title" content="${name} for Cobalt">
+<meta property="og:description" content="${summary}">
+<meta property="og:url" content="${canonical}">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="${name} for Cobalt">
+<meta name="twitter:description" content="${summary}">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap" data-app-id="${id}">
+  <p class="eyebrow">Kobo app</p>
+  <h1>${name}</h1>
+  <p class="summary">${summary}</p>
+  <div class="meta"><span>Version ${escape(app.version)}</span><span>${capabilities}</span></div>
+  <section class="panel setup" id="setup-panel">
+    <p class="eyebrow">First-time setup</p>
+    <h2>New to Cobalt? Set it up once.</h2>
+    <p>Cobalt adds a secure app platform without replacing the Kobo reader. The first setup uses a USB cable; after that, apps install and update over Wi-Fi.</p>
+    <ol>
+      <li>Check that your Kobo model and firmware are supported.</li>
+      <li>Connect the charged Kobo to a Mac or Linux computer and run the guided setup.</li>
+      <li>Restart, open Cobalt, and return here. You will not need the cable for future apps.</li>
+    </ol>
+    <a class="button-link" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">View the setup guide</a>
+  </section>
+  <section class="panel" id="pair-panel">
+    <p class="eyebrow">Already using Cobalt?</p>
+    <h2>Link your Kobo</h2>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <form id="pair-form">
+      <div class="field">
+        <label for="pair-code">Pairing code</label>
+        <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <button type="submit">Link Kobo</button>
+    </form>
+    <p class="status" id="pair-status" role="status" aria-live="polite"></p>
+    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
+  </section>
+  <section class="panel" id="install-panel" hidden>
+    <h2>Install on <span id="device-name">your Kobo</span></h2>
+    <p>Cobalt verifies the signed catalog and app package before changing the installed copy.</p>
+    <div class="actions">
+      <button type="button" id="install">Install ${name}</button>
+      <button type="button" id="forget" class="secondary">Forget this Kobo</button>
+    </div>
+    <p class="status" id="install-status" role="status" aria-live="polite"></p>
+  </section>
+</main>
+<script src="../install.js" defer></script>
+</body>
+</html>
+`;
+  const output = resolve(root, "docs/apps", app.id, "index.html");
+  mkdirSync(dirname(output), { recursive: true });
+  writeFileSync(output, html);
+}
+
+const home = readFileSync(resolve(root, "docs/index.html"), "utf8");
+for (const app of catalog.apps) {
+  if (!home.includes(`href="apps/${app.id}/"`)) {
+    throw new Error(`docs/index.html does not link to app page: ${app.id}`);
+  }
+}

--- a/tools/generate-app-pages.mjs
+++ b/tools/generate-app-pages.mjs
@@ -70,11 +70,15 @@ for (const app of catalog.apps) {
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
-    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code or enter the code shown there.</p>
+    <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
       <div class="field">
         <label for="pair-code">Pairing code</label>
         <input id="pair-code" name="code" inputmode="text" autocomplete="one-time-code" maxlength="8" required>
+      </div>
+      <div class="field" id="pair-secret-field">
+        <label for="pair-secret">Verification key</label>
+        <input class="secret" id="pair-secret" name="secret" inputmode="text" autocomplete="off" autocapitalize="none" spellcheck="false" maxlength="45" required>
       </div>
       <button type="submit">Link Kobo</button>
     </form>


### PR DESCRIPTION
## Summary
- add accountless QR and pairing-code installs from generated GitHub Pages app links
- keep decryption, signed-catalog resolution, install classification, replay protection, and recovery inside `kobod`
- improve Store pairing states, offline queue guidance, unpair controls, and Settings update notices

## Behavior
- first-time visitors get the one-time Cobalt USB setup path before browser pairing
- linked readers handle install, update, already installed, included, unavailable, expiry, offline, and removed-catalog states
- app requests wait up to 24 hours and resume when App Store opens

## Notes
- the deployed relay uses Cloudflare Free-plan Durable Objects; its private source and deployment configuration are not included in this branch
- `kobo app-link status|unpair --device <address>` provides host-side maintenance

## Checks
- workspace tests and strict Clippy
- browser page generation and JavaScript syntax
- relay type-check, integration tests, deployment health, and security review

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790343394&installation_model_id=20525&pr_number=61&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F61&signature=82fb26325f20f65a2a0a20cea61f5a45ed1bbcb97cc668035377294e27dffc8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->