### PR TITLE
Fix deprecated Gemini model in chat app

### DIFF
--- a/apps/catalog.json
+++ b/apps/catalog.json
@@ -7,7 +7,7 @@
       "display_name": "arXiv",
       "short_label": "arXiv",
       "summary": "Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo.",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "note",
       "capabilities": ["network"]
@@ -18,7 +18,7 @@
       "display_name": "Audiobook Studio",
       "short_label": "Audiobooks",
       "summary": "Turn a topic into an original narrated audiobook and listen on your Kobo.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "headphones",
       "capabilities": ["network", "audio", "bluetooth-audio", "bluetooth-control"]
@@ -29,7 +29,7 @@
       "display_name": "Daily Brief",
       "short_label": "Daily Brief",
       "summary": "Build a daily news brief in the background while you use other apps.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "clock",
       "capabilities": ["network"]
@@ -40,7 +40,7 @@
       "display_name": "AI Command Center",
       "short_label": "AI Chat",
       "summary": "Ask a question, then read and navigate the answer with touch controls.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "chat",
       "capabilities": ["network"]
@@ -51,7 +51,7 @@
       "display_name": "Components",
       "short_label": "Components",
       "summary": "See every Cobalt UI component on the device in one reference app.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "chart",
       "capabilities": ["network"]
@@ -62,7 +62,7 @@
       "display_name": "Gutenbird",
       "short_label": "Gutenbird",
       "summary": "Browse OPDS libraries and read their books on your Kobo.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "book",
       "capabilities": ["network", "frontlight-control"]
@@ -73,7 +73,7 @@
       "display_name": "Hacker News",
       "short_label": "Hacker News",
       "summary": "Read Top, New, Ask, and Show stories with complete comment threads.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "news",
       "capabilities": ["network"]
@@ -84,7 +84,7 @@
       "display_name": "Magnet",
       "short_label": "Magnet",
       "summary": "Find the hall sensor behind the bezel and watch it respond to a magnet.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "magnet",
       "capabilities": ["cover-sensor"]
@@ -95,7 +95,7 @@
       "display_name": "Morse",
       "short_label": "Morse",
       "summary": "Type a message and send it in Morse code with the front light.",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "light",
       "capabilities": ["frontlight-control", "keep-awake"]
@@ -106,7 +106,7 @@
       "display_name": "Feeds",
       "short_label": "Feeds",
       "summary": "Follow website feeds and read their articles without the web page around them.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "rss",
       "capabilities": ["network"]
@@ -117,7 +117,7 @@
       "display_name": "Sidekick",
       "short_label": "Sidekick",
       "summary": "Answer coding-agent permission prompts from your Kobo.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "key",
       "capabilities": ["network"]
@@ -128,7 +128,7 @@
       "display_name": "Sudoku",
       "short_label": "Sudoku",
       "summary": "Play touch-first Sudoku designed for an e-ink screen.",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "grid",
       "capabilities": []
@@ -139,7 +139,7 @@
       "display_name": "Tic-tac-toe",
       "short_label": "Tic-tac-toe",
       "summary": "Play tic-tac-toe together on one Kobo.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "grid",
       "capabilities": []
@@ -150,7 +150,7 @@
       "display_name": "Todo",
       "short_label": "Todo",
       "summary": "Keep a simple to-do list that stays on your Kobo.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "check",
       "capabilities": []
@@ -161,7 +161,7 @@
       "display_name": "Zotero Reader",
       "short_label": "Zotero",
       "summary": "Browse Zotero collections, read metadata and indexed paper text, and keep papers available offline.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "book",
       "capabilities": ["network", "frontlight-control"],

--- a/crates/kobo-policy/src/credentials.rs
+++ b/crates/kobo-policy/src/credentials.rs
@@ -69,7 +69,7 @@ pub fn allowed(app: &str, credential: &Credential, url: &str, usage: CredentialU
         ("gemini", SecretHeader::Named(header)) => {
             header.eq_ignore_ascii_case("x-goog-api-key")
                 && url
-                    == "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"
+                    == "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.6-flash:generateContent"
                 && has_origin(url, "generativelanguage.googleapis.com", 443)
         }
         _ => false,
@@ -180,6 +180,32 @@ mod tests {
             ("chat", "https://attacker.invalid/collect"),
         ] {
             assert!(!allowed(app, &openai, url, CredentialUse::Fetch));
+        }
+    }
+
+    /// This is the second of two places that name Gemini's exact endpoint --
+    /// `examples/chat/src/conversation.rs` is the other -- and the two went
+    /// out of sync once already: the application moved to a current model
+    /// after Google retired `gemini-2.0-flash`, this allowlist did not, and
+    /// every Gemini request was refused as though no key were installed. This
+    /// does not close the gap (this crate cannot depend on an application to
+    /// compare against), but it does mean an edit to the URL on just one side
+    /// fails a test instead of shipping silently.
+    #[test]
+    fn gemini_credentials_are_bound_to_the_current_model_endpoint() {
+        let gemini = Credential::in_header("gemini", "x-goog-api-key");
+        assert!(allowed(
+            "chat",
+            &gemini,
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.6-flash:generateContent",
+            CredentialUse::Fetch
+        ));
+        for url in [
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent",
+            "https://generativelanguage.googleapis.com.attacker.invalid/v1beta/models/gemini-3.6-flash:generateContent",
+            "https://attacker.invalid/collect",
+        ] {
+            assert!(!allowed("chat", &gemini, url, CredentialUse::Fetch));
         }
     }
 

