### PR TITLE
Add a public product roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Cobalt is an open-source application platform for Kobo. It provides a launcher,
 an App Store, a Rust SDK, a runtime with capability isolation, and a Clara BW
 simulator.
 
+See the [public roadmap](ROADMAP.md) for the product outcomes Cobalt is working
+toward and the principles used to choose them.
+
 After one USB installation, users can install, update, and remove signed apps
 over Wi-Fi. App releases are independent from Cobalt platform releases, so a
 new app can appear in Store without reinstalling or updating Cobalt.
@@ -260,6 +263,7 @@ cargo run -p kobo-cli -- run --sim --app sudoku
 
 Additional guides:
 
+- [Roadmap](ROADMAP.md)
 - [Contributing](CONTRIBUTING.md)
 - [Developing Cobalt](docs/DEVELOPING.md)
 - [Working with devices](docs/DEVICES.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,117 @@
+# Cobalt roadmap
+
+Cobalt is an open-source application platform for e-readers. This roadmap
+describes the product outcomes the project is working toward. It is a statement
+of direction, not a release schedule. Priorities may change as device testing
+and community use reveal better answers.
+
+## Product principles
+
+- Keep the default experience small and understandable.
+- Make important operations recoverable.
+- Work offline wherever practical.
+- Keep user-created data portable.
+- Give applications only the access they require.
+- Build shared platform capabilities when several applications need the same
+  behavior.
+- Support only hardware that has completed the required device testing.
+
+## Now
+
+### A shared content foundation
+
+Create a safe way for applications to offer books, articles, papers, documents,
+and audio to Cobalt.
+
+The first work establishes stable content identity and an inbox contract before
+adding broader library features. It must also define how content already saved
+by current applications can be adopted without losing state or forcing a
+migration.
+
+Success means:
+
+- An application can offer content without gaining unrestricted file access.
+- Duplicate imports can be recognized.
+- Malformed or oversized content is rejected before it reaches the library.
+- An interrupted import cannot damage accepted content.
+- Existing applications continue to work while the shared foundation is
+  introduced.
+
+### Reliable daily use
+
+Strengthen recovery across suspend, wake, low storage, interrupted work, and
+application failure.
+
+Success means:
+
+- Saved content and reading state survive an unexpected interruption.
+- Failed applications cannot prevent an owner from leaving Cobalt.
+- Temporary work can be discarded safely after a restart.
+- Supported devices pass repeatable suspend and recovery checks.
+
+### Complete the reading experience
+
+Finish the reading features already under development, with an initial focus on
+search, annotations, and durable session behavior.
+
+Success means:
+
+- A reader can find text inside a book.
+- Highlights and notes survive restarts.
+- Returning to a book restores a stable reading position.
+- Reading remains available without a network connection or account.
+
+## Next
+
+### Library
+
+Provide one place to find saved books, articles, papers, documents, and audio.
+The first library should favor a small set of dependable views over elaborate
+organization features.
+
+### Wireless delivery
+
+Let owners send supported content from a computer or phone to a connected
+reader without repeating the initial Cobalt installation process.
+
+### Portable reading data
+
+Provide clear backup and export for annotations, reading state, and library
+metadata before adding multi-device synchronization.
+
+### Easier installation
+
+Reduce the tools required for the first USB installation while retaining exact
+device checks, visible changes, and a documented recovery path.
+
+## Later
+
+- Optional synchronization between devices.
+- Dictionary and vocabulary tools.
+- Private reading insights and statistics.
+- Additional document formats.
+- Owner-approved service connections.
+- More applications built and maintained by the community.
+- Support for more devices after hardware testing is complete.
+
+## Not currently planned
+
+- Replacing the device operating system or boot process.
+- Requiring a cloud account for ordinary reading.
+- Unrestricted background applications.
+- General-purpose desktop or mobile application compatibility.
+- Features that compromise recovery, battery life, or owner control.
+- Bundling every available application into the default installation.
+
+## Help shape the roadmap
+
+Cobalt develops in public. Owners and contributors can help by:
+
+- [Requesting an application or product improvement](https://github.com/BandarLabs/Cobalt/issues/26).
+- [Reporting a problem](https://github.com/BandarLabs/Cobalt/issues/new).
+- [Helping test another device model](CONTRIBUTING.md#device-testing).
+- [Building and publishing an application](docs/CONTRIBUTING_APPS.md).
+- Improving documentation, translations, tests, or device evidence.
+
+Completed work is recorded in release notes and the repository history. This
+file stays focused on work that remains useful to owners.


### PR DESCRIPTION
## Summary

- add a concise public roadmap organized as Now, Next, and Later
- define product principles, observable outcomes, and current non-goals
- link the roadmap near the README introduction and in its guide list

## Scope

The roadmap describes product direction without release dates, competitor comparisons, or implementation details. It does not change runtime behavior.

## Checks

- `git diff --check`
- checked the roadmap for competitor names and dash punctuation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790692478&installation_model_id=20525&pr_number=75&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F75&signature=6b1c81102791538bfb9da44dc5c14b63e013a5a57c9287e9f990c13a0db57856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->