### PR TITLE
Make touch feedback and screen updates responsive

### DIFF
--- a/crates/kobo-hal/src/display.rs
+++ b/crates/kobo-hal/src/display.rs
@@ -528,7 +528,8 @@ impl DisplaySession {
         for refresh in work.matching(selected) {
             let wait_started = Instant::now();
             self.wait_for_marker(refresh.marker)?;
-            debug_assert!(work.remove(refresh.marker));
+            let removed = work.remove(refresh.marker);
+            debug_assert!(removed);
             timing.oldest = timing.oldest.max(refresh.sent_at.elapsed());
             timing.wait += wait_started.elapsed();
             timing.completed += 1;

--- a/crates/kobo-hal/src/display.rs
+++ b/crates/kobo-hal/src/display.rs
@@ -17,10 +17,12 @@ use crate::refresh::{Backend, Rect, RefreshPlan};
 use crate::surface::{self, RegionSnapshot, SurfaceError, SurfaceGeometry};
 use kobo_abi::{hwtcon, mxcfb};
 use kobo_profile::{DeviceProfile, DeviceSnapshot, WRITE_EVIDENCE_PENDING};
+use std::collections::VecDeque;
 use std::fmt;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Read};
 use std::path::Path;
+use std::sync::Mutex;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
@@ -169,6 +171,48 @@ pub struct DisplaySession {
     backend: Backend,
     profile: &'static DeviceProfile,
     snapshot: DeviceSnapshot,
+    panel_work: Mutex<PanelWork>,
+}
+
+/// Maximum number of panel updates Cobalt will leave unfinished at once.
+///
+/// The controller has its own finite queue, but that capacity is not part of
+/// either stable userspace interface. Keeping a smaller bound here prevents a
+/// burst of disjoint changes from depending on an undocumented driver limit.
+const PANEL_WORK_LIMIT: usize = 8;
+
+#[derive(Clone, Copy, Debug)]
+struct PanelRefresh {
+    marker: u32,
+    region: Rect,
+    sent_at: Instant,
+}
+
+#[derive(Debug, Default)]
+struct PanelWork {
+    unfinished: VecDeque<PanelRefresh>,
+}
+
+impl PanelWork {
+    fn matching(&self, mut selected: impl FnMut(&PanelRefresh) -> bool) -> Vec<PanelRefresh> {
+        self.unfinished
+            .iter()
+            .filter(|refresh| selected(refresh))
+            .copied()
+            .collect()
+    }
+
+    fn remove(&mut self, marker: u32) -> bool {
+        let Some(index) = self
+            .unfinished
+            .iter()
+            .position(|refresh| refresh.marker == marker)
+        else {
+            return false;
+        };
+        self.unfinished.remove(index);
+        true
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -256,6 +300,7 @@ impl DisplaySession {
             backend: Backend::from_controller(profile.framebuffer_controller),
             profile,
             snapshot,
+            panel_work: Mutex::new(PanelWork::default()),
         })
     }
 
@@ -286,6 +331,7 @@ impl DisplaySession {
     ///
     /// Returns an error when the region is invalid or the read fails.
     pub fn capture(&self, region: Rect) -> Result<RegionSnapshot, DisplayError> {
+        let _work = self.lock_panel_work()?;
         Ok(surface::read_region(
             &self.framebuffer,
             self.geometry,
@@ -299,10 +345,35 @@ impl DisplaySession {
     ///
     /// # Errors
     ///
-    /// Returns an error when the write fails.
+    /// Returns an error when an overlapping panel update cannot be completed
+    /// or the write fails.
     pub fn restore(&self, snapshot: &RegionSnapshot) -> Result<(), DisplayError> {
+        self.restore_timed(snapshot).map(|_| ())
+    }
+
+    /// [`Self::restore`], with the time spent making the destination safe to
+    /// overwrite.
+    ///
+    /// Panel updates read from the shared framebuffer after submission. A
+    /// later write may proceed immediately when it is elsewhere on the panel,
+    /// but an overlapping write first completes the earlier update. The lock
+    /// covers both that check and the write, so two callers cannot race a new
+    /// overlapping submission into the gap.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the work lock is unavailable, an overlapping
+    /// update cannot be completed, or the framebuffer write fails.
+    pub fn restore_timed(
+        &self,
+        snapshot: &RegionSnapshot,
+    ) -> Result<RefreshFenceTiming, DisplayError> {
+        let mut work = self.lock_panel_work()?;
+        let region = snapshot.placement().region();
+        let timing =
+            self.finish_matching(&mut work, |unfinished| unfinished.region.intersects(region))?;
         surface::write_region(&self.framebuffer, self.geometry, snapshot)?;
-        Ok(())
+        Ok(timing)
     }
 
     /// Submits one hardware update for `plan` and waits for it to complete.
@@ -318,6 +389,62 @@ impl DisplaySession {
         self.refresh_timed(plan).map(|_| ())
     }
 
+    /// Submits one update without waiting for the panel to finish it.
+    ///
+    /// The update remains owned by this session. Before a later framebuffer
+    /// write touches the same region, [`Self::restore`] completes it. Full
+    /// cleaning updates first complete all earlier work so the controller
+    /// cannot combine a clean with stale partial updates. The outstanding set
+    /// is bounded even when every update is disjoint.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the region is invalid, the work lock is
+    /// unavailable, an earlier update cannot be completed, or submission
+    /// fails.
+    pub fn refresh_deferred(
+        &self,
+        plan: RefreshPlan,
+    ) -> Result<RefreshSubmissionTiming, DisplayError> {
+        surface::RegionPlacement::new(self.geometry, plan.region)?;
+        let mut work = self.lock_panel_work()?;
+        let prior = if plan.full {
+            self.finish_matching(&mut work, |_| true)?
+        } else if work.unfinished.len() >= PANEL_WORK_LIMIT {
+            let oldest = work.unfinished.front().map(|refresh| refresh.marker);
+            self.finish_matching(&mut work, |refresh| Some(refresh.marker) == oldest)?
+        } else {
+            RefreshFenceTiming::default()
+        };
+        let issued = self.issue(plan)?;
+        work.unfinished.push_back(PanelRefresh {
+            marker: issued.marker,
+            region: plan.region,
+            sent_at: Instant::now(),
+        });
+        Ok(RefreshSubmissionTiming {
+            submitted_waveform: issued.submitted_waveform,
+            translated_waveform: issued.translated_waveform,
+            submit: issued.submit,
+            prior,
+            unfinished: work.unfinished.len(),
+        })
+    }
+
+    /// Completes every update submitted through [`Self::refresh_deferred`].
+    ///
+    /// Called before the panel is handed back to the stock reader and before
+    /// lifecycle operations that change display ownership.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the work lock is unavailable or an unfinished
+    /// update cannot be completed.
+    pub fn finish_pending(&self) -> Result<RefreshFenceTiming, DisplayError> {
+        let mut work = self.lock_panel_work()?;
+        self.finish_matching(&mut work, |_| true)
+    }
+
     /// [`Self::refresh`], instrumented.
     ///
     /// Measures the submit and wait ioctls separately and reads back the
@@ -331,49 +458,127 @@ impl DisplaySession {
     pub fn refresh_timed(&self, plan: RefreshPlan) -> Result<RefreshTiming, DisplayError> {
         // Validate the region against this exact surface before the kernel sees it.
         surface::RegionPlacement::new(self.geometry, plan.region)?;
+        let mut work = self.lock_panel_work()?;
+        self.finish_matching(&mut work, |_| true)?;
+        let issued = self.issue(plan)?;
+        let wait_started = Instant::now();
+        self.wait_for_marker(issued.marker)?;
+        Ok(RefreshTiming {
+            submitted_waveform: issued.submitted_waveform,
+            translated_waveform: issued.translated_waveform,
+            submit: issued.submit,
+            wait: wait_started.elapsed(),
+        })
+    }
+
+    fn issue(&self, plan: RefreshPlan) -> Result<IssuedRefresh, DisplayError> {
         let marker = unique_marker()?;
-        // The two backends' wait requests happen to be the same number over
-        // the same struct, so one path would work for both. It is still
-        // written out twice: the coincidence belongs to this kernel, not to
-        // the interface, and a device whose wait struct grew a field would
-        // otherwise be served a MediaTek ioctl through an i.MX session with
-        // nothing in the code to make that visible.
         let submitted_waveform = plan.waveform(self.backend);
-        let (translated_waveform, submit, wait) = match self.backend {
+        let (translated_waveform, submit) = match self.backend {
             Backend::Hwtcon => {
                 let mut update = plan.hwtcon_update_data(marker);
                 let submit_started = Instant::now();
                 hwtcon::send_update(&self.framebuffer, &mut update)?;
-                let submit = submit_started.elapsed();
-                let mut wait = hwtcon::HwtconUpdateMarkerData {
-                    update_marker: marker,
-                    collision_test: 0,
-                };
-                let wait_started = Instant::now();
-                hwtcon::wait_for_update_complete(&self.framebuffer, &mut wait)?;
-                (update.waveform_mode, submit, wait_started.elapsed())
+                (update.waveform_mode, submit_started.elapsed())
             }
             Backend::Mxcfb => {
                 let mut update = plan.mxcfb_update_data(marker);
                 let submit_started = Instant::now();
                 mxcfb::send_update(&self.framebuffer, &mut update)?;
-                let submit = submit_started.elapsed();
+                (update.waveform_mode, submit_started.elapsed())
+            }
+        };
+        Ok(IssuedRefresh {
+            marker,
+            submitted_waveform,
+            translated_waveform,
+            submit,
+        })
+    }
+
+    fn wait_for_marker(&self, marker: u32) -> Result<(), DisplayError> {
+        // The two backends currently use the same request shape. Keeping the
+        // calls separate makes the hardware boundary explicit if either ABI
+        // changes later.
+        match self.backend {
+            Backend::Hwtcon => {
+                let mut wait = hwtcon::HwtconUpdateMarkerData {
+                    update_marker: marker,
+                    collision_test: 0,
+                };
+                hwtcon::wait_for_update_complete(&self.framebuffer, &mut wait)?;
+            }
+            Backend::Mxcfb => {
                 let mut wait = mxcfb::MxcfbUpdateMarkerData {
                     update_marker: marker,
                     collision_test: 0,
                 };
-                let wait_started = Instant::now();
                 mxcfb::wait_for_update_complete(&self.framebuffer, &mut wait)?;
-                (update.waveform_mode, submit, wait_started.elapsed())
             }
-        };
-        Ok(RefreshTiming {
-            submitted_waveform,
-            translated_waveform,
-            submit,
-            wait,
-        })
+        }
+        Ok(())
     }
+
+    fn finish_matching(
+        &self,
+        work: &mut PanelWork,
+        selected: impl FnMut(&PanelRefresh) -> bool,
+    ) -> Result<RefreshFenceTiming, DisplayError> {
+        let mut timing = RefreshFenceTiming::default();
+        for refresh in work.matching(selected) {
+            let wait_started = Instant::now();
+            self.wait_for_marker(refresh.marker)?;
+            debug_assert!(work.remove(refresh.marker));
+            timing.oldest = timing.oldest.max(refresh.sent_at.elapsed());
+            timing.wait += wait_started.elapsed();
+            timing.completed += 1;
+        }
+        Ok(timing)
+    }
+
+    fn lock_panel_work(&self) -> Result<std::sync::MutexGuard<'_, PanelWork>, DisplayError> {
+        self.panel_work
+            .lock()
+            .map_err(|_| DisplayError::Io(io::Error::other("display work lock was poisoned")))
+    }
+}
+
+impl Drop for DisplaySession {
+    fn drop(&mut self) {
+        let _ = self.finish_pending();
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct IssuedRefresh {
+    marker: u32,
+    submitted_waveform: u32,
+    translated_waveform: u32,
+    submit: Duration,
+}
+
+/// Work completed before a framebuffer write or refresh submission could
+/// safely proceed.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct RefreshFenceTiming {
+    /// Number of earlier updates completed.
+    pub completed: usize,
+    /// Time spent inside completion ioctls.
+    pub wait: Duration,
+    /// Age of the oldest completed update when the fence began.
+    pub oldest: Duration,
+}
+
+/// What one non-blocking refresh submission measured.
+#[derive(Clone, Copy, Debug)]
+pub struct RefreshSubmissionTiming {
+    pub submitted_waveform: u32,
+    pub translated_waveform: u32,
+    pub submit: Duration,
+    /// Earlier work completed before this update could be submitted.
+    pub prior: RefreshFenceTiming,
+    /// Number of unfinished updates retained after submission.
+    pub unfinished: usize,
 }
 
 /// What one instrumented refresh measured.
@@ -636,9 +841,9 @@ fn unique_marker() -> Result<u32, DisplayError> {
 #[cfg(test)]
 mod tests {
     use super::{
-        unique_marker, AttendedSmokeStage, DisplayError, DisplaySession, Rect, RefreshPlan,
-        WritePolicy, ATTENDED_SMOKE_UNLOCK_PHRASE, OWNER_UNLOCK_PHRASE, SMOKE_FIXED_REGION,
-        SMOKE_PATCH_REGION, SMOKE_UPDATE_IS_FULL, SMOKE_VISIBLE_HOLD,
+        unique_marker, AttendedSmokeStage, DisplayError, DisplaySession, PanelRefresh, PanelWork,
+        Rect, RefreshPlan, WritePolicy, ATTENDED_SMOKE_UNLOCK_PHRASE, OWNER_UNLOCK_PHRASE,
+        SMOKE_FIXED_REGION, SMOKE_PATCH_REGION, SMOKE_UPDATE_IS_FULL, SMOKE_VISIBLE_HOLD,
     };
     use crate::surface::{RegionPlacement, SurfaceGeometry};
     use kobo_abi::{hwtcon, mxcfb};
@@ -647,6 +852,78 @@ mod tests {
         CLARA_BW_391, ELIPSA_2E_389, WRITE_EVIDENCE_PENDING,
     };
     use std::path::Path;
+    use std::time::Instant;
+
+    fn pending(marker: u32, region: Rect) -> PanelRefresh {
+        PanelRefresh {
+            marker,
+            region,
+            sent_at: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn selecting_overlapping_panel_work_keeps_disjoint_updates_in_order() {
+        let mut work = PanelWork::default();
+        work.unfinished.push_back(pending(
+            1,
+            Rect {
+                x: 0,
+                y: 0,
+                width: 20,
+                height: 20,
+            },
+        ));
+        work.unfinished.push_back(pending(
+            2,
+            Rect {
+                x: 100,
+                y: 100,
+                width: 20,
+                height: 20,
+            },
+        ));
+        work.unfinished.push_back(pending(
+            3,
+            Rect {
+                x: 10,
+                y: 10,
+                width: 20,
+                height: 20,
+            },
+        ));
+        let write = Rect {
+            x: 15,
+            y: 15,
+            width: 2,
+            height: 2,
+        };
+
+        let selected = work.matching(|refresh| refresh.region.intersects(write));
+        assert_eq!(
+            selected
+                .iter()
+                .map(|refresh| refresh.marker)
+                .collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+        assert_eq!(
+            work.unfinished
+                .iter()
+                .map(|refresh| refresh.marker)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3],
+        );
+        assert!(work.remove(1));
+        assert!(work.remove(3));
+        assert_eq!(
+            work.unfinished
+                .iter()
+                .map(|refresh| refresh.marker)
+                .collect::<Vec<_>>(),
+            vec![2]
+        );
+    }
 
     fn matched_snapshot() -> DeviceSnapshot {
         snapshot_for(

--- a/crates/kobo-hal/src/refresh.rs
+++ b/crates/kobo-hal/src/refresh.rs
@@ -105,6 +105,19 @@ impl Rect {
             height: bottom - self.y,
         })
     }
+
+    /// Whether two non-empty panel regions share at least one pixel.
+    #[must_use]
+    pub fn intersects(self, other: Self) -> bool {
+        self.width > 0
+            && self.height > 0
+            && other.width > 0
+            && other.height > 0
+            && self.x < other.x.saturating_add(other.width)
+            && other.x < self.x.saturating_add(self.width)
+            && self.y < other.y.saturating_add(other.height)
+            && other.y < self.y.saturating_add(self.height)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -341,5 +354,33 @@ mod tests {
         let mut markers = UpdateMarker::new(u32::MAX);
         assert_eq!(markers.take(), u32::MAX);
         assert_eq!(markers.take(), 1);
+    }
+
+    #[test]
+    fn region_intersection_excludes_edges_and_empty_rectangles() {
+        let left = Rect {
+            x: 10,
+            y: 20,
+            width: 30,
+            height: 40,
+        };
+        assert!(left.intersects(Rect {
+            x: 39,
+            y: 59,
+            width: 2,
+            height: 2,
+        }));
+        assert!(!left.intersects(Rect {
+            x: 40,
+            y: 20,
+            width: 1,
+            height: 40,
+        }));
+        assert!(!left.intersects(Rect {
+            x: 10,
+            y: 20,
+            width: 0,
+            height: 40,
+        }));
     }
 }

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -44,8 +44,8 @@ use kobo_hal::{Rect, RefreshIntent, RefreshPlan, RegionSnapshot};
 use kobo_policy::{Backends, Capability, Declared, DeviceServices, PowerPolicy, TaskRunner};
 use kobo_protocol::{Frame, Lifecycle, Message, TaskError, TaskOutcome};
 use kobo_ui::{
-    render_all, ActionId, Chrome, FontHandle, FramePlanner, PanelWaveform, PictureCache, Screen,
-    Surface,
+    render_all, ActionId, CellStyle, Chrome, FontHandle, FramePlanner, Layout, LayoutKind,
+    PanelWaveform, PictureCache, Screen, Surface,
 };
 use std::collections::BTreeMap;
 use std::fs;
@@ -617,7 +617,7 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
     // two portrait poses.
     let forward_is_194 = pose.rotation() % 4 == profile.reference_rotation % 4;
 
-    let outcome = host_applications(
+    let application_outcome = host_applications(
         application,
         &display,
         whole_screen,
@@ -626,6 +626,17 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
         forward_is_194,
         &watchdog,
     );
+    // No panel work may outlive Cobalt's ownership of the display. This is an
+    // explicit lifecycle fence rather than a timing assumption: the stock
+    // reader can start drawing as soon as the session gives the descriptor
+    // back.
+    let panel_idle = display
+        .finish_pending()
+        .map_err(|error| format!("finish panel updates before handoff: {error}"));
+    let outcome = match (application_outcome, panel_idle) {
+        (Ok(summary), Ok(_)) => Ok(summary),
+        (Err(error), _) | (_, Err(error)) => Err(error),
+    };
     trace("session finished, handing the panel back");
     println!("session finished, handing the panel back");
 
@@ -1237,7 +1248,12 @@ fn host_applications(
         // The rectangle a finger is resting on, with the metrics its mark was
         // drawn against. Both, because the mark is undone by drawing it again
         // and that is only exact if nothing about it is recomputed.
-        let mut pressed: Option<(kobo_ui::Rect, kobo_ui::DisplayMetrics)> = None;
+        let mut pressed: Option<(kobo_ui::Rect, kobo_ui::DisplayMetrics, FeedbackKind)> = None;
+        // A released control is restored with the application's answer when
+        // that answer arrives promptly. If it does not, this deadline makes
+        // the release visible on its own instead of leaving a key held down
+        // while an application works or fails.
+        let mut release_due: Option<Instant> = None;
         // When and where the finger landed, for telling a tap from a hold.
         let mut landed: Option<(Instant, i32, i32)> = None;
 
@@ -1247,6 +1263,10 @@ fn host_applications(
             // the runtime is still serving the panel rather than merely that
             // the process has not been reaped.
             watchdog.beat();
+            if release_due.is_some_and(|deadline| now >= deadline) {
+                panel.paint(display, whole_screen, &surface)?;
+                release_due = None;
+            }
             // The band is the only thing on the panel that changes without
             // anybody touching it, so the loop has to notice it on its own.
             // Repainting is conditional on the reading having moved, and the
@@ -1330,6 +1350,9 @@ fn host_applications(
                 .min(STATUS_POLL)
                 .min(back_offered.map_or(BEAT_INTERVAL, |(_, offered_at)| {
                     (offered_at + BACK_GRACE).saturating_duration_since(now)
+                }))
+                .min(release_due.map_or(BEAT_INTERVAL, |deadline| {
+                    deadline.saturating_duration_since(now)
                 }));
             match events.recv_timeout(wait) {
                 Ok(Event::Stopping(number)) => {
@@ -1475,30 +1498,36 @@ fn host_applications(
                     // the finished surface, so the planner sees a change of
                     // pure black and white in one small rectangle and picks
                     // the fast waveform for it.
+                    let mut released = None;
                     if let Some(current) = screen.as_ref() {
                         match event {
                             TouchEvent::Down { x, y } => {
+                                // A new feedback frame also carries any older
+                                // deferred release, so its fallback is no
+                                // longer needed.
+                                release_due = None;
                                 if let (Ok(x), Ok(y)) = (i32::try_from(x), i32::try_from(y)) {
                                     landed = Some((Instant::now(), x, y));
-                                    if let Some(rect) = current
-                                        .layout_with(&metrics_for(current), &chrome)
-                                        .pressed_control(x, y)
-                                    {
+                                    let layout =
+                                        current.layout_with(&metrics_for(current), &chrome);
+                                    if let Some(rect) = layout.pressed_control(x, y) {
                                         let metrics = metrics_for(current);
                                         surface.invert_press(rect, &metrics);
                                         panel.paint(display, whole_screen, &surface)?;
-                                        pressed = Some((rect, metrics));
+                                        pressed =
+                                            Some((rect, metrics, feedback_kind(&layout, rect)));
                                     }
                                 }
                             }
                             TouchEvent::Up { .. } => {
-                                // Put back before the action is delivered, so
-                                // that an application which repaints does so
-                                // over a control in its resting state rather
-                                // than over an inverted one.
-                                if let Some((rect, metrics)) = pressed.take() {
+                                // Restore the surface before the application
+                                // draws, but do not submit the release yet.
+                                // The action is delivered first and a prompt
+                                // answer carries both the release and the new
+                                // screen in one update.
+                                if let Some((rect, metrics, class)) = pressed.take() {
                                     surface.invert_press(rect, &metrics);
-                                    panel.paint(display, whole_screen, &surface)?;
+                                    released = Some(class);
                                 }
                             }
                             TouchEvent::Move { x, y } => {
@@ -1521,11 +1550,11 @@ fn host_applications(
                                 let off = match (i32::try_from(x), i32::try_from(y)) {
                                     (Ok(x), Ok(y)) => pressed
                                         .as_ref()
-                                        .is_some_and(|(rect, _)| !rect.contains(x, y)),
+                                        .is_some_and(|(rect, _, _)| !rect.contains(x, y)),
                                     _ => true,
                                 };
                                 if off {
-                                    if let Some((rect, metrics)) = pressed.take() {
+                                    if let Some((rect, metrics, _)) = pressed.take() {
                                         surface.invert_press(rect, &metrics);
                                         panel.paint(display, whole_screen, &surface)?;
                                     }
@@ -1543,13 +1572,14 @@ fn host_applications(
                             .is_some_and(|(at, _, _)| at.elapsed() >= HOLD_TIME),
                         _ => false,
                     };
-                    match deliver_touch(
+                    let disposition = deliver_touch(
                         &mut apps[index].stream,
                         event,
                         screen.as_ref(),
                         &chrome,
                         held,
-                    )? {
+                    )?;
+                    match disposition {
                         Tap::Handled => {}
                         Tap::OfferedBack => back_offered = Some((front, Instant::now())),
                         Tap::Leave => {
@@ -1572,6 +1602,10 @@ fn host_applications(
                                 &mut status,
                             )?;
                         }
+                    }
+                    if let Some(class) = released {
+                        release_due = (disposition != Tap::Leave)
+                            .then(|| Instant::now() + release_grace(class));
                     }
                 }
                 Ok(Event::App(id, frame)) => {
@@ -1609,6 +1643,7 @@ fn host_applications(
                                 // it, or releasing the finger would invert a
                                 // rectangle of the new screen instead.
                                 pressed = None;
+                                release_due = None;
                                 render_all(
                                     &screen,
                                     &metrics_for(&screen),
@@ -2761,6 +2796,39 @@ fn installed_name(path: &Path) -> Result<String, String> {
 /// concludes the panel is ignoring them and lifts off.
 const HOLD_TIME: Duration = Duration::from_millis(500);
 
+/// Briefly holds a release so an application's next screen can carry it.
+///
+/// These are far shorter than a panel transition and therefore add no visible
+/// hold. A keyboard gets a little more room because one key commonly changes
+/// both the key face and a text field at the opposite end of the screen.
+const CONTROL_RELEASE_GRACE: Duration = Duration::from_millis(12);
+const KEYBOARD_RELEASE_GRACE: Duration = Duration::from_millis(30);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FeedbackKind {
+    Control,
+    KeyboardKey,
+}
+
+fn feedback_kind(layout: &Layout, rect: kobo_ui::Rect) -> FeedbackKind {
+    if layout
+        .nodes
+        .iter()
+        .any(|node| node.rect == rect && matches!(node.kind, LayoutKind::Cell(_, CellStyle::Key)))
+    {
+        FeedbackKind::KeyboardKey
+    } else {
+        FeedbackKind::Control
+    }
+}
+
+fn release_grace(class: FeedbackKind) -> Duration {
+    match class {
+        FeedbackKind::Control => CONTROL_RELEASE_GRACE,
+        FeedbackKind::KeyboardKey => KEYBOARD_RELEASE_GRACE,
+    }
+}
+
 /// How far the finger may wander and still be holding, in pixels.
 ///
 /// A finger resting on glass is never still, and this panel reports every
@@ -3135,8 +3203,8 @@ impl Painter {
         let frame = RegionSnapshot::from_grayscale(display.geometry(), region, &region_gray)
             .map_err(|error| format!("prepare the frame: {error}"))?;
         let converted = started.elapsed();
-        display
-            .restore(&frame)
+        let fence = display
+            .restore_timed(&frame)
             .map_err(|error| format!("write the frame: {error}"))?;
         let written = started.elapsed();
         let plan = RefreshPlan::new(
@@ -3148,7 +3216,7 @@ impl Painter {
         )
         .ok_or_else(|| "the refresh region is not inside the screen".to_owned())?;
         let timing = display
-            .refresh_timed(plan)
+            .refresh_deferred(plan)
             .map_err(|error| format!("show the frame: {error}"))?;
         // One line per frame: how long the grayscale conversion, the
         // framebuffer write and the two ioctls each took, and what was
@@ -3159,14 +3227,16 @@ impl Painter {
         // line; start.sh already captures stderr.
         if frame_timing_wanted() {
             eprintln!(
-                "frame {}x{} wf={} convert={}ms write={}ms submit={}us wait={}ms",
+                "frame {}x{} wf={} convert={}ms write={}ms submit={}us fence={}ms completed={} pending={}",
                 region.width,
                 region.height,
                 timing.submitted_waveform,
                 converted.as_millis(),
                 written.saturating_sub(converted).as_millis(),
                 timing.submit.as_micros(),
-                timing.wait.as_millis(),
+                fence.wait.saturating_add(timing.prior.wait).as_millis(),
+                fence.completed.saturating_add(timing.prior.completed),
+                timing.unfinished,
             );
         }
 
@@ -3822,5 +3892,51 @@ mod hosting_tests {
             assert!(!super::system_request_allowed("settings", &request));
             assert!(!super::system_request_allowed("todo", &request));
         }
+    }
+
+    #[test]
+    fn keyboard_release_gets_one_short_app_response_window() {
+        assert_eq!(
+            super::release_grace(super::FeedbackKind::Control),
+            super::CONTROL_RELEASE_GRACE
+        );
+        assert_eq!(
+            super::release_grace(super::FeedbackKind::KeyboardKey),
+            super::KEYBOARD_RELEASE_GRACE
+        );
+        assert!(super::KEYBOARD_RELEASE_GRACE > super::CONTROL_RELEASE_GRACE);
+        assert!(super::KEYBOARD_RELEASE_GRACE < std::time::Duration::from_millis(50));
+    }
+
+    #[test]
+    fn keyboard_cells_use_the_keyboard_feedback_window() {
+        let screen = kobo_ui::Screen::new(
+            1,
+            vec![kobo_ui::Node::Grid {
+                id: kobo_ui::NodeId(1),
+                columns: 2,
+                square: false,
+                cells: vec![
+                    kobo_ui::Cell::new(kobo_ui::ActionId(1), "A"),
+                    kobo_ui::Cell::new(kobo_ui::ActionId(2), "B"),
+                ],
+            }],
+        );
+        let layout = screen.layout();
+        let key = layout
+            .nodes
+            .iter()
+            .find(|node| {
+                matches!(
+                    node.kind,
+                    kobo_ui::LayoutKind::Cell(_, kobo_ui::CellStyle::Key)
+                )
+            })
+            .expect("keyboard key")
+            .rect;
+        assert_eq!(
+            super::feedback_kind(&layout, key),
+            super::FeedbackKind::KeyboardKey
+        );
     }
 }

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -1502,10 +1502,6 @@ fn host_applications(
                     if let Some(current) = screen.as_ref() {
                         match event {
                             TouchEvent::Down { x, y } => {
-                                // A new feedback frame also carries any older
-                                // deferred release, so its fallback is no
-                                // longer needed.
-                                release_due = None;
                                 if let (Ok(x), Ok(y)) = (i32::try_from(x), i32::try_from(y)) {
                                     landed = Some((Instant::now(), x, y));
                                     let layout =
@@ -1514,6 +1510,12 @@ fn host_applications(
                                         let metrics = metrics_for(current);
                                         surface.invert_press(rect, &metrics);
                                         panel.paint(display, whole_screen, &surface)?;
+                                        // This feedback frame also carried any
+                                        // older deferred release, so its
+                                        // fallback is no longer needed. A press
+                                        // outside every control paints nothing
+                                        // and must leave the deadline armed.
+                                        release_due = None;
                                         pressed =
                                             Some((rect, metrics, feedback_kind(&layout, rect)));
                                     }


### PR DESCRIPTION
## What changes

- Submit normal panel updates without waiting for each transition to finish.
- Track unfinished updates by marker, region, and age.
- Wait before overwriting an intersecting region, before a full cleaning refresh, and before display handoff.
- Deliver touch actions immediately after release.
- Let release feedback and a prompt application response share one paint.
- Give keyboard releases a short, bounded coalescing window.
- Keep the existing blocking refresh API for restoration, diagnostics, and tests.
- Extend frame timing output with completion waits and unfinished update counts.

## Why

The runtime previously waited for the panel after press feedback, waited again after release feedback, and only then delivered the action or displayed the application response. Those serialized waits made ordinary taps and typing feel much slower than the underlying device.

## Safety boundaries

- Framebuffer writes wait for intersecting unfinished updates.
- Full cleaning refreshes complete earlier work first.
- The unfinished queue has a fixed bound.
- Display handoff completes all remaining updates.
- Screen restoration continues to use the blocking path.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `node --test tools/check-app-versions.test.mjs`
- Source and metadata provenance scan passed.

The local ARM check is blocked because this Mac does not have `arm-linux-musleabihf-gcc`; the repository CI installs it. On-device timing and interaction validation is still required before merge because the reader is not currently reachable over SSH.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790720284&installation_model_id=20525&pr_number=78&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F78&signature=23f50a25f944aebddef8cd00701fe2dc81ac5e7a91b176adc97e5c7e45056274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->