--- a/docs/apps/arxiv/index.html
+++ b/docs/apps/arxiv/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/arxiv.png">
 <meta name="twitter:image:alt" content="The newest machine learning preprints listed in the arXiv app on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-KG3A5RuvfqSKsOv05PAm/q3M6RON/Gly5SoOY839eI8='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-qMyezlrvQgeeU5RLFVrwmUKH+/r3e0J8Za9YThEXVak='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.3.4",
+      "softwareVersion": "1.3.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>arXiv</h1>
       <p class="summary">Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo.</p>
-      <div class="meta"><span>Version 1.3.4</span><span>network</span></div>
+      <div class="meta"><span>Version 1.3.5</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/arxiv.png" width="1072" height="1448" alt="The newest machine learning preprints listed in the arXiv app on a Kobo">

--- a/docs/apps/audiobook/index.html
+++ b/docs/apps/audiobook/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Turn a topic into an original narrated audiobook and listen on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/audiobook.png">
 <meta name="twitter:image:alt" content="An audiobook player with cover art and playback controls on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-Ahww41n6kU1iwNao57tZMQN+Y7d3IuMc4obJZGCK7hk='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-YaoCLqixIGmSasi4ZqZA51wGU/FkQPQD/Gn6L2O0pCI='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Audiobook Studio</h1>
       <p class="summary">Turn a topic into an original narrated audiobook and listen on your Kobo.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network, audio, bluetooth-audio, bluetooth-control</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network, audio, bluetooth-audio, bluetooth-control</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/audiobook.png" width="1072" height="1448" alt="An audiobook player with cover art and playback controls on a Kobo">

--- a/docs/apps/brief/index.html
+++ b/docs/apps/brief/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Build a daily news brief in the background while you use other apps. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/brief.png">
 <meta name="twitter:image:alt" content="A numbered daily news brief on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-XUMtZuZW24adGFcezkUD9/W0G4bpBDumiqFbQ4bu/7k='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-1MOccWTocIMN2gq6er3QX2nSyUWhKELfs+WsiHQtjfI='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Daily Brief</h1>
       <p class="summary">Build a daily news brief in the background while you use other apps.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/brief.png" width="1072" height="1448" alt="A numbered daily news brief on a Kobo">

--- a/docs/apps/chat/index.html
+++ b/docs/apps/chat/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Ask a question, then read and navigate the answer with touch controls. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/chat.png">
 <meta name="twitter:image:alt" content="An answer displayed for touch-friendly reading on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-XSFY4KVO2xMZcWXiIlkLYHwBv2MacHExIsgb1r0yLvI='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-KKtsPTPRkfo9ppLG5mGYJUo54P/xiwXwgs5bFqT02LI='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>AI Command Center</h1>
       <p class="summary">Ask a question, then read and navigate the answer with touch controls.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/chat.png" width="1072" height="1448" alt="An answer displayed for touch-friendly reading on a Kobo">

--- a/docs/apps/gallery/index.html
+++ b/docs/apps/gallery/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="See every Cobalt UI component on the device in one reference app. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/components.png">
 <meta name="twitter:image:alt" content="Cobalt typography and interface components on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-20omitd/kxuZyl/UHWy5uP3YP5nfvYrcQNwf7wEWuhU='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-bR+gIZNItLrCiLygaFv8o+DYyeuufY+TK5i3eQa4sF0='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Components</h1>
       <p class="summary">See every Cobalt UI component on the device in one reference app.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/components.png" width="1072" height="1448" alt="Cobalt typography and interface components on a Kobo">

