### PR TITLE
Release 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "icon-import"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "image"
@@ -548,14 +548,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-abi"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "kobo-app-store"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-arxiv"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-audiobook"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-doc",
  "kobo-json",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-bookview"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-brief"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-chat"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-app-store",
  "kobo-image",
@@ -625,14 +625,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-dict"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "unicode-normalization",
 ]
 
 [[package]]
 name = "kobo-doc"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-html",
  "miniz_oxide 0.9.1",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doctor"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -649,14 +649,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-gallery"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-guard"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gutenbird"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-hal"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-abi",
  "kobo-doc",
@@ -688,21 +688,21 @@ dependencies = [
 
 [[package]]
 name = "kobo-handoff"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-hello"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-hn"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-html"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "ratex-layout",
  "ratex-parser",
@@ -722,18 +722,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-image"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "image",
 ]
 
 [[package]]
 name = "kobo-json"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "kobo-launcher"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-magnet"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-morse"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-net"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "http",
  "httparse",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-opds"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-json",
  "kobo-xml",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-policy"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-abi",
  "kobo-dict",
@@ -787,18 +787,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-profile"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "kobo-protocol"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-ui",
 ]
 
 [[package]]
 name = "kobo-read"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-rss"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sdk"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-policy",
  "kobo-protocol",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-settings"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-shell"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-abi",
  "kobo-policy",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekick"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekickd"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sim"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-net",
  "kobo-policy",
@@ -879,14 +879,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-smoke"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-store"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sudoku"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tap"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-term"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-ui",
  "vt100",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-terminal"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-policy",
  "kobo-sdk",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-text"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "fontdue",
  "kobo-ui",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tictactoe"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-todo"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -957,18 +957,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-ui"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "kobo-xml"
-version = "0.3.0"
+version = "0.3.1"
 
 [[package]]
 name = "kobod"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64",
  "kobo-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.85.1"
 license = "AGPL-3.0-only"

--- a/apps/catalog.json
+++ b/apps/catalog.json
@@ -7,7 +7,7 @@
       "display_name": "arXiv",
       "short_label": "arXiv",
       "summary": "Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo.",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "note",
       "capabilities": ["network"]
@@ -18,7 +18,7 @@
       "display_name": "Audiobook Studio",
       "short_label": "Audiobooks",
       "summary": "Turn a topic into an original narrated audiobook and listen on your Kobo.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "headphones",
       "capabilities": ["network", "audio", "bluetooth-audio", "bluetooth-control"]
@@ -29,7 +29,7 @@
       "display_name": "Daily Brief",
       "short_label": "Daily Brief",
       "summary": "Build a daily news brief in the background while you use other apps.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "clock",
       "capabilities": ["network"]
@@ -40,7 +40,7 @@
       "display_name": "AI Command Center",
       "short_label": "AI Chat",
       "summary": "Ask a question, then read and navigate the answer with touch controls.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "chat",
       "capabilities": ["network"]
@@ -51,7 +51,7 @@
       "display_name": "Components",
       "short_label": "Components",
       "summary": "See every Cobalt UI component on the device in one reference app.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "chart",
       "capabilities": ["network"]
@@ -62,7 +62,7 @@
       "display_name": "Gutenbird",
       "short_label": "Gutenbird",
       "summary": "Browse OPDS libraries and read their books on your Kobo.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "book",
       "capabilities": ["network", "frontlight-control"]
@@ -73,7 +73,7 @@
       "display_name": "Hacker News",
       "short_label": "Hacker News",
       "summary": "Read Top, New, Ask, and Show stories with complete comment threads.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "news",
       "capabilities": ["network"]
@@ -84,7 +84,7 @@
       "display_name": "Magnet",
       "short_label": "Magnet",
       "summary": "Find the hall sensor behind the bezel and watch it respond to a magnet.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "magnet",
       "capabilities": ["cover-sensor"]
@@ -95,7 +95,7 @@
       "display_name": "Morse",
       "short_label": "Morse",
       "summary": "Type a message and send it in Morse code with the front light.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "light",
       "capabilities": ["frontlight-control", "keep-awake"]
