### PR TITLE
Simplify app install pages

### DIFF
--- a/docs/apps/arxiv/index.html
+++ b/docs/apps/arxiv/index.html
@@ -41,7 +41,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
   </section>
   <section class="panel setup" id="setup-panel">
     <p class="eyebrow">Cobalt not installed?</p>

--- a/docs/apps/audiobook/index.html
+++ b/docs/apps/audiobook/index.html
@@ -41,7 +41,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
   </section>
   <section class="panel setup" id="setup-panel">
     <p class="eyebrow">Cobalt not installed?</p>

--- a/docs/apps/brief/index.html
+++ b/docs/apps/brief/index.html
@@ -41,7 +41,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
   </section>
   <section class="panel setup" id="setup-panel">
     <p class="eyebrow">Cobalt not installed?</p>

--- a/docs/apps/chat/index.html
+++ b/docs/apps/chat/index.html
@@ -41,7 +41,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
   </section>
   <section class="panel setup" id="setup-panel">
     <p class="eyebrow">Cobalt not installed?</p>

--- a/docs/apps/gallery/index.html
+++ b/docs/apps/gallery/index.html
@@ -41,7 +41,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
   </section>
   <section class="panel setup" id="setup-panel">
     <p class="eyebrow">Cobalt not installed?</p>

--- a/docs/apps/gutenbird/index.html
+++ b/docs/apps/gutenbird/index.html
@@ -41,7 +41,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
   </section>
   <section class="panel setup" id="setup-panel">
     <p class="eyebrow">Cobalt not installed?</p>

--- a/docs/apps/hn/index.html
+++ b/docs/apps/hn/index.html
@@ -41,7 +41,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
   </section>
   <section class="panel setup" id="setup-panel">
     <p class="eyebrow">Cobalt not installed?</p>

--- a/docs/apps/launcher/index.html
+++ b/docs/apps/launcher/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Launcher for Cobalt</title>
+<meta name="description" content="Opens installed apps and always keeps a route back to the Kobo reader.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/launcher/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Launcher for Cobalt">
+<meta property="og:description" content="Opens installed apps and always keeps a route back to the Kobo reader.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/launcher/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Launcher for Cobalt">
+<meta name="twitter:description" content="Opens installed apps and always keeps a route back to the Kobo reader.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self'; img-src 'self'; base-uri 'none'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap">
+  <p class="eyebrow">Cobalt system app</p>
+  <h1>Launcher</h1>
+  <p class="summary">Opens installed apps and always keeps a route back to the Kobo reader.</p>
+  <div class="meta"><span>Included with Cobalt</span></div>
+  <section class="panel setup">
+    <p class="eyebrow">No separate install needed</p>
+    <h2>Available after Cobalt setup</h2>
+    <p>Launcher is part of the Cobalt platform and is installed automatically with Cobalt. It does not need a separate App Store download.</p>
+    <a class="button-link" href="../../#install">Set up Cobalt</a>
+  </section>
+</main>
+</body>
+</html>

--- a/docs/apps/magnet/index.html
+++ b/docs/apps/magnet/index.html
@@ -41,7 +41,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
   </section>
   <section class="panel setup" id="setup-panel">
     <p class="eyebrow">Cobalt not installed?</p>

--- a/docs/apps/morse/index.html
+++ b/docs/apps/morse/index.html
@@ -41,7 +41,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
   </section>
   <section class="panel setup" id="setup-panel">
     <p class="eyebrow">Cobalt not installed?</p>

--- a/docs/apps/rss/index.html
+++ b/docs/apps/rss/index.html
@@ -41,7 +41,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
   </section>
   <section class="panel setup" id="setup-panel">
     <p class="eyebrow">Cobalt not installed?</p>

