### PR TITLE
Add pre-install setup metadata for app pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,11 @@ jobs:
       - name: Install the ARM cross-compiler the packaging tests look for
         run: sudo apt-get update && sudo apt-get install --yes gcc-arm-linux-gnueabihf
       - run: cargo fmt --all -- --check
-      - run: node --test tools/check-app-versions.test.mjs
+      - run: node --test tools/*.test.mjs
+      - name: Require current generated app pages
+        run: |
+          node tools/generate-app-pages.mjs
+          git diff --exit-code -- docs/apps docs/sitemap.xml
       - run: cargo test --workspace --all-targets --all-features
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           node tools/generate-app-pages.mjs
           git diff --exit-code -- docs/apps docs/sitemap.xml
+          test -z "$(git status --porcelain --untracked-files=all -- docs/apps docs/sitemap.xml)"
       - run: cargo test --workspace --all-targets --all-features
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -868,8 +868,9 @@ fn parse_release_app(value: &kobo_json::Value) -> Result<ReleaseApp, String> {
         "glyph",
         "capabilities",
     ];
-    // `setup` is website-only metadata. The page generator validates its
-    // nested schema; release manifests deliberately contain none of it.
+    // `setup` is an accepted website-only registry field. The page generator
+    // validates its nested schema; the CLI ignores it and release manifests
+    // deliberately contain none of it.
     let fields = strict_registry_object(value, "app", &FIELDS, &["setup"])?;
     let string = |name| {
         registry_field(fields, name)?

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -812,7 +812,7 @@ fn read_release_registry(path: &Path) -> Result<Vec<ReleaseApp>, String> {
         fs::read_to_string(path).map_err(|error| format!("read {}: {error}", path.display()))?;
     let document =
         kobo_json::parse(&text).map_err(|error| format!("parse {}: {error}", path.display()))?;
-    let fields = strict_registry_object(&document, "registry", &["format_version", "apps"])?;
+    let fields = strict_registry_object(&document, "registry", &["format_version", "apps"], &[])?;
     if registry_field(fields, "format_version")?.as_i64() != Some(1) {
         return Err("app registry format_version must be 1".to_owned());
     }
@@ -868,7 +868,9 @@ fn parse_release_app(value: &kobo_json::Value) -> Result<ReleaseApp, String> {
         "glyph",
         "capabilities",
     ];
-    let fields = strict_registry_object(value, "app", &FIELDS)?;
+    // `setup` is website-only metadata. The page generator validates its
+    // nested schema; release manifests deliberately contain none of it.
+    let fields = strict_registry_object(value, "app", &FIELDS, &["setup"])?;
     let string = |name| {
         registry_field(fields, name)?
             .as_str()
@@ -902,21 +904,22 @@ fn parse_release_app(value: &kobo_json::Value) -> Result<ReleaseApp, String> {
 fn strict_registry_object<'a>(
     value: &'a kobo_json::Value,
     object: &str,
-    allowed: &[&str],
+    required: &[&str],
+    optional: &[&str],
 ) -> Result<&'a [(String, kobo_json::Value)], String> {
     let kobo_json::Value::Object(fields) = value else {
         return Err(format!("{object} must be an object"));
     };
     let mut seen = BTreeSet::new();
     for (name, _) in fields {
-        if !allowed.contains(&name.as_str()) {
+        if !required.contains(&name.as_str()) && !optional.contains(&name.as_str()) {
             return Err(format!("unknown field '{name}' in {object}"));
         }
         if !seen.insert(name.as_str()) {
             return Err(format!("duplicate field '{name}' in {object}"));
         }
     }
-    for name in allowed {
+    for name in required {
         if !seen.contains(name) {
             return Err(format!("missing field '{name}' in {object}"));
         }
@@ -5364,6 +5367,28 @@ mod tests {
             [7_u8; 32]
         );
         fs::remove_dir_all(root).expect("remove fixture");
+    }
+
+    #[test]
+    fn release_registry_accepts_website_setup_metadata() {
+        let value = kobo_json::parse(
+            r#"{
+                "package":"kobo-library",
+                "id":"library",
+                "display_name":"Library",
+                "short_label":"Library",
+                "summary":"Read a personal library.",
+                "version":"1.0.0",
+                "minimum_cobalt_version":"0.2.4",
+                "glyph":"book",
+                "capabilities":["network"],
+                "setup":{"steps":[{"text":"Create a read-only key."}]}
+            }"#,
+        )
+        .expect("registry fixture");
+
+        let app = super::parse_release_app(&value).expect("setup metadata is registry-only");
+        assert_eq!(app.id, "library");
     }
 
     #[test]

--- a/docs/CONTRIBUTING_APPS.md
+++ b/docs/CONTRIBUTING_APPS.md
@@ -35,7 +35,7 @@ capability. Request only capabilities the app actually uses.
 
 If an app needs an account, API key, named secret, self-hosted service, or
 other preparation outside Cobalt, add a `setup` object to its registry entry.
-The generated install page puts these steps in a **Before installing** panel,
+The generated install page puts these steps in a **Before you install** panel,
 so owners see the requirements before installing rather than discovering them
 on first launch. Each step has plain `text` and may add one HTTPS `link` and
 one shell `command`:

--- a/docs/CONTRIBUTING_APPS.md
+++ b/docs/CONTRIBUTING_APPS.md
@@ -28,9 +28,44 @@ Registry fields:
 | `minimum_cobalt_version` | Oldest platform release that supports the SDK protocol and every runtime service the app uses |
 | `glyph` | A built-in Cobalt glyph name |
 | `capabilities` | Runtime services the app needs |
+| `setup` | Optional website-only prerequisites shown before the install controls |
 
 Public apps cannot use a platform-reserved ID or request the `shell`
 capability. Request only capabilities the app actually uses.
+
+If an app needs an account, API key, named secret, self-hosted service, or
+other preparation outside Cobalt, add a `setup` object to its registry entry.
+The generated install page puts these steps in a **Before installing** panel,
+so owners see the requirements before installing rather than discovering them
+on first launch. Each step has plain `text` and may add one HTTPS `link` and
+one shell `command`:
+
+```json
+"setup": {
+  "steps": [
+    {
+      "text": "Create a dedicated read-only key.",
+      "link": {
+        "label": "Service key settings",
+        "url": "https://example.com/settings/keys"
+      }
+    },
+    {
+      "text": "Install the key under the exact secret name used by the app.",
+      "command": "kobo secret set service --device <address>"
+    },
+    {
+      "text": "Launch the app and finish its on-device setup."
+    }
+  ]
+}
+```
+
+Use one to six short steps. Links must be absolute HTTPS URLs without embedded
+credentials. Do not put HTML or Markdown in these fields; the generator
+escapes all catalog text. The setup block is website metadata and does not
+enter the signed device catalog, so correcting these instructions does not by
+itself require an app version bump.
 
 Apps built from the current SDK require Cobalt 0.2.4 or newer because that is
 the first release supporting the current wire protocol. A newer runtime

--- a/docs/apps/install.css
+++ b/docs/apps/install.css
@@ -92,6 +92,18 @@ h1 {
 }
 
 .panel + .panel { margin-top: 22px; }
+.prerequisites { background: var(--paper-deep); }
+.prerequisites ol { margin: 20px 0 0; padding-left: 22px; color: var(--muted); }
+.prerequisites li + li { margin-top: 12px; }
+.setup-command {
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  margin-top: 8px;
+  overflow-wrap: anywhere;
+  color: var(--ink);
+  font: 14px/1.5 var(--mono);
+}
 .setup { background: var(--paper-deep); }
 .setup ol { margin: 20px 0 24px; padding-left: 22px; color: var(--muted); }
 .setup li + li { margin-top: 8px; }

--- a/tools/app-page-setup.mjs
+++ b/tools/app-page-setup.mjs
@@ -1,0 +1,96 @@
+const SETUP_FIELDS = new Set(["steps"]);
+const STEP_FIELDS = new Set(["text", "link", "command"]);
+const LINK_FIELDS = new Set(["label", "url"]);
+
+function object(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value;
+}
+
+function exactFields(value, allowed, label) {
+  for (const field of Object.keys(value)) {
+    if (!allowed.has(field)) throw new Error(`unknown field '${field}' in ${label}`);
+  }
+}
+
+function boundedText(value, label, maximum) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  if (value.length > maximum) throw new Error(`${label} must be at most ${maximum} characters`);
+  return value;
+}
+
+function validatedLink(value, label) {
+  const link = object(value, label);
+  exactFields(link, LINK_FIELDS, label);
+  const linkLabel = boundedText(link.label, `${label} label`, 80);
+  const urlText = boundedText(link.url, `${label} URL`, 500);
+  let url;
+  try {
+    url = new URL(urlText);
+  } catch {
+    throw new Error(`${label} URL must be an absolute HTTPS URL`);
+  }
+  if (url.protocol !== "https:" || url.username || url.password) {
+    throw new Error(`${label} URL must be an absolute HTTPS URL without credentials`);
+  }
+  return { label: linkLabel, url: urlText };
+}
+
+export function validatedSetup(app) {
+  if (app.setup === undefined) return null;
+  const label = `${app.id || "app"} setup`;
+  const setup = object(app.setup, label);
+  exactFields(setup, SETUP_FIELDS, label);
+  if (!Array.isArray(setup.steps) || setup.steps.length === 0 || setup.steps.length > 6) {
+    throw new Error(`${label} steps must contain between 1 and 6 entries`);
+  }
+  const steps = setup.steps.map((value, index) => {
+    const stepLabel = `${label} step ${index + 1}`;
+    const step = object(value, stepLabel);
+    exactFields(step, STEP_FIELDS, stepLabel);
+    return {
+      text: boundedText(step.text, `${stepLabel} text`, 240),
+      ...(step.link === undefined ? {} : { link: validatedLink(step.link, `${stepLabel} link`) }),
+      ...(step.command === undefined
+        ? {}
+        : { command: boundedText(step.command, `${stepLabel} command`, 200) })
+    };
+  });
+  return { steps };
+}
+
+export function escapeHtml(value) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+export function setupPanel(app) {
+  const setup = validatedSetup(app);
+  if (!setup) return "";
+  const steps = setup.steps
+    .map(step => {
+      const link = step.link
+        ? ` <a href="${escapeHtml(step.link.url)}">${escapeHtml(step.link.label)}</a>`
+        : "";
+      const command = step.command
+        ? `\n        <code class="setup-command">${escapeHtml(step.command)}</code>`
+        : "";
+      return `      <li>${escapeHtml(step.text)}${link}${command}</li>`;
+    })
+    .join("\n");
+  return `
+  <section class="panel prerequisites" aria-labelledby="prerequisites-title">
+    <p class="eyebrow">App setup</p>
+    <h2 id="prerequisites-title">Before you install</h2>
+    <ol>
+${steps}
+    </ol>
+  </section>`;
+}

--- a/tools/app-page-setup.test.mjs
+++ b/tools/app-page-setup.test.mjs
@@ -1,0 +1,64 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { setupPanel, validatedSetup } from "./app-page-setup.mjs";
+
+test("apps without setup metadata keep the ordinary install page", () => {
+  assert.equal(validatedSetup({ id: "plain" }), null);
+  assert.equal(setupPanel({ id: "plain" }), "");
+});
+
+test("setup metadata renders escaped steps links and commands", () => {
+  const html = setupPanel({
+    id: "library",
+    setup: {
+      steps: [
+        {
+          text: "Create a read-only key.",
+          link: { label: "Key settings", url: "https://example.com/settings/keys?a=1&b=2" }
+        },
+        {
+          text: "Install the key under the exact secret name.",
+          command: "kobo secret set library --device <address>"
+        }
+      ]
+    }
+  });
+
+  assert.match(html, /Before you install/);
+  assert.match(html, /https:\/\/example\.com\/settings\/keys\?a=1&amp;b=2/);
+  assert.match(html, /kobo secret set library --device &lt;address&gt;/);
+  assert.doesNotMatch(html, /<address>/);
+});
+
+test("setup metadata rejects unsafe links and unknown fields", () => {
+  assert.throws(
+    () =>
+      validatedSetup({
+        id: "unsafe",
+        setup: {
+          steps: [
+            {
+              text: "Open settings.",
+              link: { label: "Settings", url: "http://example.com/settings" }
+            }
+          ]
+        }
+      }),
+    /absolute HTTPS URL/
+  );
+  assert.throws(
+    () => validatedSetup({ id: "unknown", setup: { steps: [{ text: "Prepare.", html: "<b>" }] } }),
+    /unknown field 'html'/
+  );
+});
+
+test("setup metadata keeps pages short and scannable", () => {
+  assert.throws(
+    () =>
+      validatedSetup({
+        id: "long",
+        setup: { steps: Array.from({ length: 7 }, () => ({ text: "One step." })) }
+      }),
+    /between 1 and 6 entries/
+  );
+});

--- a/tools/generate-app-pages.mjs
+++ b/tools/generate-app-pages.mjs
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { setupPanel } from "./app-page-setup.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const catalog = JSON.parse(readFileSync(resolve(root, "apps/catalog.json"), "utf8"));
@@ -149,6 +150,7 @@ for (const app of catalog.apps) {
   const image = `https://bandarlabs.github.io/Cobalt/media/site/apps/${screenshot}`;
   const structuredData = jsonLd(appSchema(app, canonical, screenshot, screenshotAlt));
   const structuredDataHash = scriptHash(structuredData);
+  const prerequisites = setupPanel(app);
   const html = `<!doctype html>
 <html lang="en">
 <head>
@@ -202,7 +204,7 @@ for (const app of catalog.apps) {
     <figure class="app-shot">
       <img src="../../media/site/apps/${screenshot}" width="1072" height="1448" alt="${escape(screenshotAlt)}">
     </figure>
-  </div>
+  </div>${prerequisites}
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>


### PR DESCRIPTION
## Summary

- add optional website-only `setup.steps` metadata to app registry entries
- render validated prerequisites, HTTPS links, and commands before install controls
- escape all catalog-provided content and reject unsafe or malformed setup metadata
- document the schema for contributors
- run all JavaScript tool tests and reject stale generated app pages in pull-request CI

## Why

Some Store apps need account setup, named secrets, or another prerequisite outside Cobalt. Their install pages currently describe the app but cannot show those requirements, so owners discover them only after installation. This gives every app a consistent **Before you install** panel without adding website copy to the signed device catalog or forcing an app version bump for documentation-only corrections.

## Validation

- `cargo fmt --all -- --check`
- `node --test tools/*.test.mjs`
- `node tools/generate-app-pages.mjs` with no stale generated output
- `cargo run --quiet -p kobo-cli -- app-list --registry apps/catalog.json`
- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790755697&installation_model_id=20525&pr_number=84&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F84&signature=c73e09909f31e011c323c2f6a9735d4f8b2d6530b040af992233b6cd338ec188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->