--- a/docs/apps/gutenbird/index.html
+++ b/docs/apps/gutenbird/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Browse OPDS libraries and read their books on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/gutenbird.png">
 <meta name="twitter:image:alt" content="A shelf of books from an OPDS library on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-2oT54E6+MVL8PHotEskZaFAKy5j9dOJxOjjuZn2tI1A='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-YosvSeEe351OlKZ77xznunr0lsjrWs7UJsqXrzKyADI='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Gutenbird</h1>
       <p class="summary">Browse OPDS libraries and read their books on your Kobo.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network, frontlight-control</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network, frontlight-control</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/gutenbird.png" width="1072" height="1448" alt="A shelf of books from an OPDS library on a Kobo">

--- a/docs/apps/hn/index.html
+++ b/docs/apps/hn/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Read Top, New, Ask, and Show stories with complete comment threads. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/hackernews.png">
 <meta name="twitter:image:alt" content="A ranked list of Hacker News stories on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-MxxF+XcURi1a2K0vQlv5WNApKJP/pNtP19rS0pcanyM='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-L+d3oCDXS9GO4sIM+VsZKlCVGlLCL18Lqma3kL2MKwU='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Hacker News</h1>
       <p class="summary">Read Top, New, Ask, and Show stories with complete comment threads.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/hackernews.png" width="1072" height="1448" alt="A ranked list of Hacker News stories on a Kobo">

--- a/docs/apps/magnet/index.html
+++ b/docs/apps/magnet/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Find the hall sensor behind the bezel and watch it respond to a magnet. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/magnet.png">
 <meta name="twitter:image:alt" content="The Kobo hall sensor responding to a magnet">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-QvodGU13hsb1t6mYZZUM7rZz7crL5PmT6nQrBbc0hnA='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-tlr5JvI5tzBKy+tFpfXrgXyMJJAbAPzEIbqqpqLBDdw='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Magnet</h1>
       <p class="summary">Find the hall sensor behind the bezel and watch it respond to a magnet.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>cover-sensor</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>cover-sensor</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/magnet.png" width="1072" height="1448" alt="The Kobo hall sensor responding to a magnet">

--- a/docs/apps/morse/index.html
+++ b/docs/apps/morse/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Type a message and send it in Morse code with the front light. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/morse.png">
 <meta name="twitter:image:alt" content="A letter filling the Kobo screen while the front light sends Morse code">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-dHeoeZcXp0vdCAg42bMFhHFocNYc5SH39Tb6Hiine3g='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-//CvvphYABcrNMdEshEbPoLdGQHzzvPMajaWdZglAjU='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.6",
+      "softwareVersion": "1.0.7",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Morse</h1>
       <p class="summary">Type a message and send it in Morse code with the front light.</p>
-      <div class="meta"><span>Version 1.0.6</span><span>frontlight-control, keep-awake</span></div>
+      <div class="meta"><span>Version 1.0.7</span><span>frontlight-control, keep-awake</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/morse.png" width="1072" height="1448" alt="A letter filling the Kobo screen while the front light sends Morse code">

--- a/docs/apps/rss/index.html
+++ b/docs/apps/rss/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Follow website feeds and read their articles without the web page around them. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/feeds.png">
 <meta name="twitter:image:alt" content="Subscribed feeds and articles in the Feeds app on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-rlnDMyGYs0s4qfIEie6w81ODU9VQhkOydQ9pyg6Cg/Y='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-WSAVMaXaN+UN0fiPgB7m4Ux5Iu80Ci71k3D1YUzTQUU='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Feeds</h1>
       <p class="summary">Follow website feeds and read their articles without the web page around them.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/feeds.png" width="1072" height="1448" alt="Subscribed feeds and articles in the Feeds app on a Kobo">

--- a/docs/apps/sidekick/index.html
+++ b/docs/apps/sidekick/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Answer coding-agent permission prompts from your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/sidekick.png">
 <meta name="twitter:image:alt" content="A coding-agent request with tappable responses on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-s69Kd8Qts6805VMM6X3g2uchkb9eGWjyDjxPtxDazrQ='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-Ai+Nx5Hc04n69DWk07rQgDiE9inXw0zCnddZpqu75C8='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Sidekick</h1>
       <p class="summary">Answer coding-agent permission prompts from your Kobo.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/sidekick.png" width="1072" height="1448" alt="A coding-agent request with tappable responses on a Kobo">

--- a/docs/apps/sudoku/index.html
+++ b/docs/apps/sudoku/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Play touch-first Sudoku designed for an e-ink screen. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/sudoku.png">
 <meta name="twitter:image:alt" content="A Sudoku game designed for the Kobo touch screen">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-R6Micmn4q48nGp6YFwfvB753vpBPtib7PmtQ5ek5lPg='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-Oiwyf+GBsmTfQSOt7gzIjXH45goWNz8SUo/xcl0nP+U='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.5",