@@ -106,7 +106,7 @@
       "display_name": "Feeds",
       "short_label": "Feeds",
       "summary": "Follow website feeds and read their articles without the web page around them.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "rss",
       "capabilities": ["network"]
@@ -117,7 +117,7 @@
       "display_name": "Sidekick",
       "short_label": "Sidekick",
       "summary": "Answer coding-agent permission prompts from your Kobo.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "key",
       "capabilities": ["network"]
@@ -128,7 +128,7 @@
       "display_name": "Sudoku",
       "short_label": "Sudoku",
       "summary": "Play touch-first Sudoku designed for an e-ink screen.",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "grid",
       "capabilities": []
@@ -139,7 +139,7 @@
       "display_name": "Tic-tac-toe",
       "short_label": "Tic-tac-toe",
       "summary": "Play tic-tac-toe together on one Kobo.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "grid",
       "capabilities": []
@@ -150,7 +150,7 @@
       "display_name": "Todo",
       "short_label": "Todo",
       "summary": "Keep a simple to-do list that stays on your Kobo.",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "check",
       "capabilities": []

--- a/crates/kobo-policy/Cargo.toml
+++ b/crates/kobo-policy/Cargo.toml
@@ -9,10 +9,10 @@ repository.workspace = true
 description = "Capability, task, storage, and credential policy for Kobo applications"
 
 [dependencies]
-kobo-abi = { version = "0.3.0", path = "../kobo-abi" }
-kobo-dict = { version = "0.3.0", path = "../kobo-dict" }
-kobo-net = { version = "0.3.0", path = "../kobo-net" }
-kobo-protocol = { version = "0.3.0", path = "../kobo-protocol" }
+kobo-abi = { version = "0.3.1", path = "../kobo-abi" }
+kobo-dict = { version = "0.3.1", path = "../kobo-dict" }
+kobo-net = { version = "0.3.1", path = "../kobo-net" }
+kobo-protocol = { version = "0.3.1", path = "../kobo-protocol" }
 
 [lints]
 workspace = true

--- a/crates/kobo-protocol/Cargo.toml
+++ b/crates/kobo-protocol/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 description = "Bounded wire protocol between Kobo applications and the Cobalt runtime"
 
 [dependencies]
-kobo-ui = { version = "0.3.0", path = "../kobo-ui" }
+kobo-ui = { version = "0.3.1", path = "../kobo-ui" }
 
 [lints]
 workspace = true

--- a/crates/kobo-sdk/Cargo.toml
+++ b/crates/kobo-sdk/Cargo.toml
@@ -17,10 +17,10 @@ default = ["text"]
 text = ["dep:kobo-text"]
 
 [dependencies]
-kobo-policy = { version = "0.3.0", path = "../kobo-policy" }
-kobo-protocol = { version = "0.3.0", path = "../kobo-protocol" }
-kobo-text = { version = "0.3.0", path = "../kobo-text", optional = true }
-kobo-ui = { version = "0.3.0", path = "../kobo-ui" }
+kobo-policy = { version = "0.3.1", path = "../kobo-policy" }
+kobo-protocol = { version = "0.3.1", path = "../kobo-protocol" }
+kobo-text = { version = "0.3.1", path = "../kobo-text", optional = true }
+kobo-ui = { version = "0.3.1", path = "../kobo-ui" }
 
 [lints]
 workspace = true

--- a/crates/kobo-text/Cargo.toml
+++ b/crates/kobo-text/Cargo.toml
@@ -10,7 +10,7 @@ description = "Real type for the Kobo application platform"
 
 [dependencies]
 fontdue = "0.9"
-kobo-ui = { version = "0.3.0", path = "../kobo-ui" }
+kobo-ui = { version = "0.3.1", path = "../kobo-ui" }
 unicode-linebreak = "0.1.5"
 unicode-segmentation = "1.12"
 

