### PR TITLE
Harden app publishing and compatibility checks

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: cobalt-app-catalog
@@ -83,8 +84,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
       - name: Load the release tool
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
@@ -95,6 +99,21 @@ jobs:
         with:
           pattern: verified-app-*
           path: dist/artifacts
+      - name: Require versions for changed app packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          published_sha="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/apps.yml/runs?status=success&per_page=1" \
+            --jq '.workflow_runs[0].head_sha')"
+          test -n "$published_sha"
+          curl --fail --location --retry 3 \
+            --output published-app-catalog.json \
+            https://github.com/BandarLabs/Cobalt/releases/download/app-catalog/cobalt-app-catalog.json
+          node tools/check-app-versions.mjs \
+            --registry apps/catalog.json \
+            --published-catalog published-app-catalog.json \
+            --base "$published_sha"
       - name: Sign the app packages and catalog
         env:
           COBALT_APP_SIGNING_SEED: ${{ secrets.COBALT_APP_SIGNING_SEED }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   host:
@@ -19,6 +20,7 @@ jobs:
       - name: Install the ARM cross-compiler the packaging tests look for
         run: sudo apt-get update && sudo apt-get install --yes gcc-arm-linux-gnueabihf
       - run: cargo fmt --all -- --check
+      - run: node --test tools/check-app-versions.test.mjs
       - run: cargo test --workspace --all-targets --all-features
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
@@ -26,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           toolchain: 1.85.1
@@ -39,6 +43,21 @@ jobs:
         env:
           CC_armv7_unknown_linux_musleabihf: arm-linux-gnueabihf-gcc
           CFLAGS_armv7_unknown_linux_musleabihf: -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
+      - name: Require versions for changed app packages
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          published_sha="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/apps.yml/runs?status=success&per_page=1" \
+            --jq '.workflow_runs[0].head_sha')"
+          test -n "$published_sha"
+          curl --fail --location --retry 3 \
+            --output published-app-catalog.json \
+            https://github.com/BandarLabs/Cobalt/releases/download/app-catalog/cobalt-app-catalog.json
+          node tools/check-app-versions.mjs \
+            --registry apps/catalog.json \
+            --published-catalog published-app-catalog.json \
+            --base "$published_sha"
 
   advisories:
     runs-on: ubuntu-latest

--- a/apps/catalog.json
+++ b/apps/catalog.json
@@ -7,7 +7,7 @@
       "display_name": "arXiv",
       "short_label": "arXiv",
       "summary": "Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo.",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "note",
       "capabilities": ["network"]
@@ -18,7 +18,7 @@
       "display_name": "Audiobook Studio",
       "short_label": "Audiobooks",
       "summary": "Turn a topic into an original narrated audiobook and listen on your Kobo.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "headphones",
       "capabilities": ["network", "audio", "bluetooth-audio", "bluetooth-control"]
@@ -29,7 +29,7 @@
       "display_name": "Daily Brief",
       "short_label": "Daily Brief",
       "summary": "Build a daily news brief in the background while you use other apps.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "clock",
       "capabilities": ["network"]
@@ -40,7 +40,7 @@
       "display_name": "AI Command Center",
       "short_label": "AI Chat",
       "summary": "Ask a question, then read and navigate the answer with touch controls.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "chat",
       "capabilities": ["network"]
@@ -51,7 +51,7 @@
       "display_name": "Components",
       "short_label": "Components",
       "summary": "See every Cobalt UI component on the device in one reference app.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "chart",
       "capabilities": ["network"]
@@ -62,7 +62,7 @@
       "display_name": "Gutenbird",
       "short_label": "Gutenbird",
       "summary": "Browse OPDS libraries and read their books on your Kobo.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "book",
       "capabilities": ["network", "frontlight-control"]
@@ -73,7 +73,7 @@
       "display_name": "Hacker News",
       "short_label": "Hacker News",
       "summary": "Read Top, New, Ask, and Show stories with complete comment threads.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "news",
       "capabilities": ["network"]
@@ -84,7 +84,7 @@
       "display_name": "Magnet",
       "short_label": "Magnet",
       "summary": "Find the hall sensor behind the bezel and watch it respond to a magnet.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "magnet",
       "capabilities": ["cover-sensor"]
@@ -95,7 +95,7 @@
       "display_name": "Morse",
       "short_label": "Morse",
       "summary": "Type a message and send it in Morse code with the front light.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "light",
       "capabilities": ["frontlight-control", "keep-awake"]
@@ -106,7 +106,7 @@
       "display_name": "Feeds",
       "short_label": "Feeds",
       "summary": "Follow website feeds and read their articles without the web page around them.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "rss",
       "capabilities": ["network"]
@@ -117,7 +117,7 @@
       "display_name": "Sidekick",
       "short_label": "Sidekick",
       "summary": "Answer coding-agent permission prompts from your Kobo.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "key",
       "capabilities": ["network"]
@@ -128,7 +128,7 @@
       "display_name": "Sudoku",
       "short_label": "Sudoku",
       "summary": "Play touch-first Sudoku designed for an e-ink screen.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "grid",
       "capabilities": []
@@ -139,7 +139,7 @@
       "display_name": "Tic-tac-toe",
       "short_label": "Tic-tac-toe",
       "summary": "Play tic-tac-toe together on one Kobo.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "grid",
       "capabilities": []
@@ -150,7 +150,7 @@
       "display_name": "Todo",
       "short_label": "Todo",
       "summary": "Keep a simple to-do list that stays on your Kobo.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "minimum_cobalt_version": "0.2.0",
       "glyph": "check",
       "capabilities": []

--- a/apps/catalog.json
+++ b/apps/catalog.json
@@ -8,7 +8,7 @@
       "short_label": "arXiv",
       "summary": "Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo.",
       "version": "1.3.1",
-      "minimum_cobalt_version": "0.2.0",
+      "minimum_cobalt_version": "0.2.4",
       "glyph": "note",
       "capabilities": ["network"]
     },
@@ -19,7 +19,7 @@
       "short_label": "Audiobooks",
       "summary": "Turn a topic into an original narrated audiobook and listen on your Kobo.",
       "version": "1.0.1",
-      "minimum_cobalt_version": "0.2.0",
+      "minimum_cobalt_version": "0.2.4",
       "glyph": "headphones",
       "capabilities": ["network", "audio", "bluetooth-audio", "bluetooth-control"]
     },
@@ -30,7 +30,7 @@
       "short_label": "Daily Brief",
       "summary": "Build a daily news brief in the background while you use other apps.",
       "version": "1.0.1",
-      "minimum_cobalt_version": "0.2.0",
+      "minimum_cobalt_version": "0.2.4",
       "glyph": "clock",
       "capabilities": ["network"]
     },
@@ -41,7 +41,7 @@
       "short_label": "AI Chat",
       "summary": "Ask a question, then read and navigate the answer with touch controls.",
       "version": "1.0.1",
-      "minimum_cobalt_version": "0.2.0",
+      "minimum_cobalt_version": "0.2.4",
       "glyph": "chat",
       "capabilities": ["network"]
     },
@@ -52,7 +52,7 @@
       "short_label": "Components",
       "summary": "See every Cobalt UI component on the device in one reference app.",
       "version": "1.0.1",
-      "minimum_cobalt_version": "0.2.0",
+      "minimum_cobalt_version": "0.2.4",
       "glyph": "chart",
       "capabilities": ["network"]
     },
@@ -63,7 +63,7 @@
       "short_label": "Gutenbird",
       "summary": "Browse OPDS libraries and read their books on your Kobo.",
       "version": "1.0.1",
-      "minimum_cobalt_version": "0.2.0",
+      "minimum_cobalt_version": "0.2.4",
       "glyph": "book",
       "capabilities": ["network", "frontlight-control"]
     },
@@ -74,7 +74,7 @@
       "short_label": "Hacker News",
       "summary": "Read Top, New, Ask, and Show stories with complete comment threads.",
       "version": "1.0.1",
-      "minimum_cobalt_version": "0.2.0",
+      "minimum_cobalt_version": "0.2.4",
       "glyph": "news",
       "capabilities": ["network"]
     },
@@ -85,7 +85,7 @@
       "short_label": "Magnet",
       "summary": "Find the hall sensor behind the bezel and watch it respond to a magnet.",
       "version": "1.0.1",
-      "minimum_cobalt_version": "0.2.0",
+      "minimum_cobalt_version": "0.2.4",
       "glyph": "magnet",
       "capabilities": ["cover-sensor"]
     },
@@ -96,7 +96,7 @@
       "short_label": "Morse",
       "summary": "Type a message and send it in Morse code with the front light.",
       "version": "1.0.3",
-      "minimum_cobalt_version": "0.2.0",
+      "minimum_cobalt_version": "0.2.4",
       "glyph": "light",
       "capabilities": ["frontlight-control", "keep-awake"]
     },
@@ -107,7 +107,7 @@
       "short_label": "Feeds",
       "summary": "Follow website feeds and read their articles without the web page around them.",
       "version": "1.0.1",
-      "minimum_cobalt_version": "0.2.0",
+      "minimum_cobalt_version": "0.2.4",
       "glyph": "rss",
       "capabilities": ["network"]
     },
@@ -118,7 +118,7 @@
       "short_label": "Sidekick",
       "summary": "Answer coding-agent permission prompts from your Kobo.",
       "version": "1.0.1",
-      "minimum_cobalt_version": "0.2.0",
+      "minimum_cobalt_version": "0.2.4",
       "glyph": "key",
       "capabilities": ["network"]
     },
