### PR TITLE
Fix keyboard rows drawing bold and oversized on narrow panels

### DIFF
--- a/apps/catalog.json
+++ b/apps/catalog.json
@@ -7,7 +7,7 @@
       "display_name": "arXiv",
       "short_label": "arXiv",
       "summary": "Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo.",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "note",
       "capabilities": ["network"]
@@ -18,7 +18,7 @@
       "display_name": "Audiobook Studio",
       "short_label": "Audiobooks",
       "summary": "Turn a topic into an original narrated audiobook and listen on your Kobo.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "headphones",
       "capabilities": ["network", "audio", "bluetooth-audio", "bluetooth-control"]
@@ -29,7 +29,7 @@
       "display_name": "Daily Brief",
       "short_label": "Daily Brief",
       "summary": "Build a daily news brief in the background while you use other apps.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "clock",
       "capabilities": ["network"]
@@ -40,7 +40,7 @@
       "display_name": "AI Command Center",
       "short_label": "AI Chat",
       "summary": "Ask a question, then read and navigate the answer with touch controls.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "chat",
       "capabilities": ["network"]
@@ -51,7 +51,7 @@
       "display_name": "Components",
       "short_label": "Components",
       "summary": "See every Cobalt UI component on the device in one reference app.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "chart",
       "capabilities": ["network"]
@@ -62,7 +62,7 @@
       "display_name": "Gutenbird",
       "short_label": "Gutenbird",
       "summary": "Browse OPDS libraries and read their books on your Kobo.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "book",
       "capabilities": ["network", "frontlight-control"]
@@ -73,7 +73,7 @@
       "display_name": "Hacker News",
       "short_label": "Hacker News",
       "summary": "Read Top, New, Ask, and Show stories with complete comment threads.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "news",
       "capabilities": ["network"]
@@ -84,7 +84,7 @@
       "display_name": "Magnet",
       "short_label": "Magnet",
       "summary": "Find the hall sensor behind the bezel and watch it respond to a magnet.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "magnet",
       "capabilities": ["cover-sensor"]
@@ -95,7 +95,7 @@
       "display_name": "Morse",
       "short_label": "Morse",
       "summary": "Type a message and send it in Morse code with the front light.",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "light",
       "capabilities": ["frontlight-control", "keep-awake"]
@@ -106,7 +106,7 @@
       "display_name": "Feeds",
       "short_label": "Feeds",
       "summary": "Follow website feeds and read their articles without the web page around them.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "rss",
       "capabilities": ["network"]
@@ -117,7 +117,7 @@
       "display_name": "Sidekick",
       "short_label": "Sidekick",
       "summary": "Answer coding-agent permission prompts from your Kobo.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "key",
       "capabilities": ["network"]
@@ -128,7 +128,7 @@
       "display_name": "Sudoku",
       "short_label": "Sudoku",
       "summary": "Play touch-first Sudoku designed for an e-ink screen.",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "grid",
       "capabilities": []
@@ -139,7 +139,7 @@
       "display_name": "Tic-tac-toe",
       "short_label": "Tic-tac-toe",
       "summary": "Play tic-tac-toe together on one Kobo.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "grid",
       "capabilities": []
@@ -150,7 +150,7 @@
       "display_name": "Todo",
       "short_label": "Todo",
       "summary": "Keep a simple to-do list that stays on your Kobo.",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "check",
       "capabilities": []
@@ -161,7 +161,7 @@
       "display_name": "Zotero Reader",
       "short_label": "Zotero",
       "summary": "Browse Zotero collections, read metadata and indexed paper text, and keep papers available offline.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "book",
       "capabilities": ["network", "frontlight-control"],