--- a/docs/apps/arxiv/index.html
+++ b/docs/apps/arxiv/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/arxiv.png">
 <meta name="twitter:image:alt" content="The newest machine learning preprints listed in the arXiv app on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-iznxJ3rkfdpoyREnOiLcS2ROg5K51ldwJdfRWyWSH8M='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-nS82JMiuo+mKQi9ADXUu/5D4iZx0LWbTFI25kfTIpPo='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.3.2",
+      "softwareVersion": "1.3.3",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>arXiv</h1>
       <p class="summary">Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo.</p>
-      <div class="meta"><span>Version 1.3.2</span><span>network</span></div>
+      <div class="meta"><span>Version 1.3.3</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/arxiv.png" width="1072" height="1448" alt="The newest machine learning preprints listed in the arXiv app on a Kobo">

--- a/docs/apps/audiobook/index.html
+++ b/docs/apps/audiobook/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Turn a topic into an original narrated audiobook and listen on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/audiobook.png">
 <meta name="twitter:image:alt" content="An audiobook player with cover art and playback controls on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-SuaGkDE4YOg8eWXgFNb32OUNTYRs6Voa9LB1X0Vrml8='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-qkvXWqs0NUD/gSG3aidoh/eKNTaBRHoMKz1wVMRRH0A='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.2",
+      "softwareVersion": "1.0.3",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Audiobook Studio</h1>
       <p class="summary">Turn a topic into an original narrated audiobook and listen on your Kobo.</p>
-      <div class="meta"><span>Version 1.0.2</span><span>network, audio, bluetooth-audio, bluetooth-control</span></div>
+      <div class="meta"><span>Version 1.0.3</span><span>network, audio, bluetooth-audio, bluetooth-control</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/audiobook.png" width="1072" height="1448" alt="An audiobook player with cover art and playback controls on a Kobo">

--- a/docs/apps/brief/index.html
+++ b/docs/apps/brief/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Build a daily news brief in the background while you use other apps. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/brief.png">
 <meta name="twitter:image:alt" content="A numbered daily news brief on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-CdZwny912hzqO8WvFj7jYWApzTKBKKn/RtV+yY9HtMU='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-KH0kAXonXDGkY4OPTfOAi7elvtJeydp1Vh9XZtupeJM='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.2",
+      "softwareVersion": "1.0.3",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Daily Brief</h1>
       <p class="summary">Build a daily news brief in the background while you use other apps.</p>
-      <div class="meta"><span>Version 1.0.2</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.3</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/brief.png" width="1072" height="1448" alt="A numbered daily news brief on a Kobo">

--- a/docs/apps/chat/index.html
+++ b/docs/apps/chat/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Ask a question, then read and navigate the answer with touch controls. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/chat.png">
 <meta name="twitter:image:alt" content="An answer displayed for touch-friendly reading on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-5re8//sy4ERIav7Kw0BL9dmmEMa4qDYS2a6AZXTAQTc='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-5XTEbz1HkZYcNXDObaClUu6cta7tBAWHgDHvkrS1FVo='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.2",
+      "softwareVersion": "1.0.3",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>AI Command Center</h1>
       <p class="summary">Ask a question, then read and navigate the answer with touch controls.</p>
-      <div class="meta"><span>Version 1.0.2</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.3</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/chat.png" width="1072" height="1448" alt="An answer displayed for touch-friendly reading on a Kobo">

--- a/docs/apps/gallery/index.html
+++ b/docs/apps/gallery/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="See every Cobalt UI component on the device in one reference app. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/components.png">
 <meta name="twitter:image:alt" content="Cobalt typography and interface components on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-vYQXfQeD7w/ZF8rucab6ro5Ahrmbxp0yNbPU2kUku0U='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-OxiWxuBdyntorUBRlf7ymYQAWfy3onA9lcu8rbJGibI='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.2",
+      "softwareVersion": "1.0.3",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Components</h1>
       <p class="summary">See every Cobalt UI component on the device in one reference app.</p>
-      <div class="meta"><span>Version 1.0.2</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.3</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/components.png" width="1072" height="1448" alt="Cobalt typography and interface components on a Kobo">

