### PR TITLE
Document app evidence and source setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,13 @@ the [app request thread](https://github.com/BandarLabs/Cobalt/issues/41).
 
 ## Install
 
-Install Rust, add the ARM target and connect a charged, fully supported reader
-over USB:
+Install [rustup](https://rustup.rs), let it install the stable Rust toolchain,
+then add the ARM target and connect a charged, fully supported reader over USB.
+You do not need a separate operating-system `rust` package; rustup supplies
+`rustc` and `cargo`:
 
 ```sh
+rustup default stable
 git clone https://github.com/BandarLabs/Cobalt.git
 cd Cobalt
 rustup target add armv7-unknown-linux-musleabihf
@@ -218,7 +221,11 @@ App contributions are regular pull requests:
 2. Add its release metadata to `apps/catalog.json`.
 3. Add unit tests and layout checks for every affected supported profile.
 4. Run the app in the browser and runtime simulators.
-5. Open a pull request.
+5. Run it on a physical, fully supported Kobo and attach a GIF, video, or
+   photos to the pull request.
+6. Include one clean panel screenshot for the app README and generated website
+   install page.
+7. Open a pull request.
 
 After the PR is reviewed and merged, the `Publish apps` workflow builds every
 registered app for ARM, signs the packages and catalog, and updates the fixed

--- a/README.md
+++ b/README.md
@@ -132,9 +132,10 @@ You do not need a separate operating-system `rust` package; rustup supplies
 `rustc` and `cargo`:
 
 ```sh
-rustup default stable
+rustup toolchain install stable
 git clone https://github.com/BandarLabs/Cobalt.git
 cd Cobalt
+rustup override set stable
 rustup target add armv7-unknown-linux-musleabihf
 cargo run -p kobo-cli -- setup
 ```

--- a/SDK.md
+++ b/SDK.md
@@ -119,13 +119,19 @@ refresh planner the panel uses. Its diagnostics panel reports content past the
 fold, clipping, undersized targets and text overflow, which is where most
 first-draft screens fail.
 
-**5. Ship it.** Two registrations, both one line:
+**5. Choose how it ships.** The quickstart above creates a bundled example.
+Register one only when it is a platform-owned system app:
 
 - `INSTALLED_PACKAGES` in `crates/kobo-cli/src/main.rs`, so `package` builds it.
 - `ENTRIES` in `examples/launcher/src/main.rs`, so it gets a tile. The entry
   states what starting it costs the device, because a launcher that starts
   something without saying what it reaches for is asking the owner to find out
   afterwards.
+
+For a contributed app that owners install on demand, put it under `apps/` and
+follow [the Store contribution guide](docs/CONTRIBUTING_APPS.md). Register it in
+`STORE_PACKAGES` and `apps/catalog.json`; do not add it to `INSTALLED_PACKAGES`
+or the launcher's built-in entries.
 
 **6. Put it on the reader.** With SSH already working, no cable and no reboot:
 

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -3422,15 +3422,17 @@ fn dry_run_plan(options: &SetupOptions, reader: &setup::Mounted) -> String {
         } else if !would_stage {
             if menu::marker_stale(&reader.volume) {
                 format!(
-                    "would write a Cobalt entry to {}, and stage nothing. NickelMenu's\n\
-                     \x20 own files predate the last firmware update, though, and an update\n\
-                     \x20 removes the plugin: pass --menu to stage it again",
+                    "would write only a Cobalt entry to {}. It would not write or reinstall\n\
+                     \x20 any NickelMenu files or stage a KoboRoot.tgz. NickelMenu's own files\n\
+                     \x20 predate the last firmware update, though, and an update removes the\n\
+                     \x20 plugin: pass --menu to stage it again",
                     menu::CONFIG,
                 )
             } else {
                 format!(
-                    "would write a Cobalt entry to {}, and stage nothing, because NickelMenu\n\
-                     \x20 is already installed on this reader",
+                    "would write only a Cobalt entry to {}. It would not write or reinstall\n\
+                     \x20 any NickelMenu files or stage a KoboRoot.tgz, because NickelMenu is\n\
+                     \x20 already installed on this reader",
                     menu::CONFIG,
                 )
             }
@@ -6780,6 +6782,9 @@ mod tests {
             let parsed = parse_setup(&arguments(&["--enable-ssh", "--dry-run"])).expect("parse");
             let plan = dry_run_plan(&parsed, &reader);
             assert!(plan.contains("already installed on this reader"), "{plan}");
+            assert!(plan.contains("would not write or reinstall"), "{plan}");
+            assert!(plan.contains("any NickelMenu files"), "{plan}");
+            assert!(plan.contains("or stage a KoboRoot.tgz"), "{plan}");
             assert!(!plan.contains("stage NickelMenu"), "{plan}");
             assert!(!plan.contains("same .kobo/KoboRoot.tgz"), "{plan}");
             assert!(

--- a/docs/CONTRIBUTING_APPS.md
+++ b/docs/CONTRIBUTING_APPS.md
@@ -71,10 +71,11 @@ Every new app pull request needs two different kinds of visual evidence:
    panel capture without a bezel, hand, camera perspective, or e-ink residue.
 
 Put the clean image under `apps/<app-id>/screenshots/`, show it from
-`apps/<app-id>/README.md`, and copy the same bytes to
-`docs/media/site/apps/<app-id>.png`. Add its filename and useful alt text to
-the `screenshots` map in `tools/generate-app-pages.mjs`. A photograph attached
-to the pull request does not replace this clean checked-in image.
+`apps/<app-id>/README.md`, then choose a site filename and copy the same bytes
+to `docs/media/site/apps/<site-filename>.png`. Register that exact filename and
+useful alt text in the `screenshots` map in `tools/generate-app-pages.mjs`. A
+photograph attached to the pull request does not replace this clean checked-in
+image.
 
 Add the app's card and `apps/<app-id>/` link to `docs/index.html`, then generate
 and commit the install page and sitemap:

--- a/docs/CONTRIBUTING_APPS.md
+++ b/docs/CONTRIBUTING_APPS.md
@@ -9,6 +9,11 @@ the Cobalt platform.
 2. Name the Cargo package `kobo-<app-id>`.
 3. Add the package to the workspace members in the root `Cargo.toml`.
 4. Add one entry to `apps/catalog.json`.
+5. Add the package to `STORE_PACKAGES` in `crates/kobo-cli/src/main.rs`.
+
+Store apps are downloaded only when an owner installs them. Do not add a
+contributed app to `INSTALLED_PACKAGES` or `MANAGED_BUILTINS`; those lists put
+the binary in the Cobalt platform package and are reserved for system apps.
 
 Registry fields:
 
@@ -54,12 +59,42 @@ cargo run --manifest-path ../../crates/kobo-cli/Cargo.toml -- dev
 Layout tests should use `CLARA_BW_METRICS` and verify that controls fit, remain
 tappable, and do not move when app state changes.
 
+## Show the app running
+
+Every new app pull request needs two different kinds of visual evidence:
+
+1. Attach a GIF, video, or photos showing the app running on a physical,
+   fully supported Kobo. This is review evidence: it proves the real panel,
+   touch controls, page buttons where applicable, and return to the launcher.
+2. Check in one clean 1072×1448 panel screenshot for the app README and its
+   generated website install page. This is the product image: use a direct
+   panel capture without a bezel, hand, camera perspective, or e-ink residue.
+
+Put the clean image under `apps/<app-id>/screenshots/`, show it from
+`apps/<app-id>/README.md`, and copy the same bytes to
+`docs/media/site/apps/<app-id>.png`. Add its filename and useful alt text to
+the `screenshots` map in `tools/generate-app-pages.mjs`. A photograph attached
+to the pull request does not replace this clean checked-in image.
+
+Add the app's card and `apps/<app-id>/` link to `docs/index.html`, then generate
+and commit the install page and sitemap:
+
+```sh
+node tools/generate-app-pages.mjs
+git diff --check
+```
+
+The publish workflow runs the generator again and refuses stale generated
+files. It does not create or commit missing screenshots, homepage cards,
+install pages, or sitemap entries after merge.
+
 ## Publish or update an app
 
-Open a pull request containing the app source, tests, workspace entry, and
-registry metadata. Increment only the app's `version` when updating that app.
-A Cobalt version change is needed only when the app requires a new platform or
-SDK capability.
+Open a pull request containing the app source, tests, workspace and Store
+entries, registry metadata, README, clean screenshot, generated website files,
+and physical-device evidence. Increment only the app's `version` when updating
+that app. A Cobalt version change is needed only when the app requires a new
+platform or SDK capability.
 
 After merge to `main`, `.github/workflows/apps.yml`:
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -31,7 +31,10 @@ at.
 - **An internet connection**, and **`curl`** on your path. Setup downloads
   NickelMenu v0.6.0 (the one piece that cannot live on the book partition) and
   checks it against a recorded SHA-256.
-- [**Rust**](https://rustup.rs), stable.
+- [**rustup**](https://rustup.rs) with its stable Rust toolchain. You do not
+  need a separate operating-system `rust` package: rustup supplies `rustc` and
+  `cargo`. If rustup is installed without a default toolchain, run
+  `rustup default stable`.
 - An **ARM cross-compiler**, because the TLS stack carries C and assembly that
   is built from source. Everything else is linked by `rust-lld`, which the Rust
   toolchain already ships.
@@ -49,6 +52,7 @@ at.
 ## 1. Get the code and the cross-compilation target
 
 ```sh
+rustup default stable
 git clone https://github.com/BandarLabs/Cobalt
 cd Cobalt
 rustup target add armv7-unknown-linux-musleabihf

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -33,8 +33,8 @@ at.
   checks it against a recorded SHA-256.
 - [**rustup**](https://rustup.rs) with its stable Rust toolchain. You do not
   need a separate operating-system `rust` package: rustup supplies `rustc` and
-  `cargo`. If rustup is installed without a default toolchain, run
-  `rustup default stable`.
+  `cargo`. If stable is not installed, run `rustup toolchain install stable`;
+  the next section selects it only for this checkout.
 - An **ARM cross-compiler**, because the TLS stack carries C and assembly that
   is built from source. Everything else is linked by `rust-lld`, which the Rust
   toolchain already ships.
@@ -52,9 +52,10 @@ at.
 ## 1. Get the code and the cross-compilation target
 
 ```sh
-rustup default stable
+rustup toolchain install stable
 git clone https://github.com/BandarLabs/Cobalt
 cd Cobalt
+rustup override set stable
 rustup target add armv7-unknown-linux-musleabihf
 ```
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -670,7 +670,8 @@ cargo run -p kobo-cli -- setup</code></pre>
       <li><strong>Build it.</strong> Add the app as a workspace package under <code class="inline">apps/&lt;app-id&gt;/</code> and register it in <code class="inline">apps/catalog.json</code>.</li>
       <li><strong>Test it.</strong> Add unit and layout tests, and run it in the browser and runtime simulators.</li>
       <li><strong>Run it on your own device.</strong> A real, fully supported reader, not just the Clara-sized simulator.</li>
-      <li><strong>Open a PR with a gif or photos of it running.</strong> Once reviewed and merged, the publish workflow signs it and it appears in Store. No platform release needed.</li>
+      <li><strong>Open a PR with a GIF, video, or photos of it running.</strong> This is the physical-device review evidence.</li>
+      <li><strong>Include one clean panel screenshot.</strong> The app README and generated website install page use this checked-in image. Once reviewed and merged, the publish workflow signs the app and it appears in Store. No platform release needed.</li>
     </ol>
     <p class="measure quiet" style="margin-top:22px">Own a different Kobo? No coding is required to help test it. <a href="https://github.com/BandarLabs/Cobalt/issues">Join an existing thread for your model or create a new one</a>, then follow the <a href="https://github.com/BandarLabs/Cobalt/blob/main/CONTRIBUTING.md#device-testing">device testing guide</a>. App details are in <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/CONTRIBUTING_APPS.md">docs/CONTRIBUTING_APPS.md</a>.</p>
   </div>


### PR DESCRIPTION
## Summary

- distinguish physical-device review evidence from the clean panel screenshot used by an app README and generated install page
- document the complete website generation and Store-only registration path so contributed apps do not enter the platform package
- name rustup and its stable toolchain explicitly in source-install instructions
- replace the ambiguous dry-run phrase “stage nothing” with an explicit promise that an existing NickelMenu installation is not written or reinstalled and no KoboRoot.tgz is staged

The automatic ForceWifiOn and AutoSleepMinutes setup behavior raised in #37 is a separate behavioral concern; documenting it more prominently would not resolve the concern.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p kobo-cli` (204 passed)
- `node tools/generate-app-pages.mjs`
- `git diff --check`

Refs #37

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790664619&installation_model_id=20525&pr_number=72&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F72&signature=586e75f005946b3814763d7a6237265838c0156e4368a022e4074188f0f3f0d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->