### PR TITLE
Ignore dev-only dependencies in app version checks

### DIFF
--- a/tools/check-app-versions.mjs
+++ b/tools/check-app-versions.mjs
@@ -139,6 +139,26 @@ function isInside(path, directory) {
   return path === directory || path.startsWith(`${directory}/`);
 }
 
+// Returns the dependency edges capable of changing a release artifact.
+//
+// Cargo includes dev dependencies in the resolved metadata graph even when
+// they are used only to compile tests. Following those edges made an
+// unrelated test fixture change look like an app binary change and forced
+// contributors to bump and republish unaffected apps. Normal and build
+// dependencies still count, including an edge used as both dev and normal.
+export function releaseDependencyIds(node) {
+  return node.deps
+    .filter(dependency => {
+      const kinds = dependency.dep_kinds;
+      return (
+        !Array.isArray(kinds) ||
+        kinds.length === 0 ||
+        kinds.some(dependencyKind => dependencyKind.kind !== "dev")
+      );
+    })
+    .map(dependency => dependency.pkg);
+}
+
 export function affectedWorkspacePackages(baseRevision) {
   const metadata = JSON.parse(command("cargo", ["metadata", "--format-version", "1", "--locked"]));
   const workspaceRoot = resolve(metadata.workspace_root);
@@ -167,7 +187,7 @@ export function affectedWorkspacePackages(baseRevision) {
   }
 
   const dependencies = new Map(
-    metadata.resolve.nodes.map(node => [node.id, node.deps.map(dependency => dependency.pkg)])
+    metadata.resolve.nodes.map(node => [node.id, releaseDependencyIds(node)])
   );
   function dependsOnChanged(id, seen = new Set()) {
     if (changedIds.has(id)) return true;

--- a/tools/check-app-versions.test.mjs
+++ b/tools/check-app-versions.test.mjs
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { checkEntries, checkProtocolMinimums } from "./check-app-versions.mjs";
+import {
+  checkEntries,
+  checkProtocolMinimums,
+  releaseDependencyIds
+} from "./check-app-versions.mjs";
 
 function fixture({ currentVersion = "1.0.0", summary = "Summary" } = {}) {
   const app = {
@@ -76,4 +80,25 @@ test("accepts the first Cobalt release supporting the package protocol", () => {
   assert.doesNotThrow(() =>
     checkProtocolMinimums(values.registry, 10, new Map([[10, "0.2.4"]]))
   );
+});
+
+test("release inputs ignore exclusively dev-only dependency edges", () => {
+  const dependencies = releaseDependencyIds({
+    deps: [
+      { pkg: "normal", dep_kinds: [{ kind: null, target: null }] },
+      { pkg: "build", dep_kinds: [{ kind: "build", target: null }] },
+      { pkg: "dev-only", dep_kinds: [{ kind: "dev", target: null }] },
+      {
+        pkg: "normal-and-dev",
+        dep_kinds: [
+          { kind: "dev", target: null },
+          { kind: null, target: "cfg(unix)" }
+        ]
+      },
+      // Fail conservatively if older Cargo metadata omits dependency kinds.
+      { pkg: "unspecified", dep_kinds: [] }
+    ]
+  });
+
+  assert.deepEqual(dependencies, ["normal", "build", "normal-and-dev", "unspecified"]);
 });


### PR DESCRIPTION
## Summary

- exclude exclusively dev-only Cargo dependency edges from release-input propagation
- keep normal, build, mixed normal/dev, and unspecified edges conservative
- add a regression test covering each dependency kind

## Why

Cargo metadata includes dev dependencies in its resolved graph. The app version check followed every edge, so a test-only dependency change could require unrelated apps to bump and republish their versions. That makes valid contributor PRs fail device-build CI.

This fixes the dependency graph at the source instead of special-casing packages or requiring unnecessary version bumps.

## Validation

- `node --test tools/check-app-versions.test.mjs`
- `node --check tools/check-app-versions.mjs`
- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- merged PR #81 into this fix locally and reran the exact published-catalog version check that failed CI; it passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790754635&installation_model_id=20525&pr_number=82&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F82&signature=9f1f5406077d6365c12a29d10ed4c9a11f80fe3fe399ef06ee4d42135d9ffa67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->