--- a/docs/apps/gutenbird/index.html
+++ b/docs/apps/gutenbird/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Browse OPDS libraries and read their books on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/gutenbird.png">
 <meta name="twitter:image:alt" content="A shelf of books from an OPDS library on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-8mLXkpBs3GDcResy8iAxZTp8a2am1/pKDvrd/zHU/9c='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-80yYCcPq7E21hNpdVSzX+lkSMs7Symop6J4sclJiMnE='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.2",
+      "softwareVersion": "1.0.3",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Gutenbird</h1>
       <p class="summary">Browse OPDS libraries and read their books on your Kobo.</p>
-      <div class="meta"><span>Version 1.0.2</span><span>network, frontlight-control</span></div>
+      <div class="meta"><span>Version 1.0.3</span><span>network, frontlight-control</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/gutenbird.png" width="1072" height="1448" alt="A shelf of books from an OPDS library on a Kobo">

--- a/docs/apps/hn/index.html
+++ b/docs/apps/hn/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Read Top, New, Ask, and Show stories with complete comment threads. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/hackernews.png">
 <meta name="twitter:image:alt" content="A ranked list of Hacker News stories on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-Vzxw/SzPZ5E94a+KmfG6FOmntC8mc3pKY6991Ng4JVI='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-a3FJQ6waUlOTrmc1LDegTcXHdRgYfR5VAliFI28D4Qw='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.2",
+      "softwareVersion": "1.0.3",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Hacker News</h1>
       <p class="summary">Read Top, New, Ask, and Show stories with complete comment threads.</p>
-      <div class="meta"><span>Version 1.0.2</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.3</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/hackernews.png" width="1072" height="1448" alt="A ranked list of Hacker News stories on a Kobo">

--- a/docs/apps/magnet/index.html
+++ b/docs/apps/magnet/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Find the hall sensor behind the bezel and watch it respond to a magnet. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/magnet.png">
 <meta name="twitter:image:alt" content="The Kobo hall sensor responding to a magnet">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-d606lgXEjqStAKcNiThjMMVBjrAX7sx5CSWaUiLHq3Y='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-l4rSRsz6+BB26BftNLuz+ip4bcO+dr/vQC/eqWAbky0='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.2",
+      "softwareVersion": "1.0.3",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Magnet</h1>
       <p class="summary">Find the hall sensor behind the bezel and watch it respond to a magnet.</p>
-      <div class="meta"><span>Version 1.0.2</span><span>cover-sensor</span></div>
+      <div class="meta"><span>Version 1.0.3</span><span>cover-sensor</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/magnet.png" width="1072" height="1448" alt="The Kobo hall sensor responding to a magnet">

--- a/docs/apps/morse/index.html
+++ b/docs/apps/morse/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Type a message and send it in Morse code with the front light. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/morse.png">
 <meta name="twitter:image:alt" content="A letter filling the Kobo screen while the front light sends Morse code">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-vCPbZqzHriRx9mpmkLbji7rinzHlXwX59QJKagV/d5E='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-No2serylk9xaiAJq2Y2Swgo0TbqYdoD5VZb0HrfSlyI='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Morse</h1>
       <p class="summary">Type a message and send it in Morse code with the front light.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>frontlight-control, keep-awake</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>frontlight-control, keep-awake</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/morse.png" width="1072" height="1448" alt="A letter filling the Kobo screen while the front light sends Morse code">

--- a/docs/apps/rss/index.html
+++ b/docs/apps/rss/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Follow website feeds and read their articles without the web page around them. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/feeds.png">
 <meta name="twitter:image:alt" content="Subscribed feeds and articles in the Feeds app on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-Y7lVtiVAtsM8GjfCxMFDyV3w4OfKijrGkmzvJpElc10='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-VH9s1XyJXiznuYhH/uVYWhrPLJAw1BWLI8wRUKMv/eU='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.2",
+      "softwareVersion": "1.0.3",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Feeds</h1>
       <p class="summary">Follow website feeds and read their articles without the web page around them.</p>
-      <div class="meta"><span>Version 1.0.2</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.3</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/feeds.png" width="1072" height="1448" alt="Subscribed feeds and articles in the Feeds app on a Kobo">

