### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "Cobalt",
+  "user": "ubuntu",
+  "install": "./.cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for the Cobalt Rust workspace.
+# Mirrors the toolchain the CI `host` and `device-build` jobs use so a fresh
+# agent can build, test, lint, run the browser simulator, and cross-compile
+# device binaries.
+set -euo pipefail
+
+TOOLCHAIN="1.85.1"
+ARM_TARGET="armv7-unknown-linux-musleabihf"
+
+# Pin the workspace toolchain (Cargo.toml rust-version) with the components the
+# `cargo fmt`/`cargo clippy` checks require.
+rustup toolchain install "$TOOLCHAIN" --profile minimal --component clippy,rustfmt
+rustup default "$TOOLCHAIN"
+
+# ARM hard-float musl target used for the on-device (Kobo) binaries.
+rustup target add "$ARM_TARGET"
+
+# The `ring` TLS crate and the packaging tests need an ARM cross C compiler.
+if ! command -v arm-linux-gnueabihf-gcc >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install --yes --no-install-recommends gcc-arm-linux-gnueabihf
+fi
+
+# Warm the host build cache so the first agent build and the simulator start
+# quickly. Kept out of `start` so it is not re-run on every boot.
+cargo build --workspace --locked


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Cloud Agent environment definition so a fresh agent can build, test, lint, cross-compile device binaries, and run the Clara BW browser simulator for the Cobalt workspace out of the box.

The repository previously had no `.cursor/environment.json`, and the default image ships Rust 1.83.0 while the workspace pins `rust-version = 1.85.1` (`Cargo.toml`) and the ARM device build needs a cross C compiler that is not preinstalled.

## Changes

- `.cursor/environment.json` — uses the default image, runs as `ubuntu`, and calls the install script.
- `.cursor/install.sh` — idempotent bootstrap that:
  - installs Rust `1.85.1` with `clippy` and `rustfmt` and sets it as the default toolchain (matches the CI `host`/`device-build` jobs),
  - adds the `armv7-unknown-linux-musleabihf` target,
  - installs `gcc-arm-linux-gnueabihf` (only when missing) for the `ring` TLS crate and packaging tests,
  - warms the host build cache with `cargo build --workspace --locked`.

Slow one-time setup lives in `install`; there is no always-on service, so `start`/`terminals` are intentionally omitted.

## Validation

All checks were run on the VM after applying this configuration:

| Check | Result |
| --- | --- |
| `cargo build -p kobo-cli` | Passed |
| `cargo test --workspace --all-targets --all-features` | Passed (0 failed) |
| `cargo fmt --all --check` | Passed |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | Passed |
| ARM device check (`cargo check --target armv7-unknown-linux-musleabihf`) | Passed |
| Install idempotence | Ran twice; second run fully cached |
| Headless simulator (`kobo run --sim --app sudoku`) | Rendered a full Sudoku screen |
| Browser simulator (`kobo dev --builtin`) | Live and interactive |

### Headless render of the Sudoku app

[Sudoku app rendered by the host simulator](https://cursor.com/agents/bc-adf5db00-a80b-4308-a6a5-5f5699536620/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsudoku_render.png)

### Live browser simulator (Counter app incrementing with e-ink refresh diagnostics)

[kobo_simulator_demo.mp4](https://cursor.com/agents/bc-adf5db00-a80b-4308-a6a5-5f5699536620/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkobo_simulator_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adf5db00-a80b-4308-a6a5-5f5699536620?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adf5db00-a80b-4308-a6a5-5f5699536620&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790406087&installation_model_id=20525&pr_number=64&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F64&signature=65859c06eec91ba1ac82f4367ad53ddf39f9713daba9c75d668df9a58d9706ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->