### PR TITLE
Make the website owner first

### DIFF
--- a/docs/apps/arxiv/index.html
+++ b/docs/apps/arxiv/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/arxiv/index.html
+++ b/docs/apps/arxiv/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/audiobook/index.html
+++ b/docs/apps/audiobook/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/audiobook/index.html
+++ b/docs/apps/audiobook/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/brief/index.html
+++ b/docs/apps/brief/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/brief/index.html
+++ b/docs/apps/brief/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/chat/index.html
+++ b/docs/apps/chat/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/chat/index.html
+++ b/docs/apps/chat/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/gallery/index.html
+++ b/docs/apps/gallery/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/gallery/index.html
+++ b/docs/apps/gallery/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/gutenbird/index.html
+++ b/docs/apps/gutenbird/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/gutenbird/index.html
+++ b/docs/apps/gutenbird/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/hn/index.html
+++ b/docs/apps/hn/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/hn/index.html
+++ b/docs/apps/hn/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/launcher/index.html
+++ b/docs/apps/launcher/index.html
@@ -81,7 +81,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/launcher/index.html
+++ b/docs/apps/launcher/index.html
@@ -81,7 +81,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/magnet/index.html
+++ b/docs/apps/magnet/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/magnet/index.html
+++ b/docs/apps/magnet/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/morse/index.html
+++ b/docs/apps/morse/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/morse/index.html
+++ b/docs/apps/morse/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/rss/index.html
+++ b/docs/apps/rss/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/rss/index.html
+++ b/docs/apps/rss/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/settings/index.html
+++ b/docs/apps/settings/index.html
@@ -81,7 +81,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/settings/index.html
+++ b/docs/apps/settings/index.html
@@ -81,7 +81,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/sidekick/index.html
+++ b/docs/apps/sidekick/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/sidekick/index.html
+++ b/docs/apps/sidekick/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/store/index.html
+++ b/docs/apps/store/index.html
@@ -81,7 +81,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/store/index.html
+++ b/docs/apps/store/index.html
@@ -81,7 +81,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/sudoku/index.html
+++ b/docs/apps/sudoku/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/sudoku/index.html
+++ b/docs/apps/sudoku/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/terminal/index.html
+++ b/docs/apps/terminal/index.html
@@ -81,7 +81,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/terminal/index.html
+++ b/docs/apps/terminal/index.html
@@ -81,7 +81,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/tictactoe/index.html
+++ b/docs/apps/tictactoe/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/tictactoe/index.html
+++ b/docs/apps/tictactoe/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/todo/index.html
+++ b/docs/apps/todo/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/apps/todo/index.html
+++ b/docs/apps/todo/index.html
@@ -82,7 +82,7 @@
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>

--- a/docs/developers.html
+++ b/docs/developers.html
@@ -116,7 +116,6 @@ footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
 @media (min-width: 900px) {
   .intro { padding: 82px 0 76px; }
   .intro-grid { grid-template-columns: minmax(0, .9fr) minmax(360px, 1.1fr); gap: 54px; align-items: center; }
-  .testimonial { max-height: 680px; }
   .path { grid-template-columns: repeat(4, minmax(0, 1fr)); }
   .example { grid-template-columns: minmax(240px, .75fr) minmax(0, 1.25fr); gap: 56px; }
 }
@@ -155,7 +154,7 @@ footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
         </div>
       </div>
       <aside class="testimonial" aria-label="Community testimonial">
-        <blockquote class="twitter-tweet" data-theme="dark" data-dnt="true">
+        <blockquote class="twitter-tweet" data-theme="dark" data-dnt="true" data-cards="hidden">
           <p lang="en" dir="ltr">Kobo Aura 2 with Cobalt.<br><br>Running Linux on my ebook reader is so funny.<br><br>Time to hack and see how far I can go with this new toy.<br><br>First test: Hermes Agent on it. <a href="https://t.co/2gEvzD0A0O">pic.twitter.com/2gEvzD0A0O</a></p>
           <p>Marco Franzon (@mfranz_on), <a href="https://x.com/mfranz_on/status/2092370523556602367?ref_src=twsrc%5Etfw">August 25, 2026</a></p>
         </blockquote>

--- a/docs/developers.html
+++ b/docs/developers.html
@@ -48,6 +48,11 @@ nav.top a.active, nav.top a:hover { color: var(--cobalt); }
 .icon-link { display: inline-flex; align-items: center; gap: 6px; }
 .icon-link svg { width: 15px; height: 15px; flex: none; fill: currentColor; }
 .intro { padding: 48px 0; border-bottom: 1px solid var(--rule); }
+.intro-grid { display: grid; grid-template-columns: 1fr; gap: 34px; align-items: start; }
+.intro-grid > * { min-width: 0; }
+.testimonial { width: 100%; max-width: 550px; overflow: hidden; }
+.testimonial .twitter-tweet { margin: 0 !important; }
+.testimonial iframe { width: 100% !important; max-width: 550px !important; }
 .kicker {
   font-family: var(--mono); font-size: 13px; letter-spacing: .14em;
   text-transform: uppercase; color: var(--cobalt); margin-bottom: 14px;
@@ -110,6 +115,7 @@ footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
 }
 @media (min-width: 900px) {
   .intro { padding: 82px 0 76px; }
+  .intro-grid { grid-template-columns: minmax(0, .9fr) minmax(360px, 1.1fr); gap: 54px; align-items: center; }
   .path { grid-template-columns: repeat(4, minmax(0, 1fr)); }
   .example { grid-template-columns: minmax(240px, .75fr) minmax(0, 1.25fr); gap: 56px; }
 }
@@ -136,15 +142,23 @@ footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
 
 <main>
   <div class="intro">
-    <div class="wrap">
-      <p class="kicker">Build for Cobalt</p>
-      <h1>Put your idea on an e-ink screen.</h1>
-      <p class="lede">Create a Rust app, run it in our simulator, try it on a supported reader, and publish it to Cobalt Store.</p>
-      <p class="quiet">You can start without a device. Hardware testing comes after the interaction works in the simulator.</p>
-      <div class="cta">
-        <a class="btn primary" href="sdk.html#quick-start">Create an app</a>
-        <a class="btn" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/CONTRIBUTING_APPS.md">Publish an app</a>
+    <div class="wrap intro-grid">
+      <div>
+        <p class="kicker">Build for Cobalt</p>
+        <h1>Put your idea on an e-ink screen.</h1>
+        <p class="lede">Create a Rust app, run it in our simulator, try it on a supported reader, and publish it to Cobalt Store.</p>
+        <p class="quiet">You can start without a device. Hardware testing comes after the interaction works in the simulator.</p>
+        <div class="cta">
+          <a class="btn primary" href="sdk.html#quick-start">Create an app</a>
+          <a class="btn" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/CONTRIBUTING_APPS.md">Publish an app</a>
+        </div>
       </div>
+      <aside class="testimonial" aria-label="Community testimonial">
+        <blockquote class="twitter-tweet" data-theme="dark" data-dnt="true">
+          <p lang="en" dir="ltr">Kobo Aura 2 with Cobalt.<br><br>Running Linux on my ebook reader is so funny.<br><br>Time to hack and see how far I can go with this new toy.<br><br>First test: Hermes Agent on it. <a href="https://t.co/2gEvzD0A0O">pic.twitter.com/2gEvzD0A0O</a></p>
+          <p>Marco Franzon (@mfranz_on), <a href="https://x.com/mfranz_on/status/2092370523556602367?ref_src=twsrc%5Etfw">August 25, 2026</a></p>
+        </blockquote>
+      </aside>
     </div>
   </div>
 
@@ -242,5 +256,6 @@ kobo dev</code></pre>
     </nav>
   </div>
 </footer>
+<script async src="https://platform.x.com/widgets.js" charset="utf-8"></script>
 </body>
 </html>

--- a/docs/developers.html
+++ b/docs/developers.html
@@ -116,6 +116,7 @@ footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
 @media (min-width: 900px) {
   .intro { padding: 82px 0 76px; }
   .intro-grid { grid-template-columns: minmax(0, .9fr) minmax(360px, 1.1fr); gap: 54px; align-items: center; }
+  .testimonial { max-height: 680px; }
   .path { grid-template-columns: repeat(4, minmax(0, 1fr)); }
   .example { grid-template-columns: minmax(240px, .75fr) minmax(0, 1.25fr); gap: 56px; }
 }

--- a/docs/developers.html
+++ b/docs/developers.html
@@ -114,8 +114,8 @@ footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
   footer nav { margin-top: 0; }
 }
 @media (min-width: 900px) {
-  .intro { padding: 82px 0 76px; }
-  .intro-grid { grid-template-columns: minmax(0, .9fr) minmax(360px, 1.1fr); gap: 54px; align-items: center; }
+  .intro { padding: 56px 0; }
+  .intro-grid { grid-template-columns: minmax(0, .9fr) minmax(360px, 1.1fr); gap: 54px; align-items: start; }
   .path { grid-template-columns: repeat(4, minmax(0, 1fr)); }
   .example { grid-template-columns: minmax(240px, .75fr) minmax(0, 1.25fr); gap: 56px; }
 }
@@ -154,7 +154,7 @@ footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
         </div>
       </div>
       <aside class="testimonial" aria-label="Community testimonial">