--- a/docs/apps/settings/index.html
+++ b/docs/apps/settings/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Settings for Cobalt</title>
+<meta name="description" content="Connectivity, hardware and platform updates, kept separate from Store.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/settings/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Settings for Cobalt">
+<meta property="og:description" content="Connectivity, hardware and platform updates, kept separate from Store.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/settings/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Settings for Cobalt">
+<meta name="twitter:description" content="Connectivity, hardware and platform updates, kept separate from Store.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self'; img-src 'self'; base-uri 'none'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap">
+  <p class="eyebrow">Cobalt system app</p>
+  <h1>Settings</h1>
+  <p class="summary">Connectivity, hardware and platform updates, kept separate from Store.</p>
+  <div class="meta"><span>Included with Cobalt</span></div>
+  <section class="panel setup">
+    <p class="eyebrow">No separate install needed</p>
+    <h2>Available after Cobalt setup</h2>
+    <p>Settings is part of the Cobalt platform and is installed automatically with Cobalt. It does not need a separate App Store download.</p>
+    <a class="button-link" href="../../#install">Set up Cobalt</a>
+  </section>
+</main>
+</body>
+</html>

--- a/docs/apps/sidekick/index.html
+++ b/docs/apps/sidekick/index.html
@@ -41,7 +41,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
   </section>
   <section class="panel setup" id="setup-panel">
     <p class="eyebrow">Cobalt not installed?</p>

--- a/docs/apps/store/index.html
+++ b/docs/apps/store/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>App Store for Cobalt</title>
+<meta name="description" content="Installs, updates, removes and reinstalls signed apps over Wi-Fi.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/store/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="App Store for Cobalt">
+<meta property="og:description" content="Installs, updates, removes and reinstalls signed apps over Wi-Fi.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/store/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="App Store for Cobalt">
+<meta name="twitter:description" content="Installs, updates, removes and reinstalls signed apps over Wi-Fi.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self'; img-src 'self'; base-uri 'none'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap">
+  <p class="eyebrow">Cobalt system app</p>
+  <h1>App Store</h1>
+  <p class="summary">Installs, updates, removes and reinstalls signed apps over Wi-Fi.</p>
+  <div class="meta"><span>Included with Cobalt</span></div>
+  <section class="panel setup">
+    <p class="eyebrow">No separate install needed</p>
+    <h2>Available after Cobalt setup</h2>
+    <p>App Store is part of the Cobalt platform and is installed automatically with Cobalt. It does not need a separate App Store download.</p>
+    <a class="button-link" href="../../#install">Set up Cobalt</a>
+  </section>
+</main>
+</body>
+</html>

--- a/docs/apps/sudoku/index.html
+++ b/docs/apps/sudoku/index.html
@@ -41,7 +41,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
   </section>
   <section class="panel setup" id="setup-panel">
     <p class="eyebrow">Cobalt not installed?</p>

--- a/docs/apps/terminal/index.html
+++ b/docs/apps/terminal/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Terminal for Cobalt</title>
+<meta name="description" content="A panel-native shell with keys that send input immediately.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/apps/terminal/">
+<meta property="og:type" content="website">
+<meta property="og:title" content="Terminal for Cobalt">
+<meta property="og:description" content="A panel-native shell with keys that send input immediately.">
+<meta property="og:url" content="https://bandarlabs.github.io/Cobalt/apps/terminal/">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Terminal for Cobalt">
+<meta name="twitter:description" content="A panel-native shell with keys that send input immediately.">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self'; img-src 'self'; base-uri 'none'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap">
+  <p class="eyebrow">Cobalt system app</p>
+  <h1>Terminal</h1>
+  <p class="summary">A panel-native shell with keys that send input immediately.</p>
+  <div class="meta"><span>Included with Cobalt</span></div>
+  <section class="panel setup">
+    <p class="eyebrow">No separate install needed</p>
+    <h2>Available after Cobalt setup</h2>
+    <p>Terminal is part of the Cobalt platform and is installed automatically with Cobalt. It does not need a separate App Store download.</p>
+    <a class="button-link" href="../../#install">Set up Cobalt</a>
+  </section>
+</main>
+</body>
+</html>