--- a/crates/kobo-ui/src/lib.rs
+++ b/crates/kobo-ui/src/lib.rs
@@ -4052,7 +4052,13 @@ pub enum LayoutKind {
     NavDestinationSelected(ActionId, Option<Glyph>),
     Row(ActionId),
     Cell(ActionId, CellStyle),
-    CellLabel,
+    /// A grid cell's label. Carries whether the cell is a board mark (an X,
+    /// an O, a Sudoku digit) rather than a keyboard key: only a board mark
+    /// grows to `FontSize::Heading` when it is one or two characters. A
+    /// keyboard key is also short and square-ish once a row has enough
+    /// columns for its cells to turn taller than they are wide, so the size
+    /// this label draws at cannot be read off its own rectangle.
+    CellLabel(bool),
     /// One cell of a table, drawn in the body face.
     TableCell,
     /// One cell of a table's heading row, drawn muted so the rule under it
@@ -6173,7 +6179,7 @@ fn layout_node(
                     None => layout.nodes.push(LayoutNode {
                         id: *id,
                         rect,
-                        kind: LayoutKind::CellLabel,
+                        kind: LayoutKind::CellLabel(style == CellStyle::Board),
                         text_lines: vec![cell.label.clone()],
                     }),
                 }
@@ -9901,7 +9907,7 @@ const fn is_tappable(kind: LayoutKind) -> bool {
 fn layout_text_style(node: &LayoutNode) -> Option<(FontSize, Face)> {
     let size = match node.kind {
         LayoutKind::Heading(level) => FontSize::for_heading_level(level),
-        LayoutKind::CellLabel
+        LayoutKind::CellLabel(true)
             if node
                 .text_lines
                 .first()
@@ -9937,7 +9943,7 @@ fn layout_text_style(node: &LayoutNode) -> Option<(FontSize, Face)> {
         | LayoutKind::BarAction(_)
         | LayoutKind::RowTitle
         | LayoutKind::RowTitleDone
-        | LayoutKind::CellLabel
+        | LayoutKind::CellLabel(_)
         | LayoutKind::ChoicePrompt
         | LayoutKind::ChoiceOption(_, _)
         | LayoutKind::StepperValue
@@ -10639,19 +10645,22 @@ fn render_all_with_selected_font(
                 tone::SURFACE,
                 clip,
             ),
-            LayoutKind::CellLabel => {
-                // A short label in a tall cell is a mark rather than a word:
-                // an X, an O or a letter key is the content of the cell and
-                // should fill it. A short label in a *wide* cell is one word
-                // among several, and setting it larger than its neighbours is
-                // how a row of `esc tab ctrl up down left right` came out with
-                // one enormous `up` in the middle of it.
+            LayoutKind::CellLabel(board) => {
+                // A short label on a board is a mark rather than a word: an X,
+                // an O or a Sudoku digit is the content of the cell and should
+                // fill it. A short label on a keyboard key is one letter among
+                // several, and setting it larger than its neighbours is how a
+                // row of `esc tab ctrl up down left right` came out with one
+                // enormous `up` in the middle of it, and how a ten-key letter
+                // row -- narrower per cell than the nine-key rows either side
+                // of it, so taller than it is wide -- once came out bold and
+                // oversized while every other row stayed put.
                 //
-                // The cell's own shape is the signal, and the layout has
-                // already decided it: square for a board, a touch target for
-                // a key. Nothing else needs to be threaded through.
-                let mark = node.rect.height >= node.rect.width;
-                let size = if mark
+                // So this is carried rather than read off the cell's own
+                // rectangle: a board cell and a keyboard key can be the same
+                // shape, and only the board's mark is meant to be the size of
+                // the whole cell.
+                let size = if board
                     && node
                         .text_lines
                         .first()
@@ -12515,6 +12524,67 @@ mod tests {
                 node.rect
             );
         }
+    }
+
+    /// A ten-key row on a narrow panel turns each cell taller than it is
+    /// wide -- the same rectangle a Sudoku digit or a tic-tac-toe mark draws
+    /// in -- and a rule that read the cell's own shape once took that as "this
+    /// is a mark" and grew it to heading size, so the qwertyuiop row of a real
+    /// keyboard came out bold and oversized while the row below it, nine keys
+    /// wide and so a little shorter than it is tall, did not.
+    #[test]
+    fn a_keyboard_key_never_becomes_a_board_mark_however_narrow_its_row() {
+        let cells = ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p"]
+            .into_iter()
+            .enumerate()
+            .map(|(index, letter)| Cell::new(ActionId(index as u32 + 1), letter))
+            .collect();
+        let screen = Screen::new(
+            1,
+            vec![Node::Grid {
+                id: NodeId(1),
+                columns: 10,
+                square: false,
+                cells,
+            }],
+        );
+        let layout = screen.layout_with(&CLARA_BW_METRICS, &Chrome::default());
+        let labels: Vec<_> = layout
+            .nodes
+            .iter()
+            .filter(|node| matches!(node.kind, LayoutKind::CellLabel(_)))
+            .collect();
+        assert_eq!(labels.len(), 10, "every key should have drawn a label");
+        for node in labels {
+            assert_eq!(
+                node.kind,
+                LayoutKind::CellLabel(false),
+                "a keyboard key at {:?} was drawn as though it were a board mark",
+                node.rect
+            );
+        }
+    }
+
+    /// The rule the test above guards against still has to fire for what it
+    /// was written for: a short mark on an actual board.
+    #[test]
+    fn a_mark_on_a_board_still_grows_to_heading_size() {
+        let screen = Screen::new(
+            1,
+            vec![Node::Grid {
+                id: NodeId(1),
+                columns: 3,
+                square: true,
+                cells: vec![Cell::new(ActionId(1), "X")],
+            }],
+        );
+        let layout = screen.layout_with(&CLARA_BW_METRICS, &Chrome::default());
+        let label = layout
+            .nodes
+            .iter()
+            .find(|node| matches!(node.kind, LayoutKind::CellLabel(_)))
+            .expect("the mark drew a label");
+        assert_eq!(label.kind, LayoutKind::CellLabel(true));
     }
 
     #[test]

--- a/docs/apps/arxiv/index.html
+++ b/docs/apps/arxiv/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/arxiv.png">
 <meta name="twitter:image:alt" content="The newest machine learning preprints listed in the arXiv app on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-KG3A5RuvfqSKsOv05PAm/q3M6RON/Gly5SoOY839eI8='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-qMyezlrvQgeeU5RLFVrwmUKH+/r3e0J8Za9YThEXVak='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.3.4",
+      "softwareVersion": "1.3.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>arXiv</h1>
       <p class="summary">Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo.</p>
-      <div class="meta"><span>Version 1.3.4</span><span>network</span></div>
+      <div class="meta"><span>Version 1.3.5</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/arxiv.png" width="1072" height="1448" alt="The newest machine learning preprints listed in the arXiv app on a Kobo">

--- a/docs/apps/audiobook/index.html
+++ b/docs/apps/audiobook/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Turn a topic into an original narrated audiobook and listen on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/audiobook.png">
 <meta name="twitter:image:alt" content="An audiobook player with cover art and playback controls on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-Ahww41n6kU1iwNao57tZMQN+Y7d3IuMc4obJZGCK7hk='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-YaoCLqixIGmSasi4ZqZA51wGU/FkQPQD/Gn6L2O0pCI='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Audiobook Studio</h1>
       <p class="summary">Turn a topic into an original narrated audiobook and listen on your Kobo.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network, audio, bluetooth-audio, bluetooth-control</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network, audio, bluetooth-audio, bluetooth-control</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/audiobook.png" width="1072" height="1448" alt="An audiobook player with cover art and playback controls on a Kobo">

--- a/docs/apps/brief/index.html
+++ b/docs/apps/brief/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Build a daily news brief in the background while you use other apps. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/brief.png">
 <meta name="twitter:image:alt" content="A numbered daily news brief on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-XUMtZuZW24adGFcezkUD9/W0G4bpBDumiqFbQ4bu/7k='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-1MOccWTocIMN2gq6er3QX2nSyUWhKELfs+WsiHQtjfI='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Daily Brief</h1>
       <p class="summary">Build a daily news brief in the background while you use other apps.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/brief.png" width="1072" height="1448" alt="A numbered daily news brief on a Kobo">

--- a/docs/apps/chat/index.html
+++ b/docs/apps/chat/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Ask a question, then read and navigate the answer with touch controls. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/chat.png">
 <meta name="twitter:image:alt" content="An answer displayed for touch-friendly reading on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-XSFY4KVO2xMZcWXiIlkLYHwBv2MacHExIsgb1r0yLvI='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-KKtsPTPRkfo9ppLG5mGYJUo54P/xiwXwgs5bFqT02LI='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>AI Command Center</h1>
       <p class="summary">Ask a question, then read and navigate the answer with touch controls.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/chat.png" width="1072" height="1448" alt="An answer displayed for touch-friendly reading on a Kobo">

--- a/docs/apps/gallery/index.html
+++ b/docs/apps/gallery/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="See every Cobalt UI component on the device in one reference app. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/components.png">
 <meta name="twitter:image:alt" content="Cobalt typography and interface components on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-20omitd/kxuZyl/UHWy5uP3YP5nfvYrcQNwf7wEWuhU='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-bR+gIZNItLrCiLygaFv8o+DYyeuufY+TK5i3eQa4sF0='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Components</h1>
       <p class="summary">See every Cobalt UI component on the device in one reference app.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/components.png" width="1072" height="1448" alt="Cobalt typography and interface components on a Kobo">

--- a/docs/apps/gutenbird/index.html
+++ b/docs/apps/gutenbird/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Browse OPDS libraries and read their books on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/gutenbird.png">
 <meta name="twitter:image:alt" content="A shelf of books from an OPDS library on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-2oT54E6+MVL8PHotEskZaFAKy5j9dOJxOjjuZn2tI1A='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-YosvSeEe351OlKZ77xznunr0lsjrWs7UJsqXrzKyADI='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Gutenbird</h1>
       <p class="summary">Browse OPDS libraries and read their books on your Kobo.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network, frontlight-control</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network, frontlight-control</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/gutenbird.png" width="1072" height="1448" alt="A shelf of books from an OPDS library on a Kobo">

--- a/docs/apps/hn/index.html
+++ b/docs/apps/hn/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Read Top, New, Ask, and Show stories with complete comment threads. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/hackernews.png">
 <meta name="twitter:image:alt" content="A ranked list of Hacker News stories on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-MxxF+XcURi1a2K0vQlv5WNApKJP/pNtP19rS0pcanyM='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-L+d3oCDXS9GO4sIM+VsZKlCVGlLCL18Lqma3kL2MKwU='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Hacker News</h1>
       <p class="summary">Read Top, New, Ask, and Show stories with complete comment threads.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/hackernews.png" width="1072" height="1448" alt="A ranked list of Hacker News stories on a Kobo">

--- a/docs/apps/magnet/index.html
+++ b/docs/apps/magnet/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Find the hall sensor behind the bezel and watch it respond to a magnet. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/magnet.png">
 <meta name="twitter:image:alt" content="The Kobo hall sensor responding to a magnet">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-QvodGU13hsb1t6mYZZUM7rZz7crL5PmT6nQrBbc0hnA='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-tlr5JvI5tzBKy+tFpfXrgXyMJJAbAPzEIbqqpqLBDdw='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Magnet</h1>
       <p class="summary">Find the hall sensor behind the bezel and watch it respond to a magnet.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>cover-sensor</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>cover-sensor</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/magnet.png" width="1072" height="1448" alt="The Kobo hall sensor responding to a magnet">

--- a/docs/apps/morse/index.html
+++ b/docs/apps/morse/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Type a message and send it in Morse code with the front light. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/morse.png">
 <meta name="twitter:image:alt" content="A letter filling the Kobo screen while the front light sends Morse code">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-dHeoeZcXp0vdCAg42bMFhHFocNYc5SH39Tb6Hiine3g='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-//CvvphYABcrNMdEshEbPoLdGQHzzvPMajaWdZglAjU='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.6",
+      "softwareVersion": "1.0.7",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Morse</h1>
       <p class="summary">Type a message and send it in Morse code with the front light.</p>
-      <div class="meta"><span>Version 1.0.6</span><span>frontlight-control, keep-awake</span></div>
+      <div class="meta"><span>Version 1.0.7</span><span>frontlight-control, keep-awake</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/morse.png" width="1072" height="1448" alt="A letter filling the Kobo screen while the front light sends Morse code">

--- a/docs/apps/rss/index.html
+++ b/docs/apps/rss/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Follow website feeds and read their articles without the web page around them. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/feeds.png">
 <meta name="twitter:image:alt" content="Subscribed feeds and articles in the Feeds app on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-rlnDMyGYs0s4qfIEie6w81ODU9VQhkOydQ9pyg6Cg/Y='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-WSAVMaXaN+UN0fiPgB7m4Ux5Iu80Ci71k3D1YUzTQUU='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Feeds</h1>
       <p class="summary">Follow website feeds and read their articles without the web page around them.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/feeds.png" width="1072" height="1448" alt="Subscribed feeds and articles in the Feeds app on a Kobo">

--- a/docs/apps/sidekick/index.html
+++ b/docs/apps/sidekick/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Answer coding-agent permission prompts from your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/sidekick.png">
 <meta name="twitter:image:alt" content="A coding-agent request with tappable responses on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-s69Kd8Qts6805VMM6X3g2uchkb9eGWjyDjxPtxDazrQ='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-Ai+Nx5Hc04n69DWk07rQgDiE9inXw0zCnddZpqu75C8='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Sidekick</h1>
       <p class="summary">Answer coding-agent permission prompts from your Kobo.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/sidekick.png" width="1072" height="1448" alt="A coding-agent request with tappable responses on a Kobo">

--- a/docs/apps/sudoku/index.html
+++ b/docs/apps/sudoku/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Play touch-first Sudoku designed for an e-ink screen. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/sudoku.png">
 <meta name="twitter:image:alt" content="A Sudoku game designed for the Kobo touch screen">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-R6Micmn4q48nGp6YFwfvB753vpBPtib7PmtQ5ek5lPg='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-Oiwyf+GBsmTfQSOt7gzIjXH45goWNz8SUo/xcl0nP+U='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.5",
+      "softwareVersion": "1.0.6",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Sudoku</h1>
       <p class="summary">Play touch-first Sudoku designed for an e-ink screen.</p>
-      <div class="meta"><span>Version 1.0.5</span><span>No additional permissions</span></div>
+      <div class="meta"><span>Version 1.0.6</span><span>No additional permissions</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/sudoku.png" width="1072" height="1448" alt="A Sudoku game designed for the Kobo touch screen">

--- a/docs/apps/tictactoe/index.html
+++ b/docs/apps/tictactoe/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Play tic-tac-toe together on one Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/tictactoe.png">
 <meta name="twitter:image:alt" content="A completed game of tic-tac-toe on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-LFdYE6Y9Jx0im4jyCWNDeNJeBSJ6tV9szU6FLWNH8BQ='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-kjyZ43SNT3t44um6Ov1R4Tr2yDLZPhxrBueju5tAPHk='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Tic-tac-toe</h1>
       <p class="summary">Play tic-tac-toe together on one Kobo.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>No additional permissions</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>No additional permissions</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/tictactoe.png" width="1072" height="1448" alt="A completed game of tic-tac-toe on a Kobo">

--- a/docs/apps/todo/index.html
+++ b/docs/apps/todo/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Keep a simple to-do list that stays on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/todo.png">
 <meta name="twitter:image:alt" content="A to-do list with completed items on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-OPfqVORdFp0mKKn52YZWatG0INDO8DxmySjQIoPHUGo='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-DeOH7GC0gNl0Tbg5/vdtPTPoL9AS+sNYSLr9k+tk/O4='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Todo</h1>
       <p class="summary">Keep a simple to-do list that stays on your Kobo.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>No additional permissions</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>No additional permissions</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/todo.png" width="1072" height="1448" alt="A to-do list with completed items on a Kobo">

--- a/docs/apps/zotero-reader/index.html
+++ b/docs/apps/zotero-reader/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Browse Zotero collections, read metadata and indexed paper text, and keep papers available offline. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/zotero-reader.png">
 <meta name="twitter:image:alt" content="Reading a paper with structured layout and Zotero metadata on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-FfDPgL3N/vn7teKiknGavWhGqPX7o2gKUMdxeCOBuo4='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-vJOd2P2nFYEpAyUEjjjnrZ4jLIi7hCwd2+JEGgkIvqQ='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.0",
+      "softwareVersion": "1.0.1",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Zotero Reader</h1>
       <p class="summary">Browse Zotero collections, read metadata and indexed paper text, and keep papers available offline.</p>
-      <div class="meta"><span>Version 1.0.0</span><span>network, frontlight-control</span></div>
+      <div class="meta"><span>Version 1.0.1</span><span>network, frontlight-control</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/zotero-reader.png" width="1072" height="1448" alt="Reading a paper with structured layout and Zotero metadata on a Kobo">


### PR DESCRIPTION
## Summary
- A grid cell's label was grown to `FontSize::Heading` whenever the cell was taller than it was wide, on the assumption that a short label in a tall cell is a board mark (an X, an O, a Sudoku digit).
- That assumption breaks for the on-screen keyboard: `qwertyuiop` packs 10 columns into the same width the 9-column rows below it use, so its cells are narrower and can end up taller than they are wide on some panels — triggering the same "board mark" styling. The result: the top keyboard row renders bold and oversized while every other row does not.
- Fix: `LayoutKind::CellLabel` now carries an explicit `bool` for whether the cell is actually a board cell (computed once, where the grid already knows `CellStyle::Board` vs `CellStyle::Key`), instead of inferring it from the cell's aspect ratio at draw time.

Found and reproduced on a real Kobo Libra Colour, in two different apps' keyboards (`chat` and a new Wikipedia app I've been building) — screenshots below.

## Test plan
- [x] `cargo test -p kobo-ui` (225 tests, incl. 2 new regression tests: a narrow 10-column row never becomes a board mark; an actual board mark still grows to heading size)
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p kobo-ui --all-targets --all-features -- -D warnings`
- [x] Verified on a real Kobo Libra Colour: keyboard rows are now a consistent size

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ps4WcGHVxjRU4uz8urehe1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790787800&installation_model_id=20525&pr_number=88&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F88&signature=fd32ae656f4e815c38e85927ee3e51bb0323b0fe86e3e2ded99e99ea15e16724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->