--- a/docs/apps/sidekick/index.html
+++ b/docs/apps/sidekick/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Answer coding-agent permission prompts from your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/sidekick.png">
 <meta name="twitter:image:alt" content="A coding-agent request with tappable responses on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-UTI8ZYUH5yAcQHkTa4R1QMxgDDlZ77dO76adD+i0szs='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-ALkQ3U6wB0be9W/NjhAOhtm8Wbm+NnCWHAIr9hB+Kw4='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.2",
+      "softwareVersion": "1.0.3",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Sidekick</h1>
       <p class="summary">Answer coding-agent permission prompts from your Kobo.</p>
-      <div class="meta"><span>Version 1.0.2</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.3</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/sidekick.png" width="1072" height="1448" alt="A coding-agent request with tappable responses on a Kobo">

--- a/docs/apps/sudoku/index.html
+++ b/docs/apps/sudoku/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Play touch-first Sudoku designed for an e-ink screen. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/sudoku.png">
 <meta name="twitter:image:alt" content="A Sudoku game designed for the Kobo touch screen">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-cwQPXWrVUa8PwpKKhP6iIZ7yKCjGdSen0hjV3WImMQE='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-2ajH95LdDHPZtooQHnaPj7eCh26XT9sKUZ/9NcDrm60='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.3",
+      "softwareVersion": "1.0.4",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Sudoku</h1>
       <p class="summary">Play touch-first Sudoku designed for an e-ink screen.</p>
-      <div class="meta"><span>Version 1.0.3</span><span>No additional permissions</span></div>
+      <div class="meta"><span>Version 1.0.4</span><span>No additional permissions</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/sudoku.png" width="1072" height="1448" alt="A Sudoku game designed for the Kobo touch screen">

--- a/docs/apps/tictactoe/index.html
+++ b/docs/apps/tictactoe/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Play tic-tac-toe together on one Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/tictactoe.png">
 <meta name="twitter:image:alt" content="A completed game of tic-tac-toe on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-JHniq8fv1MrDaY4ybubGy41PjCkYmjYg3gJiFown3rQ='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-SU2ccWLqpOOHa/O/E4x6jMAXH6BxrjknAT4uab+zRY8='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.2",
+      "softwareVersion": "1.0.3",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Tic-tac-toe</h1>
       <p class="summary">Play tic-tac-toe together on one Kobo.</p>
-      <div class="meta"><span>Version 1.0.2</span><span>No additional permissions</span></div>
+      <div class="meta"><span>Version 1.0.3</span><span>No additional permissions</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/tictactoe.png" width="1072" height="1448" alt="A completed game of tic-tac-toe on a Kobo">

--- a/docs/apps/todo/index.html
+++ b/docs/apps/todo/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Keep a simple to-do list that stays on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/todo.png">
 <meta name="twitter:image:alt" content="A to-do list with completed items on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-nTO9aTv/Ur1xLX7Nzi02btijVa32lrgI4h4jNQKAU/U='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-NvgugmXuo6hNvs+d2uUSo9A8xeNATq2af2Bm4t9tnsQ='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.2",
+      "softwareVersion": "1.0.3",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Todo</h1>
       <p class="summary">Keep a simple to-do list that stays on your Kobo.</p>
-      <div class="meta"><span>Version 1.0.2</span><span>No additional permissions</span></div>
+      <div class="meta"><span>Version 1.0.3</span><span>No additional permissions</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/todo.png" width="1072" height="1448" alt="A to-do list with completed items on a Kobo">


### PR DESCRIPTION
Bumps the workspace and the four internal crate pins to 0.3.1 so the `v0.3.1` tag passes the release workflow's version check.

The store catalog already requires Cobalt 0.3.1 for the protocol 11 apps, so this release unblocks installs. Once merged, tagging `v0.3.1` publishes the release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790758672&installation_model_id=20525&pr_number=86&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F86&signature=e5a49f41c563475f67f3f2b80da6dc1383e061b8452b6f60a657a3bc224da932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->