--- a/docs/apps/tictactoe/index.html
+++ b/docs/apps/tictactoe/index.html
@@ -41,7 +41,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
   </section>
   <section class="panel setup" id="setup-panel">
     <p class="eyebrow">Cobalt not installed?</p>

--- a/docs/apps/todo/index.html
+++ b/docs/apps/todo/index.html
@@ -41,7 +41,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
   </section>
   <section class="panel setup" id="setup-panel">
     <p class="eyebrow">Cobalt not installed?</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -374,13 +374,13 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
     <p class="measure quiet">Every screenshot below is a capture from a Kobo Clara BW. Open an app to set up Cobalt or install it on a linked reader. Cobalt is installed once over USB; later apps arrive over Wi-Fi.</p>
     <div class="apps-grid">
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/examples/launcher/README.md"><img src="media/site/apps/launcher.png" width="1072" height="1448" loading="lazy" alt="Cobalt launcher app grid on e-ink"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/examples/launcher/README.md">Launcher</a></h3>
+        <a class="shot" href="apps/launcher/"><img src="media/site/apps/launcher.png" width="1072" height="1448" loading="lazy" alt="Cobalt launcher app grid on e-ink"></a>
+        <h3><a href="apps/launcher/">Launcher</a></h3>
         <p>Opens installed apps and always keeps a route back to the Kobo reader.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/APP_STORE.md"><img src="media/site/apps/store.png" width="1072" height="1448" loading="lazy" alt="Cobalt App Store catalog listing installed and available apps"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/APP_STORE.md">App Store</a></h3>
+        <a class="shot" href="apps/store/"><img src="media/site/apps/store.png" width="1072" height="1448" loading="lazy" alt="Cobalt App Store catalog listing installed and available apps"></a>
+        <h3><a href="apps/store/">App Store</a></h3>
         <p>Installs, updates, removes and reinstalls signed apps over Wi-Fi.</p>
       </div>
       <div class="app">
@@ -434,8 +434,8 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
         <p>Approve or deny requests from coding agents, away from the keyboard.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/examples/terminal/README.md"><img src="media/site/apps/terminal.png" width="1072" height="1448" loading="lazy" alt="A shell and touch keyboard on the Kobo display"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/examples/terminal/README.md">Terminal</a></h3>
+        <a class="shot" href="apps/terminal/"><img src="media/site/apps/terminal.png" width="1072" height="1448" loading="lazy" alt="A shell and touch keyboard on the Kobo display"></a>
+        <h3><a href="apps/terminal/">Terminal</a></h3>
         <p>A panel-native shell with keys that send input immediately.</p>
       </div>
       <div class="app">
@@ -444,8 +444,8 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
         <p>The UI toolkit's controls, layouts, typography and states, on the panel.</p>
       </div>
       <div class="app">
-        <a class="shot" href="https://github.com/BandarLabs/Cobalt/blob/main/examples/settings/README.md"><img src="media/site/apps/settings.png" width="1072" height="1448" loading="lazy" alt="Battery status and hardware facts in Settings"></a>
-        <h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/examples/settings/README.md">Settings</a></h3>
+        <a class="shot" href="apps/settings/"><img src="media/site/apps/settings.png" width="1072" height="1448" loading="lazy" alt="Battery status and hardware facts in Settings"></a>
+        <h3><a href="apps/settings/">Settings</a></h3>
         <p>Connectivity, hardware, and platform updates, kept separate from Store.</p>
       </div>
       <div class="app">