-        <blockquote class="twitter-tweet" data-theme="dark" data-dnt="true" data-cards="hidden">
+        <blockquote class="twitter-tweet" data-theme="dark" data-dnt="true">
           <p lang="en" dir="ltr">Kobo Aura 2 with Cobalt.<br><br>Running Linux on my ebook reader is so funny.<br><br>Time to hack and see how far I can go with this new toy.<br><br>First test: Hermes Agent on it. <a href="https://t.co/2gEvzD0A0O">pic.twitter.com/2gEvzD0A0O</a></p>
           <p>Marco Franzon (@mfranz_on), <a href="https://x.com/mfranz_on/status/2092370523556602367?ref_src=twsrc%5Etfw">August 25, 2026</a></p>
         </blockquote>

--- a/docs/developers.html
+++ b/docs/developers.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Build for Cobalt</title>
-<meta name="description" content="Create, test, and publish apps for Cobalt on supported e-readers.">
+<meta name="description" content="Create a Rust app, run it in the Cobalt simulator, and publish it for supported e-readers.">
 <link rel="canonical" href="https://bandarlabs.github.io/Cobalt/developers.html">
 <link rel="icon" href="logo.svg" type="image/svg+xml">
 <style>
@@ -121,11 +121,11 @@ footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
     <div class="wrap">
       <p class="kicker">Build for Cobalt</p>
       <h1>Put your idea on an e-ink screen.</h1>
-      <p class="lede">Create a Rust app, run it in a browser, try it on a supported reader, and publish it to Cobalt Store.</p>
+      <p class="lede">Create a Rust app, run it in our simulator, try it on a supported reader, and publish it to Cobalt Store.</p>
       <p class="quiet">You can start without a device. Hardware testing comes after the interaction works in the simulator.</p>
       <div class="cta">
         <a class="btn primary" href="sdk.html#quick-start">Create an app</a>
-        <a class="btn" href="CONTRIBUTING_APPS.md">Publish an app</a>
+        <a class="btn" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/CONTRIBUTING_APPS.md">Publish an app</a>
       </div>
     </div>
   </div>
@@ -135,7 +135,7 @@ footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
       <h2>From idea to Store</h2>
       <div class="path">
         <div class="step"><b>1. Create</b><p>Start from the app template and build one useful screen.</p></div>
-        <div class="step"><b>2. Run</b><p>Use the browser simulator for quick interaction and failure-state checks.</p></div>
+        <div class="step"><b>2. Run</b><p>Use the Cobalt simulator for quick interaction and failure-state checks.</p></div>
         <div class="step"><b>3. Test</b><p>Confirm the final interface and device behavior on supported hardware.</p></div>
         <div class="step"><b>4. Publish</b><p>Submit the app for review and independent Store delivery.</p></div>
       </div>
@@ -151,8 +151,8 @@ kobo dev</code></pre>
       <h2>Developer pages</h2>
       <div class="resources">
         <div class="resource"><h3><a href="sdk.html">SDK reference</a></h3><p>Application lifecycle, interface components, services, capabilities, commands, and limits.</p></div>
-        <div class="resource"><h3><a href="CONTRIBUTING_APPS.md">Publish an app</a></h3><p>Repository layout, review requirements, screenshots, tests, and Store submission.</p></div>
-        <div class="resource"><h3><a href="DEVICES.md">Test on a reader</a></h3><p>Supported devices, connection steps, diagnostics, and hardware evidence.</p></div>
+        <div class="resource"><h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/CONTRIBUTING_APPS.md">Publish an app</a></h3><p>Repository layout, review requirements, screenshots, tests, and Store submission.</p></div>
+        <div class="resource"><h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md">Test on a reader</a></h3><p>Supported devices, connection steps, diagnostics, and hardware evidence.</p></div>
         <div class="resource"><h3><a href="APP_STORE.md">Store format</a></h3><p>Signed packages, the public catalog, updates, rollback behavior, and release flow.</p></div>
       </div>
     </div>
@@ -165,8 +165,8 @@ kobo dev</code></pre>
     <nav>
       <a href="index.html">For owners</a>
       <a href="sdk.html">SDK reference</a>
-      <a href="CONTRIBUTING_APPS.md">Contribute an app</a>
-      <a href="https://github.com/BandarLabs/Cobalt/issues">Issues</a>
+      <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/CONTRIBUTING_APPS.md">Contribute an app</a>
+      <a href="https://github.com/BandarLabs/Cobalt/issues">Report an issue</a>
     </nav>
   </div>
 </footer>

--- a/docs/developers.html
+++ b/docs/developers.html
@@ -114,6 +114,7 @@ footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
 @media (min-width: 900px) {
   .intro { padding: 56px 0; }
   .intro-grid { grid-template-columns: minmax(0, .9fr) minmax(360px, 1.1fr); gap: 54px; align-items: start; }
+  .intro-grid > div:first-child { padding-top: 56px; }
   .path { grid-template-columns: repeat(4, minmax(0, 1fr)); }
   .example { grid-template-columns: minmax(240px, .75fr) minmax(0, 1.25fr); gap: 56px; }
 }

--- a/docs/developers.html
+++ b/docs/developers.html
@@ -76,10 +76,20 @@ h2 { font-size: 30px; line-height: 1.12; margin-bottom: 18px; }
 .resource h3 { margin-bottom: 7px; font-size: 20px; }
 .resource a { color: var(--ink); }
 .resource a:hover { color: var(--cobalt); }