+      "softwareVersion": "1.0.6",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Sudoku</h1>
       <p class="summary">Play touch-first Sudoku designed for an e-ink screen.</p>
-      <div class="meta"><span>Version 1.0.5</span><span>No additional permissions</span></div>
+      <div class="meta"><span>Version 1.0.6</span><span>No additional permissions</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/sudoku.png" width="1072" height="1448" alt="A Sudoku game designed for the Kobo touch screen">

--- a/docs/apps/tictactoe/index.html
+++ b/docs/apps/tictactoe/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Play tic-tac-toe together on one Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/tictactoe.png">
 <meta name="twitter:image:alt" content="A completed game of tic-tac-toe on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-LFdYE6Y9Jx0im4jyCWNDeNJeBSJ6tV9szU6FLWNH8BQ='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-kjyZ43SNT3t44um6Ov1R4Tr2yDLZPhxrBueju5tAPHk='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Tic-tac-toe</h1>
       <p class="summary">Play tic-tac-toe together on one Kobo.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>No additional permissions</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>No additional permissions</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/tictactoe.png" width="1072" height="1448" alt="A completed game of tic-tac-toe on a Kobo">

--- a/docs/apps/todo/index.html
+++ b/docs/apps/todo/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Keep a simple to-do list that stays on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/todo.png">
 <meta name="twitter:image:alt" content="A to-do list with completed items on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-OPfqVORdFp0mKKn52YZWatG0INDO8DxmySjQIoPHUGo='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-DeOH7GC0gNl0Tbg5/vdtPTPoL9AS+sNYSLr9k+tk/O4='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Todo</h1>
       <p class="summary">Keep a simple to-do list that stays on your Kobo.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>No additional permissions</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>No additional permissions</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/todo.png" width="1072" height="1448" alt="A to-do list with completed items on a Kobo">

--- a/docs/apps/zotero-reader/index.html
+++ b/docs/apps/zotero-reader/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Browse Zotero collections, read metadata and indexed paper text, and keep papers available offline. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/zotero-reader.png">
 <meta name="twitter:image:alt" content="Reading a paper with structured layout and Zotero metadata on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-FfDPgL3N/vn7teKiknGavWhGqPX7o2gKUMdxeCOBuo4='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-vJOd2P2nFYEpAyUEjjjnrZ4jLIi7hCwd2+JEGgkIvqQ='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.0.1",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Zotero Reader</h1>
       <p class="summary">Browse Zotero collections, read metadata and indexed paper text, and keep papers available offline.</p>
-      <div class="meta"><span>Version 1.0.0</span><span>network, frontlight-control</span></div>
+      <div class="meta"><span>Version 1.0.1</span><span>network, frontlight-control</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/zotero-reader.png" width="1072" height="1448" alt="Reading a paper with structured layout and Zotero metadata on a Kobo">

--- a/examples/chat/src/conversation.rs
+++ b/examples/chat/src/conversation.rs
@@ -64,7 +64,7 @@ impl Provider {
         match self {
             Self::OpenAi => "gpt-4o-mini",
             Self::Anthropic => "claude-3-5-haiku-latest",
-            Self::Gemini => "gemini-2.0-flash",
+            Self::Gemini => "gemini-3.6-flash",
         }
     }
 
@@ -75,7 +75,7 @@ impl Provider {
             Self::Anthropic => "https://api.anthropic.com/v1/messages",
             Self::Gemini => concat!(
                 "https://generativelanguage.googleapis.com/v1beta/models/",
-                "gemini-2.0-flash:generateContent"
+                "gemini-3.6-flash:generateContent"
             ),
         }
     }


### PR DESCRIPTION
## Summary
- `examples/chat`'s Gemini provider was hardcoded to `gemini-2.0-flash`, both as the model name in the request body and in the endpoint URL.
- Google's API now refuses that model outright: `"This model models/gemini-2.0-flash is no longer available... use models/gemini-3.6-flash"`. Every Gemini request in the chat app currently fails regardless of whether the installed key is valid.
- Confirmed live against `generativelanguage.googleapis.com`: a valid key gets a `404` on `gemini-2.0-flash` and a normal `200` reply on `gemini-3.6-flash`.

## Test plan
- [x] `cargo test -p kobo-chat` (44 tests)
- [x] `cargo fmt --all --check`
- [x] Verified against the live Gemini API with a real key that the old model 404s and the new one succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ps4WcGHVxjRU4uz8urehe1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790783854&installation_model_id=20525&pr_number=87&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F87&signature=7b5f819384fb6d95ae2a4360110bfc9f9c7d7dda2e51b39747b6b001f0e8e2bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->