--- a/tools/generate-app-pages.mjs
+++ b/tools/generate-app-pages.mjs
@@ -4,6 +4,28 @@ import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const catalog = JSON.parse(readFileSync(resolve(root, "apps/catalog.json"), "utf8"));
+const systemApps = [
+  {
+    id: "launcher",
+    display_name: "Launcher",
+    summary: "Opens installed apps and always keeps a route back to the Kobo reader."
+  },
+  {
+    id: "store",
+    display_name: "App Store",
+    summary: "Installs, updates, removes and reinstalls signed apps over Wi-Fi."
+  },
+  {
+    id: "terminal",
+    display_name: "Terminal",
+    summary: "A panel-native shell with keys that send input immediately."
+  },
+  {
+    id: "settings",
+    display_name: "Settings",
+    summary: "Connectivity, hardware and platform updates, kept separate from Store."
+  }
+];
 const appsRoot = resolve(root, "docs/apps");
 for (const app of catalog.apps) {
   if (
@@ -17,7 +39,7 @@ for (const app of catalog.apps) {
     throw new Error(`invalid app id: ${String(app.id)}`);
   }
 }
-const appIds = new Set(catalog.apps.map(app => app.id));
+const appIds = new Set([...catalog.apps, ...systemApps].map(app => app.id));
 
 mkdirSync(appsRoot, { recursive: true });
 for (const entry of readdirSync(appsRoot, { withFileTypes: true })) {
@@ -114,8 +136,55 @@ for (const app of catalog.apps) {
   writeFileSync(output, html);
 }
 
+for (const app of systemApps) {
+  const id = escape(app.id);
+  const name = escape(app.display_name);
+  const summary = escape(app.summary);
+  const canonical = `https://bandarlabs.github.io/Cobalt/apps/${id}/`;
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${name} for Cobalt</title>
+<meta name="description" content="${summary}">
+<link rel="canonical" href="${canonical}">
+<meta property="og:type" content="website">
+<meta property="og:title" content="${name} for Cobalt">
+<meta property="og:description" content="${summary}">
+<meta property="og:url" content="${canonical}">
+<meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="${name} for Cobalt">
+<meta name="twitter:description" content="${summary}">
+<meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self'; img-src 'self'; base-uri 'none'">
+<link rel="stylesheet" href="../install.css">
+</head>
+<body>
+<header><div class="wrap"><a class="brand" href="../../">Cobalt</a><a class="back" href="../../#apps">All apps</a></div></header>
+<main class="wrap">
+  <p class="eyebrow">Cobalt system app</p>
+  <h1>${name}</h1>
+  <p class="summary">${summary}</p>
+  <div class="meta"><span>Included with Cobalt</span></div>
+  <section class="panel setup">
+    <p class="eyebrow">No separate install needed</p>
+    <h2>Available after Cobalt setup</h2>
+    <p>${name} is part of the Cobalt platform and is installed automatically with Cobalt. It does not need a separate App Store download.</p>
+    <a class="button-link" href="../../#install">Set up Cobalt</a>
+  </section>
+</main>
+</body>
+</html>
+`;
+  const output = resolve(root, "docs/apps", app.id, "index.html");
+  mkdirSync(dirname(output), { recursive: true });
+  writeFileSync(output, html);
+}
+
 const home = readFileSync(resolve(root, "docs/index.html"), "utf8");
-for (const app of catalog.apps) {
+for (const app of [...catalog.apps, ...systemApps]) {
   if (!home.includes(`href="apps/${app.id}/"`)) {
     throw new Error(`docs/index.html does not link to app page: ${app.id}`);
   }

--- a/tools/generate-app-pages.mjs
+++ b/tools/generate-app-pages.mjs
@@ -83,7 +83,6 @@ for (const app of catalog.apps) {
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-    <p class="privacy">No account is required. The install request is encrypted in this browser and can only be opened by the linked Kobo.</p>
   </section>
   <section class="panel setup" id="setup-panel">
     <p class="eyebrow">Cobalt not installed?</p>


### PR DESCRIPTION
Remove the redundant privacy sentence from generated app install pages.\n\nInstallable cards on the Apps section already link to their individual install pages; built-in system surfaces remain documentation links because they are not independently installable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790370616&installation_model_id=20525&pr_number=62&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F62&signature=48c229bc1d93c84abc3622e36cd20fa3d621b67e2d90b53660e660665f8ccd4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->