+.example { display: grid; grid-template-columns: 1fr; gap: 28px; align-items: start; }
+.example > * { min-width: 0; }
+.example p { color: var(--ink-soft); }
+.example p + p { margin-top: 14px; }
 pre {
   margin-top: 24px; padding: 16px 18px; overflow-wrap: anywhere;
   white-space: pre-wrap; border-left: 3px solid var(--cobalt);
   background: var(--ink); color: #e8e2d4; font: 13px/1.6 var(--mono);
+}
+pre .kw { color: #8fb4ff; }
+pre .str { color: #c9b98a; }
+code.inline {
+  padding: 2px 6px; border: 1px solid var(--rule); background: var(--paper-deep);
+  font: .82em var(--mono);
 }
 footer { padding: 42px 0 48px; color: #fff; background: var(--cobalt); font-size: 15px; }
 footer a { color: #fff; text-decoration: underline; text-underline-offset: 3px; }
@@ -101,6 +111,7 @@ footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
 @media (min-width: 900px) {
   .intro { padding: 82px 0 76px; }
   .path { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .example { grid-template-columns: minmax(240px, .75fr) minmax(0, 1.25fr); gap: 56px; }
 }
 </style>
 </head>
@@ -150,6 +161,60 @@ footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
 kobo new my-app
 cd my-app
 kobo dev</code></pre>
+    </div>
+  </section>
+
+  <section>
+    <div class="wrap example">
+      <div>
+        <h2>An app is one Rust file.</h2>
+        <p>Implement <code class="inline">KoboApp</code>, draw the current screen, and handle named actions.</p>
+        <p>This counter has one value and one button. Run it with <code class="inline">kobo dev</code>, then add only the services the app needs.</p>
+        <p><a href="sdk.html#quick-start">Continue with the SDK reference</a></p>
+      </div>
+<pre><code><span class="kw">use</span> kobo_sdk::{
+    action_id, ActionId, Context,
+    KoboApp, ScreenBuilder,
+};
+
+#[derive(Default)]
+<span class="kw">struct</span> Counter { taps: u32 }
+
+<span class="kw">impl</span> KoboApp <span class="kw">for</span> Counter {
+    <span class="kw">fn</span> on_start(&amp;<span class="kw">mut</span> self, ctx: &amp;<span class="kw">mut</span> Context) {
+        self.show(ctx);
+    }
+
+    <span class="kw">fn</span> on_action(
+        &amp;<span class="kw">mut</span> self,
+        ctx: &amp;<span class="kw">mut</span> Context,
+        action: ActionId,
+    ) {
+        <span class="kw">if</span> action == action_id(<span class="str">"tap"</span>) {
+            self.taps += 1;
+        }
+        self.show(ctx);
+    }
+}
+
+<span class="kw">impl</span> Counter {
+    <span class="kw">fn</span> show(&amp;self, ctx: &amp;<span class="kw">mut</span> Context) {
+        ctx.set_screen(
+            ScreenBuilder::new(<span class="str">"counter"</span>)
+                .top_bar(<span class="str">"Counter"</span>)
+                .heading(format!(<span class="str">"{} taps"</span>, self.taps))
+                .primary_button(<span class="str">"tap"</span>, <span class="str">"Tap"</span>)
+                .build(),
+        );
+    }
+}
+
+<span class="kw">fn</span> main() {
+    <span class="kw">let</span> _ = kobo_sdk::run(
+        <span class="str">"counter"</span>,
+        Counter::default(),
+    );
+}</code></pre>
     </div>
   </section>
 

--- a/docs/developers.html
+++ b/docs/developers.html
@@ -45,6 +45,8 @@ nav.top {
 }
 nav.top a { color: var(--ink); white-space: nowrap; }
 nav.top a.active, nav.top a:hover { color: var(--cobalt); }
+.icon-link { display: inline-flex; align-items: center; gap: 6px; }
+.icon-link svg { width: 15px; height: 15px; flex: none; fill: currentColor; }
 .intro { padding: 48px 0; border-bottom: 1px solid var(--rule); }
 .kicker {
   font-family: var(--mono); font-size: 13px; letter-spacing: .14em;
@@ -111,7 +113,12 @@ footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
       <a class="active" href="developers.html">Developers</a>
       <a href="sdk.html">SDK reference</a>
       <a href="faq.html">FAQ</a>
-      <a href="https://github.com/BandarLabs/Cobalt">GitHub</a>
+      <a class="icon-link" href="https://github.com/BandarLabs/Cobalt">
+        <svg viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.49c-2.23.49-2.7-1.08-2.7-1.08-.37-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.22 2.2.82A7.66 7.66 0 0 1 8 3.72a7.7 7.7 0 0 1 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.08-1.88 3.75-3.66 3.95.29.25.54.74.54 1.5v2.32c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"/>
+        </svg>
+        GitHub
+      </a>
     </nav>
   </div>
 </header>

--- a/docs/developers.html
+++ b/docs/developers.html
@@ -220,7 +220,7 @@ kobo dev</code></pre>
 
   <section>
     <div class="wrap">
-      <h2>Developer pages</h2>
+      <h2>Documentation</h2>
       <div class="resources">
         <div class="resource"><h3><a href="sdk.html">SDK reference</a></h3><p>Application lifecycle, interface components, services, capabilities, commands, and limits.</p></div>
         <div class="resource"><h3><a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/CONTRIBUTING_APPS.md">Publish an app</a></h3><p>Repository layout, review requirements, screenshots, tests, and Store submission.</p></div>

--- a/docs/developers.html
+++ b/docs/developers.html
@@ -53,14 +53,6 @@ nav.top a.active, nav.top a:hover { color: var(--cobalt); }
 .testimonial { width: 100%; max-width: 550px; overflow: hidden; }
 .testimonial .twitter-tweet { margin: 0 !important; }
 .testimonial iframe { width: 100% !important; max-width: 550px !important; }
-.kicker {
-  font-family: var(--mono); font-size: 13px; letter-spacing: .14em;
-  text-transform: uppercase; color: var(--cobalt); margin-bottom: 14px;
-}
-.kicker::before {
-  content: ""; display: inline-block; width: 9px; height: 9px;
-  margin-right: 10px; background: var(--cobalt);
-}
 h1 { font-size: 38px; line-height: 1.06; letter-spacing: -.015em; max-width: 13em; }
 .lede { margin-top: 20px; max-width: 38em; font-size: 20px; }
 .quiet { margin-top: 10px; color: var(--ink-soft); max-width: 43em; }
@@ -72,6 +64,12 @@ h1 { font-size: 38px; line-height: 1.06; letter-spacing: -.015em; max-width: 13e
 .btn:hover { color: var(--paper); background: var(--ink); text-decoration: none; }
 .btn.primary { color: #fff; background: var(--cobalt); border-color: var(--cobalt); }
 .btn.primary:hover { background: var(--cobalt-deep); border-color: var(--cobalt-deep); }
+.hero-start { margin-top: 34px; max-width: 34em; }
+.hero-start > p {
+  color: var(--ink-soft); font: 12px/1.4 var(--mono);
+  letter-spacing: .12em; text-transform: uppercase;
+}
+.hero-start pre { margin-top: 10px; }
 section { padding: 48px 0; border-bottom: 1px solid var(--rule); }
 h2 { font-size: 30px; line-height: 1.12; margin-bottom: 18px; }
 .path, .resources { display: grid; grid-template-columns: 1fr; gap: 1px; background: var(--rule); border: 1px solid var(--rule); }
@@ -144,13 +142,19 @@ footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
   <div class="intro">
     <div class="wrap intro-grid">
       <div>
-        <p class="kicker">Build for Cobalt</p>
         <h1>Put your idea on an e-ink screen.</h1>
         <p class="lede">Create a Rust app, run it in our simulator, try it on a supported reader, and publish it to Cobalt Store.</p>
         <p class="quiet">You can start without a device. Hardware testing comes after the interaction works in the simulator.</p>
         <div class="cta">
           <a class="btn primary" href="sdk.html#quick-start">Create an app</a>
           <a class="btn" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/CONTRIBUTING_APPS.md">Publish an app</a>
+        </div>
+        <div class="hero-start">
+          <p>Start in the simulator</p>
+<pre><code>cargo install --path crates/kobo-cli
+kobo new my-app
+cd my-app
+kobo dev</code></pre>
         </div>
       </div>
       <aside class="testimonial" aria-label="Community testimonial">
@@ -171,10 +175,6 @@ footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
         <div class="step"><b>3. Test</b><p>Confirm the final interface and device behavior on supported hardware.</p></div>
         <div class="step"><b>4. Publish</b><p>Submit the app for review and independent Store delivery.</p></div>
       </div>
-<pre><code>cargo install --path crates/kobo-cli
-kobo new my-app
-cd my-app
-kobo dev</code></pre>
     </div>
   </section>
 

--- a/docs/developers.html
+++ b/docs/developers.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Build for Cobalt</title>
+<meta name="description" content="Create, test, and publish apps for Cobalt on supported e-readers.">
+<link rel="canonical" href="https://bandarlabs.github.io/Cobalt/developers.html">
+<link rel="icon" href="logo.svg" type="image/svg+xml">
+<style>
+:root {
+  --paper: #f6f2ea;
+  --paper-deep: #eee8db;
+  --ink: #1b1813;
+  --ink-soft: #5a5347;
+  --rule: #d9d1c0;
+  --cobalt: #1a41a8;
+  --cobalt-deep: #143283;
+  --serif: "Charter", "Iowan Old Style", "Palatino", "Georgia", serif;
+  --mono: "SF Mono", "Menlo", "Consolas", monospace;
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html { max-width: 100%; overflow-x: hidden; }
+body {
+  background: var(--paper) url("media/site/grain.png") repeat;
+  background-size: 128px 128px;
+  background-blend-mode: multiply;
+  color: var(--ink);
+  font-family: var(--serif);
+  font-size: 17px;
+  line-height: 1.58;
+  border-top: 5px solid var(--cobalt);
+  max-width: 100%; overflow-x: hidden;
+}
+a { color: var(--cobalt); text-decoration: none; }
+a:hover { text-decoration: underline; text-underline-offset: 3px; }
+.wrap { width: 100%; max-width: 1080px; margin: 0 auto; padding: 0 18px; }
+header { border-bottom: 1px solid var(--ink); padding: 14px 0; }
+header .wrap { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.brand { display: flex; align-items: center; color: var(--ink); }
+.brand img { width: auto; height: 34px; }
+nav.top {
+  display: flex; width: 100%; gap: 18px; overflow-x: auto;
+  padding-bottom: 4px; font-size: 15px; scrollbar-width: thin;
+}
+nav.top a { color: var(--ink); white-space: nowrap; }
+nav.top a.active, nav.top a:hover { color: var(--cobalt); }
+.intro { padding: 48px 0; border-bottom: 1px solid var(--rule); }
+.kicker {
+  font-family: var(--mono); font-size: 13px; letter-spacing: .14em;
+  text-transform: uppercase; color: var(--cobalt); margin-bottom: 14px;
+}
+.kicker::before {
+  content: ""; display: inline-block; width: 9px; height: 9px;
+  margin-right: 10px; background: var(--cobalt);
+}
+h1 { font-size: 38px; line-height: 1.06; letter-spacing: -.015em; max-width: 13em; }
+.lede { margin-top: 20px; max-width: 38em; font-size: 20px; }
+.quiet { margin-top: 10px; color: var(--ink-soft); max-width: 43em; }
+.cta { display: grid; grid-template-columns: 1fr; gap: 10px; margin-top: 28px; }
+.btn {
+  display: block; padding: 12px 16px; border: 1.5px solid var(--ink);
+  color: var(--ink); text-align: center;
+}
+.btn:hover { color: var(--paper); background: var(--ink); text-decoration: none; }
+.btn.primary { color: #fff; background: var(--cobalt); border-color: var(--cobalt); }
+.btn.primary:hover { background: var(--cobalt-deep); border-color: var(--cobalt-deep); }
+section { padding: 48px 0; border-bottom: 1px solid var(--rule); }
+h2 { font-size: 30px; line-height: 1.12; margin-bottom: 18px; }
+.path, .resources { display: grid; grid-template-columns: 1fr; gap: 1px; background: var(--rule); border: 1px solid var(--rule); }
+.step, .resource { padding: 22px 20px; background: var(--paper); }
+.step b { display: block; margin-bottom: 8px; font-size: 19px; }
+.step p, .resource p { color: var(--ink-soft); font-size: 16px; }
+.resource h3 { margin-bottom: 7px; font-size: 20px; }
+.resource a { color: var(--ink); }
+.resource a:hover { color: var(--cobalt); }
+pre {
+  margin-top: 24px; padding: 16px 18px; overflow-wrap: anywhere;
+  white-space: pre-wrap; border-left: 3px solid var(--cobalt);
+  background: var(--ink); color: #e8e2d4; font: 13px/1.6 var(--mono);
+}
+footer { padding: 42px 0 48px; color: #fff; background: var(--cobalt); font-size: 15px; }
+footer a { color: #fff; text-decoration: underline; text-underline-offset: 3px; }
+footer nav { display: flex; flex-wrap: wrap; gap: 16px 20px; margin-top: 20px; }
+@media (min-width: 620px) {
+  .wrap { padding-left: 24px; padding-right: 24px; }
+  header { padding: 18px 0; }
+  header .wrap { justify-content: space-between; flex-wrap: nowrap; }
+  nav.top { width: auto; overflow: visible; padding: 0; }
+  .intro, section { padding: 68px 0; }
+  h1 { font-size: 50px; }
+  .cta { display: flex; flex-wrap: wrap; }
+  .btn { display: inline-block; padding: 11px 20px; }
+  .path { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .resources { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  footer .wrap { display: flex; justify-content: space-between; align-items: center; gap: 24px; }
+  footer nav { margin-top: 0; }
+}
+@media (min-width: 900px) {
+  .intro { padding: 82px 0 76px; }
+  .path { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+}
+</style>
+</head>
+<body>
+<header>
+  <div class="wrap">
+    <a class="brand" href="index.html"><img src="logo.svg" alt="Cobalt" width="81" height="34"></a>
+    <nav class="top">
+      <a href="index.html">Home</a>
+      <a class="active" href="developers.html">Developers</a>
+      <a href="sdk.html">SDK reference</a>
+      <a href="faq.html">FAQ</a>
+      <a href="https://github.com/BandarLabs/Cobalt">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <div class="intro">
+    <div class="wrap">
+      <p class="kicker">Build for Cobalt</p>
+      <h1>Put your idea on an e-ink screen.</h1>
+      <p class="lede">Create a Rust app, run it in a browser, try it on a supported reader, and publish it to Cobalt Store.</p>
+      <p class="quiet">You can start without a device. Hardware testing comes after the interaction works in the simulator.</p>
+      <div class="cta">
+        <a class="btn primary" href="sdk.html#quick-start">Create an app</a>
+        <a class="btn" href="CONTRIBUTING_APPS.md">Publish an app</a>
+      </div>
+    </div>
+  </div>
+
+  <section>
+    <div class="wrap">
+      <h2>From idea to Store</h2>
+      <div class="path">
+        <div class="step"><b>1. Create</b><p>Start from the app template and build one useful screen.</p></div>
+        <div class="step"><b>2. Run</b><p>Use the browser simulator for quick interaction and failure-state checks.</p></div>
+        <div class="step"><b>3. Test</b><p>Confirm the final interface and device behavior on supported hardware.</p></div>
+        <div class="step"><b>4. Publish</b><p>Submit the app for review and independent Store delivery.</p></div>
+      </div>
+<pre><code>cargo install --path crates/kobo-cli
+kobo new my-app
+cd my-app
+kobo dev</code></pre>
+    </div>
+  </section>
+
+  <section>
+    <div class="wrap">
+      <h2>Developer pages</h2>
+      <div class="resources">
+        <div class="resource"><h3><a href="sdk.html">SDK reference</a></h3><p>Application lifecycle, interface components, services, capabilities, commands, and limits.</p></div>
+        <div class="resource"><h3><a href="CONTRIBUTING_APPS.md">Publish an app</a></h3><p>Repository layout, review requirements, screenshots, tests, and Store submission.</p></div>
+        <div class="resource"><h3><a href="DEVICES.md">Test on a reader</a></h3><p>Supported devices, connection steps, diagnostics, and hardware evidence.</p></div>
+        <div class="resource"><h3><a href="APP_STORE.md">Store format</a></h3><p>Signed packages, the public catalog, updates, rollback behavior, and release flow.</p></div>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer>
+  <div class="wrap">
+    <p>Cobalt · AGPL-3.0 · <a href="https://github.com/BandarLabs/Cobalt">BandarLabs/Cobalt</a></p>
+    <nav>
+      <a href="index.html">For owners</a>
+      <a href="sdk.html">SDK reference</a>
+      <a href="CONTRIBUTING_APPS.md">Contribute an app</a>
+      <a href="https://github.com/BandarLabs/Cobalt/issues">Issues</a>
+    </nav>
+  </div>
+</footer>
+</body>
+</html>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -180,7 +180,7 @@ footer nav { display: flex; gap: 20px; flex-wrap: wrap; }
     <a class="brand" href="index.html"><img src="logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top">
       <a href="index.html">Home</a>
-      <a href="sdk.html">SDK</a>
+      <a href="sdk.html">Developers</a>
       <a class="active" href="faq.html">FAQ</a>
       <a href="INSTALL.md">Install</a>
       <a href="https://github.com/BandarLabs/Cobalt">GitHub</a>
@@ -243,7 +243,7 @@ footer nav { display: flex; gap: 20px; flex-wrap: wrap; }
     <p>Cobalt · AGPL-3.0 · <a href="https://github.com/BandarLabs/Cobalt">BandarLabs/Cobalt</a></p>
     <nav>
       <a href="index.html">Home</a>
-      <a href="sdk.html">SDK docs</a>
+      <a href="sdk.html">Developers</a>
       <a href="https://www.reddit.com/r/CobaltForKobo/">Community</a>
       <a href="INSTALL.md">Install</a>
       <a href="https://github.com/BandarLabs/Cobalt/blob/main/SECURITY.md">Security</a>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -180,7 +180,7 @@ footer nav { display: flex; gap: 20px; flex-wrap: wrap; }
     <a class="brand" href="index.html"><img src="logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top">
       <a href="index.html">Home</a>
-      <a href="sdk.html">Developers</a>
+      <a href="developers.html">Developers</a>
       <a class="active" href="faq.html">FAQ</a>
       <a href="INSTALL.md">Install</a>
       <a href="https://github.com/BandarLabs/Cobalt">GitHub</a>
@@ -243,7 +243,7 @@ footer nav { display: flex; gap: 20px; flex-wrap: wrap; }
     <p>Cobalt · AGPL-3.0 · <a href="https://github.com/BandarLabs/Cobalt">BandarLabs/Cobalt</a></p>
     <nav>
       <a href="index.html">Home</a>
-      <a href="sdk.html">Developers</a>
+      <a href="developers.html">Developers</a>
       <a href="https://www.reddit.com/r/CobaltForKobo/">Community</a>
       <a href="INSTALL.md">Install</a>
       <a href="https://github.com/BandarLabs/Cobalt/blob/main/SECURITY.md">Security</a>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -118,6 +118,8 @@ header.masthead { border-bottom: 1px solid var(--ink); padding: 18px 0; }
 nav.top { display: flex; gap: 24px; font-size: 16px; flex-wrap: wrap; }
 nav.top a { color: var(--ink); }
 nav.top a.active, nav.top a:hover { color: var(--cobalt); }
+.icon-link { display: inline-flex; align-items: center; gap: 6px; }
+.icon-link svg { width: 15px; height: 15px; flex: none; fill: currentColor; }
 main { padding-top: 68px; padding-bottom: 86px; }
 .intro { padding-bottom: 52px; border-bottom: 1px solid var(--ink); }
 .kicker {
@@ -183,7 +185,12 @@ footer nav { display: flex; gap: 20px; flex-wrap: wrap; }
       <a href="developers.html">Developers</a>
       <a class="active" href="faq.html">FAQ</a>
       <a href="INSTALL.md">Install</a>
-      <a href="https://github.com/BandarLabs/Cobalt">GitHub</a>
+      <a class="icon-link" href="https://github.com/BandarLabs/Cobalt">
+        <svg viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.49c-2.23.49-2.7-1.08-2.7-1.08-.37-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.22 2.2.82A7.66 7.66 0 0 1 8 3.72a7.7 7.7 0 0 1 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.08-1.88 3.75-3.66 3.95.29.25.54.74.54 1.5v2.32c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"/>
+        </svg>
+        GitHub
+      </a>
     </nav>
   </div>
 </header>

--- a/docs/index.html
+++ b/docs/index.html
@@ -403,14 +403,14 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
       <div class="tested-devices">
         <h3>Tested devices</h3>
         <ol>
-          <li>Kobo Clara BW N365</li>
+          <li>Kobo Clara BW N365 / P365</li>
           <li>Kobo Clara Colour N367</li>
           <li>Kobo Elipsa 2E N605</li>
           <li>Kobo Clara HD N249</li>
           <li>Kobo Libra 2 N418</li>
           <li>Kobo Libra Colour N428</li>
         </ol>
-        <p>The 2025 Clara BW P365 refresh is also supported after matching the tested N365 hardware and firmware. More devices are coming. To help test yours, <a href="https://github.com/BandarLabs/Cobalt/issues">join an existing device thread or create a new one</a>.</p>
+        <p>More devices are coming. To help test yours, <a href="https://github.com/BandarLabs/Cobalt/issues">join an existing device thread or create a new one</a>.</p>
       </div>
     </div>
   </div>
@@ -418,7 +418,6 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
 
 <section id="why-cobalt">
   <div class="wrap">
-    <p class="kicker">Why Cobalt</p>
     <h2 class="measure">More freedom without giving up your reader.</h2>
     <p class="measure quiet">Cobalt adds a place for useful e-ink apps while keeping the reading experience and library already on the device.</p>
     <div class="reasons">
@@ -444,8 +443,8 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
 
 <section id="field">
   <div class="wrap">
-    <h2 class="measure">Read papers. Answer requests. Stay on the reader.</h2>
-    <p class="measure quiet">Read complete papers with sections, mathematics, tables, and figures. When work needs a simple decision, answer it from the same screen. Every photograph below is from a supported device.</p>
+    <h2 class="measure">Read research papers, manage Claude &amp; Codex.</h2>
+    <p class="measure quiet">Read complete papers with sections, mathematics, tables, and figures. When work needs a simple decision, answer it from the same screen.</p>
     <div class="field-grid">
       <figure>
         <img src="media/site/arxiv-preprint-kobo-clara-bw.jpg" width="1000" height="1333" loading="lazy"
@@ -481,8 +480,8 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
 <section id="apps">
   <div class="wrap">
     <p class="kicker">Apps</p>
-    <h2 class="measure">The apps.</h2>
-    <p class="measure quiet">Every screenshot below is a capture from a Kobo Clara BW. Open an app to set up Cobalt or install it on a linked reader. Cobalt is installed once over USB; later apps arrive over Wi-Fi.</p>
+    <h2 class="measure">Some of the current apps.</h2>
+    <p class="measure quiet">You can install new apps from the Cobalt App Store over Wi-Fi.</p>
     <div class="apps-grid">
       <div class="app">
         <a class="shot" href="apps/launcher/"><img src="media/site/apps/launcher.png" width="1072" height="1448" loading="lazy" alt="Cobalt launcher app grid on e-ink"></a>
@@ -616,7 +615,7 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
     <div class="measure">
       <p class="kicker">Create</p>
       <h2>Make the app you wish this screen had.</h2>
-      <p>Start a Rust app, run it in the browser simulator, test it on a supported reader, and submit it to Store. An app can ship without waiting for a Cobalt platform release.</p>
+      <p>Start a Rust app, run it in the Cobalt simulator, test it on a supported reader, and submit it to Store. An app can ship without waiting for a Cobalt platform release.</p>
       <div class="cta" style="margin-top:26px">
         <a class="btn primary" href="developers.html">Build for Cobalt</a>
         <a class="btn" href="sdk.html">SDK reference</a>
@@ -658,7 +657,7 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
       <text x="110" y="304" text-anchor="middle" font-family="ui-monospace, monospace" font-size="10" fill="currentColor" letter-spacing="1">FIG. 1 CLARA BW N365</text>
     </svg>
     <p class="kicker">Install</p>
-    <h2 class="measure">One USB installation.</h2>
+    <h2 class="measure">How to install</h2>
     <ol class="steps">
       <li><strong>Charge a fully supported reader</strong> and connect it over USB. The Clara BW N365, Clara Colour N367, Elipsa 2E N605, Clara HD N249, Libra 2 N418, and Libra Colour N428 are fully tested at the exact versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>.</li>
       <li><strong>Run the setup:</strong></li>
@@ -671,7 +670,7 @@ cargo run -p kobo-cli -- setup</code></pre>
       <li><strong>Restart the reader</strong> and open <strong>Cobalt</strong> from Kobo's menu.</li>
       <li><strong>Open Store.</strong> Everything from here on arrives over Wi-Fi.</li>
     </ol>
-    <p class="measure quiet" style="margin-top:22px">The 2025 Clara BW P365 (device code 395) hardware refresh is also supported: its measured panel, touch, firmware, and kernel facts match the attended-tested N365 Clara BW. The complete walkthrough, including recovery steps, is in <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">docs/INSTALL.md</a>.</p>
+    <p class="measure quiet" style="margin-top:22px">The complete walkthrough, including recovery steps, is in <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">docs/INSTALL.md</a>.</p>
   </div>
 </section>
 
@@ -680,7 +679,7 @@ cargo run -p kobo-cli -- setup</code></pre>
     <p class="kicker">Safety</p>
     <h2>Your original reader stays available.</h2>
     <p>Cobalt does not replace Kobo's boot chain. Normal panel-write entry points require an exact hardware and firmware match, and a reboot returns to the stock reader. The first installation does modify files on the user storage partition, and it is provided without warranty.</p>
-    <p>The Clara BW N365, Clara BW P365 refresh, Clara Colour N367, Elipsa 2E N605, Clara HD N249, Libra 2 N418, and Libra Colour N428 profiles are supported at the exact firmware and kernel versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>. P365 support inherits the attended N365 evidence after its read-only doctor report matched the same panel, touch, firmware, and kernel. Other identity or firmware combinations remain unsupported until separately verified. Cobalt is an independent project, not affiliated with Rakuten Kobo.</p>
+    <p>The Clara BW N365 / P365, Clara Colour N367, Elipsa 2E N605, Clara HD N249, Libra 2 N418, and Libra Colour N428 profiles are supported at the exact firmware and kernel versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>. Other identity or firmware combinations remain unsupported until separately verified. Cobalt is an independent project, not affiliated with Rakuten Kobo.</p>
   </div>
 </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,21 +3,21 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Cobalt: apps and an SDK for Kobo e-readers</title>
-<meta name="description" content="Cobalt is an open-source app platform for Kobo e-readers: a launcher, a signed App Store, a Rust SDK, and a capability-isolated runtime. One USB install; every app after that arrives over Wi-Fi.">
+<title>Cobalt: apps for Kobo e-readers</title>
+<meta name="description" content="Install useful apps on a supported Kobo e-reader. Set up Cobalt once over USB, then add, update, and remove apps over Wi-Fi.">
 <link rel="canonical" href="https://bandarlabs.github.io/Cobalt/">
 <link rel="icon" href="logo.svg" type="image/svg+xml">
 <meta property="og:type" content="website">
-<meta property="og:title" content="Cobalt: apps and an SDK for Kobo e-readers">
-<meta property="og:description" content="A launcher, a signed App Store, a Rust SDK, and a capability-isolated runtime for supported Kobo e-readers. Install once over USB; everything after that arrives over Wi-Fi.">
+<meta property="og:title" content="Cobalt: apps for Kobo e-readers">
+<meta property="og:description" content="Install useful apps on a supported Kobo e-reader. Set up Cobalt once over USB, then add, update, and remove apps over Wi-Fi.">
 <meta property="og:url" content="https://bandarlabs.github.io/Cobalt/">
 <meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:alt" content="The Cobalt launcher on a Kobo Clara BW: Settings, App Store, Terminal, AI Chat, Audiobooks, Components, Daily Brief, Feeds and Gutenbird.">
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Cobalt: apps and an SDK for Kobo e-readers">
-<meta name="twitter:description" content="A launcher, a signed App Store, a Rust SDK, and a capability-isolated runtime for supported Kobo e-readers.">
+<meta name="twitter:title" content="Cobalt: apps for Kobo e-readers">
+<meta name="twitter:description" content="Install useful apps on a supported Kobo e-reader, then manage them over Wi-Fi.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
 <script type="application/ld+json">
 {
@@ -311,11 +311,10 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
     </a>
     <nav class="top">
       <a href="#apps">Apps</a>
-      <a href="sdk.html">SDK</a>
+      <a href="sdk.html">Developers</a>
       <a href="faq.html">FAQ</a>
       <a href="#store">Store</a>
       <a href="#install">Install</a>
-      <a href="#contributing">Contributing</a>
       <a class="icon-link" href="https://github.com/BandarLabs/Cobalt">
         <svg viewBox="0 0 16 16" aria-hidden="true">
           <path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.49c-2.23.49-2.7-1.08-2.7-1.08-.37-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.22 2.2.82A7.66 7.66 0 0 1 8 3.72a7.7 7.7 0 0 1 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.08-1.88 3.75-3.66 3.95.29.25.54.74.54 1.5v2.32c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"/>
@@ -366,8 +365,8 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
       <figcaption>Recorded on-device at 3× speed. <a href="cobalt-tour.mp4">Watch as video.</a></figcaption>
     </figure>
     <div class="measure">
-      <h2>Running on a Kobo.</h2>
-      <p>Every app is a static ARM binary running as its own unprivileged process on stock hardware. The App Store installs, updates and removes them over Wi-Fi, with signatures verified before anything launches.</p>
+      <h2>More to do on the reader.</h2>
+      <p>Read books and papers, follow feeds, play a game, listen to audio, or check a task without changing devices. Install only the apps you want, then update or remove them over Wi-Fi.</p>
       <div class="tested-devices">
         <h3>Tested devices</h3>
         <ol>
@@ -386,8 +385,8 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
 
 <section id="field">
   <div class="wrap">
-    <h2 class="measure">arXiv papers and coding agents, on the panel.</h2>
-    <p class="measure quiet">These are photographs of the device, not simulator captures. The arXiv app reads the HTML rendering arXiv publishes for every paper since December 2023: abstracts, sections, math and result tables, paginated for the panel.</p>
+    <h2 class="measure">Read papers. Answer requests. Stay on the reader.</h2>
+    <p class="measure quiet">Read complete papers with sections, mathematics, tables, and figures. When work needs a simple decision, answer it from the same screen. Every photograph below is from a supported device.</p>
     <div class="field-grid">
       <figure>
         <img src="media/site/arxiv-preprint-kobo-clara-bw.jpg" width="1000" height="1333" loading="lazy"
@@ -535,77 +534,15 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
   </div>
 </section>
 
-<section id="sdk">
-  <div class="wrap sdk">
-    <div class="measure">
-      <p class="kicker">The SDK</p>
-      <h2>An app is one Rust file.</h2>
-      <p>Implement <code class="inline">KoboApp</code>, describe screens declaratively, and the runtime handles layout, e-ink refresh planning, Back navigation and lifecycle.</p>
-      <p>Apps don't open device resources; they ask. Network, storage, audio, frontlight and Wi-Fi are capability-gated, and a refusal comes back as a value the app can handle.</p>
-      <dl class="sdk-list">
-        <div><dt>E-ink UI</dt><dd>Text, tiles, dialogs, keyboards, pagination, partial refresh planning</dd></div>
-        <div><dt>Simulators</dt><dd>Browser and runtime simulators with layout diagnostics</dd></div>
-        <div><dt>Async work</dt><dd>HTTPS, ranged downloads, cancellable tasks, scheduled wakes</dd></div>
-        <div><dt>State</dt><dd>Atomic per-app keyed storage</dd></div>
-        <div><dt>Shipping</dt><dd>Signed static ARMv7 binaries, published when an app PR merges</dd></div>
-      </dl>
-<pre style="margin-top:26px"><code>kobo new my-app
-<span class="k">cd</span> my-app
-kobo dev</code></pre>
-      <p style="margin-top:18px"><a href="sdk.html">Read the SDK docs</a></p>
-    </div>
-    <div>
-<pre><code><span class="k">use</span> kobo_sdk::{
-    ActionId, Context, KoboApp, ScreenBuilder,
-};
-
-#[derive(Default)]
-<span class="k">struct</span> Hello { taps: u32 }
-
-<span class="k">impl</span> KoboApp <span class="k">for</span> Hello {
-    <span class="k">fn</span> on_start(&amp;<span class="k">mut</span> <span class="k">self</span>, ctx: &amp;<span class="k">mut</span> Context) {
-        <span class="k">self</span>.show(ctx);
-    }
-
-    <span class="k">fn</span> on_action(
-        &amp;<span class="k">mut</span> <span class="k">self</span>, ctx: &amp;<span class="k">mut</span> Context, a: ActionId,
-    ) {
-        <span class="k">if</span> a == kobo_sdk::action_id(<span class="s">"tap"</span>) {
-            <span class="k">self</span>.taps += 1;
-        }
-        <span class="k">self</span>.show(ctx);
-    }
-}
-
-<span class="k">impl</span> Hello {
-    <span class="k">fn</span> show(&amp;<span class="k">self</span>, ctx: &amp;<span class="k">mut</span> Context) {
-        <span class="k">let</span> screen = ScreenBuilder::new(<span class="s">"hello"</span>)
-            .top_bar(<span class="s">"Hello"</span>)
-            .heading(format!(<span class="s">"{} taps"</span>, <span class="k">self</span>.taps))
-            .button(<span class="s">"tap"</span>, <span class="s">"Tap me"</span>)
-            .build();
-        ctx.set_screen(screen);
-    }
-}
-
-<span class="k">fn</span> main() {
-    <span class="k">let</span> app = Hello::default();
-    <span class="k">let</span> _ = kobo_sdk::run(<span class="s">"hello"</span>, app);
-}</code></pre>
-    </div>
-  </div>
-</section>
-
 <section id="store">
   <div class="wrap store">
     <div class="measure">
       <p class="kicker">The Store</p>
-      <h2>Signed packages, verified before launch.</h2>
-      <p>Store reads a signed catalog from a fixed GitHub release. Each package holds one ARM executable and a signed canonical manifest. The runtime verifies the catalog, the package, the installed manifest and the binary before an app runs.</p>
-      <p>App releases are independent of platform releases: merging an app PR builds it for ARM, signs it, and updates the catalog. No Cobalt version bump, no reinstall. The app simply appears in Store.</p>
-      <p>The Cobalt platform itself also updates over Wi-Fi, through Settings, on a channel separate from the app catalog. The USB cable is only ever needed once.</p>
-      <p class="quiet">Install and catalog transactions are recovery-safe; an interrupted update leaves the reader with the version it had.</p>
-      <p style="margin-top:20px"><a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/CONTRIBUTING_APPS.md">Publish your own app →</a></p>
+      <h2>Add an app without reconnecting USB.</h2>
+      <p>Browse available apps on the reader, install one over Wi-Fi, and remove it when you no longer want it. App updates arrive without reinstalling Cobalt.</p>
+      <p>Every package is checked before it opens. An interrupted install or update leaves the working version in place.</p>
+      <p class="quiet">Cobalt updates remain separate from app updates, so the Store cannot replace the platform itself.</p>
+      <p style="margin-top:20px"><a href="sdk.html">Build and publish an app</a></p>
     </div>
     <figure>
       <img src="media/store-demo.gif" width="430" height="580" loading="lazy"
@@ -644,7 +581,7 @@ kobo dev</code></pre>
       <text x="110" y="304" text-anchor="middle" font-family="ui-monospace, monospace" font-size="10" fill="currentColor" letter-spacing="1">FIG. 1 CLARA BW N365</text>
     </svg>
     <p class="kicker">Install</p>
-    <h2 class="measure">Installing from source.</h2>
+    <h2 class="measure">One USB installation.</h2>
     <ol class="steps">
       <li><strong>Charge a fully supported reader</strong> and connect it over USB. The Clara BW N365, Clara Colour N367, Elipsa 2E N605, Clara HD N249, Libra 2 N418, and Libra Colour N428 are fully tested at the exact versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>.</li>
       <li><strong>Run the setup:</strong></li>
@@ -661,26 +598,10 @@ cargo run -p kobo-cli -- setup</code></pre>
   </div>
 </section>
 
-<section id="contributing">
-  <div class="wrap">
-    <p class="kicker">Contributing</p>
-    <h2 class="measure">Contribute an app.</h2>
-    <p class="measure quiet">App contributions are regular pull requests. If it runs on your device and the PR shows it running, it gets merged and published.</p>
-    <ol class="steps" style="margin-top:26px">
-      <li><strong>Build it.</strong> Add the app as a workspace package under <code class="inline">apps/&lt;app-id&gt;/</code> and register it in <code class="inline">apps/catalog.json</code>.</li>
-      <li><strong>Test it.</strong> Add unit and layout tests, and run it in the browser and runtime simulators.</li>
-      <li><strong>Run it on your own device.</strong> A real, fully supported reader, not just the Clara-sized simulator.</li>
-      <li><strong>Open a PR with a GIF, video, or photos of it running.</strong> This is the physical-device review evidence.</li>
-      <li><strong>Include one clean panel screenshot.</strong> The app README and generated website install page use this checked-in image. Once reviewed and merged, the publish workflow signs the app and it appears in Store. No platform release needed.</li>
-    </ol>
-    <p class="measure quiet" style="margin-top:22px">Own a different Kobo? No coding is required to help test it. <a href="https://github.com/BandarLabs/Cobalt/issues">Join an existing thread for your model or create a new one</a>, then follow the <a href="https://github.com/BandarLabs/Cobalt/blob/main/CONTRIBUTING.md#device-testing">device testing guide</a>. App details are in <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/CONTRIBUTING_APPS.md">docs/CONTRIBUTING_APPS.md</a>.</p>
-  </div>
-</section>
-
 <section class="safety">
   <div class="wrap measure">
     <p class="kicker">Safety</p>
-    <h2>Device support and safety.</h2>
+    <h2>Your original reader stays available.</h2>
     <p>Cobalt does not replace Kobo's boot chain. Normal panel-write entry points require an exact hardware and firmware match, and a reboot returns to the stock reader. The first installation does modify files on the user storage partition, and it is provided without warranty.</p>
     <p>The Clara BW N365, Clara BW P365 refresh, Clara Colour N367, Elipsa 2E N605, Clara HD N249, Libra 2 N418, and Libra Colour N428 profiles are supported at the exact firmware and kernel versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>. P365 support inherits the attended N365 evidence after its read-only doctor report matched the same panel, touch, firmware, and kernel. Other identity or firmware combinations remain unsupported until separately verified. Cobalt is an independent project, not affiliated with Rakuten Kobo.</p>
   </div>
@@ -693,7 +614,7 @@ cargo run -p kobo-cli -- setup</code></pre>
       <p>Cobalt · AGPL-3.0 · <a href="https://github.com/BandarLabs/Cobalt">BandarLabs/Cobalt</a></p>
     </div>
     <nav>
-      <a href="sdk.html">SDK docs</a>
+      <a href="sdk.html">Developers</a>
       <a href="faq.html">FAQ</a>
       <a href="https://www.reddit.com/r/CobaltForKobo/">Community</a>
       <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Install</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -50,7 +50,7 @@
   --mono: "SF Mono", "Menlo", "Consolas", monospace;
 }
 * { margin: 0; padding: 0; box-sizing: border-box; }
-html { scroll-behavior: smooth; }
+html { scroll-behavior: smooth; max-width: 100%; overflow-x: hidden; }
 body {
   background: var(--paper) url("media/site/grain.png") repeat;
   background-size: 128px 128px;
@@ -61,6 +61,7 @@ body {
   line-height: 1.55;
   -webkit-font-smoothing: antialiased;
   border-top: 5px solid var(--cobalt);
+  max-width: 100%; overflow-x: hidden;
 }
 ::selection { background: var(--cobalt); color: var(--paper); }
 a { color: var(--cobalt); text-decoration: none; }
@@ -278,7 +279,7 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
   pre { font-size: 12px; padding: 16px 18px; white-space: pre-wrap; word-break: break-word; }
   .hero .wrap, .tour, .sdk, .store { grid-template-columns: 1fr; gap: 40px; }
   .suggest-app { grid-template-columns: 1fr; }
-  .field-grid { grid-template-columns: 1fr 1fr; }
+  .field-grid { grid-template-columns: 1fr; }
   .field-wide { grid-template-columns: 1fr; }
   .tested-devices ol { grid-template-columns: 1fr; }
   section { padding: 56px 0; }
@@ -291,14 +292,35 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
   .device-engraving { display: none; }
 }
 @media (max-width: 520px) {
-  .field-grid { grid-template-columns: 1fr; }
+  .wrap { padding-left: 18px; padding-right: 18px; }
   header.masthead { padding: 14px 0; }
-  .masthead .wrap { gap: 12px; }
-  nav.top { gap: 14px; flex-wrap: wrap; font-size: 15px; }
-  .btn { padding: 11px 16px; font-size: 16px; }
+  .masthead .wrap { align-items: center; gap: 12px; }
+  nav.top {
+    width: 100%; gap: 18px; flex-wrap: nowrap; overflow-x: auto;
+    padding-bottom: 4px; font-size: 15px; scrollbar-width: thin;
+  }
+  nav.top a { white-space: nowrap; }
+  .hero { padding: 28px 0 42px; }
+  .hero h1 { font-size: 38px; }
+  .cta { display: grid; grid-template-columns: 1fr; gap: 10px; }
+  .btn { padding: 12px 16px; font-size: 16px; text-align: center; }
   .hero-proof span { display: block; }
   .hero-proof span + span { margin-top: 3px; }
   .hero-proof span + span::before { content: none; }
+  .facts .wrap { display: block; padding-top: 12px; padding-bottom: 12px; }
+  .facts span { display: block; white-space: normal; }
+  .facts span + span { margin-top: 3px; }
+  .facts span + span::before { content: none; }
+  section { padding: 48px 0; }
+  .apps-grid { gap: 30px; margin-top: 34px; }
+  .suggest-app { margin-top: 38px; padding: 22px 20px; }
+  .install pre {
+    margin-left: -18px; margin-right: -18px; padding: 16px 18px;
+    border-left-width: 3px;
+  }
+  footer { padding: 42px 0 48px; }
+  footer .wrap { display: block; }
+  footer nav { margin-top: 22px; }
 }
 </style>
 </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -479,7 +479,6 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
 
 <section id="apps">
   <div class="wrap">
-    <p class="kicker">Apps</p>
     <h2 class="measure">Some of the current apps.</h2>
     <p class="measure quiet">You can install new apps from the Cobalt App Store over Wi-Fi.</p>
     <div class="apps-grid">
@@ -595,7 +594,6 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
 <section id="store">
   <div class="wrap store">
     <div class="measure">
-      <p class="kicker">The Store</p>
       <h2>Add an app without reconnecting USB.</h2>
       <p>Browse available apps on the reader, install one over Wi-Fi, and remove it when you no longer want it. App updates arrive without reinstalling Cobalt.</p>
       <p>Every package is checked before it opens. An interrupted install or update leaves the working version in place.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -611,7 +611,6 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
 <section id="build">
   <div class="wrap sdk">
     <div class="measure">
-      <p class="kicker">Create</p>
       <h2>Make the app you wish this screen had.</h2>
       <p>Start a Rust app, run it in the Cobalt simulator, test it on a supported reader, and submit it to Store. An app can ship without waiting for a Cobalt platform release.</p>
       <div class="cta" style="margin-top:26px">
@@ -654,7 +653,6 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
       <line x1="190" y1="278" x2="190" y2="286" stroke="currentColor" stroke-width="0.5"/>
       <text x="110" y="304" text-anchor="middle" font-family="ui-monospace, monospace" font-size="10" fill="currentColor" letter-spacing="1">FIG. 1 CLARA BW N365</text>
     </svg>
-    <p class="kicker">Install</p>
     <h2 class="measure">How to install</h2>
     <ol class="steps">
       <li><strong>Charge a fully supported reader</strong> and connect it over USB. The Clara BW N365, Clara Colour N367, Elipsa 2E N605, Clara HD N249, Libra 2 N418, and Libra Colour N428 are fully tested at the exact versions in the <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">device support matrix</a>.</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -398,7 +398,7 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
       <figcaption>Recorded on-device at 3× speed. <a href="cobalt-tour.mp4">Watch as video.</a></figcaption>
     </figure>
     <div class="measure">
-      <h2>More to do on the reader.</h2>
+      <h2>More to do on your Kobo.</h2>
       <p>Read books and papers, follow feeds, play a game, listen to audio, or check a task without changing devices. Install only the apps you want, then update or remove them over Wi-Fi.</p>
       <div class="tested-devices">
         <h3>Tested devices</h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -198,6 +198,16 @@ p.quiet { color: var(--ink-soft); }
 .suggest-app h3 { font-size: 24px; line-height: 1.2; margin-bottom: 8px; }
 .suggest-app p { color: var(--ink-soft); max-width: 43em; font-size: 16px; }
 
+/* ---------- reasons ---------- */
+.reasons {
+  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px; margin-top: 36px; border: 1px solid var(--rule);
+  background: var(--rule);
+}
+.reason { padding: 28px; background: var(--paper); }
+.reason h3 { font-size: 20px; line-height: 1.2; margin-bottom: 9px; }
+.reason p { color: var(--ink-soft); font-size: 16px; }
+
 /* ---------- SDK ---------- */
 .hero .wrap > *, .tour > *, .sdk > *, .store > * { min-width: 0; }
 .sdk { display: grid; grid-template-columns: 1fr 1fr; gap: 64px; align-items: start; }
@@ -279,6 +289,7 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
   pre { font-size: 12px; padding: 16px 18px; white-space: pre-wrap; word-break: break-word; }
   .hero .wrap, .tour, .sdk, .store { grid-template-columns: 1fr; gap: 40px; }
   .suggest-app { grid-template-columns: 1fr; }
+  .reasons { grid-template-columns: 1fr; }
   .field-grid { grid-template-columns: 1fr; }
   .field-wide { grid-template-columns: 1fr; }
   .tested-devices ol { grid-template-columns: 1fr; }
@@ -333,7 +344,7 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
     </a>
     <nav class="top">
       <a href="#apps">Apps</a>
-      <a href="sdk.html">Developers</a>
+      <a href="developers.html">Developers</a>
       <a href="faq.html">FAQ</a>
       <a href="#store">Store</a>
       <a href="#install">Install</a>
@@ -400,6 +411,32 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
           <li>Kobo Libra Colour N428</li>
         </ol>
         <p>The 2025 Clara BW P365 refresh is also supported after matching the tested N365 hardware and firmware. More devices are coming. To help test yours, <a href="https://github.com/BandarLabs/Cobalt/issues">join an existing device thread or create a new one</a>.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="why-cobalt">
+  <div class="wrap">
+    <p class="kicker">Why Cobalt</p>
+    <h2 class="measure">More freedom without giving up your reader.</h2>
+    <p class="measure quiet">Cobalt adds a place for useful e-ink apps while keeping the reading experience and library already on the device.</p>
+    <div class="reasons">
+      <div class="reason">
+        <h3>Keep the reader you bought</h3>
+        <p>Open Cobalt from the reader's menu, use an app, then return to the original reader. A restart always returns there too.</p>
+      </div>
+      <div class="reason">
+        <h3>Install apps on the device</h3>
+        <p>After one USB setup, browse, install, update, and remove apps over Wi-Fi. You do not need to reconnect a cable for every app.</p>
+      </div>
+      <div class="reason">
+        <h3>Choose only what belongs</h3>
+        <p>Apps are separate choices, not a bundle you must accept. Remove one without disturbing the others or reinstalling Cobalt.</p>
+      </div>
+      <div class="reason">
+        <h3>Made for an e-ink screen</h3>
+        <p>Large touch targets, deliberate refreshes, readable type, and simple screens make the device feel like itself rather than a small tablet.</p>
       </div>
     </div>
   </div>
@@ -564,12 +601,30 @@ footer nav { display: flex; gap: 22px; flex-wrap: wrap; }
       <p>Browse available apps on the reader, install one over Wi-Fi, and remove it when you no longer want it. App updates arrive without reinstalling Cobalt.</p>
       <p>Every package is checked before it opens. An interrupted install or update leaves the working version in place.</p>
       <p class="quiet">Cobalt updates remain separate from app updates, so the Store cannot replace the platform itself.</p>
-      <p style="margin-top:20px"><a href="sdk.html">Build and publish an app</a></p>
+      <p style="margin-top:20px"><a href="developers.html">Build and publish an app</a></p>
     </div>
     <figure>
       <img src="media/store-demo.gif" width="430" height="580" loading="lazy"
            alt="The Cobalt App Store installing an app over Wi-Fi on a Kobo Clara BW">
       <figcaption>Sudoku arriving over Wi-Fi.</figcaption>
+    </figure>
+  </div>
+</section>
+
+<section id="build">
+  <div class="wrap sdk">
+    <div class="measure">
+      <p class="kicker">Create</p>
+      <h2>Make the app you wish this screen had.</h2>
+      <p>Start a Rust app, run it in the browser simulator, test it on a supported reader, and submit it to Store. An app can ship without waiting for a Cobalt platform release.</p>
+      <div class="cta" style="margin-top:26px">
+        <a class="btn primary" href="developers.html">Build for Cobalt</a>
+        <a class="btn" href="sdk.html">SDK reference</a>
+      </div>
+    </div>
+    <figure>
+      <img src="media/site/apps/components.png" width="1072" height="1448" loading="lazy" alt="Cobalt interface controls and typography rendered on an e-ink screen">
+      <figcaption>The component gallery on a supported reader.</figcaption>
     </figure>
   </div>
 </section>
@@ -636,7 +691,7 @@ cargo run -p kobo-cli -- setup</code></pre>
       <p>Cobalt · AGPL-3.0 · <a href="https://github.com/BandarLabs/Cobalt">BandarLabs/Cobalt</a></p>
     </div>
     <nav>
-      <a href="sdk.html">Developers</a>
+      <a href="developers.html">Developers</a>
       <a href="faq.html">FAQ</a>
       <a href="https://www.reddit.com/r/CobaltForKobo/">Community</a>
       <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Install</a>

--- a/docs/sdk.html
+++ b/docs/sdk.html
@@ -198,7 +198,8 @@ footer nav { display: flex; gap: 20px; flex-wrap: wrap; }
     <a class="brand" href="index.html"><img src="logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top">
       <a href="index.html">Home</a>
-      <a class="active" href="sdk.html">Developers</a>
+      <a href="developers.html">Developers</a>
+      <a class="active" href="sdk.html">SDK reference</a>
       <a href="faq.html">FAQ</a>
       <a href="APP_STORE.md">App Store</a>
       <a href="INSTALL.md">Install</a>

--- a/docs/sdk.html
+++ b/docs/sdk.html
@@ -3,12 +3,12 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Cobalt SDK documentation</title>
+<title>Build apps for Cobalt</title>
 <meta name="description" content="Developer documentation for building Kobo e-reader applications with the Cobalt Rust SDK: UI components, lifecycle, runtime services, capabilities, companion crates, testing and shipping.">
 <link rel="canonical" href="https://bandarlabs.github.io/Cobalt/sdk.html">
 <link rel="icon" href="logo.svg" type="image/svg+xml">
 <meta property="og:type" content="website">
-<meta property="og:title" content="Cobalt SDK documentation">
+<meta property="og:title" content="Build apps for Cobalt">
 <meta property="og:description" content="Build declarative, capability-isolated Rust applications for Kobo e-readers.">
 <meta property="og:url" content="https://bandarlabs.github.io/Cobalt/sdk.html">
 <meta property="og:image" content="https://bandarlabs.github.io/Cobalt/media/site/og-card.jpg">
@@ -198,7 +198,7 @@ footer nav { display: flex; gap: 20px; flex-wrap: wrap; }
     <a class="brand" href="index.html"><img src="logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top">
       <a href="index.html">Home</a>
-      <a class="active" href="sdk.html">SDK</a>
+      <a class="active" href="sdk.html">Developers</a>
       <a href="faq.html">FAQ</a>
       <a href="APP_STORE.md">App Store</a>
       <a href="INSTALL.md">Install</a>
@@ -210,6 +210,7 @@ footer nav { display: flex; gap: 20px; flex-wrap: wrap; }
 <main class="wrap docs">
   <nav class="contents" aria-label="SDK documentation sections">
     <h2>On this page</h2>
+    <a href="#path">Start here</a>
     <a href="#quick-start">Quick start</a>
     <a href="#application-model">Application model</a>
     <a href="#ui">UI components</a>
@@ -223,15 +224,28 @@ footer nav { display: flex; gap: 20px; flex-wrap: wrap; }
 
   <article>
     <div class="page-intro">
-      <h1>Cobalt SDK</h1>
-      <p class="lede">A declarative Rust API for E Ink UI, asynchronous work, private storage and capability-gated device services.</p>
-      <p class="sub">Applications manage state. The runtime handles layout, refresh planning, hardware access, network credentials and process isolation.</p>
+      <h1>Build apps for Cobalt.</h1>
+      <p class="lede">Create a Rust application, run it in the simulator, and publish it for supported e-readers.</p>
+      <p class="sub">Cobalt provides the interface, device services, application lifecycle, packaging, and Store delivery.</p>
       <div class="cta">
         <a class="btn primary" href="#quick-start">Quick start</a>
-        <a class="btn" href="https://github.com/BandarLabs/Cobalt/blob/main/SDK.md">Detailed guide</a>
-        <a class="btn" href="https://github.com/BandarLabs/Cobalt/tree/main/examples/gallery">Component gallery</a>
+        <a class="btn" href="CONTRIBUTING_APPS.md">Publish an app</a>
       </div>
     </div>
+    <section id="path">
+      <h2>From idea to Store</h2>
+      <div class="cards">
+        <div class="card"><h3>1. Create</h3><p>Start from the application template and describe each screen with the public SDK.</p></div>
+        <div class="card"><h3>2. Test</h3><p>Run the browser and runtime simulators, check failure states, and verify the interface on a supported reader.</p></div>
+        <div class="card"><h3>3. Submit</h3><p>Open a pull request with tests, a clean panel screenshot, and evidence from the physical device.</p></div>
+        <div class="card"><h3>4. Publish</h3><p>After review, the release workflow signs the application and adds it to Store without a platform release.</p></div>
+      </div>
+      <div class="links">
+        <a href="CONTRIBUTING_APPS.md">Application contribution guide</a>
+        <a href="https://github.com/BandarLabs/Cobalt/tree/main/examples">Worked examples</a>
+        <a href="https://github.com/BandarLabs/Cobalt/tree/main/examples/gallery">Component gallery</a>
+      </div>
+    </section>
     <section id="quick-start">
       <h2>Create an application</h2>
       <p>Install the CLI, create an application and start the browser simulator:</p>

--- a/docs/sdk.html
+++ b/docs/sdk.html
@@ -54,6 +54,8 @@ header.masthead { border-bottom: 1px solid var(--ink); padding: 18px 0; }
 nav.top { display: flex; gap: 24px; font-size: 16px; flex-wrap: wrap; }
 nav.top a { color: var(--ink); }
 nav.top a.active, nav.top a:hover { color: var(--cobalt); }
+.icon-link { display: inline-flex; align-items: center; gap: 6px; }
+.icon-link svg { width: 15px; height: 15px; flex: none; fill: currentColor; }
 h1 { font-size: clamp(36px, 5vw, 52px); line-height: 1.06; }
 .cta { display: flex; gap: 14px; flex-wrap: wrap; margin-top: 30px; }
 .btn {
@@ -203,7 +205,12 @@ footer nav { display: flex; gap: 20px; flex-wrap: wrap; }
       <a href="faq.html">FAQ</a>
       <a href="APP_STORE.md">App Store</a>
       <a href="INSTALL.md">Install</a>
-      <a href="https://github.com/BandarLabs/Cobalt">GitHub</a>
+      <a class="icon-link" href="https://github.com/BandarLabs/Cobalt">
+        <svg viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M8 0a8 8 0 0 0-2.53 15.59c.4.07.55-.17.55-.38v-1.49c-2.23.49-2.7-1.08-2.7-1.08-.37-.93-.9-1.18-.9-1.18-.73-.5.06-.49.06-.49.8.06 1.23.83 1.23.83.72 1.23 1.88.87 2.34.67.07-.52.28-.87.51-1.07-1.78-.2-3.65-.89-3.65-3.96 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.22 2.2.82A7.66 7.66 0 0 1 8 3.72a7.7 7.7 0 0 1 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.28.82 2.15 0 3.08-1.88 3.75-3.66 3.95.29.25.54.74.54 1.5v2.32c0 .21.15.46.55.38A8 8 0 0 0 8 0Z"/>
+        </svg>
+        GitHub
+      </a>
     </nav>
   </div>
 </header>

--- a/tools/generate-app-pages.mjs
+++ b/tools/generate-app-pages.mjs
@@ -182,7 +182,7 @@ for (const app of catalog.apps) {
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>
@@ -308,7 +308,7 @@ for (const app of systemApps) {
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">SDK</a>
+      <a href="../../sdk.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>


### PR DESCRIPTION
## Summary

- keep the existing homepage hero design and copy
- make the homepage an owner journey centered on what Cobalt enables
- explain why Cobalt is different without naming other products
- add a short app-building preview on the homepage
- add a dedicated, mobile-first developer landing page
- keep the detailed SDK reference, publishing guide, device guide, and Store format as separate pages
- keep app discovery, installation, safety, and return-to-reader outcomes prominent

## Verification

- checked the homepage, developer landing page, and SDK reference at 390 by 844
- confirmed no horizontal page overflow
- confirmed the homepage hero heading and messaging remain unchanged
- confirmed owner and developer navigation routes to the intended pages
- ran git diff --check