@@ -129,7 +129,7 @@
       "short_label": "Sudoku",
       "summary": "Play touch-first Sudoku designed for an e-ink screen.",
       "version": "1.0.2",
-      "minimum_cobalt_version": "0.2.0",
+      "minimum_cobalt_version": "0.2.4",
       "glyph": "grid",
       "capabilities": []
     },
@@ -140,7 +140,7 @@
       "short_label": "Tic-tac-toe",
       "summary": "Play tic-tac-toe together on one Kobo.",
       "version": "1.0.1",
-      "minimum_cobalt_version": "0.2.0",
+      "minimum_cobalt_version": "0.2.4",
       "glyph": "grid",
       "capabilities": []
     },
@@ -151,7 +151,7 @@
       "short_label": "Todo",
       "summary": "Keep a simple to-do list that stays on your Kobo.",
       "version": "1.0.1",
-      "minimum_cobalt_version": "0.2.0",
+      "minimum_cobalt_version": "0.2.4",
       "glyph": "check",
       "capabilities": []
     }

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -6602,7 +6602,7 @@ mod tests {
                     .iter()
                     .find(|app| app.id == "sudoku")
                     .expect("Sudoku registry entry");
-                assert_eq!(sudoku.version, "1.0.1");
+                assert_eq!(sudoku.version, "1.0.2");
             }
         }
     }

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -1076,11 +1076,25 @@ pub enum AppLinkState {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RemoteInstallOutcome {
     None,
-    Installed { id: String },
-    Updated { id: String },
-    AlreadyInstalled { id: String },
-    Included { id: String },
-    Unavailable { id: String },
+    Installed {
+        id: String,
+    },
+    Updated {
+        id: String,
+    },
+    AlreadyInstalled {
+        id: String,
+    },
+    Included {
+        id: String,
+    },
+    Unavailable {
+        id: String,
+    },
+    RequiresCobalt {
+        id: String,
+        minimum_cobalt_version: String,
+    },
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1249,6 +1263,8 @@ pub struct AppInfo {
     pub label: String,
     pub summary: String,
     pub version: String,
+    /// Oldest Cobalt platform release that can run this app package.
+    pub minimum_cobalt_version: String,
     pub glyph: Glyph,
     pub capabilities: Vec<String>,
     /// The installed version when present. A different `version` means an
@@ -1268,6 +1284,33 @@ impl AppInfo {
             .as_ref()
             .is_some_and(|installed| installed != &self.version)
     }
+
+    #[must_use]
+    pub fn is_compatible_with(&self, cobalt_version: &str) -> bool {
+        numeric_version_at_least(cobalt_version, &self.minimum_cobalt_version)
+    }
+}
+
+fn numeric_version_at_least(current: &str, minimum: &str) -> bool {
+    let parse = |version: &str| -> Option<Vec<u64>> {
+        version
+            .split('.')
+            .map(|part| {
+                if part.is_empty() || !part.bytes().all(|byte| byte.is_ascii_digit()) {
+                    None
+                } else {
+                    part.parse().ok()
+                }
+            })
+            .collect()
+    };
+    let (Some(mut current), Some(mut minimum)) = (parse(current), parse(minimum)) else {
+        return false;
+    };
+    let width = current.len().max(minimum.len());
+    current.resize(width, 0);
+    minimum.resize(width, 0);
+    current >= minimum
 }
 
 /// A source accepted by the runtime-owned audio player.
@@ -2811,22 +2854,33 @@ fn encode_remote_install(
     output: &mut Vec<u8>,
     outcome: &RemoteInstallOutcome,
 ) -> Result<(), ProtocolError> {
-    let (tag, id) = match outcome {
+    let (tag, id, minimum_cobalt_version) = match outcome {
         RemoteInstallOutcome::None => {
             output.push(1);
             return Ok(());
         }
-        RemoteInstallOutcome::Installed { id } => (2, id),
-        RemoteInstallOutcome::Updated { id } => (3, id),
-        RemoteInstallOutcome::AlreadyInstalled { id } => (4, id),
-        RemoteInstallOutcome::Included { id } => (5, id),
-        RemoteInstallOutcome::Unavailable { id } => (6, id),
+        RemoteInstallOutcome::Installed { id } => (2, id, None),
+        RemoteInstallOutcome::Updated { id } => (3, id, None),
+        RemoteInstallOutcome::AlreadyInstalled { id } => (4, id, None),
+        RemoteInstallOutcome::Included { id } => (5, id, None),
+        RemoteInstallOutcome::Unavailable { id } => (6, id, None),
+        RemoteInstallOutcome::RequiresCobalt {
+            id,
+            minimum_cobalt_version,
+        } => (7, id, Some(minimum_cobalt_version)),
     };
     if !valid_app_id(id) {
         return Err(ProtocolError::InvalidValue("application id"));
     }
+    if minimum_cobalt_version.is_some_and(|version| !valid_cobalt_version(version)) {
+        return Err(ProtocolError::InvalidValue("Cobalt version"));
+    }
     output.push(tag);
-    push_string(output, id)
+    push_string(output, id)?;
+    if let Some(version) = minimum_cobalt_version {
+        push_string(output, version)?;
+    }
+    Ok(())
 }
 
 fn encode_app_info(output: &mut Vec<u8>, entry: &AppInfo) -> Result<(), ProtocolError> {
@@ -2837,6 +2891,7 @@ fn encode_app_info(output: &mut Vec<u8>, entry: &AppInfo) -> Result<(), Protocol
         &entry.label,
         &entry.summary,
         &entry.version,
+        &entry.minimum_cobalt_version,
     ] {
         push_string(output, text)?;
     }
@@ -2864,6 +2919,7 @@ fn validate_app_info(entry: &AppInfo) -> Result<(), ProtocolError> {
         || entry.summary.is_empty()
         || entry.summary.len() > 512
         || !valid_version(&entry.version)
+        || !valid_cobalt_version(&entry.minimum_cobalt_version)
         || entry
             .installed_version
             .as_deref()
@@ -2885,6 +2941,14 @@ fn valid_version(version: &str) -> bool {
         && version
             .bytes()
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'+'))
+}
+
+fn valid_cobalt_version(version: &str) -> bool {
+    !version.is_empty()
+        && version.len() <= MAX_APP_VERSION_LEN
+        && version
+            .split('.')
+            .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
 }
 
 fn decode_device_result(reader: &mut Reader<'_>) -> Result<DeviceResult, ProtocolError> {
@@ -3027,7 +3091,7 @@ fn decode_remote_install(reader: &mut Reader<'_>) -> Result<DeviceResult, Protoc
     if tag == 1 {
         return Ok(DeviceResult::RemoteInstall(RemoteInstallOutcome::None));
     }
-    if !(2..=6).contains(&tag) {
+    if !(2..=7).contains(&tag) {
         return Err(ProtocolError::InvalidValue("remote install outcome"));
     }
     let id = reader.string()?;
@@ -3040,6 +3104,16 @@ fn decode_remote_install(reader: &mut Reader<'_>) -> Result<DeviceResult, Protoc
         4 => RemoteInstallOutcome::AlreadyInstalled { id },
         5 => RemoteInstallOutcome::Included { id },
         6 => RemoteInstallOutcome::Unavailable { id },
+        7 => {
+            let minimum_cobalt_version = reader.string()?;
+            if !valid_cobalt_version(&minimum_cobalt_version) {
+                return Err(ProtocolError::InvalidValue("Cobalt version"));
+            }
+            RemoteInstallOutcome::RequiresCobalt {
+                id,
+                minimum_cobalt_version,
+            }
+        }
         _ => unreachable!("tag range checked above"),
     };
     Ok(DeviceResult::RemoteInstall(outcome))
@@ -3109,6 +3183,7 @@ fn decode_apps_result(reader: &mut Reader<'_>) -> Result<DeviceResult, ProtocolE
         let label = reader.string()?;
         let summary = reader.string()?;
         let version = reader.string()?;
+        let minimum_cobalt_version = reader.string()?;
         let glyph =
             decode_glyph(reader.u8()?).ok_or(ProtocolError::InvalidValue("application glyph"))?;
         let capability_count = usize::from(reader.u8()?);
@@ -3132,6 +3207,7 @@ fn decode_apps_result(reader: &mut Reader<'_>) -> Result<DeviceResult, ProtocolE
             label,
             summary,
             version,
+            minimum_cobalt_version,
             glyph,
             capabilities,
             installed_version,
@@ -6386,6 +6462,7 @@ mod tests {
                     label: "Words".to_owned(),
                     summary: "Counts words in a note.".to_owned(),
                     version: "1.2.0".to_owned(),
+                    minimum_cobalt_version: "0.3.0".to_owned(),
                     glyph: Glyph::Note,
                     capabilities: vec!["shared-files".to_owned()],
                     installed_version: Some("1.1.0".to_owned()),
@@ -6427,6 +6504,10 @@ mod tests {
             }),
             DeviceResult::RemoteInstall(RemoteInstallOutcome::Unavailable {
                 id: "word-count".to_owned(),
+            }),
+            DeviceResult::RemoteInstall(RemoteInstallOutcome::RequiresCobalt {
+                id: "word-count".to_owned(),
+                minimum_cobalt_version: "0.4.0".to_owned(),
             }),
         ];
         for result in results {
@@ -6471,6 +6552,7 @@ mod tests {
                     label: "App".to_owned(),
                     summary: "One application.".to_owned(),
                     version: "1.0.0".to_owned(),
+                    minimum_cobalt_version: "0.3.0".to_owned(),
                     glyph: Glyph::App,
                     capabilities: Vec::new(),
                     installed_version: None,
@@ -6489,6 +6571,7 @@ mod tests {
             label: "Version".to_owned(),
             summary: "Checks the application version wire bound.".to_owned(),
             version,
+            minimum_cobalt_version: "0.3.0".to_owned(),
             glyph: Glyph::App,
             capabilities: Vec::new(),
             installed_version: None,
@@ -6507,6 +6590,31 @@ mod tests {
             }),
         })
         .is_err());
+    }
+
+    #[test]
+    fn app_compatibility_uses_numeric_cobalt_versions() {
+        let app = AppInfo {
+            id: "version-test".to_owned(),
+            title: "Version Test".to_owned(),
+            label: "Version".to_owned(),
+            summary: "Checks minimum Cobalt versions.".to_owned(),
+            version: "1.0.0".to_owned(),
+            minimum_cobalt_version: "0.2.4".to_owned(),
+            glyph: Glyph::App,
+            capabilities: Vec::new(),
+            installed_version: None,
+        };
+        assert!(app.is_compatible_with("0.3.0"));
+        assert!(app.is_compatible_with("0.3"));
+        assert!(!app.is_compatible_with("0.2.3"));
+        assert!(!app.is_compatible_with("nightly"));
+
+        let newer = AppInfo {
+            minimum_cobalt_version: "0.4.0".to_owned(),
+            ..app
+        };
+        assert!(!newer.is_compatible_with("0.3.0"));
     }
 
     #[test]
@@ -6684,7 +6792,7 @@ mod tests {
         })
         .expect("valid empty outcome");
         let last = bad_outcome.len() - 1;
-        bad_outcome[last] = 7;
+        bad_outcome[last] = 8;
         assert_eq!(
             decode(&bad_outcome),
             Err(ProtocolError::InvalidValue("remote install outcome"))

--- a/crates/kobo-sim/src/lib.rs
+++ b/crates/kobo-sim/src/lib.rs
@@ -1008,6 +1008,7 @@ fn simulated_app(
         label: label.to_owned(),
         summary: summary.to_owned(),
         version: "1.0.0".to_owned(),
+        minimum_cobalt_version: env!("CARGO_PKG_VERSION").to_owned(),
         glyph,
         capabilities: capabilities
             .iter()

--- a/crates/kobod/src/app_link.rs
+++ b/crates/kobod/src/app_link.rs
@@ -781,6 +781,12 @@ fn resume_pending(
                 final_pending.save(root)?;
                 return finish_pending(root, relay, credential, &final_pending);
             }
+            if matches!(outcome, RemoteInstallOutcome::RequiresCobalt { .. }) {
+                let final_pending =
+                    pending.final_outcome_failure("requires-cobalt", outcome.clone());
+                final_pending.save(root)?;
+                return finish_pending(root, relay, credential, &final_pending);
+            }
             if run {
                 if let Err(error) = install(root, &pending.app_id) {
                     let final_pending = pending.final_failure(failure_code(error), error);
@@ -1167,6 +1173,22 @@ impl Pending {
                 .set("error", device_error_name(*error)),
             PendingPhase::Final { .. } => return Err(DeviceError::Backend),
         };
+        if let Some(minimum_cobalt_version) = match &self.phase {
+            PendingPhase::Ready { outcome, .. }
+            | PendingPhase::Final {
+                report: Report::Outcome(outcome),
+                ..
+            } => match outcome {
+                RemoteInstallOutcome::RequiresCobalt {
+                    minimum_cobalt_version,
+                    ..
+                } => Some(minimum_cobalt_version),
+                _ => None,
+            },
+            PendingPhase::Final { .. } => None,
+        } {
+            body = body.set("minimum_cobalt_version", minimum_cobalt_version.clone());
+        }
         atomic_write(
             &state_root(root).join(PENDING_FILE),
             body.build().to_json().as_bytes(),
@@ -1242,6 +1264,7 @@ fn outcome_name(outcome: &RemoteInstallOutcome) -> String {
         RemoteInstallOutcome::AlreadyInstalled { .. } => "already-installed",
         RemoteInstallOutcome::Included { .. } => "included",
         RemoteInstallOutcome::Unavailable { .. } => "unavailable",
+        RemoteInstallOutcome::RequiresCobalt { .. } => "requires-cobalt",
     }
     .to_owned()
 }
@@ -1257,6 +1280,21 @@ fn parse_outcome(value: &Value) -> Result<RemoteInstallOutcome, DeviceError> {
         "already-installed" => Ok(RemoteInstallOutcome::AlreadyInstalled { id }),
         "included" => Ok(RemoteInstallOutcome::Included { id }),
         "unavailable" => Ok(RemoteInstallOutcome::Unavailable { id }),
+        "requires-cobalt" => {
+            let minimum_cobalt_version = required_string(value, "minimum_cobalt_version")?;
+            if minimum_cobalt_version.is_empty()
+                || minimum_cobalt_version.len() > 32
+                || !minimum_cobalt_version
+                    .split('.')
+                    .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+            {
+                return Err(DeviceError::Integrity);
+            }
+            Ok(RemoteInstallOutcome::RequiresCobalt {
+                id,
+                minimum_cobalt_version,
+            })
+        }
         _ => Err(DeviceError::Integrity),
     }
 }
@@ -1267,7 +1305,9 @@ fn relay_outcome(outcome: &RemoteInstallOutcome) -> Option<&'static str> {
         RemoteInstallOutcome::Updated { .. } => Some("updated"),
         RemoteInstallOutcome::AlreadyInstalled { .. } => Some("already-installed"),
         RemoteInstallOutcome::Included { .. } => Some("included"),
-        RemoteInstallOutcome::None | RemoteInstallOutcome::Unavailable { .. } => None,
+        RemoteInstallOutcome::None
+        | RemoteInstallOutcome::Unavailable { .. }
+        | RemoteInstallOutcome::RequiresCobalt { .. } => None,
     }
 }
 
@@ -1964,6 +2004,30 @@ mod tests {
         ));
         assert!(Pending::load(&root).expect("pending state").is_none());
         assert_eq!(completed(&root).expect("completed"), vec![request_id()]);
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn cobalt_requirement_survives_a_pending_install_restart() {
+        let root = root("requires-cobalt-pending");
+        let pending = Pending {
+            command_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa".to_owned(),
+            request_id: request_id(),
+            app_id: "word-count".to_owned(),
+            expires_at: 2_000_000_000,
+            phase: PendingPhase::Ready {
+                install: false,
+                outcome: RemoteInstallOutcome::RequiresCobalt {
+                    id: "word-count".to_owned(),
+                    minimum_cobalt_version: "0.4.0".to_owned(),
+                },
+            },
+        };
+        pending.save(&root).expect("save pending requirement");
+        assert_eq!(
+            Pending::load(&root).expect("load pending requirement"),
+            Some(pending)
+        );
         let _ignored = fs::remove_dir_all(root);
     }
 

--- a/crates/kobod/src/app_store.rs
+++ b/crates/kobod/src/app_store.rs
@@ -250,7 +250,10 @@ fn prepare_remote_install_with(
         entry.manifest().minimum_cobalt_version(),
     ) {
         return Ok(RemoteInstallPlan {
-            outcome: RemoteInstallOutcome::Unavailable { id: id.to_owned() },
+            outcome: RemoteInstallOutcome::RequiresCobalt {
+                id: id.to_owned(),
+                minimum_cobalt_version: entry.manifest().minimum_cobalt_version().to_owned(),
+            },
             install: false,
         });
     }
@@ -511,6 +514,7 @@ fn builtin_info(app: &BuiltinApp) -> AppInfo {
         label: app.label.to_owned(),
         summary: app.summary.to_owned(),
         version: app.version.to_owned(),
+        minimum_cobalt_version: env!("CARGO_PKG_VERSION").to_owned(),
         glyph: app.glyph,
         capabilities: app
             .capabilities
@@ -543,6 +547,7 @@ fn manifest_info(
         label: manifest.short_label().to_owned(),
         summary: manifest.summary().to_owned(),
         version: manifest.version().to_owned(),
+        minimum_cobalt_version: manifest.minimum_cobalt_version().to_owned(),
         glyph: glyph(manifest.glyph()).ok_or(DeviceError::InvalidInput)?,
         capabilities: manifest.capabilities().map(str::to_owned).collect(),
         installed_version: installed_version.map(str::to_owned),
@@ -963,6 +968,15 @@ mod tests {
     }
 
     fn release_for(seed: &[u8; 32], id: &str, version: &str) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        release_for_minimum(seed, id, version, env!("CARGO_PKG_VERSION"))
+    }
+
+    fn release_for_minimum(
+        seed: &[u8; 32],
+        id: &str,
+        version: &str,
+        minimum_cobalt_version: &str,
+    ) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
         let binary = format!("{id} app binary").into_bytes();
         let manifest = Manifest::new_public(ManifestInput {
             id: id.to_owned(),
@@ -970,7 +984,7 @@ mod tests {
             short_label: id.to_owned(),
             summary: format!("The {id} test application."),
             version: version.to_owned(),
-            minimum_cobalt_version: env!("CARGO_PKG_VERSION").to_owned(),
+            minimum_cobalt_version: minimum_cobalt_version.to_owned(),
             glyph: "note".to_owned(),
             capabilities: Vec::new(),
             binary_sha256: kobo_net::sha256::hex_digest(&binary),
@@ -1220,6 +1234,31 @@ mod tests {
         assert!(!plan.install);
         let installed = installed_with_key(&root, &key).expect("installed app remains");
         assert!(installed.iter().any(|app| app.id == "word-count"));
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_remote_app_requiring_newer_cobalt_reports_the_required_version() {
+        let root = root();
+        let seed = [9_u8; 32];
+        let key = derive_public_key(&seed).expect("key");
+        let (json, signature, _) = release_for_minimum(&seed, "word-count", "1.0.0", "999.0.0");
+        let plan = prepare_remote_install_with(&root, "word-count", &key, |url, _| {
+            if url == CATALOG_URL {
+                Ok(json.clone())
+            } else {
+                Ok(signature.clone())
+            }
+        })
+        .expect("compatibility plan");
+        assert_eq!(
+            plan.outcome,
+            RemoteInstallOutcome::RequiresCobalt {
+                id: "word-count".to_owned(),
+                minimum_cobalt_version: "999.0.0".to_owned(),
+            }
+        );
+        assert!(!plan.install);
         let _ignored = fs::remove_dir_all(root);
     }
 

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -2389,7 +2389,8 @@ fn remote_installed_id(outcome: &kobo_protocol::RemoteInstallOutcome) -> Option<
         kobo_protocol::RemoteInstallOutcome::None
         | kobo_protocol::RemoteInstallOutcome::AlreadyInstalled { .. }
         | kobo_protocol::RemoteInstallOutcome::Included { .. }
-        | kobo_protocol::RemoteInstallOutcome::Unavailable { .. } => None,
+        | kobo_protocol::RemoteInstallOutcome::Unavailable { .. }
+        | kobo_protocol::RemoteInstallOutcome::RequiresCobalt { .. } => None,
     }
 }
 

--- a/docs/APP_STORE.md
+++ b/docs/APP_STORE.md
@@ -5,6 +5,8 @@ Cobalt platform releases and Store app releases are separate:
 - Tagged `v*` releases publish the USB-installable Cobalt platform package.
 - Every accepted merge to `main` runs the app publishing workflow.
 - App-only changes do not require a Cobalt version bump or platform update.
+- Every changed app package requires a new app version, including changes from
+  a shared SDK or protocol dependency.
 
 Installed readers use the fixed app channel:
 
@@ -56,6 +58,11 @@ kobo app-link unpair --device <reader-address>
 Store apps are workspace packages declared in `apps/catalog.json`. The
 registry supplies public metadata; binary size and SHA-256 are calculated from
 the exact ARM release binary during publishing.
+
+`minimum_cobalt_version` must cover both the SDK wire protocol and the runtime
+services used by the app. Current SDK builds require Cobalt 0.2.4 or newer.
+The publishing check rejects a lower value, and a future protocol version
+cannot publish until its first compatible Cobalt release is recorded.
 
 The initial Cobalt applications are registered too. Their `0.2.0` copies are
 bundled for a useful first boot, appear as installed in Store, and can later be

--- a/docs/APP_STORE.md
+++ b/docs/APP_STORE.md
@@ -73,8 +73,11 @@ See [CONTRIBUTING_APPS.md](CONTRIBUTING_APPS.md) for the contribution format.
    executable load segment.
 4. Uploads exactly one immutable artifact from each app runner.
 5. Downloads those artifacts on a fresh runner that has not executed app code.
-6. Builds and signs the packages and catalog only after that isolation.
-7. Replaces the assets on the fixed `app-catalog` GitHub release.
+6. Compares each app's code, local dependencies and public manifest with the
+   last successfully published catalog, and requires a new app version for any
+   change.
+7. Builds and signs the packages and catalog only after that isolation.
+8. Replaces the assets on the fixed `app-catalog` GitHub release.
 
 The workflow uses the protected `COBALT_APP_SIGNING_SEED` secret. Publishing
 fails if the seed does not derive the public key pinned in released runtimes.

--- a/docs/APP_STORE.md
+++ b/docs/APP_STORE.md
@@ -40,7 +40,9 @@ mint, alter, or replay install commands.
 Install requests wait for up to 72 hours. If the Kobo is offline, open Cobalt
 App Store after reconnecting to process the queue. The result distinguishes a
 new install, an update, an app already at the current version, an app included
-with Cobalt, and an app unavailable from the current catalog.
+with Cobalt, an app unavailable from the current catalog, and an app that
+requires a newer Cobalt release. In the last case the device reports the exact
+minimum release and does not download or run the app.
 
 Use **Disconnect all** on the Kobo to revoke every linked browser. With SSH
 enabled, the host maintenance command can do the same:

--- a/docs/CONTRIBUTING_APPS.md
+++ b/docs/CONTRIBUTING_APPS.md
@@ -24,13 +24,18 @@ Registry fields:
 | `display_name` | Full Store title |
 | `short_label` | Compact launcher label |
 | `summary` | Short Store description |
-| `version` | App version, independent from Cobalt |
-| `minimum_cobalt_version` | Oldest compatible platform version |
+| `version` | App release version, independent from Cobalt. Bump it whenever the published binary or metadata changes |
+| `minimum_cobalt_version` | Oldest platform release that supports the SDK protocol and every runtime service the app uses |
 | `glyph` | A built-in Cobalt glyph name |
 | `capabilities` | Runtime services the app needs |
 
 Public apps cannot use a platform-reserved ID or request the `shell`
 capability. Request only capabilities the app actually uses.
+
+Apps built from the current SDK require Cobalt 0.2.4 or newer because that is
+the first release supporting the current wire protocol. A newer runtime
+service can require a higher minimum. CI rejects a registry entry below the
+SDK protocol floor.
 
 ## Test the app
 
@@ -93,9 +98,14 @@ install pages, or sitemap entries after merge.
 
 Open a pull request containing the app source, tests, workspace and Store
 entries, registry metadata, README, clean screenshot, generated website files,
-and physical-device evidence. Increment only the app's `version` when updating
-that app. A Cobalt version change is needed only when the app requires a new
-platform or SDK capability.
+and physical-device evidence. Increment the app's `version` whenever its code,
+local dependencies, release inputs, or public metadata change. Shared SDK and
+protocol changes count because they produce a different binary. CI compares
+each package with the last published catalog and rejects a reused version.
+
+Do not change the Cobalt platform version for an ordinary app update. Raise
+`minimum_cobalt_version` when the app starts using a protocol or runtime
+service absent from older platform releases.
 
 After merge to `main`, `.github/workflows/apps.yml`:
 

--- a/docs/apps/arxiv/index.html
+++ b/docs/apps/arxiv/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="arxiv" data-minimum-cobalt-version="0.2.0">
+<main class="wrap" data-app-id="arxiv" data-minimum-cobalt-version="0.2.4">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/arxiv/index.html
+++ b/docs/apps/arxiv/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/arxiv.png">
 <meta name="twitter:image:alt" content="The newest machine learning preprints listed in the arXiv app on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-QKwLMHduly3oQODOCjebxJkNJ9/2YZor+vithk5/vsA='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-LEZFgH16xl//lhSauu02yMdjum4E29ZN9u3yDu3nQ5s='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.3.0",
+      "softwareVersion": "1.3.1",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>arXiv</h1>
       <p class="summary">Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo.</p>
-      <div class="meta"><span>Version 1.3.0</span><span>network</span></div>
+      <div class="meta"><span>Version 1.3.1</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/arxiv.png" width="1072" height="1448" alt="The newest machine learning preprints listed in the arXiv app on a Kobo">

--- a/docs/apps/arxiv/index.html
+++ b/docs/apps/arxiv/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="arxiv">
+<main class="wrap" data-app-id="arxiv" data-minimum-cobalt-version="0.2.0">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/audiobook/index.html
+++ b/docs/apps/audiobook/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="audiobook" data-minimum-cobalt-version="0.2.0">
+<main class="wrap" data-app-id="audiobook" data-minimum-cobalt-version="0.2.4">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/audiobook/index.html
+++ b/docs/apps/audiobook/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Turn a topic into an original narrated audiobook and listen on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/audiobook.png">
 <meta name="twitter:image:alt" content="An audiobook player with cover art and playback controls on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-oruv8V1jtBq/d022u6xx8N5xd4Wgh0kpnnFX3sJ/7Dc='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-Oa69pg3L2fwaghVhRmmeG9uOkfqUF4Dgx10v5k/iGNM='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.0.1",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Audiobook Studio</h1>
       <p class="summary">Turn a topic into an original narrated audiobook and listen on your Kobo.</p>
-      <div class="meta"><span>Version 1.0.0</span><span>network, audio, bluetooth-audio, bluetooth-control</span></div>
+      <div class="meta"><span>Version 1.0.1</span><span>network, audio, bluetooth-audio, bluetooth-control</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/audiobook.png" width="1072" height="1448" alt="An audiobook player with cover art and playback controls on a Kobo">

--- a/docs/apps/audiobook/index.html
+++ b/docs/apps/audiobook/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="audiobook">
+<main class="wrap" data-app-id="audiobook" data-minimum-cobalt-version="0.2.0">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/brief/index.html
+++ b/docs/apps/brief/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Build a daily news brief in the background while you use other apps. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/brief.png">
 <meta name="twitter:image:alt" content="A numbered daily news brief on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-Yy7YXxKDVPUFkMXDgtjNE5r+MB1fwXfVBUvRYzZvXok='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-B7qqGnEpsD091jMg6t2UpykHlnxzh8W/FV9wHKywf1Q='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.0.1",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Daily Brief</h1>
       <p class="summary">Build a daily news brief in the background while you use other apps.</p>
-      <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.1</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/brief.png" width="1072" height="1448" alt="A numbered daily news brief on a Kobo">

--- a/docs/apps/brief/index.html
+++ b/docs/apps/brief/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="brief" data-minimum-cobalt-version="0.2.0">
+<main class="wrap" data-app-id="brief" data-minimum-cobalt-version="0.2.4">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/brief/index.html
+++ b/docs/apps/brief/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="brief">
+<main class="wrap" data-app-id="brief" data-minimum-cobalt-version="0.2.0">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/chat/index.html
+++ b/docs/apps/chat/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Ask a question, then read and navigate the answer with touch controls. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/chat.png">
 <meta name="twitter:image:alt" content="An answer displayed for touch-friendly reading on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-Fqc0BJD2Xp3kJ6OeRC4ya9u5Kezjeg8VPbhNog6tuNU='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-VrMVpRfDX0IKJAU8301e6PLD7i+KfuloOjLCwWSOsyI='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.0.1",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>AI Command Center</h1>
       <p class="summary">Ask a question, then read and navigate the answer with touch controls.</p>
-      <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.1</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/chat.png" width="1072" height="1448" alt="An answer displayed for touch-friendly reading on a Kobo">

--- a/docs/apps/chat/index.html
+++ b/docs/apps/chat/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="chat" data-minimum-cobalt-version="0.2.0">
+<main class="wrap" data-app-id="chat" data-minimum-cobalt-version="0.2.4">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/chat/index.html
+++ b/docs/apps/chat/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="chat">
+<main class="wrap" data-app-id="chat" data-minimum-cobalt-version="0.2.0">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/gallery/index.html
+++ b/docs/apps/gallery/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="See every Cobalt UI component on the device in one reference app. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/components.png">
 <meta name="twitter:image:alt" content="Cobalt typography and interface components on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-O61rfKMUBeEBYS+pNVVCOAZZGgLfdppA6GA2aQyuZQE='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-U+0L+O4JKqA8VGQJPTjNc9WUro3FfrogfjjlSedH2U8='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.0.1",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Components</h1>
       <p class="summary">See every Cobalt UI component on the device in one reference app.</p>
-      <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.1</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/components.png" width="1072" height="1448" alt="Cobalt typography and interface components on a Kobo">

--- a/docs/apps/gallery/index.html
+++ b/docs/apps/gallery/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="gallery">
+<main class="wrap" data-app-id="gallery" data-minimum-cobalt-version="0.2.0">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/gallery/index.html
+++ b/docs/apps/gallery/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="gallery" data-minimum-cobalt-version="0.2.0">
+<main class="wrap" data-app-id="gallery" data-minimum-cobalt-version="0.2.4">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/gutenbird/index.html
+++ b/docs/apps/gutenbird/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Browse OPDS libraries and read their books on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/gutenbird.png">
 <meta name="twitter:image:alt" content="A shelf of books from an OPDS library on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-b7OYGAf5/XrcWpSncSSYjYZUiEONYrhVYpbJkVwKpQo='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-y4DK8ISgbHg1u4v8og3LtJ3+U6jDlEyhJQBsKnW5X+k='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.0.1",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Gutenbird</h1>
       <p class="summary">Browse OPDS libraries and read their books on your Kobo.</p>
-      <div class="meta"><span>Version 1.0.0</span><span>network, frontlight-control</span></div>
+      <div class="meta"><span>Version 1.0.1</span><span>network, frontlight-control</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/gutenbird.png" width="1072" height="1448" alt="A shelf of books from an OPDS library on a Kobo">

--- a/docs/apps/gutenbird/index.html
+++ b/docs/apps/gutenbird/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="gutenbird">
+<main class="wrap" data-app-id="gutenbird" data-minimum-cobalt-version="0.2.0">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/gutenbird/index.html
+++ b/docs/apps/gutenbird/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="gutenbird" data-minimum-cobalt-version="0.2.0">
+<main class="wrap" data-app-id="gutenbird" data-minimum-cobalt-version="0.2.4">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/hn/index.html
+++ b/docs/apps/hn/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="hn" data-minimum-cobalt-version="0.2.0">
+<main class="wrap" data-app-id="hn" data-minimum-cobalt-version="0.2.4">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/hn/index.html
+++ b/docs/apps/hn/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Read Top, New, Ask, and Show stories with complete comment threads. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/hackernews.png">
 <meta name="twitter:image:alt" content="A ranked list of Hacker News stories on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-9p8mlf/xz9NkrauWNPXI01YxZjOr/WA5s1kh1eHH3WM='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-DTdKSCqb66PkrXrXplSUblKjDCv58OHz/amOFFQcjGI='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.0.1",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Hacker News</h1>
       <p class="summary">Read Top, New, Ask, and Show stories with complete comment threads.</p>
-      <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.1</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/hackernews.png" width="1072" height="1448" alt="A ranked list of Hacker News stories on a Kobo">

--- a/docs/apps/hn/index.html
+++ b/docs/apps/hn/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="hn">
+<main class="wrap" data-app-id="hn" data-minimum-cobalt-version="0.2.0">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/install.js
+++ b/docs/apps/install.js
@@ -5,6 +5,7 @@ const STORAGE_KEY = "cobalt.install-link.v1";
 const encoder = new TextEncoder();
 const app = document.querySelector("main");
 const appId = app.dataset.appId;
+const minimumCobaltVersion = app.dataset.minimumCobaltVersion;
 const setupPanel = document.querySelector("#setup-panel");
 const pairPanel = document.querySelector("#pair-panel");
 const installPanel = document.querySelector("#install-panel");
@@ -377,6 +378,12 @@ function resultMessage(state) {
     }
     if (state.failure === "unavailable") {
       return { tone: "warning", text: "This app is not available in the current catalog. Nothing changed." };
+    }
+    if (state.failure === "requires-cobalt") {
+      const required = /^\d+(?:\.\d+)*$/.test(minimumCobaltVersion || "")
+        ? ` ${minimumCobaltVersion}`
+        : " a newer release";
+      return { tone: "warning", text: `This app requires Cobalt${required}. Update Cobalt on your Kobo, then send it again.` };
     }
     return { tone: "error", text: "The install could not be completed. Open App Store on your Kobo and try again." };
   }

--- a/docs/apps/magnet/index.html
+++ b/docs/apps/magnet/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="magnet">
+<main class="wrap" data-app-id="magnet" data-minimum-cobalt-version="0.2.0">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/magnet/index.html
+++ b/docs/apps/magnet/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="magnet" data-minimum-cobalt-version="0.2.0">
+<main class="wrap" data-app-id="magnet" data-minimum-cobalt-version="0.2.4">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/magnet/index.html
+++ b/docs/apps/magnet/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Find the hall sensor behind the bezel and watch it respond to a magnet. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/magnet.png">
 <meta name="twitter:image:alt" content="The Kobo hall sensor responding to a magnet">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-d1lRHEaxCemPd0NDXFggyZQkhfz2y4n4argUVP/3DxA='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-3+PkPoDK8BuCtZb4KhbVF389R0GSODoRHoWamrkVJ2g='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.0.1",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Magnet</h1>
       <p class="summary">Find the hall sensor behind the bezel and watch it respond to a magnet.</p>
-      <div class="meta"><span>Version 1.0.0</span><span>cover-sensor</span></div>
+      <div class="meta"><span>Version 1.0.1</span><span>cover-sensor</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/magnet.png" width="1072" height="1448" alt="The Kobo hall sensor responding to a magnet">

--- a/docs/apps/morse/index.html
+++ b/docs/apps/morse/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Type a message and send it in Morse code with the front light. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/morse.png">
 <meta name="twitter:image:alt" content="A letter filling the Kobo screen while the front light sends Morse code">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-thCeiXG+xzZmS2gYW4vjJb3Ng0fFjIykXG8JtvpDY2c='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-QmljaAAuL+wMkP83TCOBB7I5uNJV8/JVa5xK4c0cb7U='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.2",
+      "softwareVersion": "1.0.3",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Morse</h1>
       <p class="summary">Type a message and send it in Morse code with the front light.</p>
-      <div class="meta"><span>Version 1.0.2</span><span>frontlight-control, keep-awake</span></div>
+      <div class="meta"><span>Version 1.0.3</span><span>frontlight-control, keep-awake</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/morse.png" width="1072" height="1448" alt="A letter filling the Kobo screen while the front light sends Morse code">

--- a/docs/apps/morse/index.html
+++ b/docs/apps/morse/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="morse">
+<main class="wrap" data-app-id="morse" data-minimum-cobalt-version="0.2.0">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/morse/index.html
+++ b/docs/apps/morse/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="morse" data-minimum-cobalt-version="0.2.0">
+<main class="wrap" data-app-id="morse" data-minimum-cobalt-version="0.2.4">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/rss/index.html
+++ b/docs/apps/rss/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="rss">
+<main class="wrap" data-app-id="rss" data-minimum-cobalt-version="0.2.0">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/rss/index.html
+++ b/docs/apps/rss/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="rss" data-minimum-cobalt-version="0.2.0">
+<main class="wrap" data-app-id="rss" data-minimum-cobalt-version="0.2.4">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/rss/index.html
+++ b/docs/apps/rss/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Follow website feeds and read their articles without the web page around them. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/feeds.png">
 <meta name="twitter:image:alt" content="Subscribed feeds and articles in the Feeds app on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-JqCHqektAYtl9HRDeTTA2QP2EkX5+WDK/1rLvpFSu7A='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-2EHulKCe0vW6NZjHCqYPChzMU6KA3icF6E6rUFc5ryE='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.0.1",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Feeds</h1>
       <p class="summary">Follow website feeds and read their articles without the web page around them.</p>
-      <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.1</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/feeds.png" width="1072" height="1448" alt="Subscribed feeds and articles in the Feeds app on a Kobo">

--- a/docs/apps/sidekick/index.html
+++ b/docs/apps/sidekick/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="sidekick" data-minimum-cobalt-version="0.2.0">
+<main class="wrap" data-app-id="sidekick" data-minimum-cobalt-version="0.2.4">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/sidekick/index.html
+++ b/docs/apps/sidekick/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="sidekick">
+<main class="wrap" data-app-id="sidekick" data-minimum-cobalt-version="0.2.0">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/sidekick/index.html
+++ b/docs/apps/sidekick/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Answer coding-agent permission prompts from your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/sidekick.png">
 <meta name="twitter:image:alt" content="A coding-agent request with tappable responses on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-rMyU65xOCEOo9ddugPHFXJaeTcDNEK0DJqUKsOGQSsY='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-fOTKhd0oGldih4K9o5KUSQHe9lbWCLVRkFNuKkh3Cs8='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.0.1",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Sidekick</h1>
       <p class="summary">Answer coding-agent permission prompts from your Kobo.</p>
-      <div class="meta"><span>Version 1.0.0</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.1</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/sidekick.png" width="1072" height="1448" alt="A coding-agent request with tappable responses on a Kobo">

--- a/docs/apps/sudoku/index.html
+++ b/docs/apps/sudoku/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="sudoku" data-minimum-cobalt-version="0.2.0">
+<main class="wrap" data-app-id="sudoku" data-minimum-cobalt-version="0.2.4">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/sudoku/index.html
+++ b/docs/apps/sudoku/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="sudoku">
+<main class="wrap" data-app-id="sudoku" data-minimum-cobalt-version="0.2.0">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/sudoku/index.html
+++ b/docs/apps/sudoku/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Play touch-first Sudoku designed for an e-ink screen. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/sudoku.png">
 <meta name="twitter:image:alt" content="A Sudoku game designed for the Kobo touch screen">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-ffhf9Hqk6iMSWfp/NKm+loCwl6Rg9uQDZsg9BkmVce4='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-VkIL6NaIpG5lhVCWQm4W7061W+g+1aZQ8Qvwbh6dfSg='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.1",
+      "softwareVersion": "1.0.2",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Sudoku</h1>
       <p class="summary">Play touch-first Sudoku designed for an e-ink screen.</p>
-      <div class="meta"><span>Version 1.0.1</span><span>No additional permissions</span></div>
+      <div class="meta"><span>Version 1.0.2</span><span>No additional permissions</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/sudoku.png" width="1072" height="1448" alt="A Sudoku game designed for the Kobo touch screen">

--- a/docs/apps/tictactoe/index.html
+++ b/docs/apps/tictactoe/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Play tic-tac-toe together on one Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/tictactoe.png">
 <meta name="twitter:image:alt" content="A completed game of tic-tac-toe on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-2I2yFgIrI5UqGSej7yCpoMupY1ylen55j8zV2Zs9YZw='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-xc+P8e7ByXwDj1rTmVK0l11XUGvVvvPVY+O6nsKGCQk='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.0.1",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Tic-tac-toe</h1>
       <p class="summary">Play tic-tac-toe together on one Kobo.</p>
-      <div class="meta"><span>Version 1.0.0</span><span>No additional permissions</span></div>
+      <div class="meta"><span>Version 1.0.1</span><span>No additional permissions</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/tictactoe.png" width="1072" height="1448" alt="A completed game of tic-tac-toe on a Kobo">

--- a/docs/apps/tictactoe/index.html
+++ b/docs/apps/tictactoe/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="tictactoe" data-minimum-cobalt-version="0.2.0">
+<main class="wrap" data-app-id="tictactoe" data-minimum-cobalt-version="0.2.4">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/tictactoe/index.html
+++ b/docs/apps/tictactoe/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="tictactoe">
+<main class="wrap" data-app-id="tictactoe" data-minimum-cobalt-version="0.2.0">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/todo/index.html
+++ b/docs/apps/todo/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Keep a simple to-do list that stays on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/todo.png">
 <meta name="twitter:image:alt" content="A to-do list with completed items on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-poBtu56QbJN4/4k65wyrqkt6wVWl0lNvirnDjpH1L60='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-QAyaaYmaxgA+9tRyW0JDYVE0NkW0j388ueYIgZc6Un0='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.0.1",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Todo</h1>
       <p class="summary">Keep a simple to-do list that stays on your Kobo.</p>
-      <div class="meta"><span>Version 1.0.0</span><span>No additional permissions</span></div>
+      <div class="meta"><span>Version 1.0.1</span><span>No additional permissions</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/todo.png" width="1072" height="1448" alt="A to-do list with completed items on a Kobo">

--- a/docs/apps/todo/index.html
+++ b/docs/apps/todo/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="todo" data-minimum-cobalt-version="0.2.0">
+<main class="wrap" data-app-id="todo" data-minimum-cobalt-version="0.2.4">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/apps/todo/index.html
+++ b/docs/apps/todo/index.html
@@ -91,7 +91,7 @@
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="todo">
+<main class="wrap" data-app-id="todo" data-minimum-cobalt-version="0.2.0">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://bandarlabs.github.io/Cobalt/</loc></url>
+  <url><loc>https://bandarlabs.github.io/Cobalt/developers.html</loc></url>
   <url><loc>https://bandarlabs.github.io/Cobalt/faq.html</loc></url>
   <url><loc>https://bandarlabs.github.io/Cobalt/sdk.html</loc></url>
   <url><loc>https://bandarlabs.github.io/Cobalt/apps/arxiv/</loc></url>

--- a/examples/launcher/src/main.rs
+++ b/examples/launcher/src/main.rs
@@ -453,6 +453,7 @@ mod tests {
                 label: "Words".to_owned(),
                 summary: "Counts words in a note.".to_owned(),
                 version: "1.0.0".to_owned(),
+                minimum_cobalt_version: env!("CARGO_PKG_VERSION").to_owned(),
                 glyph: Glyph::Note,
                 capabilities: Vec::new(),
                 installed_version: Some("1.0.0".to_owned()),

--- a/examples/store/src/main.rs
+++ b/examples/store/src/main.rs
@@ -18,6 +18,7 @@ const BEGIN_LINK: &str = "begin-link";
 const DISCONNECT_LINK: &str = "disconnect-link";
 const PREVIOUS: &str = "previous";
 const NEXT: &str = "next";
+const UPDATE_COBALT: &str = "update-cobalt";
 const QR_HANDLE: PictureHandle = PictureHandle(1);
 const QR_SCALE: u32 = 7;
 const QR_QUIET_ZONE: i32 = 4;
@@ -329,6 +330,7 @@ impl Store {
         };
         let installed = entry.installed_version.as_deref();
         let system = is_system_app(id);
+        let compatible = entry.is_compatible_with(env!("CARGO_PKG_VERSION"));
         let mut screen = ScreenBuilder::new("store-detail")
             .top_bar(entry.title.clone())
             .owns_back(true)
@@ -340,6 +342,7 @@ impl Store {
             .facts([
                 ("Available", entry.version.clone()),
                 ("Installed", installed.unwrap_or("Not installed").to_owned()),
+                ("Requires Cobalt", entry.minimum_cobalt_version.clone()),
                 (
                     "Management",
                     if system {
@@ -359,6 +362,20 @@ impl Store {
             ]);
         screen = if system {
             screen.bottom_action_marked(open_action(id), "Open", entry.glyph)
+        } else if !compatible {
+            if installed.is_some() {
+                screen.action_bar_marked(vec![
+                    (
+                        UPDATE_COBALT.to_owned(),
+                        "Update Cobalt",
+                        Some(Glyph::Refresh),
+                    ),
+                    (open_action(id), "Open", Some(entry.glyph)),
+                    (remove_action(id), "Uninstall", Some(Glyph::Trash)),
+                ])
+            } else {
+                screen.bottom_action_marked(UPDATE_COBALT, "Update Cobalt", Glyph::Refresh)
+            }
         } else if installed.is_some() {
             let mut actions = vec![
                 (open_action(id), "Open", Some(entry.glyph)),
@@ -474,6 +491,10 @@ impl KoboApp for Store {
             context.applications().refresh_catalog();
             return;
         }
+        if action == action_id(UPDATE_COBALT) {
+            context.launch("settings");
+            return;
+        }
         if action == action_id(PREVIOUS) || action == action_id(NEXT) {
             self.page = if action == action_id(NEXT) {
                 self.page.saturating_add(1)
@@ -498,10 +519,13 @@ impl KoboApp for Store {
                 || action == action_id(&remove_action(&entry.id))
         }) {
             let id = entry.id.clone();
+            let compatible = entry.is_compatible_with(env!("CARGO_PKG_VERSION"));
             if action == action_id(&open_action(&id)) {
                 context.launch(id);
             } else if action == action_id(&remove_action(&id)) {
                 self.request_uninstall(context, id);
+            } else if !compatible {
+                context.launch("settings");
             } else {
                 self.request_install(context, id);
             }
@@ -676,6 +700,14 @@ fn remote_install_notice(outcome: &RemoteInstallOutcome, entries: &[AppInfo]) ->
             "{} is not available in the current catalog. Nothing changed.",
             name(id)
         )),
+        RemoteInstallOutcome::RequiresCobalt {
+            id,
+            minimum_cobalt_version,
+        } => Some(format!(
+            "{} requires Cobalt {}. Update Cobalt, then try again.",
+            name(id),
+            minimum_cobalt_version
+        )),
     }
 }
 
@@ -694,6 +726,9 @@ fn denied(reason: DenyReason) -> &'static str {
 fn app_state(entry: &AppInfo) -> String {
     if is_system_app(&entry.id) {
         return "Installed · system".to_owned();
+    }
+    if !entry.is_compatible_with(env!("CARGO_PKG_VERSION")) {
+        return format!("Requires Cobalt {}", entry.minimum_cobalt_version);
     }
     match &entry.installed_version {
         None => "Available".to_owned(),
@@ -755,6 +790,7 @@ mod tests {
             label: id.to_owned(),
             summary: "A useful public Cobalt application.".to_owned(),
             version: "1.1.0".to_owned(),
+            minimum_cobalt_version: env!("CARGO_PKG_VERSION").to_owned(),
             glyph: Glyph::App,
             capabilities: vec!["network".to_owned()],
             installed_version: installed.map(str::to_owned),
@@ -821,6 +857,58 @@ mod tests {
         assert!(!commands
             .iter()
             .any(|command| matches!(command, Command::Device(DeviceRequest::Update { .. }))));
+    }
+
+    #[test]
+    fn an_incompatible_app_opens_the_cobalt_updater_instead_of_installing() {
+        let mut incompatible = app("notes", None);
+        incompatible.minimum_cobalt_version = "9.0.0".to_owned();
+        assert_eq!(app_state(&incompatible), "Requires Cobalt 9.0.0");
+
+        let mut runner = AppRunner::new(Store::default());
+        runner.start();
+        runner.device_result(DeviceResult::Apps {
+            entries: vec![incompatible.clone()],
+        });
+        runner.device_result(DeviceResult::AppLink(AppLinkState::Unpaired));
+        runner.device_result(DeviceResult::Apps {
+            entries: vec![incompatible],
+        });
+        runner.action(action_id(&app_action("notes")));
+        let commands = runner.action(action_id(&install_action("notes")));
+        assert!(commands
+            .iter()
+            .any(|command| matches!(command, Command::Launch(id) if id == "settings")));
+        assert!(!commands
+            .iter()
+            .any(|command| matches!(command, Command::Device(DeviceRequest::InstallApp { .. }))));
+    }
+
+    #[test]
+    fn an_incompatible_installed_app_can_still_open_or_be_removed() {
+        let mut incompatible = app("notes", Some("1.0.0"));
+        incompatible.minimum_cobalt_version = "9.0.0".to_owned();
+
+        let mut runner = AppRunner::new(Store::default());
+        runner.start();
+        runner.device_result(DeviceResult::Apps {
+            entries: vec![incompatible.clone()],
+        });
+        runner.device_result(DeviceResult::AppLink(AppLinkState::Unpaired));
+        runner.device_result(DeviceResult::Apps {
+            entries: vec![incompatible],
+        });
+        runner.action(action_id(&app_action("notes")));
+        let open = runner.action(action_id(&open_action("notes")));
+        assert!(open
+            .iter()
+            .any(|command| matches!(command, Command::Launch(id) if id == "notes")));
+
+        let remove = runner.action(action_id(&remove_action("notes")));
+        assert!(remove.iter().any(|command| matches!(
+            command,
+            Command::Device(DeviceRequest::UninstallApp { id }) if id == "notes"
+        )));
     }
 
     #[test]
@@ -1079,6 +1167,17 @@ mod tests {
             )
             .as_deref(),
             Some("removed-app is not available in the current catalog. Nothing changed.")
+        );
+        assert_eq!(
+            remote_install_notice(
+                &RemoteInstallOutcome::RequiresCobalt {
+                    id: "sudoku".to_owned(),
+                    minimum_cobalt_version: "0.4.0".to_owned(),
+                },
+                &[app("sudoku", None)]
+            )
+            .as_deref(),
+            Some("sudoku app requires Cobalt 0.4.0. Update Cobalt, then try again.")
         );
     }
 

--- a/tools/check-app-versions.mjs
+++ b/tools/check-app-versions.mjs
@@ -12,6 +12,11 @@ const MANIFEST_FIELDS = [
   "glyph"
 ];
 
+// Store packages are built from the current SDK and therefore speak its exact
+// wire protocol. A new protocol must add its first compatible Cobalt release
+// here before the catalog can be published.
+const PROTOCOL_MINIMUMS = new Map([[10, "0.2.4"]]);
+
 function readJson(path, label) {
   try {
     const value = JSON.parse(readFileSync(path, "utf8"));
@@ -78,6 +83,48 @@ export function checkEntries(registry, published, affectedPackages) {
   if (failures.length > 0) {
     throw new Error(`${failures.join("\n")}\nBump each affected version in the app registry.`);
   }
+}
+
+function versionParts(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value);
+  if (!match) throw new Error(`invalid Cobalt version ${value}`);
+  return match.slice(1).map(Number);
+}
+
+function versionIsOlder(value, minimum) {
+  const left = versionParts(value);
+  const right = versionParts(minimum);
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return left[index] < right[index];
+  }
+  return false;
+}
+
+export function checkProtocolMinimums(registry, protocolVersion, baselines = PROTOCOL_MINIMUMS) {
+  if (!Array.isArray(registry.apps)) throw new Error("registry apps must be an array");
+  const minimum = baselines.get(protocolVersion);
+  if (!minimum) {
+    throw new Error(
+      `protocol ${protocolVersion} has no minimum Cobalt release; add it to PROTOCOL_MINIMUMS`
+    );
+  }
+  const failures = registry.apps
+    .filter(app => versionIsOlder(app.minimum_cobalt_version, minimum))
+    .map(
+      app =>
+        `${app.id}: minimum Cobalt ${app.minimum_cobalt_version} is older than protocol ${protocolVersion}, first supported by ${minimum}`
+    );
+  if (failures.length > 0) throw new Error(failures.join("\n"));
+}
+
+function currentProtocolVersion() {
+  const source = readFileSync(
+    resolve(dirname(fileURLToPath(import.meta.url)), "../crates/kobo-protocol/src/lib.rs"),
+    "utf8"
+  );
+  const match = /pub const VERSION: u8 = (\d+);/.exec(source);
+  if (!match) throw new Error("read the current protocol version");
+  return Number(match[1]);
 }
 
 function command(name, arguments_) {
@@ -161,6 +208,7 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
     const registry = readJson(resolve(values.get("--registry")), "app registry");
     const published = readJson(resolve(values.get("--published-catalog")), "published catalog");
     const affected = affectedWorkspacePackages(values.get("--base"));
+    checkProtocolMinimums(registry, currentProtocolVersion());
     checkEntries(registry, published, affected);
     console.log("Every changed app package has a new version.");
   } catch (error) {

--- a/tools/check-app-versions.mjs
+++ b/tools/check-app-versions.mjs
@@ -1,0 +1,170 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MANIFEST_FIELDS = [
+  "id",
+  "display_name",
+  "short_label",
+  "summary",
+  "minimum_cobalt_version",
+  "glyph"
+];
+
+function readJson(path, label) {
+  try {
+    const value = JSON.parse(readFileSync(path, "utf8"));
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error("must be a JSON object");
+    }
+    return value;
+  } catch (error) {
+    throw new Error(`read ${label} ${path}: ${error.message}`);
+  }
+}
+
+function normalizedCapabilities(value, label) {
+  if (!Array.isArray(value) || value.some(capability => typeof capability !== "string")) {
+    throw new Error(`${label} capabilities must be an array of strings`);
+  }
+  return [...value].sort();
+}
+
+export function checkEntries(registry, published, affectedPackages) {
+  if (!Array.isArray(registry.apps) || !Array.isArray(published.entries)) {
+    throw new Error("registry apps and published catalog entries must be arrays");
+  }
+
+  const previousById = new Map();
+  for (const entry of published.entries) {
+    const manifest = entry?.manifest;
+    if (!manifest || typeof manifest.id !== "string") {
+      throw new Error("published catalog entry has no valid manifest identity");
+    }
+    previousById.set(manifest.id, manifest);
+  }
+
+  const failures = [];
+  for (const app of registry.apps) {
+    if (!app || typeof app.id !== "string" || typeof app.package !== "string") {
+      throw new Error("registry app has no valid identity or package name");
+    }
+    const previous = previousById.get(app.id);
+    if (!previous) continue;
+    if (typeof app.version !== "string" || typeof previous.version !== "string") {
+      throw new Error(`${app.id} has no valid version`);
+    }
+    if (app.version !== previous.version) continue;
+
+    const changed = [];
+    if (affectedPackages.has(app.package)) changed.push("release inputs");
+    for (const field of MANIFEST_FIELDS) {
+      if (app[field] !== previous[field]) changed.push(field);
+    }
+    const currentCapabilities = normalizedCapabilities(app.capabilities, app.id);
+    const previousCapabilities = normalizedCapabilities(previous.capabilities, app.id);
+    if (JSON.stringify(currentCapabilities) !== JSON.stringify(previousCapabilities)) {
+      changed.push("capabilities");
+    }
+
+    if (changed.length > 0) {
+      failures.push(
+        `${app.id}: package inputs changed (${changed.join(", ")}) but version remains ${app.version}`
+      );
+    }
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`${failures.join("\n")}\nBump each affected version in the app registry.`);
+  }
+}
+
+function command(name, arguments_) {
+  try {
+    return execFileSync(name, arguments_, { encoding: "utf8" }).trim();
+  } catch (error) {
+    throw new Error(`${name} ${arguments_.join(" ")} failed: ${error.message}`);
+  }
+}
+
+function isInside(path, directory) {
+  return path === directory || path.startsWith(`${directory}/`);
+}
+
+export function affectedWorkspacePackages(baseRevision) {
+  const metadata = JSON.parse(command("cargo", ["metadata", "--format-version", "1", "--locked"]));
+  const workspaceRoot = resolve(metadata.workspace_root);
+  const changedPaths = command("git", [
+    "diff",
+    "--name-only",
+    "--diff-filter=ACMRT",
+    `${baseRevision}...HEAD`
+  ])
+    .split("\n")
+    .filter(Boolean)
+    .map(path => path.split(sep).join("/"));
+
+  const globalInputs = new Set(["Cargo.toml", "Cargo.lock", "rust-toolchain", "rust-toolchain.toml"]);
+  if (changedPaths.some(path => globalInputs.has(path) || path.startsWith(".cargo/"))) {
+    return new Set(metadata.packages.map(package_ => package_.name));
+  }
+
+  const workspaceMembers = new Set(metadata.workspace_members);
+  const workspacePackages = metadata.packages.filter(package_ => workspaceMembers.has(package_.id));
+  const changedIds = new Set();
+  for (const package_ of workspacePackages) {
+    const directory = dirname(package_.manifest_path);
+    const relativeDirectory = relative(workspaceRoot, directory).split(sep).join("/");
+    if (changedPaths.some(path => isInside(path, relativeDirectory))) changedIds.add(package_.id);
+  }
+
+  const dependencies = new Map(
+    metadata.resolve.nodes.map(node => [node.id, node.deps.map(dependency => dependency.pkg)])
+  );
+  function dependsOnChanged(id, seen = new Set()) {
+    if (changedIds.has(id)) return true;
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return (dependencies.get(id) || []).some(dependency => dependsOnChanged(dependency, seen));
+  }
+
+  return new Set(
+    workspacePackages.filter(package_ => dependsOnChanged(package_.id)).map(package_ => package_.name)
+  );
+}
+
+function argumentsFrom(argv) {
+  const allowed = ["--registry", "--published-catalog", "--base"];
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!allowed.includes(flag) || !value) {
+      throw new Error(
+        "usage: node tools/check-app-versions.mjs --registry PATH --published-catalog PATH --base GIT_REVISION"
+      );
+    }
+    values.set(flag, value);
+  }
+  if (values.size !== allowed.length) {
+    throw new Error(
+      "usage: node tools/check-app-versions.mjs --registry PATH --published-catalog PATH --base GIT_REVISION"
+    );
+  }
+  return values;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const values = argumentsFrom(process.argv.slice(2));
+    const registry = readJson(resolve(values.get("--registry")), "app registry");
+    const published = readJson(resolve(values.get("--published-catalog")), "published catalog");
+    const affected = affectedWorkspacePackages(values.get("--base"));
+    checkEntries(registry, published, affected);
+    console.log("Every changed app package has a new version.");
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/tools/check-app-versions.test.mjs
+++ b/tools/check-app-versions.test.mjs
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { checkEntries } from "./check-app-versions.mjs";
+import { checkEntries, checkProtocolMinimums } from "./check-app-versions.mjs";
 
 function fixture({ currentVersion = "1.0.0", summary = "Summary" } = {}) {
   const app = {
@@ -58,5 +58,22 @@ test("accepts changed content with a new version", () => {
   const values = fixture({ currentVersion: "1.0.1", summary: "New summary" });
   assert.doesNotThrow(() =>
     checkEntries(values.registry, values.published, new Set(["kobo-notes"]))
+  );
+});
+
+test("rejects a minimum Cobalt release older than the package protocol", () => {
+  const values = fixture();
+  values.registry.apps[0].minimum_cobalt_version = "0.2.3";
+  assert.throws(
+    () => checkProtocolMinimums(values.registry, 10, new Map([[10, "0.2.4"]])),
+    /minimum Cobalt 0\.2\.3 is older than protocol 10, first supported by 0\.2\.4/
+  );
+});
+
+test("accepts the first Cobalt release supporting the package protocol", () => {
+  const values = fixture();
+  values.registry.apps[0].minimum_cobalt_version = "0.2.4";
+  assert.doesNotThrow(() =>
+    checkProtocolMinimums(values.registry, 10, new Map([[10, "0.2.4"]]))
   );
 });

--- a/tools/check-app-versions.test.mjs
+++ b/tools/check-app-versions.test.mjs
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { checkEntries } from "./check-app-versions.mjs";
+
+function fixture({ currentVersion = "1.0.0", summary = "Summary" } = {}) {
+  const app = {
+    package: "kobo-notes",
+    id: "notes",
+    display_name: "Notes",
+    short_label: "Notes",
+    summary,
+    version: currentVersion,
+    minimum_cobalt_version: "0.3.0",
+    glyph: "note",
+    capabilities: ["network"]
+  };
+  const previous = {
+    format_version: 1,
+    id: "notes",
+    display_name: "Notes",
+    short_label: "Notes",
+    summary: "Summary",
+    version: "1.0.0",
+    minimum_cobalt_version: "0.3.0",
+    glyph: "note",
+    capabilities: ["network"],
+    binary_sha256: "0".repeat(64),
+    binary_bytes: 3
+  };
+  return {
+    registry: { format_version: 1, apps: [app] },
+    published: { format_version: 1, entries: [{ manifest: previous }] }
+  };
+}
+
+test("accepts an unchanged app at the published version", () => {
+  const values = fixture();
+  assert.doesNotThrow(() => checkEntries(values.registry, values.published, new Set()));
+});
+
+test("requires a version bump when code or a dependency changes", () => {
+  const values = fixture();
+  assert.throws(
+    () => checkEntries(values.registry, values.published, new Set(["kobo-notes"])),
+    /package inputs changed \(release inputs\).*version remains 1\.0\.0/s
+  );
+});
+
+test("requires a version bump when public metadata changes", () => {
+  const values = fixture({ summary: "New summary" });
+  assert.throws(
+    () => checkEntries(values.registry, values.published, new Set()),
+    /package inputs changed \(summary\).*version remains 1\.0\.0/s
+  );
+});
+
+test("accepts changed content with a new version", () => {
+  const values = fixture({ currentVersion: "1.0.1", summary: "New summary" });
+  assert.doesNotThrow(() =>
+    checkEntries(values.registry, values.published, new Set(["kobo-notes"]))
+  );
+});

--- a/tools/generate-app-pages.mjs
+++ b/tools/generate-app-pages.mjs
@@ -191,7 +191,7 @@ for (const app of catalog.apps) {
     </nav>
   </div>
 </header>
-<main class="wrap" data-app-id="${id}">
+<main class="wrap" data-app-id="${id}" data-minimum-cobalt-version="${escape(app.minimum_cobalt_version)}">
   <div class="app-hero">
     <div class="app-copy">
       <p class="eyebrow">Kobo app</p>

--- a/tools/generate-app-pages.mjs
+++ b/tools/generate-app-pages.mjs
@@ -182,7 +182,7 @@ for (const app of catalog.apps) {
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>
@@ -308,7 +308,7 @@ for (const app of systemApps) {
     <a class="brand" href="../../"><img src="../../logo.svg" alt="Cobalt" width="81" height="34"></a>
     <nav class="top" aria-label="Main navigation">
       <a class="active" href="../../#apps">Apps</a>
-      <a href="../../sdk.html">Developers</a>
+      <a href="../../developers.html">Developers</a>
       <a href="../../faq.html">FAQ</a>
       <a href="../../#store">Store</a>
       <a href="../../#install">Install</a>
@@ -368,6 +368,7 @@ for (const app of [...catalog.apps, ...systemApps]) {
 
 const sitemapUrls = [
   "https://bandarlabs.github.io/Cobalt/",
+  "https://bandarlabs.github.io/Cobalt/developers.html",
   "https://bandarlabs.github.io/Cobalt/faq.html",
   "https://bandarlabs.github.io/Cobalt/sdk.html",
   ...[...catalog.apps, ...systemApps].map(


### PR DESCRIPTION
## Summary

- keep generated app-page headers linked to the developer guide
- include the developer guide in the sitemap
- require an app version change when its code, transitive local dependencies or public manifest changes
- enforce the version check in pull-request CI and again before Store publication
- carry each app's minimum Cobalt release into Store metadata
- show `Requires Cobalt <version>` before an incompatible app can be installed
- send incompatible installs to Settings instead of showing an app install button
- report the same requirement through paired website installs
- increment registered app versions because the shared protocol input changed

## Why

Generated app pages had drifted from their source template, which stopped the publication workflow. The workflow also allowed changed app packages to retain an existing version, preventing installed readers from recognizing the update.

Compatibility failures were safely blocked by the runtime, but Store presented an install or update action first and then returned a generic error. Store and paired browser installs now identify the required Cobalt release before downloading or running the package. Installed compatible copies can still be opened or removed when a newer catalog release needs a newer Cobalt version.

The version guard compares release inputs with the last successful Store publication. It does not compare raw ELF bytes because two current apps contain compiler output that is not byte-for-byte reproducible across identical builds.

## Validation

- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `node tools/generate-app-pages.mjs`
- `node --test tools/check-app-versions.test.mjs`
- current branch passes the version guard against the live catalog and last successful publication
- a known shared-runtime change correctly fails the guard for affected apps
- `git diff --check`
