### PR TITLE
Add beta update channel

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -2,7 +2,7 @@ name: Publish apps
 
 on:
   push:
-    branches: [main]
+    branches: [main, beta]
   workflow_dispatch:
 
 permissions:
@@ -10,17 +10,24 @@ permissions:
   actions: read
 
 concurrency:
-  group: cobalt-app-catalog
+  group: cobalt-app-catalog-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   trusted-tool:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta'
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.registry.outputs.packages }}
+      previous-run: ${{ steps.registry.outputs.previous-run }}
+      previous-artifact: ${{ steps.registry.outputs.previous-artifact }}
+      previous-set-name: ${{ steps.registry.outputs.previous-set-name }}
+      published-sha: ${{ steps.registry.outputs.published-sha }}
+      publish: ${{ steps.registry.outputs.publish }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           toolchain: 1.85.1
@@ -28,12 +35,278 @@ jobs:
         run: cargo build --locked -p kobo-cli
       - name: Validate the registry
         id: registry
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          echo "packages=$(target/debug/kobo app-list --registry apps/catalog.json)" >> "$GITHUB_OUTPUT"
+          all_packages="$(target/debug/kobo app-list --registry apps/catalog.json)"
+          if [ "$GITHUB_REF_NAME" = beta ]; then
+            release_tag=app-catalog-beta
+          else
+            release_tag=app-catalog
+          fi
+          has_release=false
+          repair=false
+          previous_run=
+          previous_artifact=
+          previous_set_name=
+          previous_sha=
+          api_get() {
+            output="$1"
+            endpoint="$2"
+            if ! status="$(curl --silent --show-error --location \
+              --retry 3 --retry-all-errors \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --output "$output" --write-out '%{http_code}' \
+              "https://api.github.com/${endpoint}")"
+            then
+              echo "GitHub API request failed for $endpoint" >&2
+              return 2
+            fi
+            case "$status" in
+              200) return 0 ;;
+              404)
+                rm -f "$output"
+                return 1
+                ;;
+              *)
+                echo "GitHub API request for $endpoint returned HTTP $status" >&2
+                return 2
+                ;;
+            esac
+          }
+
+          api_download_asset() {
+            output="$1"
+            asset_id="$2"
+            if ! status="$(curl --silent --show-error --location \
+              --retry 3 --retry-all-errors \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Accept: application/octet-stream" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --output "$output" --write-out '%{http_code}' \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}")"
+            then
+              echo "GitHub asset download failed for asset $asset_id" >&2
+              return 1
+            fi
+            if [ "$status" != 200 ]; then
+              echo "GitHub asset download for asset $asset_id returned HTTP $status" >&2
+              return 1
+            fi
+          }
+          asset_id() {
+            # shellcheck disable=SC2016
+            node -e '
+              const fs = require("fs");
+              const release = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+              const matches = release.assets.filter(asset => asset.name === process.argv[2]);
+              if (matches.length > 1) throw new Error(`duplicate release asset ${process.argv[2]}`);
+              if (matches.length === 1) {
+                if (!Number.isSafeInteger(matches[0].id)) throw new Error("invalid release asset id");
+                process.stdout.write(String(matches[0].id));
+              }
+            ' "$1" "$2"
+          }
+          release_state="$RUNNER_TEMP/$release_tag-release.json"
+          if api_get "$release_state" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${release_tag}"
+          then
+            has_release=true
+            catalog_present=false
+            catalog_asset_id="$(asset_id "$release_state" cobalt-app-catalog.json)"
+            if [ -n "$catalog_asset_id" ]; then
+              api_download_asset published-app-catalog.json "$catalog_asset_id"
+              catalog_present=true
+            else
+              printf '{"format_version":1,"entries":[]}\n' > published-app-catalog.json
+            fi
+            provenance_loaded=false
+            provenance_asset_id="$(
+              asset_id "$release_state" cobalt-app-catalog-provenance.json
+            )"
+            if [ -n "$provenance_asset_id" ]; then
+              api_download_asset \
+                published-app-catalog-provenance.json \
+                "$provenance_asset_id"
+              if node -e '
+                  const fs = require("fs");
+                  const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+                  const channel = process.argv[2];
+                  if (
+                    value.format_version !== 1 ||
+                    value.channel !== channel ||
+                    !/^[0-9a-f]{40}$/.test(value.source_sha) ||
+                    !Number.isSafeInteger(value.workflow_run_id) ||
+                    value.workflow_run_id <= 0 ||
+                    !Number.isSafeInteger(value.workflow_run_attempt) ||
+                    value.workflow_run_attempt <= 0 ||
+                    !/^[0-9a-f]{64}$/.test(value.catalog_sha256)
+                  ) process.exit(1);
+                ' published-app-catalog-provenance.json "$release_tag" &&
+                [ "$catalog_present" = true ] &&
+                [ "$(sha256sum published-app-catalog.json | cut -d' ' -f1)" = \
+                  "$(node -p 'require(process.argv[1]).catalog_sha256' ./published-app-catalog-provenance.json)" ]
+              then
+                provenance_loaded=true
+              fi
+            fi
+            if [ "$provenance_loaded" = false ]; then
+              # shellcheck disable=SC2016
+              transaction="$(
+                node -e '
+                  const fs = require("fs");
+                  const release = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+                  const pattern = /^cobalt-app-catalog-provenance-(\d+)-(\d+)\.json$/;
+                  const matches = release.assets.flatMap(asset => {
+                    const match = pattern.exec(asset.name);
+                    if (!match) return [];
+                    if (!Number.isSafeInteger(asset.id)) throw new Error("invalid release asset id");
+                    return [{
+                      id: asset.id,
+                      name: asset.name,
+                      run: BigInt(match[1]),
+                      attempt: BigInt(match[2]),
+                    }];
+                  });
+                  matches.sort((left, right) => {
+                    if (left.run < right.run) return -1;
+                    if (left.run > right.run) return 1;
+                    if (left.attempt < right.attempt) return -1;
+                    if (left.attempt > right.attempt) return 1;
+                    return 0;
+                  });
+                  const latest = matches.at(-1);
+                  if (latest) process.stdout.write(`${latest.id}\t${latest.name}`);
+                ' "$release_state"
+              )"
+              if [ -n "$transaction" ]; then
+                IFS=$'\t' read -r transaction_id transaction_name <<< "$transaction"
+                test -n "$transaction_name"
+                api_download_asset \
+                  published-app-catalog-provenance.json \
+                  "$transaction_id"
+                node -e '
+                  const fs = require("fs");
+                  const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+                  const channel = process.argv[2];
+                  if (
+                    value.format_version !== 1 ||
+                    value.channel !== channel ||
+                    !/^[0-9a-f]{40}$/.test(value.source_sha) ||
+                    !Number.isSafeInteger(value.workflow_run_id) ||
+                    value.workflow_run_id <= 0 ||
+                    !Number.isSafeInteger(value.workflow_run_attempt) ||
+                    value.workflow_run_attempt <= 0 ||
+                    !/^[0-9a-f]{64}$/.test(value.catalog_sha256)
+                  ) process.exit(1);
+                ' published-app-catalog-provenance.json "$release_tag"
+                provenance_loaded=true
+                repair=true
+              elif [ "$catalog_present" = false ]; then
+                repair=true
+              fi
+            fi
+            if [ "$provenance_loaded" = true ]; then
+              previous_sha="$(node -p 'require(process.argv[1]).source_sha' ./published-app-catalog-provenance.json)"
+              previous_run="$(node -p 'require(process.argv[1]).workflow_run_id' ./published-app-catalog-provenance.json)"
+              previous_set_name="verified-app-set-$(node -p 'require(process.argv[1]).workflow_run_attempt' ./published-app-catalog-provenance.json)"
+              complete_sets="$(gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${previous_run}/artifacts?per_page=100" \
+                --jq '[.artifacts[] | select(.expired == false and .name == "'"$previous_set_name"'")] | length')"
+              if [ "$complete_sets" = 1 ]; then
+                previous_artifact="set"
+              else
+                previous_run=
+                previous_set_name=
+              fi
+            fi
+            if [ "$provenance_loaded" = false ] && [ "$catalog_present" = true ]; then
+              # shellcheck disable=SC2016
+              expected="$(node -e \
+                'console.log(JSON.stringify(JSON.parse(process.argv[1]).map(name => `verified-app-${name}`).sort()))' \
+                "$all_packages")"
+              runs_file="$RUNNER_TEMP/$release_tag-successful-runs.tsv"
+              gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/apps.yml/runs?branch=${GITHUB_REF_NAME}&status=success&per_page=100" \
+                --jq '.workflow_runs[] | [.id, .head_sha] | @tsv' \
+                > "$runs_file"
+              while IFS=$'\t' read -r run_id run_sha; do
+                artifact_names="$(gh api \
+                  "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100" \
+                  --jq '[.artifacts[] | select(.name | startswith("verified-app-")) | .name] | sort')"
+                if [ "$artifact_names" = "$expected" ]; then
+                  previous_sha="$run_sha"
+                  reusable="$(gh api \
+                    "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100" \
+                    --jq '[.artifacts[] | select(.expired == false and (.name | startswith("verified-app-"))) | .name] | sort')"
+                  if [ "$reusable" = "$expected" ]; then
+                    previous_run="$run_id"
+                    previous_artifact="individual"
+                  fi
+                  break
+                fi
+              done < "$runs_file"
+            fi
+            base="${previous_sha:-$(git rev-list --max-parents=0 HEAD)}"
+          else
+            release_status=$?
+            if [ "$release_status" -eq 1 ]; then
+              printf '{"format_version":1,"entries":[]}\n' > published-app-catalog.json
+              base="$(git rev-list --max-parents=0 HEAD)"
+            else
+              exit 1
+            fi
+          fi
+          packages="$(node tools/check-app-versions.mjs --list-packages \
+            --registry apps/catalog.json \
+            --published-catalog published-app-catalog.json \
+            --base "$base")"
+          publish="$(node tools/check-app-versions.mjs --publish-needed \
+            --registry apps/catalog.json \
+            --published-catalog published-app-catalog.json \
+            --base "$base")"
+          if [ "$repair" = true ]; then
+            publish=true
+          fi
+          if [ "$publish" = true ] && [ "$has_release" = true ] && [ "$packages" != "$all_packages" ]; then
+            if [ -z "$previous_run" ]; then
+              packages="$all_packages"
+            elif [ "$previous_artifact" = individual ]; then
+              # shellcheck disable=SC2016
+              expected="$(node -e \
+                'console.log(JSON.stringify(JSON.parse(process.argv[1]).map(name => `verified-app-${name}`).sort()))' \
+                "$all_packages")"
+              reusable="$(gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${previous_run}/artifacts?per_page=100" \
+                --jq '[.artifacts[] | select(.expired == false and (.name | startswith("verified-app-"))) | .name] | sort')"
+              if [ "$reusable" != "$expected" ]; then
+                packages="$all_packages"
+                previous_run=
+                previous_artifact=
+                previous_set_name=
+              fi
+            fi
+          fi
+          if [ "$packages" = "$all_packages" ]; then
+            previous_run=
+            previous_artifact=
+            previous_set_name=
+          fi
+          {
+            echo "packages=$packages"
+            echo "previous-run=$previous_run"
+            echo "previous-artifact=$previous_artifact"
+            echo "previous-set-name=$previous_set_name"
+            echo "published-sha=$base"
+            echo "publish=$publish"
+          } >> "$GITHUB_OUTPUT"
           node tools/generate-app-pages.mjs
           git status --porcelain -- docs/apps docs/sitemap.xml
           test -z "$(git status --porcelain -- docs/apps docs/sitemap.xml)"
       - name: Save the release tool
+        if: steps.registry.outputs.publish == 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: trusted-kobo
@@ -41,7 +314,10 @@ jobs:
           if-no-files-found: error
 
   build-apps:
-    if: github.ref == 'refs/heads/main'
+    if: >-
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta') &&
+      needs.trusted-tool.outputs.publish == 'true' &&
+      needs.trusted-tool.outputs.packages != '[]'
     needs: trusted-tool
     runs-on: ubuntu-latest
     strategy:
@@ -79,7 +355,15 @@ jobs:
           if-no-files-found: error
 
   publish:
-    if: github.ref == 'refs/heads/main'
+    if: >-
+      always() &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta') &&
+      needs.trusted-tool.result == 'success' &&
+      needs.trusted-tool.outputs.publish == 'true' &&
+      (
+        (needs.trusted-tool.outputs.packages == '[]' && needs.build-apps.result == 'skipped') ||
+        (needs.trusted-tool.outputs.packages != '[]' && needs.build-apps.result == 'success')
+      )
     needs: [trusted-tool, build-apps]
     runs-on: ubuntu-latest
     permissions:
@@ -95,25 +379,133 @@ jobs:
           name: trusted-kobo
           path: trusted
       - name: Load verified app binaries
+        if: needs.trusted-tool.outputs.packages != '[]'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: verified-app-*
+          path: dist/current
+      - name: Load unchanged binaries from the previous channel run
+        if: needs.trusted-tool.outputs.previous-artifact == 'individual'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: verified-app-*
+          path: dist/previous
+          run-id: ${{ needs.trusted-tool.outputs.previous-run }}
+          github-token: ${{ github.token }}
+      - name: Load the complete binary set from the previous publication
+        if: needs.trusted-tool.outputs.previous-artifact == 'set'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ needs.trusted-tool.outputs.previous-set-name }}
+          path: dist/previous
+          run-id: ${{ needs.trusted-tool.outputs.previous-run }}
+          github-token: ${{ github.token }}
+      - name: Assemble the complete verified binary set
+        run: |
+          mkdir -p dist/merged dist/artifacts
+          if [ -d dist/previous ]; then
+            cp -R dist/previous/. dist/merged/
+          fi
+          if [ -d dist/current ]; then
+            cp -R dist/current/. dist/merged/
+          fi
+          node -e '
+            const fs = require("fs");
+            const registry = JSON.parse(fs.readFileSync("apps/catalog.json", "utf8"));
+            for (const app of registry.apps) console.log(app.package);
+          ' | while IFS= read -r package; do
+            artifact="verified-app-${package}"
+            test -d "dist/merged/$artifact"
+            cp -R "dist/merged/$artifact" dist/artifacts/
+          done
+      - name: Save the complete verified binary set
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: verified-app-set-${{ github.run_attempt }}
           path: dist/artifacts
+          if-no-files-found: error
       - name: Require versions for changed app packages
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          published_sha="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/workflows/apps.yml/runs?status=success&per_page=1" \
-            --jq '.workflow_runs[0].head_sha')"
-          test -n "$published_sha"
-          curl --fail --location --retry 3 \
-            --output published-app-catalog.json \
-            https://github.com/BandarLabs/Cobalt/releases/download/app-catalog/cobalt-app-catalog.json
+          api_get() {
+            output="$1"
+            endpoint="$2"
+            if ! status="$(curl --silent --show-error --location \
+              --retry 3 --retry-all-errors \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --output "$output" --write-out '%{http_code}' \
+              "https://api.github.com/${endpoint}")"
+            then
+              echo "GitHub API request failed for $endpoint" >&2
+              return 2
+            fi
+            case "$status" in
+              200) return 0 ;;
+              404)
+                rm -f "$output"
+                return 1
+                ;;
+              *)
+                echo "GitHub API request for $endpoint returned HTTP $status" >&2
+                return 2
+                ;;
+            esac
+          }
+          api_download_asset() {
+            output="$1"
+            asset_id="$2"
+            if ! status="$(curl --silent --show-error --location \
+              --retry 3 --retry-all-errors \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Accept: application/octet-stream" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --output "$output" --write-out '%{http_code}' \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}")"
+            then
+              echo "GitHub asset download failed for asset $asset_id" >&2
+              return 1
+            fi
+            if [ "$status" != 200 ]; then
+              echo "GitHub asset download for asset $asset_id returned HTTP $status" >&2
+              return 1
+            fi
+          }
+          if [ "$GITHUB_REF_NAME" = beta ]; then
+            release_tag=app-catalog-beta
+          else
+            release_tag=app-catalog
+          fi
+          release_state="$RUNNER_TEMP/$release_tag-release.json"
+          if api_get "$release_state" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${release_tag}"
+          then
+            catalog_asset_id="$(
+              node -e '
+                const fs = require("fs");
+                const release = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+                const matches = release.assets.filter(asset => asset.name === "cobalt-app-catalog.json");
+                if (matches.length !== 1 || !Number.isSafeInteger(matches[0].id)) {
+                  throw new Error("existing app catalog release has no unique catalog asset");
+                }
+                process.stdout.write(String(matches[0].id));
+              ' "$release_state"
+            )"
+            api_download_asset published-app-catalog.json "$catalog_asset_id"
+          else
+            release_status=$?
+            if [ "$release_status" -eq 1 ]; then
+              printf '{"format_version":1,"entries":[]}\n' > published-app-catalog.json
+            else
+              exit 1
+            fi
+          fi
           node tools/check-app-versions.mjs \
             --registry apps/catalog.json \
             --published-catalog published-app-catalog.json \
-            --base "$published_sha"
+            --base "${{ needs.trusted-tool.outputs.published-sha }}"
       - name: Sign the app packages and catalog
         env:
           COBALT_APP_SIGNING_SEED: ${{ secrets.COBALT_APP_SIGNING_SEED }}
@@ -124,6 +516,11 @@ jobs:
             exit 1
           }
           chmod +x trusted/kobo
+          if [ "$GITHUB_REF_NAME" = beta ]; then
+            release_tag=app-catalog-beta
+          else
+            release_tag=app-catalog
+          fi
           seed="$RUNNER_TEMP/cobalt-app-signing-seed"
           trap 'rm -f "$seed"' EXIT
           printf '%s' "$COBALT_APP_SIGNING_SEED" > "$seed"
@@ -132,18 +529,136 @@ jobs:
             --registry apps/catalog.json \
             --seed "$seed" \
             --out dist/apps \
-            --base-url https://github.com/BandarLabs/Cobalt/releases/download/app-catalog \
+            --base-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${release_tag}" \
             --artifact-dir dist/artifacts
+          catalog_sha256="$(sha256sum dist/apps/cobalt-app-catalog.json | cut -d' ' -f1)"
+          # shellcheck disable=SC2016
+          node -e '
+            const fs = require("fs");
+            const value = {
+              format_version: 1,
+              channel: process.argv[2],
+              source_sha: process.argv[3],
+              workflow_run_id: Number(process.argv[4]),
+              workflow_run_attempt: Number(process.argv[5]),
+              catalog_sha256: process.argv[6],
+            };
+            fs.writeFileSync(process.argv[1], `${JSON.stringify(value)}\n`);
+          ' \
+            dist/apps/cobalt-app-catalog-provenance.json \
+            "$release_tag" "$GITHUB_SHA" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT" "$catalog_sha256"
+          cp \
+            dist/apps/cobalt-app-catalog-provenance.json \
+            "dist/apps/cobalt-app-catalog-provenance-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
       - name: Publish the fixed app channel
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if gh release view app-catalog >/dev/null 2>&1; then
-            gh release upload app-catalog dist/apps/* --clobber
+          api_get() {
+            output="$1"
+            endpoint="$2"
+            if ! status="$(curl --silent --show-error --location \
+              --retry 3 --retry-all-errors \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --output "$output" --write-out '%{http_code}' \
+              "https://api.github.com/${endpoint}")"
+            then
+              echo "GitHub API request failed for $endpoint" >&2
+              return 2
+            fi
+            case "$status" in
+              200) return 0 ;;
+              404)
+                rm -f "$output"
+                return 1
+                ;;
+              *)
+                echo "GitHub API request for $endpoint returned HTTP $status" >&2
+                return 2
+                ;;
+            esac
+          }
+          download_release_asset() {
+            output="$1"
+            asset_id="$2"
+            if ! status="$(curl --silent --show-error --location \
+              --retry 3 --retry-all-errors \
+              --header "Authorization: Bearer ${GH_TOKEN}" \
+              --header "Accept: application/octet-stream" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --output "$output" --write-out '%{http_code}' \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}")"
+            then
+              echo "GitHub asset download failed for asset $asset_id" >&2
+              return 1
+            fi
+            if [ "$status" != 200 ]; then
+              echo "GitHub asset download for asset $asset_id returned HTTP $status" >&2
+              return 1
+            fi
+          }
+          if [ "$GITHUB_REF_NAME" = beta ]; then
+            release_tag=app-catalog-beta
+            title="Cobalt Beta App Catalog"
+            notes="Automatically published signed prerelease apps for Cobalt beta readers."
           else
-            gh release create app-catalog dist/apps/* \
-              --target "$GITHUB_SHA" \
-              --title "Cobalt App Catalog" \
-              --notes "Automatically published signed apps for installed Cobalt readers." \
-              --latest=false
+            release_tag=app-catalog
+            title="Cobalt App Catalog"
+            notes="Automatically published signed apps for installed Cobalt readers."
           fi
+          release_state="$RUNNER_TEMP/$release_tag-release.json"
+          if api_get "$release_state" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${release_tag}"
+          then
+            :
+          else
+            release_status=$?
+            if [ "$release_status" -eq 1 ]; then
+              gh release create "$release_tag" \
+                --target "$GITHUB_SHA" \
+                --title "$title" \
+                --notes "$notes" \
+                --latest=false
+            else
+              exit 1
+            fi
+          fi
+          api_get "$release_state" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${release_tag}"
+          for package in dist/apps/*.cobalt-app; do
+            asset_name="$(basename "$package")"
+            asset_id="$(
+              # shellcheck disable=SC2016
+              node -e '
+                const fs = require("fs");
+                const release = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+                const matches = release.assets.filter(asset => asset.name === process.argv[2]);
+                if (matches.length > 1) throw new Error(`duplicate release asset ${process.argv[2]}`);
+                if (matches.length === 1) {
+                  if (!Number.isSafeInteger(matches[0].id)) throw new Error("invalid asset id");
+                  process.stdout.write(String(matches[0].id));
+                }
+              ' "$release_state" "$asset_name"
+            )"
+            if [ -n "$asset_id" ]; then
+              published_package="$RUNNER_TEMP/published-$asset_name"
+              download_release_asset "$published_package" "$asset_id"
+              cmp "$package" "$published_package"
+            else
+              gh release upload "$release_tag" "$package"
+            fi
+          done
+          # The immutable transaction marker makes any interrupted publication
+          # recoverable from this run's complete verified binary artifact.
+          gh release upload "$release_tag" \
+            "dist/apps/cobalt-app-catalog-provenance-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
+          # Publish the signed pointer only after every referenced bundle is
+          # present, then record canonical provenance as the final commit.
+          gh release upload \
+            "$release_tag" dist/apps/cobalt-app-catalog.json.sig --clobber
+          gh release upload \
+            "$release_tag" dist/apps/cobalt-app-catalog.json --clobber
+          gh release upload \
+            "$release_tag" dist/apps/cobalt-app-catalog-provenance.json --clobber

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,0 +1,187 @@
+name: Publish beta platform
+
+on:
+  push:
+    branches: [beta]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: cobalt-beta-platform
+  cancel-in-progress: false
+
+jobs:
+  package:
+    if: github.ref == 'refs/heads/beta'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: 1.85.1
+          targets: armv7-unknown-linux-musleabihf
+      - name: Install the ring C cross-compiler
+        run: sudo apt-get update && sudo apt-get install --yes gcc-arm-linux-gnueabihf
+      - name: Read the workspace version
+        id: version
+        run: |
+          version="$(sed -n 's/^version = "\([0-9][0-9.]*\)"$/\1/p' Cargo.toml)"
+          test -n "$version"
+          test "$(printf '%s\n' "$version" | wc -l)" -eq 1
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Require a new highest beta version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -o pipefail
+          api_get() {
+            output="$1"
+            endpoint="$2"
+            if ! status="$(curl --silent --show-error --location \
+              --retry 3 --retry-all-errors \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --output "$output" --write-out '%{http_code}' \
+              "https://api.github.com/${endpoint}")"
+            then
+              echo "GitHub API request failed for $endpoint" >&2
+              return 2
+            fi
+            case "$status" in
+              200) return 0 ;;
+              404)
+                rm -f "$output"
+                return 1
+                ;;
+              *)
+                echo "GitHub API request for $endpoint returned HTTP $status" >&2
+                return 2
+                ;;
+            esac
+          }
+          require_absent() {
+            label="$1"
+            endpoint="$2"
+            state="$RUNNER_TEMP/${label}.json"
+            if api_get "$state" "$endpoint"; then
+              echo "$label already exists. Bump the workspace version before publishing another beta build." >&2
+              exit 1
+            else
+              lookup_status=$?
+              if [ "$lookup_status" -ne 1 ]; then
+                exit 1
+              fi
+            fi
+          }
+          tag="beta-v${VERSION}"
+          require_absent "$tag tag" \
+            "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}"
+          require_absent "$tag release" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}"
+          latest="$(gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/beta-v?per_page=100" \
+            --jq '.[].ref' |
+            sed -n 's#.*refs/tags/beta-v\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)$#\1#p' |
+            sort -V |
+            tail -n 1)"
+          if [ -n "$latest" ]; then
+            node -e '
+              const current = process.argv[1].split(".").map(Number);
+              const latest = process.argv[2].split(".").map(Number);
+              for (let index = 0; index < 3; index += 1) {
+                if (current[index] > latest[index]) process.exit(0);
+                if (current[index] < latest[index]) process.exit(1);
+              }
+              process.exit(1);
+            ' "$VERSION" "$latest" || {
+              echo "beta-v${VERSION} is not newer than beta-v${latest}. Bump the workspace version." >&2
+              exit 1
+            }
+          fi
+      - name: Build the device package once
+        run: cargo run --locked -p kobo-cli -- package --out dist/KoboRoot.tgz
+        env:
+          CC_armv7_unknown_linux_musleabihf: arm-linux-gnueabihf-gcc
+          CFLAGS_armv7_unknown_linux_musleabihf: -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
+      - name: Name deterministic assets and checksums
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          asset="cobalt-${VERSION}-KoboRoot.tgz"
+          legacy_asset="cobalt-${VERSION}-ClaraBW-KoboRoot.tgz"
+          digest="cobalt-${VERSION}.sha256"
+          legacy_digest="cobalt-${VERSION}-ClaraBW.sha256"
+          mv dist/KoboRoot.tgz "dist/$asset"
+          cp "dist/$asset" "dist/$legacy_asset"
+          cp THIRD-PARTY.md dist/
+          cd dist
+          sha256sum THIRD-PARTY.md "$asset" "$legacy_asset" > "$digest"
+          cp "$digest" "$legacy_digest"
+      - name: Create the immutable isolated prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          api_get() {
+            output="$1"
+            endpoint="$2"
+            if ! status="$(curl --silent --show-error --location \
+              --retry 3 --retry-all-errors \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --output "$output" --write-out '%{http_code}' \
+              "https://api.github.com/${endpoint}")"
+            then
+              echo "GitHub API request failed for $endpoint" >&2
+              return 2
+            fi
+            case "$status" in
+              200) return 0 ;;
+              404)
+                rm -f "$output"
+                return 1
+                ;;
+              *)
+                echo "GitHub API request for $endpoint returned HTTP $status" >&2
+                return 2
+                ;;
+            esac
+          }
+          require_absent() {
+            label="$1"
+            endpoint="$2"
+            state="$RUNNER_TEMP/${label}.json"
+            if api_get "$state" "$endpoint"; then
+              echo "$label already exists. Refusing to publish assets for an existing beta version." >&2
+              exit 1
+            else
+              lookup_status=$?
+              if [ "$lookup_status" -ne 1 ]; then
+                exit 1
+              fi
+            fi
+          }
+          tag="beta-v${VERSION}"
+          require_absent "$tag tag" \
+            "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}"
+          require_absent "$tag release" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}"
+          created_sha="$(gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/git/refs" \
+            --field "ref=refs/tags/${tag}" \
+            --field "sha=${GITHUB_SHA}" \
+            --jq '.object.sha')"
+          test "$created_sha" = "$GITHUB_SHA"
+          gh release create "$tag" dist/* \
+            --title "Cobalt ${VERSION} beta" \
+            --notes "Immutable prerelease built from the beta branch at ${GITHUB_SHA}." \
+            --prerelease \
+            --latest=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           published_sha="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/actions/workflows/apps.yml/runs?status=success&per_page=1" \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/apps.yml/runs?branch=main&status=success&per_page=1" \
             --jq '.workflow_runs[0].head_sha')"
           test -n "$published_sha"
           curl --fail --location --retry 3 \

--- a/.github/workflows/promote-beta.yml
+++ b/.github/workflows/promote-beta.yml
@@ -1,0 +1,255 @@
+name: Promote tested beta
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact version to promote, for example 0.3.2
+        required: true
+        type: string
+      tested_commit:
+        description: Full 40-character commit SHA tested from beta
+        required: true
+        type: string
+      expected_archive_sha256:
+        description: Expected SHA-256 of cobalt-VERSION-KoboRoot.tgz
+        required: true
+        type: string
+      confirmation:
+        description: Type promote-beta-vX.Y.Z using the same version
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: cobalt-stable-promotion
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Guard the requested version
+        env:
+          VERSION: ${{ inputs.version }}
+          TESTED_COMMIT: ${{ inputs.tested_commit }}
+          EXPECTED_ARCHIVE_SHA256: ${{ inputs.expected_archive_sha256 }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          api_get() {
+            output="$1"
+            endpoint="$2"
+            if ! status="$(curl --silent --show-error --location \
+              --retry 3 --retry-all-errors \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --output "$output" --write-out '%{http_code}' \
+              "https://api.github.com/${endpoint}")"
+            then
+              echo "GitHub API request failed for $endpoint" >&2
+              return 2
+            fi
+            case "$status" in
+              200) return 0 ;;
+              404)
+                rm -f "$output"
+                return 1
+                ;;
+              *)
+                echo "GitHub API request for $endpoint returned HTTP $status" >&2
+                return 2
+                ;;
+            esac
+          }
+          require_present() {
+            label="$1"
+            endpoint="$2"
+            output="$3"
+            if api_get "$output" "$endpoint"; then
+              return
+            else
+              lookup_status=$?
+              if [ "$lookup_status" -eq 1 ]; then
+                echo "required $label does not exist" >&2
+              fi
+              exit 1
+            fi
+          }
+          require_absent() {
+            label="$1"
+            endpoint="$2"
+            output="$3"
+            if api_get "$output" "$endpoint"; then
+              echo "$label already exists; refusing replacement" >&2
+              exit 1
+            else
+              lookup_status=$?
+              if [ "$lookup_status" -ne 1 ]; then
+                exit 1
+              fi
+            fi
+          }
+          resolve_ref_commit() {
+            state="$1"
+            depth=0
+            while :; do
+              object_type="$(node -p 'require(process.argv[1]).object.type' "$state")"
+              object_sha="$(node -p 'require(process.argv[1]).object.sha' "$state")"
+              printf '%s\n' "$object_sha" | grep -Eq '^[0-9a-f]{40}$'
+              case "$object_type" in
+                commit)
+                  printf '%s\n' "$object_sha"
+                  return
+                  ;;
+                tag)
+                  depth=$((depth + 1))
+                  if [ "$depth" -gt 8 ]; then
+                    echo "beta tag annotation chain is too deep" >&2
+                    return 1
+                  fi
+                  state="$RUNNER_TEMP/beta-tag-object-${depth}.json"
+                  require_present "beta tag object $object_sha" \
+                    "repos/${GITHUB_REPOSITORY}/git/tags/${object_sha}" \
+                    "$state"
+                  ;;
+                *)
+                  echo "beta tag resolves to unsupported object type $object_type" >&2
+                  return 1
+                  ;;
+              esac
+            done
+          }
+          printf '%s\n' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'
+          printf '%s\n' "$TESTED_COMMIT" | grep -Eq '^[0-9a-f]{40}$'
+          printf '%s\n' "$EXPECTED_ARCHIVE_SHA256" | grep -Eq '^[0-9a-f]{64}$'
+          test "$CONFIRMATION" = "promote-beta-v${VERSION}"
+          grep -Fxq "version = \"$VERSION\"" Cargo.toml
+          beta_tag="beta-v${VERSION}"
+          beta_release="$RUNNER_TEMP/beta-release.json"
+          require_present "$beta_tag release" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${beta_tag}" \
+            "$beta_release"
+          node -e '
+            const release = require(process.argv[1]);
+            if (
+              release.tag_name !== process.argv[2] ||
+              release.draft !== false ||
+              release.prerelease !== true
+            ) process.exit(1);
+          ' "$beta_release" "$beta_tag"
+          beta_ref="$RUNNER_TEMP/beta-ref.json"
+          require_present "$beta_tag tag" \
+            "repos/${GITHUB_REPOSITORY}/git/ref/tags/${beta_tag}" \
+            "$beta_ref"
+          test "$(resolve_ref_commit "$beta_ref")" = "$TESTED_COMMIT"
+          git cat-file -e "${TESTED_COMMIT}^{commit}"
+          git merge-base --is-ancestor "$TESTED_COMMIT" HEAD
+          stable_tag="v${VERSION}"
+          require_absent "$stable_tag tag" \
+            "repos/${GITHUB_REPOSITORY}/git/ref/tags/${stable_tag}" \
+            "$RUNNER_TEMP/stable-ref.json"
+          require_absent "$stable_tag release" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${stable_tag}" \
+            "$RUNNER_TEMP/stable-release.json"
+      - name: Download the exact beta assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          mkdir -p dist
+          gh release download "beta-v${VERSION}" --dir dist
+      - name: Verify beta checksums and expected assets
+        env:
+          VERSION: ${{ inputs.version }}
+          EXPECTED_ARCHIVE_SHA256: ${{ inputs.expected_archive_sha256 }}
+        run: |
+          cd dist
+          asset="cobalt-${VERSION}-KoboRoot.tgz"
+          legacy_asset="cobalt-${VERSION}-ClaraBW-KoboRoot.tgz"
+          digest="cobalt-${VERSION}.sha256"
+          test -f "$asset"
+          test -f "$legacy_asset"
+          test -f "$digest"
+          test -f "cobalt-${VERSION}-ClaraBW.sha256"
+          test -f THIRD-PARTY.md
+          test "$(find . -maxdepth 1 -type f | wc -l)" -eq 5
+          grep -Eq "^[0-9a-f]{64}  ${asset}$" "$digest"
+          grep -Eq "^[0-9a-f]{64}  ${legacy_asset}$" "$digest"
+          cmp "$digest" "cobalt-${VERSION}-ClaraBW.sha256"
+          cmp "$asset" "$legacy_asset"
+          primary_digest="$(awk -v asset="$asset" '$2 == asset { print $1 }' "$digest")"
+          test "$primary_digest" = "$EXPECTED_ARCHIVE_SHA256"
+          sha256sum --check "$digest"
+          sha256sum --check "cobalt-${VERSION}-ClaraBW.sha256"
+      - name: Publish the exact verified bytes as stable
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          TESTED_COMMIT: ${{ inputs.tested_commit }}
+        run: |
+          api_get() {
+            output="$1"
+            endpoint="$2"
+            if ! status="$(curl --silent --show-error --location \
+              --retry 3 --retry-all-errors \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --output "$output" --write-out '%{http_code}' \
+              "https://api.github.com/${endpoint}")"
+            then
+              echo "GitHub API request failed for $endpoint" >&2
+              return 2
+            fi
+            case "$status" in
+              200) return 0 ;;
+              404)
+                rm -f "$output"
+                return 1
+                ;;
+              *)
+                echo "GitHub API request for $endpoint returned HTTP $status" >&2
+                return 2
+                ;;
+            esac
+          }
+          require_absent() {
+            label="$1"
+            endpoint="$2"
+            output="$3"
+            if api_get "$output" "$endpoint"; then
+              echo "$label already exists; refusing replacement" >&2
+              exit 1
+            else
+              lookup_status=$?
+              if [ "$lookup_status" -ne 1 ]; then
+                exit 1
+              fi
+            fi
+          }
+          tag="v${VERSION}"
+          require_absent "$tag tag" \
+            "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}" \
+            "$RUNNER_TEMP/stable-ref.json"
+          require_absent "$tag release" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" \
+            "$RUNNER_TEMP/stable-release.json"
+          created_sha="$(gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/git/refs" \
+            --field "ref=refs/tags/${tag}" \
+            --field "sha=${TESTED_COMMIT}" \
+            --jq '.object.sha')"
+          test "$created_sha" = "$TESTED_COMMIT"
+          gh release create "$tag" dist/* \
+            --title "Cobalt ${VERSION}" \
+            --notes "Promoted unchanged from tested beta-v${VERSION}." \
+            --latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "icon-import"
-version = "0.3.1"
+version = "0.3.2"
 
 [[package]]
 name = "image"
@@ -548,14 +548,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-abi"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "kobo-app-store"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-arxiv"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-audiobook"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-doc",
  "kobo-json",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-bookview"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-brief"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-chat"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-app-store",
  "kobo-image",
@@ -625,14 +625,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-dict"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "unicode-normalization",
 ]
 
 [[package]]
 name = "kobo-doc"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-html",
  "miniz_oxide 0.9.1",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doctor"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -649,14 +649,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-gallery"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-guard"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gutenbird"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-hal"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-abi",
  "kobo-doc",
@@ -688,21 +688,21 @@ dependencies = [
 
 [[package]]
 name = "kobo-handoff"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-hello"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-hn"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-html"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "ratex-layout",
  "ratex-parser",
@@ -722,18 +722,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-image"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "image",
 ]
 
 [[package]]
 name = "kobo-json"
-version = "0.3.1"
+version = "0.3.2"
 
 [[package]]
 name = "kobo-launcher"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-magnet"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-morse"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-net"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "http",
  "httparse",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-opds"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-json",
  "kobo-xml",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-policy"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-abi",
  "kobo-dict",
@@ -787,18 +787,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-profile"
-version = "0.3.1"
+version = "0.3.2"
 
 [[package]]
 name = "kobo-protocol"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-ui",
 ]
 
 [[package]]
 name = "kobo-read"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-rss"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sdk"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-policy",
  "kobo-protocol",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-settings"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-shell"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-abi",
  "kobo-policy",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekick"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekickd"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sim"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-net",
  "kobo-policy",
@@ -879,14 +879,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-smoke"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-store"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sudoku"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tap"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-term"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-ui",
  "vt100",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-terminal"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-policy",
  "kobo-sdk",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-text"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "fontdue",
  "kobo-ui",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tictactoe"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-todo"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -957,18 +957,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-ui"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "kobo-xml"
-version = "0.3.1"
+version = "0.3.2"
 
 [[package]]
 name = "kobo-zotero-reader"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "kobod"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "base64",
  "kobo-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.85.1"
 license = "AGPL-3.0-only"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -22,3 +22,33 @@ not as library crates. Pushing a tag `vX.Y.Z` from a clean commit runs the
 the workspace version, builds the device package per profile, and publishes a
 GitHub release with assets named `cobalt-X.Y.Z-<device>-KoboRoot.tgz` alongside
 their checksums and third-party notices.
+
+## Stable and beta platform channels
+
+Stable remains the default. Stable readers use GitHub's latest non-prerelease
+release and Stable Store catalog. Owners can enable **Beta updates** in
+Settings to use prerelease platform releases and the separately signed
+`app-catalog-beta` Store catalog. Turning Beta updates off changes future
+checks to Stable; it does not delete apps or install older versions.
+
+The long-lived `beta` branch is the only source for beta publishing:
+
+- `.github/workflows/beta-release.yml` builds the workspace version once and
+  creates immutable `beta-vX.Y.Z` as a non-latest prerelease. The beta branch
+  must advance the workspace version for every published test build; an
+  existing beta tag or release is never moved or replaced. Assets retain the
+  stable deterministic names, including `cobalt-X.Y.Z-KoboRoot.tgz` and
+  `cobalt-X.Y.Z.sha256`.
+- `.github/workflows/apps.yml` publishes beta branch apps only to
+  `app-catalog-beta`; main continues to publish only to `app-catalog`.
+- `.github/workflows/promote-beta.yml` is a manual, guarded promotion. Supply
+  `X.Y.Z`, the full tested beta commit SHA, the expected primary archive
+  SHA-256, and the exact confirmation `promote-beta-vX.Y.Z`. It requires the
+  prerelease tag to target that commit, requires the commit to be in current
+  main, enforces the workspace version, verifies the downloaded checksum
+  files and expected archive digest, and publishes those exact bytes as
+  `vX.Y.Z` targeting the tested commit. It never rebuilds or replaces a tag or
+  release.
+
+Promotion is never automatic. Merge the tested beta commit to main first so
+the main workspace version matches the artifact being promoted.

--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ recovery steps.
 
 ## App Store
 
-Store reads a signed catalog from the fixed `app-catalog` GitHub release. Each
-package contains one ARM executable and a signed canonical manifest. The
+Store reads a signed catalog from the Stable `app-catalog` GitHub release, or
+the isolated `app-catalog-beta` release when the owner enables Beta updates.
+Each package contains one ARM executable and a signed canonical manifest. The
 runtime verifies the catalog, package, installed manifest, and binary before
 launch.
 

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -656,14 +656,15 @@ fn app_release(arguments: &[String]) -> Result<(), String> {
         .map_err(|error| format!("invalid {} metadata: {error}", app.id))?;
         let bundle = kobo_app_store::build_bundle(&manifest, &binary, &seed)
             .map_err(|error| format!("bundle {}: {error}", app.id))?;
-        let package_path = output.join(format!("{}.cobalt-app", app.id));
+        let (package_name, package_sha256) = release_package_name(&app.id, &bundle);
+        let package_path = output.join(&package_name);
         fs::write(&package_path, &bundle)
             .map_err(|error| format!("write {}: {error}", package_path.display()))?;
         entries.push(
             kobo_app_store::CatalogEntry::new(kobo_app_store::CatalogEntryInput {
                 manifest,
-                package_url: format!("{base_url}/{}.cobalt-app", app.id),
-                package_sha256: kobo_net::sha256::hex_digest(&bundle),
+                package_url: format!("{base_url}/{package_name}"),
+                package_sha256,
                 package_bytes: u64::try_from(bundle.len())
                     .map_err(|_| format!("{} package is too large", app.id))?,
             })
@@ -1019,6 +1020,11 @@ fn ensure_only_flags(arguments: &[String], flags: &[&str], usage: &str) -> Resul
         index += width;
     }
     Ok(())
+}
+
+fn release_package_name(id: &str, bundle: &[u8]) -> (String, String) {
+    let digest = kobo_net::sha256::hex_digest(bundle);
+    (format!("{id}-{digest}.cobalt-app"), digest)
 }
 
 fn read_signing_seed(path: &Path) -> Result<[u8; 32], String> {

--- a/crates/kobo-policy/Cargo.toml
+++ b/crates/kobo-policy/Cargo.toml
@@ -9,10 +9,10 @@ repository.workspace = true
 description = "Capability, task, storage, and credential policy for Kobo applications"
 
 [dependencies]
-kobo-abi = { version = "0.3.1", path = "../kobo-abi" }
-kobo-dict = { version = "0.3.1", path = "../kobo-dict" }
-kobo-net = { version = "0.3.1", path = "../kobo-net" }
-kobo-protocol = { version = "0.3.1", path = "../kobo-protocol" }
+kobo-abi = { version = "0.3.2", path = "../kobo-abi" }
+kobo-dict = { version = "0.3.2", path = "../kobo-dict" }
+kobo-net = { version = "0.3.2", path = "../kobo-net" }
+kobo-protocol = { version = "0.3.2", path = "../kobo-protocol" }
 
 [lints]
 workspace = true

--- a/crates/kobo-policy/src/services.rs
+++ b/crates/kobo-policy/src/services.rs
@@ -12,6 +12,7 @@
 use crate::{Capability, Declared, Grant, Grants, PowerPolicy};
 use kobo_protocol::{
     AudioPlaybackState, DenyReason, DeviceError, DeviceRequest, DeviceResult, DictionaryEntry,
+    UpdateChannel,
 };
 use std::collections::BTreeSet;
 use std::time::Duration;
@@ -95,6 +96,7 @@ pub struct DeviceServices {
     audio_volume: u8,
     dictionaries: kobo_dict::Index,
     auto_update: AutoUpdateChoices,
+    update_channel: UpdateChannel,
 }
 
 /// The two standing update switches, held together because they are asked
@@ -147,6 +149,7 @@ impl DeviceServices {
                 cobalt: true,
                 apps: true,
             },
+            update_channel: UpdateChannel::Stable,
         }
     }
 
@@ -316,9 +319,7 @@ impl DeviceServices {
                 .map_or(DeviceResult::Done, DeviceResult::Denied),
             DeviceRequest::ListInstalledApps
             | DeviceRequest::ReadAppCatalog
-            | DeviceRequest::RefreshAppCatalog => DeviceResult::Apps {
-                entries: Vec::new(),
-            },
+            | DeviceRequest::RefreshAppCatalog => Self::empty_apps(),
             DeviceRequest::InstallApp { .. } | DeviceRequest::UninstallApp { .. } => {
                 DeviceResult::Done
             }
@@ -329,8 +330,31 @@ impl DeviceServices {
             | DeviceRequest::BeginAppLink
             | DeviceRequest::PollAppLink
             | DeviceRequest::DisconnectAppLink => DeviceResult::Denied(DenyReason::Unsupported),
+            request @ (DeviceRequest::ReadAutoUpdate
+            | DeviceRequest::SetAutoUpdate { .. }
+            | DeviceRequest::ReadUpdateChannel
+            | DeviceRequest::SetUpdateChannel { .. }) => self.handle_update_preferences(&request),
+        }
+    }
+
+    fn empty_apps() -> DeviceResult {
+        DeviceResult::Apps {
+            entries: Vec::new(),
+        }
+    }
+
+    fn handle_update_preferences(&mut self, request: &DeviceRequest) -> DeviceResult {
+        match request {
             DeviceRequest::ReadAutoUpdate => self.auto_update_state(),
-            DeviceRequest::SetAutoUpdate { cobalt, apps } => self.choose_auto_update(cobalt, apps),
+            DeviceRequest::SetAutoUpdate { cobalt, apps } => {
+                self.choose_auto_update(*cobalt, *apps)
+            }
+            DeviceRequest::ReadUpdateChannel => DeviceResult::UpdateChannel(self.update_channel),
+            DeviceRequest::SetUpdateChannel { channel } => {
+                self.update_channel = *channel;
+                DeviceResult::UpdateChannel(self.update_channel)
+            }
+            _ => unreachable!("caller passes only update-preference requests"),
         }
     }
 
@@ -654,7 +678,9 @@ pub fn request_capability(request: &DeviceRequest) -> Option<Capability> {
         // not a radio or the panel, so no capability governs them; who may
         // ask is decided by the runtime, exactly as for the store requests.
         | DeviceRequest::ReadAutoUpdate
-        | DeviceRequest::SetAutoUpdate { .. } => return None,
+        | DeviceRequest::SetAutoUpdate { .. }
+        | DeviceRequest::ReadUpdateChannel
+        | DeviceRequest::SetUpdateChannel { .. } => return None,
     })
 }
 
@@ -666,7 +692,7 @@ fn clamp_seconds(duration: Duration) -> u32 {
 mod tests {
     use super::{Backends, DeviceServices, DeviceState};
     use crate::{Capability, Declared, PowerPolicy};
-    use kobo_protocol::{DenyReason, DeviceRequest, DeviceResult};
+    use kobo_protocol::{DenyReason, DeviceRequest, DeviceResult, UpdateChannel};
 
     fn seconds_of(duration: std::time::Duration) -> u32 {
         u32::try_from(duration.as_secs()).expect("policy fits in u32")
@@ -772,6 +798,20 @@ mod tests {
                 cobalt: false,
                 apps: true,
             }
+        );
+        assert_eq!(
+            services.handle(DeviceRequest::ReadUpdateChannel),
+            DeviceResult::UpdateChannel(UpdateChannel::Stable)
+        );
+        assert_eq!(
+            services.handle(DeviceRequest::SetUpdateChannel {
+                channel: UpdateChannel::Beta,
+            }),
+            DeviceResult::UpdateChannel(UpdateChannel::Beta)
+        );
+        assert_eq!(
+            services.handle(DeviceRequest::ReadUpdateChannel),
+            DeviceResult::UpdateChannel(UpdateChannel::Beta)
         );
     }
 

--- a/crates/kobo-protocol/Cargo.toml
+++ b/crates/kobo-protocol/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 description = "Bounded wire protocol between Kobo applications and the Cobalt runtime"
 
 [dependencies]
-kobo-ui = { version = "0.3.1", path = "../kobo-ui" }
+kobo-ui = { version = "0.3.2", path = "../kobo-ui" }
 
 [lints]
 workspace = true

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -45,7 +45,8 @@ pub const MAGIC: [u8; 4] = *b"KOBO";
 /// adds bounded rich EPUB text and runtime-held publisher-font handles.
 /// Version 10 adds exact text-hold coordinates and typed offline dictionary
 /// requests/results. Version 11 adds the identity request and its result,
-/// both tags an older side has no reading for.
+/// both tags an older side has no reading for. Update-channel requests were
+/// later added on new tags without changing the shapes of existing frames.
 pub const VERSION: u8 = 11;
 pub const HEADER_LEN: usize = 14;
 /// The largest single frame either side will read.
@@ -954,6 +955,33 @@ pub fn is_cache_key(key: &str) -> bool {
 ///
 /// Applications never open a device node. They describe an intent, the runtime
 /// decides whether to honour it, and the answer is always explicit.
+/// Which published update stream the runtime follows.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum UpdateChannel {
+    /// Normal releases. This remains the default for existing readers.
+    #[default]
+    Stable,
+    /// Prerelease platform and application catalog releases.
+    Beta,
+}
+
+impl UpdateChannel {
+    const fn wire(self) -> u8 {
+        match self {
+            Self::Stable => 0,
+            Self::Beta => 1,
+        }
+    }
+
+    fn from_wire(value: u8) -> Result<Self, ProtocolError> {
+        match value {
+            0 => Ok(Self::Stable),
+            1 => Ok(Self::Beta),
+            _ => Err(ProtocolError::InvalidValue("update channel")),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DeviceRequest {
     /// Report battery percentage and whether the device is charging.
@@ -1069,6 +1097,10 @@ pub enum DeviceRequest {
     /// as [`DeviceRequest::ReadBatteryDetail`]: the session already proved
     /// this identity at startup, so answering is a read, not a probe.
     ReadIdentity,
+    /// Report which published update stream the runtime follows.
+    ReadUpdateChannel,
+    /// Select the published update stream used for platform and app updates.
+    SetUpdateChannel { channel: UpdateChannel },
 }
 
 /// Current state of the runtime-owned App Store browser link.
@@ -1320,6 +1352,8 @@ pub enum DeviceResult {
     Failed(DeviceError),
     /// The request was refused, with the exact reason.
     Denied(DenyReason),
+    /// Which published update stream the runtime follows.
+    UpdateChannel(UpdateChannel),
 }
 
 /// Application metadata safe to show to an unprivileged launcher or Store UI.
@@ -1353,7 +1387,7 @@ impl AppInfo {
     pub fn has_update(&self) -> bool {
         self.installed_version
             .as_ref()
-            .is_some_and(|installed| installed != &self.version)
+            .is_some_and(|installed| numeric_version_is_newer(&self.version, installed))
     }
 
     #[must_use]
@@ -1363,25 +1397,40 @@ impl AppInfo {
 }
 
 fn numeric_version_at_least(current: &str, minimum: &str) -> bool {
-    let parse = |version: &str| -> Option<Vec<u64>> {
-        version
-            .split('.')
-            .map(|part| {
-                if part.is_empty() || !part.bytes().all(|byte| byte.is_ascii_digit()) {
-                    None
-                } else {
-                    part.parse().ok()
-                }
-            })
-            .collect()
-    };
-    let (Some(mut current), Some(mut minimum)) = (parse(current), parse(minimum)) else {
+    let (Some(mut current), Some(mut minimum)) =
+        (numeric_version(current), numeric_version(minimum))
+    else {
         return false;
     };
     let width = current.len().max(minimum.len());
     current.resize(width, 0);
     minimum.resize(width, 0);
     current >= minimum
+}
+
+fn numeric_version_is_newer(candidate: &str, installed: &str) -> bool {
+    let (Some(mut candidate), Some(mut installed)) =
+        (numeric_version(candidate), numeric_version(installed))
+    else {
+        return false;
+    };
+    let width = candidate.len().max(installed.len());
+    candidate.resize(width, 0);
+    installed.resize(width, 0);
+    candidate > installed
+}
+
+fn numeric_version(version: &str) -> Option<Vec<u64>> {
+    version
+        .split('.')
+        .map(|part| {
+            if part.is_empty() || !part.bytes().all(|byte| byte.is_ascii_digit()) {
+                None
+            } else {
+                part.parse().ok()
+            }
+        })
+        .collect()
 }
 
 /// A source accepted by the runtime-owned audio player.
@@ -2452,6 +2501,10 @@ fn encode_device_request(
         DeviceRequest::SetAutoUpdate { cobalt, apps } => {
             output.extend_from_slice(&[44, radio_flags(*cobalt, *apps)]);
         }
+        DeviceRequest::ReadUpdateChannel => output.push(45),
+        DeviceRequest::SetUpdateChannel { channel } => {
+            output.extend_from_slice(&[46, channel.wire()]);
+        }
     }
     Ok(())
 }
@@ -2747,6 +2800,10 @@ fn decode_device_request(reader: &mut Reader<'_>) -> Result<DeviceRequest, Proto
                 apps: flags_second(flags),
             })
         }
+        45 => Ok(DeviceRequest::ReadUpdateChannel),
+        46 => Ok(DeviceRequest::SetUpdateChannel {
+            channel: UpdateChannel::from_wire(reader.u8()?)?,
+        }),
         _ => Err(ProtocolError::InvalidValue("device request")),
     }
 }
@@ -2933,6 +2990,7 @@ fn encode_device_result(output: &mut Vec<u8>, result: &DeviceResult) -> Result<(
         DeviceResult::AutoUpdate { cobalt, apps } => {
             output.extend_from_slice(&[17, radio_flags(*cobalt, *apps)]);
         }
+        DeviceResult::UpdateChannel(channel) => output.extend_from_slice(&[18, channel.wire()]),
     }
     Ok(())
 }
@@ -3134,6 +3192,7 @@ fn decode_device_result(reader: &mut Reader<'_>) -> Result<DeviceResult, Protoco
         15 => decode_remote_install(reader),
         16 => identity(reader).map(DeviceResult::Identity),
         17 => decode_auto_update(reader),
+        18 => UpdateChannel::from_wire(reader.u8()?).map(DeviceResult::UpdateChannel),
         _ => Err(ProtocolError::InvalidValue("device result")),
     }
 }
@@ -6489,6 +6548,13 @@ mod tests {
                 cobalt: false,
                 apps: true,
             },
+            DeviceRequest::ReadUpdateChannel,
+            DeviceRequest::SetUpdateChannel {
+                channel: UpdateChannel::Stable,
+            },
+            DeviceRequest::SetUpdateChannel {
+                channel: UpdateChannel::Beta,
+            },
         ];
         for request in requests {
             let frame = Frame {
@@ -6639,6 +6705,98 @@ mod tests {
                 assert_eq!(decode(&bytes).expect("decode"), frame);
             }
         }
+    }
+
+    #[test]
+    fn protocol_11_auto_update_frames_remain_byte_compatible() {
+        let read = Frame {
+            request_id: 8,
+            message: Message::DeviceRequest(DeviceRequest::ReadAutoUpdate),
+        };
+        let read_bytes = encode(&read).expect("encode read");
+        assert_eq!(
+            read_bytes,
+            [b'K', b'O', b'B', b'O', 11, 7, 0, 0, 0, 1, 0, 0, 0, 8, 43,]
+        );
+        assert_eq!(decode(&read_bytes).expect("decode read"), read);
+
+        let request = Frame {
+            request_id: 9,
+            message: Message::DeviceRequest(DeviceRequest::SetAutoUpdate {
+                cobalt: true,
+                apps: false,
+            }),
+        };
+        let request_bytes = encode(&request).expect("encode request");
+        assert_eq!(
+            request_bytes,
+            [b'K', b'O', b'B', b'O', 11, 7, 0, 0, 0, 2, 0, 0, 0, 9, 44, 1,]
+        );
+        assert_eq!(decode(&request_bytes).expect("decode request"), request);
+
+        let result = Frame {
+            request_id: 11,
+            message: Message::DeviceResult(DeviceResult::AutoUpdate {
+                cobalt: false,
+                apps: true,
+            }),
+        };
+        let result_bytes = encode(&result).expect("encode result");
+        assert_eq!(
+            result_bytes,
+            [b'K', b'O', b'B', b'O', 11, 8, 0, 0, 0, 2, 0, 0, 0, 11, 17, 2,]
+        );
+        assert_eq!(decode(&result_bytes).expect("decode result"), result);
+    }
+
+    #[test]
+    fn update_channel_variants_round_trip() {
+        for channel in [UpdateChannel::Stable, UpdateChannel::Beta] {
+            for message in [
+                Message::DeviceRequest(DeviceRequest::SetUpdateChannel { channel }),
+                Message::DeviceResult(DeviceResult::UpdateChannel(channel)),
+            ] {
+                let frame = Frame {
+                    request_id: 9,
+                    message,
+                };
+                let bytes = encode(&frame).expect("encode");
+                assert_eq!(decode(&bytes).expect("decode"), frame);
+            }
+        }
+        let read = Frame {
+            request_id: 9,
+            message: Message::DeviceRequest(DeviceRequest::ReadUpdateChannel),
+        };
+        let bytes = encode(&read).expect("encode");
+        assert_eq!(decode(&bytes).expect("decode"), read);
+    }
+
+    #[test]
+    fn unknown_update_channels_are_refused() {
+        let request = Frame {
+            request_id: 9,
+            message: Message::DeviceRequest(DeviceRequest::SetUpdateChannel {
+                channel: UpdateChannel::Stable,
+            }),
+        };
+        let mut bytes = encode(&request).expect("encode request");
+        *bytes.last_mut().expect("channel byte") = 2;
+        assert_eq!(
+            decode(&bytes),
+            Err(ProtocolError::InvalidValue("update channel"))
+        );
+
+        let result = Frame {
+            request_id: 9,
+            message: Message::DeviceResult(DeviceResult::UpdateChannel(UpdateChannel::Stable)),
+        };
+        let mut bytes = encode(&result).expect("encode result");
+        *bytes.last_mut().expect("channel byte") = 2;
+        assert_eq!(
+            decode(&bytes),
+            Err(ProtocolError::InvalidValue("update channel"))
+        );
     }
 
     #[test]
@@ -6815,6 +6973,26 @@ mod tests {
             ..app
         };
         assert!(!newer.is_compatible_with("0.3.0"));
+    }
+
+    #[test]
+    fn app_updates_are_only_strictly_newer_numeric_versions() {
+        let app = |published: &str, installed: &str| AppInfo {
+            id: "version-test".to_owned(),
+            title: "Version Test".to_owned(),
+            label: "Version".to_owned(),
+            summary: "Checks Store update ordering.".to_owned(),
+            version: published.to_owned(),
+            minimum_cobalt_version: "0.3.2".to_owned(),
+            glyph: Glyph::App,
+            capabilities: Vec::new(),
+            installed_version: Some(installed.to_owned()),
+        };
+        assert!(app("1.2.0", "1.1.9").has_update());
+        assert!(!app("1.2.0", "1.2.0").has_update());
+        assert!(!app("1.1.9", "1.2.0").has_update());
+        assert!(!app("stable", "1.2.0").has_update());
+        assert!(!app("1.2.0", "beta").has_update());
     }
 
     #[test]

--- a/crates/kobo-sdk/Cargo.toml
+++ b/crates/kobo-sdk/Cargo.toml
@@ -29,10 +29,10 @@ text = ["dep:kobo-text"]
 runtime-settings = []
 
 [dependencies]
-kobo-policy = { version = "0.3.1", path = "../kobo-policy" }
-kobo-protocol = { version = "0.3.1", path = "../kobo-protocol" }
-kobo-text = { version = "0.3.1", path = "../kobo-text", optional = true }
-kobo-ui = { version = "0.3.1", path = "../kobo-ui" }
+kobo-policy = { version = "0.3.2", path = "../kobo-policy" }
+kobo-protocol = { version = "0.3.2", path = "../kobo-protocol" }
+kobo-text = { version = "0.3.2", path = "../kobo-text", optional = true }
+kobo-ui = { version = "0.3.2", path = "../kobo-ui" }
 
 [lints]
 workspace = true

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -10,11 +10,11 @@ pub use kobo_protocol::{
     BluetoothDevice, BluetoothDeviceKind, Credential, DenyReason, DeviceError, DeviceIdentity,
     DeviceRequest, DeviceResult, DictionaryEntry, Frame, Header, Lifecycle, LogLevel, Message,
     RemoteInstallOutcome, SecretHeader, ShellError, ShellEvent, ShellRequest, StoreError,
-    StoreRequest, StoreResult, StreamError, Task, TaskError, TaskId, TaskOutcome, WifiNetwork,
-    CACHE_PREFIX, MAX_CACHE_KEYS, MAX_FONT_BYTES, MAX_HEADERS, MAX_HEADER_NAME, MAX_HEADER_VALUE,
-    MAX_INLINE_PICTURE_BYTES, MAX_LOOKUP_WORD_BYTES, MAX_PICTURE_BYTES, MAX_PICTURE_CHUNK_BYTES,
-    MAX_RADIO_DEVICES, MAX_RADIO_NAME, MAX_SHELF_CHUNK, MAX_SHELL_CHUNK, MAX_STORE_KEYS,
-    MAX_STORE_VALUE, MAX_TASK_BYTES, MAX_URL_LEN,
+    StoreRequest, StoreResult, StreamError, Task, TaskError, TaskId, TaskOutcome, UpdateChannel,
+    WifiNetwork, CACHE_PREFIX, MAX_CACHE_KEYS, MAX_FONT_BYTES, MAX_HEADERS, MAX_HEADER_NAME,
+    MAX_HEADER_VALUE, MAX_INLINE_PICTURE_BYTES, MAX_LOOKUP_WORD_BYTES, MAX_PICTURE_BYTES,
+    MAX_PICTURE_CHUNK_BYTES, MAX_RADIO_DEVICES, MAX_RADIO_NAME, MAX_SHELF_CHUNK, MAX_SHELL_CHUNK,
+    MAX_STORE_KEYS, MAX_STORE_VALUE, MAX_TASK_BYTES, MAX_URL_LEN,
 };
 pub use kobo_ui::QuoteRole;
 pub use kobo_ui::{
@@ -4327,6 +4327,20 @@ impl Device<'_> {
     #[cfg(feature = "runtime-settings")]
     pub fn set_auto_update(&mut self, cobalt: bool, apps: bool) {
         self.request(DeviceRequest::SetAutoUpdate { cobalt, apps });
+    }
+
+    /// Asks which stable or beta release channel the runtime follows. The
+    /// reply is [`DeviceResult::UpdateChannel`].
+    #[cfg(feature = "runtime-settings")]
+    pub fn read_update_channel(&mut self) {
+        self.request(DeviceRequest::ReadUpdateChannel);
+    }
+
+    /// Atomically selects the stable or beta release channel used for both
+    /// platform and Store app updates.
+    #[cfg(feature = "runtime-settings")]
+    pub fn set_update_channel(&mut self, channel: UpdateChannel) {
+        self.request(DeviceRequest::SetUpdateChannel { channel });
     }
 
     fn bluetooth_address(

--- a/crates/kobo-text/Cargo.toml
+++ b/crates/kobo-text/Cargo.toml
@@ -10,7 +10,7 @@ description = "Real type for the Kobo application platform"
 
 [dependencies]
 fontdue = "0.9"
-kobo-ui = { version = "0.3.1", path = "../kobo-ui" }
+kobo-ui = { version = "0.3.2", path = "../kobo-ui" }
 unicode-linebreak = "0.1.5"
 unicode-segmentation = "1.12"
 

--- a/crates/kobod/src/app_link.rs
+++ b/crates/kobod/src/app_link.rs
@@ -47,12 +47,13 @@ pub fn begin(root: &Path) -> Result<DeviceResult, DeviceError> {
 
 pub fn poll(root: &Path) -> Result<DeviceResult, DeviceError> {
     let mut relay = HttpsRelay::new()?;
+    let channel = crate::autoupdate::preferences(root).channel;
     poll_with(
         root,
         &mut relay,
         now(),
-        crate::app_store::prepare_remote_install,
-        crate::app_store::install,
+        |root, id| crate::app_store::prepare_remote_install(root, id, channel),
+        |root, id| crate::app_store::install(root, id, channel),
     )
 }
 

--- a/crates/kobod/src/app_store.rs
+++ b/crates/kobod/src/app_store.rs
@@ -3,7 +3,7 @@
 use kobo_app_store::{
     parse_public_bundle, verify, Catalog, DetachedSignature, Ed25519PublicKey, Manifest,
 };
-use kobo_protocol::{AppInfo, DeviceError, RemoteInstallOutcome};
+use kobo_protocol::{AppInfo, DeviceError, RemoteInstallOutcome, UpdateChannel};
 use kobo_ui::Glyph;
 use std::collections::BTreeSet;
 use std::fs;
@@ -14,6 +14,10 @@ pub const CATALOG_URL: &str =
     "https://github.com/BandarLabs/Cobalt/releases/download/app-catalog/cobalt-app-catalog.json";
 pub const CATALOG_SIGNATURE_URL: &str =
     "https://github.com/BandarLabs/Cobalt/releases/download/app-catalog/cobalt-app-catalog.json.sig";
+pub const BETA_CATALOG_URL: &str =
+    "https://github.com/BandarLabs/Cobalt/releases/download/app-catalog-beta/cobalt-app-catalog.json";
+pub const BETA_CATALOG_SIGNATURE_URL: &str =
+    "https://github.com/BandarLabs/Cobalt/releases/download/app-catalog-beta/cobalt-app-catalog.json.sig";
 
 const CATALOG_LIMIT: u32 = 512 * 1024;
 const SIGNATURE_LIMIT: u32 = 1024;
@@ -164,16 +168,16 @@ const SYSTEM_APPS: &[BuiltinApp] = &[
     },
 ];
 
-pub fn refresh(root: &Path) -> Result<Vec<AppInfo>, DeviceError> {
+pub fn refresh(root: &Path, channel: UpdateChannel) -> Result<Vec<AppInfo>, DeviceError> {
     let key = public_key()?;
-    refresh_with(root, &key, |url, maximum| {
+    refresh_channel_with(root, channel, &key, |url, maximum| {
         kobo_net::fetch(url, maximum).map_err(network_error)
     })
 }
 
-pub fn catalog(root: &Path) -> Result<Vec<AppInfo>, DeviceError> {
+pub fn catalog(root: &Path, channel: UpdateChannel) -> Result<Vec<AppInfo>, DeviceError> {
     let key = public_key()?;
-    match read_cached_catalog(root, &key) {
+    match read_channel_catalog(root, channel, &key) {
         Ok(catalog) => catalog_info(root, &catalog, &key),
         Err(DeviceError::NotFound) => local_catalog_info(root, &key),
         Err(error) => Err(error),
@@ -203,8 +207,8 @@ fn installed_with_key(root: &Path, key: &Ed25519PublicKey) -> Result<Vec<AppInfo
     Ok(entries)
 }
 
-pub fn install(root: &Path, id: &str) -> Result<(), DeviceError> {
-    install_with(root, id, &public_key()?, |url, maximum| {
+pub fn install(root: &Path, id: &str, channel: UpdateChannel) -> Result<(), DeviceError> {
+    install_channel_with(root, id, channel, &public_key()?, |url, maximum| {
         kobo_net::fetch(url, maximum).map_err(network_error)
     })
 }
@@ -215,26 +219,42 @@ pub struct RemoteInstallPlan {
     pub install: bool,
 }
 
-pub fn prepare_remote_install(root: &Path, id: &str) -> Result<RemoteInstallPlan, DeviceError> {
+pub fn prepare_remote_install(
+    root: &Path,
+    id: &str,
+    channel: UpdateChannel,
+) -> Result<RemoteInstallPlan, DeviceError> {
     let key = public_key()?;
-    prepare_remote_install_with(root, id, &key, |url, maximum| {
+    prepare_remote_install_channel_with(root, id, channel, &key, |url, maximum| {
         kobo_net::fetch(url, maximum).map_err(network_error)
     })
 }
 
+#[cfg(test)]
 fn prepare_remote_install_with(
     root: &Path,
     id: &str,
+    key: &Ed25519PublicKey,
+    fetch: impl FnMut(&str, u32) -> Result<Vec<u8>, DeviceError>,
+) -> Result<RemoteInstallPlan, DeviceError> {
+    prepare_remote_install_channel_with(root, id, UpdateChannel::Stable, key, fetch)
+}
+
+fn prepare_remote_install_channel_with(
+    root: &Path,
+    id: &str,
+    channel: UpdateChannel,
     key: &Ed25519PublicKey,
     mut fetch: impl FnMut(&str, u32) -> Result<Vec<u8>, DeviceError>,
 ) -> Result<RemoteInstallPlan, DeviceError> {
     if !kobo_protocol::valid_app_id(id) || kobo_app_store::is_public_reserved_app_id(id) {
         return Err(DeviceError::InvalidInput);
     }
-    let json = fetch(CATALOG_URL, CATALOG_LIMIT)?;
-    let signature = fetch(CATALOG_SIGNATURE_URL, SIGNATURE_LIMIT)?;
+    let source = catalog_source(channel);
+    let json = fetch(source.url, CATALOG_LIMIT)?;
+    let signature = fetch(source.signature_url, SIGNATURE_LIMIT)?;
     let catalog = verify_catalog(&json, &signature, key)?;
-    write_catalog_cache(root, &json, &signature)?;
+    write_channel_catalog_cache(root, channel, &json, &signature)?;
     let Some(entry) = catalog
         .entries()
         .iter()
@@ -272,6 +292,18 @@ fn prepare_remote_install_with(
             } else {
                 RemoteInstallOutcome::AlreadyInstalled { id: id.to_owned() }
             },
+            install: false,
+        });
+    }
+    if current.is_some()
+        && !manifest_info(
+            entry.manifest(),
+            current.and_then(|candidate| candidate.installed_version.as_deref()),
+        )?
+        .has_update()
+    {
+        return Ok(RemoteInstallPlan {
+            outcome: RemoteInstallOutcome::AlreadyInstalled { id: id.to_owned() },
             install: false,
         });
     }
@@ -366,21 +398,43 @@ pub fn declared(root: &Path, id: &str) -> Option<kobo_policy::Declared> {
         .map(|manifest| manifest.declared_capabilities().clone())
 }
 
+#[cfg(test)]
 fn refresh_with(
     root: &Path,
     key: &Ed25519PublicKey,
+    fetch: impl FnMut(&str, u32) -> Result<Vec<u8>, DeviceError>,
+) -> Result<Vec<AppInfo>, DeviceError> {
+    refresh_channel_with(root, UpdateChannel::Stable, key, fetch)
+}
+
+fn refresh_channel_with(
+    root: &Path,
+    channel: UpdateChannel,
+    key: &Ed25519PublicKey,
     mut fetch: impl FnMut(&str, u32) -> Result<Vec<u8>, DeviceError>,
 ) -> Result<Vec<AppInfo>, DeviceError> {
-    let json = fetch(CATALOG_URL, CATALOG_LIMIT)?;
-    let signature = fetch(CATALOG_SIGNATURE_URL, SIGNATURE_LIMIT)?;
+    let source = catalog_source(channel);
+    let json = fetch(source.url, CATALOG_LIMIT)?;
+    let signature = fetch(source.signature_url, SIGNATURE_LIMIT)?;
     let catalog = verify_catalog(&json, &signature, key)?;
-    write_catalog_cache(root, &json, &signature)?;
+    write_channel_catalog_cache(root, channel, &json, &signature)?;
     catalog_info(root, &catalog, key)
 }
 
+#[cfg(test)]
 fn install_with(
     root: &Path,
     id: &str,
+    key: &Ed25519PublicKey,
+    fetch: impl FnMut(&str, u32) -> Result<Vec<u8>, DeviceError>,
+) -> Result<(), DeviceError> {
+    install_channel_with(root, id, UpdateChannel::Stable, key, fetch)
+}
+
+fn install_channel_with(
+    root: &Path,
+    id: &str,
+    channel: UpdateChannel,
     key: &Ed25519PublicKey,
     mut fetch: impl FnMut(&str, u32) -> Result<Vec<u8>, DeviceError>,
 ) -> Result<(), DeviceError> {
@@ -388,7 +442,7 @@ fn install_with(
         return Err(DeviceError::InvalidInput);
     }
     recover_interrupted_transaction(root, id, key)?;
-    let catalog = read_cached_catalog(root, key)?;
+    let catalog = read_channel_catalog(root, channel, key)?;
     let entry = catalog
         .entries()
         .iter()
@@ -399,6 +453,17 @@ fn install_with(
         entry.manifest().minimum_cobalt_version(),
     ) {
         return Err(DeviceError::InvalidInput);
+    }
+    if let Some(current) = installed_with_key(root, key)?
+        .iter()
+        .find(|candidate| candidate.id == id)
+    {
+        let candidate = manifest_info(entry.manifest(), current.installed_version.as_deref())?;
+        if current.installed_version.as_deref() != Some(entry.manifest().version())
+            && !candidate.has_update()
+        {
+            return Ok(());
+        }
     }
     let maximum = u32::try_from(entry.package_bytes()).map_err(|_| DeviceError::InvalidInput)?;
     let package = fetch(entry.package_url(), maximum)?;
@@ -434,9 +499,18 @@ fn verify_catalog(
     Ok(catalog)
 }
 
+#[cfg(test)]
 fn read_cached_catalog(root: &Path, key: &Ed25519PublicKey) -> Result<Catalog, DeviceError> {
-    recover_catalog_cache(root, key)?;
-    let cache = catalog_cache(root);
+    read_channel_catalog(root, UpdateChannel::Stable, key)
+}
+
+fn read_channel_catalog(
+    root: &Path,
+    channel: UpdateChannel,
+    key: &Ed25519PublicKey,
+) -> Result<Catalog, DeviceError> {
+    recover_channel_catalog_cache(root, channel, key)?;
+    let cache = catalog_cache(root, channel);
     read_catalog_directory(&cache, key)
 }
 
@@ -722,13 +796,24 @@ fn stage_and_swap(
     Ok(())
 }
 
+#[cfg(test)]
 fn write_catalog_cache(root: &Path, json: &[u8], signature: &[u8]) -> Result<(), DeviceError> {
+    write_channel_catalog_cache(root, UpdateChannel::Stable, json, signature)
+}
+
+fn write_channel_catalog_cache(
+    root: &Path,
+    channel: UpdateChannel,
+    json: &[u8],
+    signature: &[u8],
+) -> Result<(), DeviceError> {
     let store = cache_root(root);
     fs::create_dir_all(&store).map_err(|_| DeviceError::Backend)?;
     sync_directory(root)?;
-    let current = catalog_cache(root);
-    let next = store.join("catalog.next");
-    let previous = store.join("catalog.prev");
+    let source = catalog_source(channel);
+    let current = catalog_cache(root, channel);
+    let next = store.join(format!("{}.next", source.cache_name));
+    let previous = store.join(format!("{}.prev", source.cache_name));
     remove_directory(&next)?;
     fs::create_dir(&next).map_err(|_| DeviceError::Backend)?;
     if write_synced(&next.join("catalog.json"), json).is_err()
@@ -756,12 +841,17 @@ fn write_catalog_cache(root: &Path, json: &[u8], signature: &[u8]) -> Result<(),
     Ok(())
 }
 
-fn recover_catalog_cache(root: &Path, key: &Ed25519PublicKey) -> Result<(), DeviceError> {
-    let current = catalog_cache(root);
+fn recover_channel_catalog_cache(
+    root: &Path,
+    channel: UpdateChannel,
+    key: &Ed25519PublicKey,
+) -> Result<(), DeviceError> {
+    let source = catalog_source(channel);
+    let current = catalog_cache(root, channel);
     if safe_directory(&current)? && read_catalog_directory(&current, key).is_ok() {
         return Ok(());
     }
-    let previous = cache_root(root).join("catalog.prev");
+    let previous = cache_root(root).join(format!("{}.prev", source.cache_name));
     if safe_directory(&previous)? && read_catalog_directory(&previous, key).is_ok() {
         remove_directory(&current)?;
         rename_synced(&previous, &current, &cache_root(root))?;
@@ -864,8 +954,30 @@ fn cache_root(root: &Path) -> PathBuf {
     root.join("store")
 }
 
-fn catalog_cache(root: &Path) -> PathBuf {
-    cache_root(root).join("catalog")
+fn catalog_cache(root: &Path, channel: UpdateChannel) -> PathBuf {
+    cache_root(root).join(catalog_source(channel).cache_name)
+}
+
+#[derive(Clone, Copy)]
+struct CatalogSource {
+    url: &'static str,
+    signature_url: &'static str,
+    cache_name: &'static str,
+}
+
+const fn catalog_source(channel: UpdateChannel) -> CatalogSource {
+    match channel {
+        UpdateChannel::Stable => CatalogSource {
+            url: CATALOG_URL,
+            signature_url: CATALOG_SIGNATURE_URL,
+            cache_name: "catalog",
+        },
+        UpdateChannel::Beta => CatalogSource {
+            url: BETA_CATALOG_URL,
+            signature_url: BETA_CATALOG_SIGNATURE_URL,
+            cache_name: "catalog-beta",
+        },
+    }
 }
 
 fn app_binary(root: &Path, id: &str) -> PathBuf {
@@ -1300,6 +1412,103 @@ mod tests {
     }
 
     #[test]
+    fn stable_and_beta_catalogs_have_separate_urls_and_verified_caches() {
+        let root = root();
+        let seed = [9_u8; 32];
+        let key = derive_public_key(&seed).expect("key");
+        let (stable_json, stable_signature, _) = release_for(&seed, "word-count", "1.0.0");
+        let (beta_json, beta_signature, _) = release_for(&seed, "word-count", "2.0.0");
+
+        refresh_channel_with(&root, UpdateChannel::Stable, &key, |url, _| match url {
+            CATALOG_URL => Ok(stable_json.clone()),
+            CATALOG_SIGNATURE_URL => Ok(stable_signature.clone()),
+            _ => Err(DeviceError::NotFound),
+        })
+        .expect("stable refresh");
+        refresh_channel_with(&root, UpdateChannel::Beta, &key, |url, _| match url {
+            BETA_CATALOG_URL => Ok(beta_json.clone()),
+            BETA_CATALOG_SIGNATURE_URL => Ok(beta_signature.clone()),
+            _ => Err(DeviceError::NotFound),
+        })
+        .expect("beta refresh");
+
+        assert_eq!(
+            read_channel_catalog(&root, UpdateChannel::Stable, &key)
+                .expect("stable cache")
+                .entries()[0]
+                .manifest()
+                .version(),
+            "1.0.0"
+        );
+        assert_eq!(
+            read_channel_catalog(&root, UpdateChannel::Beta, &key)
+                .expect("beta cache")
+                .entries()[0]
+                .manifest()
+                .version(),
+            "2.0.0"
+        );
+        assert!(catalog_cache(&root, UpdateChannel::Stable).is_dir());
+        assert!(catalog_cache(&root, UpdateChannel::Beta).is_dir());
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn opting_out_of_beta_never_downgrades_an_installed_app() {
+        let root = root();
+        let seed = [9_u8; 32];
+        let key = derive_public_key(&seed).expect("key");
+        let (stable_json, stable_signature, stable_package) =
+            release_for(&seed, "word-count", "1.0.0");
+        let (beta_json, beta_signature, beta_package) = release_for(&seed, "word-count", "2.0.0");
+        refresh_channel_with(&root, UpdateChannel::Beta, &key, |url, _| {
+            if url == BETA_CATALOG_URL {
+                Ok(beta_json.clone())
+            } else {
+                Ok(beta_signature.clone())
+            }
+        })
+        .expect("beta refresh");
+        install_channel_with(&root, "word-count", UpdateChannel::Beta, &key, |_, _| {
+            Ok(beta_package.clone())
+        })
+        .expect("beta install");
+        refresh_channel_with(&root, UpdateChannel::Stable, &key, |url, _| {
+            if url == CATALOG_URL {
+                Ok(stable_json.clone())
+            } else {
+                Ok(stable_signature.clone())
+            }
+        })
+        .expect("stable refresh");
+
+        let stable_listing = catalog_info(
+            &root,
+            &read_channel_catalog(&root, UpdateChannel::Stable, &key).expect("stable cache"),
+            &key,
+        )
+        .expect("stable listing");
+        let entry = stable_listing
+            .iter()
+            .find(|entry| entry.id == "word-count")
+            .expect("word-count");
+        assert_eq!(entry.installed_version.as_deref(), Some("2.0.0"));
+        assert!(!entry.has_update());
+
+        install_channel_with(&root, "word-count", UpdateChannel::Stable, &key, |_, _| {
+            Ok(stable_package.clone())
+        })
+        .expect("stable install is a no-op");
+        assert_eq!(
+            installed_manifest(&root, "word-count", &key)
+                .expect("installed beta remains")
+                .version(),
+            "2.0.0"
+        );
+        let _ignored = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn interrupted_install_and_uninstall_renames_recover_the_working_copy() {
         let root = root();
         let seed = [9_u8; 32];
@@ -1438,7 +1647,11 @@ mod tests {
         let (json, signature, _) = release(&seed);
         write_catalog_cache(&root, &json, &signature).expect("cache");
         let store = cache_root(&root);
-        fs::rename(catalog_cache(&root), store.join("catalog.prev")).expect("retire cache");
+        fs::rename(
+            catalog_cache(&root, UpdateChannel::Stable),
+            store.join("catalog.prev"),
+        )
+        .expect("retire cache");
         fs::create_dir(store.join("catalog.next")).expect("stage cache");
         fs::write(store.join("catalog.next/catalog.json"), b"incomplete").expect("partial cache");
 
@@ -1449,7 +1662,9 @@ mod tests {
                 .len(),
             1
         );
-        assert!(catalog_cache(&root).join("catalog.json.sig").is_file());
+        assert!(catalog_cache(&root, UpdateChannel::Stable)
+            .join("catalog.json.sig")
+            .is_file());
         let _ignored = fs::remove_dir_all(root);
     }
 

--- a/crates/kobod/src/autoupdate.rs
+++ b/crates/kobod/src/autoupdate.rs
@@ -16,15 +16,16 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use kobo_protocol::DeviceError;
+use kobo_protocol::{DeviceError, UpdateChannel};
 
 /// Where releases are published. The same address the settings screen asks,
 /// so the two paths cannot disagree about what "newest" means.
-const RELEASES: &str = "https://api.github.com/repos/BandarLabs/Cobalt/releases/latest";
+const STABLE_RELEASES: &str = "https://api.github.com/repos/BandarLabs/Cobalt/releases/latest";
+const BETA_RELEASES: &str = "https://api.github.com/repos/BandarLabs/Cobalt/releases?per_page=100";
 
 /// The most a release description is allowed to be. The real reply is a few
 /// kilobytes; a reply a thousand times that size is not a release description.
-const RELEASE_LIMIT: u32 = 256 * 1024;
+const RELEASE_LIMIT: u32 = 1024 * 1024;
 
 /// The most a digest listing is allowed to be: a few lines of hex and names.
 const DIGEST_LIMIT: u32 = 16 * 1024;
@@ -39,6 +40,8 @@ pub struct Preferences {
     pub cobalt: bool,
     /// Whether installed applications are replaced when the catalog moves on.
     pub apps: bool,
+    /// Which platform and application release streams are consulted.
+    pub channel: UpdateChannel,
 }
 
 impl Default for Preferences {
@@ -48,6 +51,7 @@ impl Default for Preferences {
         Self {
             cobalt: true,
             apps: true,
+            channel: UpdateChannel::Stable,
         }
     }
 }
@@ -55,6 +59,8 @@ impl Default for Preferences {
 /// Everything the checker found that is newer than what is installed.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Plan {
+    /// The channel this plan was resolved from.
+    pub channel: UpdateChannel,
     /// Catalog applications whose installed version is no longer current.
     pub apps: Vec<String>,
     /// A newer platform release, verified digest and all, or nothing.
@@ -118,17 +124,25 @@ pub fn set_preferences(root: &Path, chosen: Preferences) -> Result<(), DeviceErr
 /// again later and there is nobody at the panel to tell.
 #[must_use]
 pub fn plan(root: &Path, chosen: Preferences, installed: &str) -> Plan {
-    let apps = if chosen.apps {
-        stale_apps(root)
-    } else {
-        Vec::new()
-    };
-    let platform = if chosen.cobalt {
-        platform_update(installed)
-    } else {
-        None
-    };
-    Plan { apps, platform }
+    plan_with(
+        chosen,
+        || stale_apps(root, chosen.channel),
+        || platform_update(installed, chosen.channel),
+    )
+}
+
+fn plan_with(
+    chosen: Preferences,
+    apps: impl FnOnce() -> Vec<String>,
+    platform: impl FnOnce() -> Option<PlatformUpdate>,
+) -> Plan {
+    let apps = if chosen.apps { apps() } else { Vec::new() };
+    let platform = if chosen.cobalt { platform() } else { None };
+    Plan {
+        channel: chosen.channel,
+        apps,
+        platform,
+    }
 }
 
 fn state_file(root: &Path) -> PathBuf {
@@ -145,6 +159,8 @@ fn parse(text: &str) -> Preferences {
             "cobalt=on" => chosen.cobalt = true,
             "apps=off" => chosen.apps = false,
             "apps=on" => chosen.apps = true,
+            "channel=stable" => chosen.channel = UpdateChannel::Stable,
+            "channel=beta" => chosen.channel = UpdateChannel::Beta,
             _ => {}
         }
     }
@@ -153,17 +169,21 @@ fn parse(text: &str) -> Preferences {
 
 fn render(chosen: Preferences) -> String {
     format!(
-        "cobalt={}\napps={}\n",
+        "cobalt={}\napps={}\nchannel={}\n",
         if chosen.cobalt { "on" } else { "off" },
-        if chosen.apps { "on" } else { "off" }
+        if chosen.apps { "on" } else { "off" },
+        match chosen.channel {
+            UpdateChannel::Stable => "stable",
+            UpdateChannel::Beta => "beta",
+        }
     )
 }
 
 /// Catalog applications that are installed at one version while the catalog
 /// publishes another. The refresh both fetches and verifies the catalog, so
 /// an identity that cannot be vouched for never reaches the list.
-fn stale_apps(root: &Path) -> Vec<String> {
-    crate::app_store::refresh(root).map_or_else(
+fn stale_apps(root: &Path, channel: UpdateChannel) -> Vec<String> {
+    crate::app_store::refresh(root, channel).map_or_else(
         |_| Vec::new(),
         |entries| {
             entries
@@ -178,10 +198,17 @@ fn stale_apps(root: &Path) -> Vec<String> {
 /// A strictly newer published release, with its digest already fetched, or
 /// nothing. All-or-nothing on purpose: a release that cannot be verified is
 /// not an update, it is a download.
-fn platform_update(installed: &str) -> Option<PlatformUpdate> {
-    let body = kobo_net::fetch(RELEASES, RELEASE_LIMIT).ok()?;
+fn platform_update(installed: &str, channel: UpdateChannel) -> Option<PlatformUpdate> {
+    let endpoint = match channel {
+        UpdateChannel::Stable => STABLE_RELEASES,
+        UpdateChannel::Beta => BETA_RELEASES,
+    };
+    let body = kobo_net::fetch(endpoint, RELEASE_LIMIT).ok()?;
     let body = String::from_utf8(body).ok()?;
-    let (version, archive, digest_url) = release_from(&body)?;
+    let (version, archive, digest_url) = match channel {
+        UpdateChannel::Stable => release_from(&body),
+        UpdateChannel::Beta => beta_release_from(&body),
+    }?;
     if !newer(&version, installed) {
         return None;
     }
@@ -199,8 +226,40 @@ fn platform_update(installed: &str) -> Option<PlatformUpdate> {
 /// URL and the digest URL this device needs.
 fn release_from(body: &str) -> Option<(String, String, String)> {
     let value = kobo_json::parse(body).ok()?;
+    release_value(&value, "v", false)
+}
+
+/// Selects the highest valid beta prerelease, independent of GitHub's reply
+/// order. Drafts, stable releases and malformed beta entries are skipped.
+fn beta_release_from(body: &str) -> Option<(String, String, String)> {
+    let value = kobo_json::parse(body).ok()?;
+    value
+        .as_array()?
+        .iter()
+        .filter_map(|release| release_value(release, "beta-v", true))
+        .max_by_key(|(version, _, _)| numbers(version))
+}
+
+fn release_value(
+    value: &kobo_json::Value,
+    tag_prefix: &str,
+    require_prerelease: bool,
+) -> Option<(String, String, String)> {
+    if value
+        .get("draft")
+        .and_then(kobo_json::Value::as_bool)
+        .unwrap_or(false)
+        || value
+            .get("prerelease")
+            .and_then(kobo_json::Value::as_bool)
+            .unwrap_or(false)
+            != require_prerelease
+    {
+        return None;
+    }
     let tag = value.get("tag_name").and_then(kobo_json::Value::as_str)?;
-    let version = tag.trim_start_matches('v').to_owned();
+    let version = tag.strip_prefix(tag_prefix)?.to_owned();
+    numbers(&version)?;
     let assets = value.get("assets").and_then(kobo_json::Value::as_array)?;
     let url_of = |name: &str| {
         assets
@@ -208,11 +267,16 @@ fn release_from(body: &str) -> Option<(String, String, String)> {
             .find(|asset| asset.get("name").and_then(kobo_json::Value::as_str) == Some(name))
             .and_then(|asset| asset.get("browser_download_url"))
             .and_then(kobo_json::Value::as_str)
+            .filter(|url| valid_release_url(url))
             .map(str::to_owned)
     };
     let archive = url_of(&archive_file(&version))?;
     let digest = url_of(&format!("cobalt-{version}.sha256"))?;
     Some((version, archive, digest))
+}
+
+fn valid_release_url(url: &str) -> bool {
+    url.starts_with("https://") && url.len() <= kobo_protocol::MAX_URL_LEN
 }
 
 fn archive_file(version: &str) -> String {
@@ -253,22 +317,31 @@ fn digest_from(listing: &str, asset: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        digest_from, newer, parse, preferences, release_from, render, set_preferences, Preferences,
+        beta_release_from, digest_from, newer, parse, plan_with, preferences, release_from, render,
+        set_preferences, PlatformUpdate, Preferences,
     };
+    use kobo_protocol::UpdateChannel;
 
     #[test]
     fn a_reader_who_chose_nothing_gets_both_updates() {
         let chosen = Preferences::default();
         assert!(chosen.cobalt);
         assert!(chosen.apps);
+        assert_eq!(chosen.channel, UpdateChannel::Stable);
     }
 
     #[test]
     fn choices_survive_being_written_and_read_back() {
         for cobalt in [false, true] {
             for apps in [false, true] {
-                let chosen = Preferences { cobalt, apps };
-                assert_eq!(parse(&render(chosen)), chosen);
+                for channel in [UpdateChannel::Stable, UpdateChannel::Beta] {
+                    let chosen = Preferences {
+                        cobalt,
+                        apps,
+                        channel,
+                    };
+                    assert_eq!(parse(&render(chosen)), chosen);
+                }
             }
         }
     }
@@ -280,6 +353,23 @@ mod tests {
         let chosen = parse("cobalt=off\ndictionaries=off\n");
         assert!(!chosen.cobalt);
         assert!(chosen.apps);
+        assert_eq!(chosen.channel, UpdateChannel::Stable);
+    }
+
+    #[test]
+    fn legacy_and_malformed_channel_values_remain_stable() {
+        assert_eq!(
+            parse("cobalt=off\napps=off\n").channel,
+            UpdateChannel::Stable
+        );
+        assert_eq!(
+            parse("channel=nightly\ncobalt=off\n").channel,
+            UpdateChannel::Stable
+        );
+        assert_eq!(
+            parse("channel=beta\nfuture=value\n").channel,
+            UpdateChannel::Beta
+        );
     }
 
     #[test]
@@ -290,6 +380,7 @@ mod tests {
         let chosen = Preferences {
             cobalt: false,
             apps: true,
+            channel: UpdateChannel::Beta,
         };
         set_preferences(&root, chosen).expect("write choices");
         assert_eq!(preferences(&root), chosen);
@@ -309,6 +400,8 @@ mod tests {
     fn a_release_is_read_down_to_its_three_facts() {
         let body = r#"{
             "tag_name": "v0.4.0",
+            "draft": false,
+            "prerelease": false,
             "assets": [
                 {"name": "cobalt-0.4.0-KoboRoot.tgz",
                  "browser_download_url": "https://example.test/cobalt-0.4.0-KoboRoot.tgz"},
@@ -326,6 +419,46 @@ mod tests {
     fn a_release_missing_either_asset_offers_nothing() {
         assert!(release_from(r#"{"tag_name": "v0.4.0", "assets": []}"#).is_none());
         assert!(release_from(r#"{"assets": []}"#).is_none());
+        assert!(
+            release_from(r#"{"tag_name":"beta-v0.4.0","prerelease":true,"assets":[]}"#).is_none()
+        );
+    }
+
+    #[test]
+    fn beta_feed_selects_the_highest_valid_prerelease() {
+        let body = r#"[
+          {"tag_name":"beta-v0.4.0","draft":false,"prerelease":true,"assets":[
+            {"name":"cobalt-0.4.0-KoboRoot.tgz","browser_download_url":"https://example.test/0.4.0.tgz"},
+            {"name":"cobalt-0.4.0.sha256","browser_download_url":"https://example.test/0.4.0.sha256"}]},
+          {"tag_name":"beta-v0.6.0","draft":true,"prerelease":true,"assets":[
+            {"name":"cobalt-0.6.0-KoboRoot.tgz","browser_download_url":"https://example.test/0.6.0.tgz"},
+            {"name":"cobalt-0.6.0.sha256","browser_download_url":"https://example.test/0.6.0.sha256"}]},
+          {"tag_name":"v0.7.0","draft":false,"prerelease":false,"assets":[]},
+          {"tag_name":"beta-v0.8.0","draft":false,"prerelease":true,"assets":[
+            {"name":"KoboRoot.tgz","browser_download_url":"https://example.test/wrong.tgz"},
+            {"name":"cobalt-0.8.0.sha256","browser_download_url":"https://example.test/0.8.0.sha256"}]},
+          {"tag_name":"beta-v0.5.0","draft":false,"prerelease":true,"assets":[
+            {"name":"cobalt-0.5.0-KoboRoot.tgz","browser_download_url":"https://example.test/0.5.0.tgz"},
+            {"name":"cobalt-0.5.0.sha256","browser_download_url":"https://example.test/0.5.0.sha256"}]}
+        ]"#;
+        let (version, archive, digest) = beta_release_from(body).expect("beta release");
+        assert_eq!(version, "0.5.0");
+        assert_eq!(archive, "https://example.test/0.5.0.tgz");
+        assert_eq!(digest, "https://example.test/0.5.0.sha256");
+    }
+
+    #[test]
+    fn malformed_and_non_beta_feeds_offer_nothing() {
+        assert!(beta_release_from("not json").is_none());
+        assert!(beta_release_from(r#"{"tag_name":"beta-v0.4.0"}"#).is_none());
+        assert!(beta_release_from(
+            r#"[{"tag_name":"beta-vnext","draft":false,"prerelease":true,"assets":[]}]"#
+        )
+        .is_none());
+        assert!(beta_release_from(
+            r#"[{"tag_name":"beta-v0.4.0","draft":false,"prerelease":false,"assets":[]}]"#
+        )
+        .is_none());
     }
 
     #[test]
@@ -347,5 +480,42 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn update_plan_checks_only_enabled_sections_in_every_channel() {
+        for channel in [UpdateChannel::Stable, UpdateChannel::Beta] {
+            for cobalt in [false, true] {
+                for apps in [false, true] {
+                    let mut app_checks = 0;
+                    let mut platform_checks = 0;
+                    let chosen = Preferences {
+                        cobalt,
+                        apps,
+                        channel,
+                    };
+                    let plan = plan_with(
+                        chosen,
+                        || {
+                            app_checks += 1;
+                            vec!["todo".to_owned()]
+                        },
+                        || {
+                            platform_checks += 1;
+                            Some(PlatformUpdate {
+                                version: "9.9.9".to_owned(),
+                                url: "https://example.test/cobalt.tgz".to_owned(),
+                                sha256: "a".repeat(64),
+                            })
+                        },
+                    );
+                    assert_eq!(app_checks, usize::from(apps));
+                    assert_eq!(platform_checks, usize::from(cobalt));
+                    assert_eq!(plan.channel, channel);
+                    assert_eq!(plan.apps.is_empty(), !apps);
+                    assert_eq!(plan.platform.is_none(), !cobalt);
+                }
+            }
+        }
     }
 }

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -1259,6 +1259,11 @@ fn host_applications(
     let result = (|| -> Result<String, String> {
         let front = start_application(&mut apps, &mut next_id, &home, whole_screen, &sender)?;
         let mut front = front;
+        // Store installation stays bound to the channel whose catalog this
+        // session last displayed. Settings may change while Store is
+        // backgrounded; resolving the channel again at install time could
+        // otherwise install a different version than the one the user saw.
+        let mut store_channel = crate::autoupdate::preferences(Path::new(COBALT_ROOT)).channel;
         let mut visited: Vec<String> = Vec::new();
         let ceiling = Instant::now() + limits.ceiling;
         let mut last_activity = Instant::now();
@@ -2090,18 +2095,27 @@ fn host_applications(
                                         )))
                                     }
                                     kobo_protocol::DeviceRequest::ReadAppCatalog => {
-                                        app_store_result(crate::app_store::catalog(Path::new(
-                                            COBALT_ROOT,
-                                        )))
+                                        let root = Path::new(COBALT_ROOT);
+                                        let channel = crate::autoupdate::preferences(root).channel;
+                                        let result = crate::app_store::catalog(root, channel);
+                                        if result.is_ok() {
+                                            store_channel = channel;
+                                        }
+                                        app_store_result(result)
                                     }
                                     kobo_protocol::DeviceRequest::RefreshAppCatalog => {
-                                        app_store_result(crate::app_store::refresh(Path::new(
-                                            COBALT_ROOT,
-                                        )))
+                                        let root = Path::new(COBALT_ROOT);
+                                        let channel = crate::autoupdate::preferences(root).channel;
+                                        let result = crate::app_store::refresh(root, channel);
+                                        if result.is_ok() {
+                                            store_channel = channel;
+                                        }
+                                        app_store_result(result)
                                     }
                                     kobo_protocol::DeviceRequest::InstallApp { id } => {
+                                        let root = Path::new(COBALT_ROOT);
                                         let result =
-                                            crate::app_store::install(Path::new(COBALT_ROOT), id);
+                                            crate::app_store::install(root, id, store_channel);
                                         if result.is_ok() {
                                             stop_named_application(&mut apps, id);
                                         }
@@ -2147,15 +2161,40 @@ fn host_applications(
                                         cobalt,
                                         apps,
                                     } => {
+                                        let current =
+                                            crate::autoupdate::preferences(Path::new(COBALT_ROOT));
                                         let chosen = crate::autoupdate::Preferences {
                                             cobalt: *cobalt,
                                             apps: *apps,
+                                            ..current
                                         };
                                         match crate::autoupdate::set_preferences(
                                             Path::new(COBALT_ROOT),
                                             chosen,
                                         ) {
                                             Ok(()) => auto_update_result(chosen),
+                                            Err(error) => {
+                                                kobo_protocol::DeviceResult::Failed(error)
+                                            }
+                                        }
+                                    }
+                                    kobo_protocol::DeviceRequest::ReadUpdateChannel => {
+                                        update_channel_result(crate::autoupdate::preferences(
+                                            Path::new(COBALT_ROOT),
+                                        ))
+                                    }
+                                    kobo_protocol::DeviceRequest::SetUpdateChannel { channel } => {
+                                        let current =
+                                            crate::autoupdate::preferences(Path::new(COBALT_ROOT));
+                                        let chosen = crate::autoupdate::Preferences {
+                                            channel: *channel,
+                                            ..current
+                                        };
+                                        match crate::autoupdate::set_preferences(
+                                            Path::new(COBALT_ROOT),
+                                            chosen,
+                                        ) {
+                                            Ok(()) => update_channel_result(chosen),
                                             Err(error) => {
                                                 kobo_protocol::DeviceResult::Failed(error)
                                             }
@@ -2479,7 +2518,9 @@ fn system_request_allowed(app: &str, request: &kobo_protocol::DeviceRequest) -> 
     match request {
         kobo_protocol::DeviceRequest::Update { .. }
         | kobo_protocol::DeviceRequest::ReadAutoUpdate
-        | kobo_protocol::DeviceRequest::SetAutoUpdate { .. } => app == "settings",
+        | kobo_protocol::DeviceRequest::SetAutoUpdate { .. }
+        | kobo_protocol::DeviceRequest::ReadUpdateChannel
+        | kobo_protocol::DeviceRequest::SetUpdateChannel { .. } => app == "settings",
         kobo_protocol::DeviceRequest::ListInstalledApps => matches!(app, "launcher" | "store"),
         kobo_protocol::DeviceRequest::ReadAppCatalog
         | kobo_protocol::DeviceRequest::RefreshAppCatalog
@@ -2581,6 +2622,10 @@ fn auto_update_result(chosen: crate::autoupdate::Preferences) -> kobo_protocol::
     }
 }
 
+fn update_channel_result(chosen: crate::autoupdate::Preferences) -> kobo_protocol::DeviceResult {
+    kobo_protocol::DeviceResult::UpdateChannel(chosen.channel)
+}
+
 /// Whether the battery can afford background writes right now. A reader whose
 /// gauge cannot be read is allowed, because refusing forever is worse than
 /// trusting hardware that boots.
@@ -2600,6 +2645,10 @@ fn auto_update_battery_permits() -> bool {
 fn apply_auto_update(plan: crate::autoupdate::Plan, apps: &mut [Hosted], front: u64) {
     let root = Path::new(COBALT_ROOT);
     let chosen = crate::autoupdate::preferences(root);
+    if chosen.channel != plan.channel {
+        trace("the update channel changed, so the old background plan was discarded");
+        return;
+    }
     let showing = apps
         .iter()
         .find(|app| app.id == front)
@@ -2610,7 +2659,7 @@ fn apply_auto_update(plan: crate::autoupdate::Plan, apps: &mut [Hosted], front: 
                 trace(&format!("{id} is on the panel, so its update waits"));
                 continue;
             }
-            match crate::app_store::install(root, &id) {
+            match crate::app_store::install(root, &id, chosen.channel) {
                 Ok(()) => {
                     stop_named_application(apps, &id);
                     trace(&format!("{id} was updated in the background"));
@@ -4146,6 +4195,10 @@ mod hosting_tests {
             DeviceRequest::SetAutoUpdate {
                 cobalt: true,
                 apps: false,
+            },
+            DeviceRequest::ReadUpdateChannel,
+            DeviceRequest::SetUpdateChannel {
+                channel: kobo_protocol::UpdateChannel::Beta,
             },
         ] {
             assert!(super::system_request_allowed("settings", &request));

--- a/docs/APP_STORE.md
+++ b/docs/APP_STORE.md
@@ -8,10 +8,17 @@ Cobalt platform releases and Store app releases are separate:
 - Every changed app package requires a new app version, including changes from
   a shared SDK or protocol dependency.
 
-Installed readers use the fixed app channel:
+Readers on the default **Stable** update channel use:
 
 - `https://github.com/BandarLabs/Cobalt/releases/download/app-catalog/cobalt-app-catalog.json`
 - `https://github.com/BandarLabs/Cobalt/releases/download/app-catalog/cobalt-app-catalog.json.sig`
+
+Readers whose owner enables **Beta updates** use the isolated
+`app-catalog-beta` release instead. Its catalog and detached signature are
+cached separately from Stable, and both channels are verified with the same
+public Ed25519 release key. Switching back to Stable changes future refreshes
+only: installed apps are not removed or downgraded. A higher beta app version
+remains installed until Stable publishes a strictly newer version.
 
 ## Install links
 
@@ -60,7 +67,7 @@ registry supplies public metadata; binary size and SHA-256 are calculated from
 the exact ARM release binary during publishing.
 
 `minimum_cobalt_version` must cover both the SDK wire protocol and the runtime
-services used by the app. Current SDK builds require Cobalt 0.2.4 or newer.
+services used by the app. Protocol 11 SDK builds require Cobalt 0.3.1 or newer.
 The publishing check rejects a lower value, and a future protocol version
 cannot publish until its first compatible Cobalt release is recorded.
 
@@ -74,19 +81,31 @@ See [CONTRIBUTING_APPS.md](CONTRIBUTING_APPS.md) for the contribution format.
 
 ## Publishing workflow
 
-`.github/workflows/apps.yml` runs on every push to `main`. It:
+`.github/workflows/apps.yml` runs on every push to `main` and `beta`. Main
+publishes the Stable `app-catalog` release; beta publishes the isolated
+`app-catalog-beta` release with separate concurrency, URLs and same-branch
+version baselines. It:
 
-1. Validates the registry and creates a package matrix.
-2. Builds each registered Cargo package on a separate runner.
+1. Validates the registry and creates a matrix only for new or affected
+   packages by comparing with the previous successful run on the same branch.
+   If neither app release inputs nor catalog entries changed, later jobs are
+   skipped successfully and the fixed release is untouched.
+2. Builds each selected Cargo package on a separate runner and reuses
+   unchanged verified binaries from that previous channel run. If the complete
+   reusable set is unavailable for a required publication, it safely falls
+   back to rebuilding all apps.
 3. Rejects binaries that are not static ARM hard-float executables with a real
    executable load segment.
 4. Uploads exactly one immutable artifact from each app runner.
 5. Downloads those artifacts on a fresh runner that has not executed app code.
 6. Compares each app's code, local dependencies and public manifest with the
    last successfully published catalog, and requires a new app version for any
-   change.
+   change. A wire-compatible platform-only change can be excluded only by an
+   exact old/new Git blob pair in `tools/app-release-compatible-changes.json`;
+   any later edit stops matching and is treated as an app release input.
 7. Builds and signs the packages and catalog only after that isolation.
-8. Replaces the assets on the fixed `app-catalog` GitHub release.
+8. Replaces only changed app bundles plus the catalog, signature, and
+   publication provenance on the fixed release for the branch's channel.
 
 The workflow uses the protected `COBALT_APP_SIGNING_SEED` secret. Publishing
 fails if the seed does not derive the public key pinned in released runtimes.
@@ -116,6 +135,9 @@ A local Clara BW can run the complete flow without a tagged Cobalt release:
 This does not create a `v*` platform tag. Updating `app-catalog` affects every
 reader already running a Store-capable development build, so use it only with
 reviewed assets signed by the production app key.
+
+Use `app-catalog-beta` for beta testing instead; it cannot overwrite the
+Stable catalog.
 
 ## Runtime verification
 

--- a/examples/settings/src/main.rs
+++ b/examples/settings/src/main.rs
@@ -5,7 +5,7 @@ use kobo_sdk::keyboard::{Keyboard, Pressed};
 use kobo_sdk::{
     action_id, ActionId, BatteryDetail, BluetoothDevice, Context, DeviceIdentity, DeviceRequest,
     DeviceResult, Glyph, Heartbeat, KoboApp, RowLead, Screen, ScreenBuilder, Task, TaskId,
-    TaskOutcome, WifiNetwork,
+    TaskOutcome, UpdateChannel, WifiNetwork,
 };
 use std::process::ExitCode;
 
@@ -20,6 +20,7 @@ const CLOSE: &str = "close";
 const TOGGLE: &str = "toggle";
 const AUTO_COBALT: &str = "auto-cobalt";
 const AUTO_APPS: &str = "auto-apps";
+const BETA_UPDATES: &str = "beta-updates";
 const RESCAN: &str = "rescan";
 const MORE: &str = "more";
 const PREVIOUS: &str = "previous";
@@ -37,6 +38,7 @@ const NETWORK_ACTIONS: [&str; 10] = [
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Where releases are published.
 const RELEASES: &str = "https://api.github.com/repos/BandarLabs/Cobalt/releases/latest";
+const BETA_RELEASES: &str = "https://api.github.com/repos/BandarLabs/Cobalt/releases?per_page=100";
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 enum View {
@@ -86,8 +88,13 @@ enum Pending {
 enum UpdateFlow {
     #[default]
     Idle,
-    Checking,
+    Checking {
+        channel: UpdateChannel,
+    },
     UpToDate {
+        latest: String,
+    },
+    Ahead {
         latest: String,
     },
     /// The release is newer; its digest file is being fetched so the
@@ -156,6 +163,8 @@ fn update_screen_owns(request: &DeviceRequest) -> bool {
         DeviceRequest::Update { .. }
             | DeviceRequest::ReadAutoUpdate
             | DeviceRequest::SetAutoUpdate { .. }
+            | DeviceRequest::ReadUpdateChannel
+            | DeviceRequest::SetUpdateChannel { .. }
     )
 }
 
@@ -186,6 +195,7 @@ struct Settings {
     /// until the first reply, so the switches are drawn from a real answer
     /// rather than a guess that a tap would then contradict.
     auto_update: Option<(bool, bool)>,
+    update_channel: Option<UpdateChannel>,
     pending: Option<Pending>,
     delayed: Option<TaskId>,
     trouble: Option<(Topic, String)>,
@@ -294,8 +304,9 @@ impl Settings {
     fn update_summary(&self) -> String {
         match &self.update {
             UpdateFlow::Idle => format!("Cobalt {VERSION}"),
-            UpdateFlow::Checking | UpdateFlow::Digest { .. } => "Checking".to_owned(),
+            UpdateFlow::Checking { .. } | UpdateFlow::Digest { .. } => "Checking".to_owned(),
             UpdateFlow::UpToDate { .. } => "Up to date".to_owned(),
+            UpdateFlow::Ahead { .. } => "Newer than this channel".to_owned(),
             UpdateFlow::Ready { version, .. } => format!("{version} available"),
             UpdateFlow::Installing { .. } => "Installing".to_owned(),
             UpdateFlow::Installed { version } => format!("Updated to {version}"),
@@ -314,7 +325,7 @@ impl Settings {
                     .text("Checking asks GitHub for the newest published release. Nothing is downloaded until you choose to install it.")
                     .button(CHECK, "Check for updates");
             }
-            UpdateFlow::Checking | UpdateFlow::Digest { .. } => {
+            UpdateFlow::Checking { .. } | UpdateFlow::Digest { .. } => {
                 screen = screen
                     .section_with_value("Installed", VERSION)
                     .text("Checking for the newest release.");
@@ -323,6 +334,12 @@ impl Settings {
                 screen = screen
                     .section_with_value("Installed", VERSION)
                     .text(format!("{latest} is the newest published release, and it is what this reader is running."))
+                    .button(CHECK, "Check again");
+            }
+            UpdateFlow::Ahead { latest } => {
+                screen = screen
+                    .section_with_value("Installed", VERSION)
+                    .text(format!("{latest} is the newest release on this channel. This reader is already running a newer version, so nothing is downgraded."))
                     .button(CHECK, "Check again");
             }
             UpdateFlow::Ready { version, .. } => {
@@ -365,37 +382,63 @@ impl Settings {
         // be tapped into recording the opposite of what it showed.
         if matches!(
             self.update,
-            UpdateFlow::Idle | UpdateFlow::UpToDate { .. } | UpdateFlow::Failed(_)
+            UpdateFlow::Idle
+                | UpdateFlow::UpToDate { .. }
+                | UpdateFlow::Ahead { .. }
+                | UpdateFlow::Failed(_)
         ) {
-            if let Some((cobalt, apps)) = self.auto_update {
-                screen = screen
-                    .section_with_value(
-                        "Update Cobalt automatically",
-                        if cobalt { "On" } else { "Off" },
-                    )
-                    .button(
-                        AUTO_COBALT,
-                        if cobalt {
-                            "Stop updating Cobalt automatically"
-                        } else {
-                            "Update Cobalt automatically"
-                        },
-                    )
-                    .section_with_value(
-                        "Update apps automatically",
-                        if apps { "On" } else { "Off" },
-                    )
-                    .button(
-                        AUTO_APPS,
-                        if apps {
-                            "Stop updating apps automatically"
-                        } else {
-                            "Update apps automatically"
-                        },
-                    );
-            }
+            screen = self.auto_update_controls(screen);
         }
         screen.build()
+    }
+
+    fn auto_update_controls(&self, mut screen: ScreenBuilder) -> ScreenBuilder {
+        let (Some((cobalt, apps)), Some(channel)) = (self.auto_update, self.update_channel) else {
+            return screen;
+        };
+        screen = screen
+            .section_with_value(
+                "Beta updates",
+                if channel == UpdateChannel::Beta {
+                    "On"
+                } else {
+                    "Off"
+                },
+            )
+            .text("Gets prerelease Cobalt and Store app updates. Turning it off uses stable for future checks; installed apps stay and nothing is downgraded.")
+            .button(
+                BETA_UPDATES,
+                if channel == UpdateChannel::Beta {
+                    "Use stable updates"
+                } else {
+                    "Get beta updates"
+                },
+            )
+            .section_with_value(
+                "Update Cobalt automatically",
+                if cobalt { "On" } else { "Off" },
+            )
+            .button(
+                AUTO_COBALT,
+                if cobalt {
+                    "Stop updating Cobalt automatically"
+                } else {
+                    "Update Cobalt automatically"
+                },
+            )
+            .section_with_value(
+                "Update apps automatically",
+                if apps { "On" } else { "Off" },
+            )
+            .button(
+                AUTO_APPS,
+                if apps {
+                    "Stop updating apps automatically"
+                } else {
+                    "Update apps automatically"
+                },
+            );
+        screen
     }
 
     fn bluetooth(&self) -> Screen {
@@ -709,17 +752,30 @@ impl Settings {
         context.device().read_wifi();
         context.device().read_battery_detail();
         context.device().read_auto_update();
+        context.device().read_update_channel();
     }
 
     /// Asks GitHub what the newest published release is. Nothing is
     /// downloaded beyond the release description until the reader chooses to
     /// install.
     fn check_for_update(&mut self, context: &mut Context) {
-        self.update = UpdateFlow::Checking;
+        let Some(channel) = self.update_channel else {
+            self.update =
+                UpdateFlow::Failed("Update preferences are still loading. Try again.".to_owned());
+            return;
+        };
+        self.update = UpdateFlow::Checking { channel };
         self.update_task = context.spawn(Task::Fetch {
-            url: RELEASES.to_owned(),
+            url: match channel {
+                UpdateChannel::Stable => RELEASES,
+                UpdateChannel::Beta => BETA_RELEASES,
+            }
+            .to_owned(),
             offset: 0,
-            max_bytes: 256 * 1024,
+            max_bytes: match channel {
+                UpdateChannel::Stable => 256 * 1024,
+                UpdateChannel::Beta => 1024 * 1024,
+            },
             credential: None,
             headers: Vec::new(),
         });
@@ -733,12 +789,20 @@ impl Settings {
     /// until the runtime has answered the first read: a switch drawn from a
     /// guess must not be flippable into recording the opposite of what it
     /// showed.
-    fn flip_auto_update(&self, context: &mut Context, cobalt_switch: bool) {
+    fn flip_auto_update(&self, context: &mut Context, choice: &str) {
         if let Some((cobalt, apps)) = self.auto_update {
-            if cobalt_switch {
-                context.device().set_auto_update(!cobalt, apps);
-            } else {
-                context.device().set_auto_update(cobalt, !apps);
+            match choice {
+                AUTO_COBALT => context.device().set_auto_update(!cobalt, apps),
+                AUTO_APPS => context.device().set_auto_update(cobalt, !apps),
+                BETA_UPDATES => {
+                    if let Some(channel) = self.update_channel {
+                        context.device().set_update_channel(match channel {
+                            UpdateChannel::Stable => UpdateChannel::Beta,
+                            UpdateChannel::Beta => UpdateChannel::Stable,
+                        });
+                    }
+                }
+                _ => {}
             }
         }
     }
@@ -771,7 +835,7 @@ impl Settings {
     fn took_update_reply(&mut self, context: &mut Context, bytes: &[u8]) {
         let body = String::from_utf8_lossy(bytes);
         match self.update.clone() {
-            UpdateFlow::Checking => match latest_release(&body) {
+            UpdateFlow::Checking { channel } => match latest_release(&body, channel) {
                 Err(reason) => self.update = UpdateFlow::Failed(reason),
                 Ok(release) if release.newer_than(VERSION) => {
                     self.update_task = context.spawn(Task::Fetch {
@@ -788,6 +852,11 @@ impl Settings {
                             version: release.version,
                             url: release.archive,
                         }
+                    };
+                }
+                Ok(release) if release.older_than(VERSION) => {
+                    self.update = UpdateFlow::Ahead {
+                        latest: release.version,
                     };
                 }
                 Ok(release) => {
@@ -915,6 +984,14 @@ impl Settings {
             self.show(context);
         }
     }
+
+    fn took_update_channel(&mut self, request: &DeviceRequest, channel: UpdateChannel) {
+        self.update_channel = Some(channel);
+        if matches!(request, DeviceRequest::SetUpdateChannel { .. }) {
+            self.update = UpdateFlow::Idle;
+            self.update_task = None;
+        }
+    }
 }
 
 impl KoboApp for Settings {
@@ -956,9 +1033,11 @@ impl KoboApp for Settings {
         } else if action == action_id(INSTALL) {
             self.install_update(context);
         } else if action == action_id(AUTO_COBALT) {
-            self.flip_auto_update(context, true);
+            self.flip_auto_update(context, AUTO_COBALT);
         } else if action == action_id(AUTO_APPS) {
-            self.flip_auto_update(context, false);
+            self.flip_auto_update(context, AUTO_APPS);
+        } else if action == action_id(BETA_UPDATES) {
+            self.flip_auto_update(context, BETA_UPDATES);
         } else if action == action_id(CLOSE) && matches!(self.update, UpdateFlow::Installed { .. })
         {
             context.exit();
@@ -1055,6 +1134,9 @@ impl KoboApp for Settings {
             }
             DeviceResult::AutoUpdate { cobalt, apps } => {
                 self.auto_update = Some((cobalt, apps));
+            }
+            DeviceResult::UpdateChannel(channel) => {
+                self.took_update_channel(&request, channel);
             }
             DeviceResult::Identity(identity) => {
                 self.identity = Some(identity);
@@ -1195,6 +1277,13 @@ impl Release {
             _ => false,
         }
     }
+
+    fn older_than(&self, installed: &str) -> bool {
+        match (numbers(&self.version), numbers(installed)) {
+            (Some(latest), Some(installed)) => latest < installed,
+            _ => false,
+        }
+    }
 }
 
 fn numbers(version: &str) -> Option<(u64, u64, u64)> {
@@ -1209,17 +1298,35 @@ fn archive_name(version: &str) -> String {
     format!("cobalt-{version}-KoboRoot.tgz")
 }
 
-/// Reads the GitHub "latest release" reply down to the two URLs this device
-/// needs. The failure strings face the reader, so they say what is missing
-/// rather than where in the JSON it was not.
-fn latest_release(body: &str) -> Result<Release, String> {
+/// Reads the selected GitHub release feed down to the two URLs this device
+/// needs. Beta selection is by numeric version rather than response order.
+fn latest_release(body: &str, channel: UpdateChannel) -> Result<Release, String> {
     let value = kobo_json::parse(body)
         .map_err(|_| "GitHub sent something that is not a release.".to_owned())?;
+    match channel {
+        UpdateChannel::Stable => stable_release(&value),
+        UpdateChannel::Beta => value
+            .as_array()
+            .and_then(|releases| {
+                releases
+                    .iter()
+                    .filter_map(|release| release_value(release, "beta-v", true))
+                    .max_by_key(|release| numbers(&release.version))
+            })
+            .ok_or_else(|| "GitHub has no valid beta release for this reader.".to_owned()),
+    }
+}
+
+fn stable_release(value: &Value) -> Result<Release, String> {
     let tag = value
         .get("tag_name")
         .and_then(Value::as_str)
         .ok_or_else(|| "The newest release does not name a version.".to_owned())?;
-    let version = tag.trim_start_matches('v').to_owned();
+    let version = tag
+        .strip_prefix('v')
+        .filter(|version| numbers(version).is_some())
+        .ok_or_else(|| "The newest release does not name a valid version.".to_owned())?
+        .to_owned();
     let empty = [];
     let assets = value
         .get("assets")
@@ -1231,6 +1338,7 @@ fn latest_release(body: &str) -> Result<Release, String> {
             .find(|asset| asset.get("name").and_then(Value::as_str) == Some(name))
             .and_then(|asset| asset.get("browser_download_url"))
             .and_then(Value::as_str)
+            .filter(|url| valid_release_url(url))
             .map(str::to_owned)
     };
     let archive = url_of(&archive_name(&version))
@@ -1242,6 +1350,43 @@ fn latest_release(body: &str) -> Result<Release, String> {
         archive,
         digest,
     })
+}
+
+fn release_value(value: &Value, tag_prefix: &str, prerelease: bool) -> Option<Release> {
+    if value.get("draft").and_then(Value::as_bool).unwrap_or(false)
+        || value
+            .get("prerelease")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+            != prerelease
+    {
+        return None;
+    }
+    let version = value
+        .get("tag_name")
+        .and_then(Value::as_str)?
+        .strip_prefix(tag_prefix)?
+        .to_owned();
+    numbers(&version)?;
+    let assets = value.get("assets").and_then(Value::as_array)?;
+    let url_of = |name: &str| {
+        assets
+            .iter()
+            .find(|asset| asset.get("name").and_then(Value::as_str) == Some(name))
+            .and_then(|asset| asset.get("browser_download_url"))
+            .and_then(Value::as_str)
+            .filter(|url| valid_release_url(url))
+            .map(str::to_owned)
+    };
+    Some(Release {
+        archive: url_of(&archive_name(&version))?,
+        digest: url_of(&format!("cobalt-{version}.sha256"))?,
+        version,
+    })
+}
+
+fn valid_release_url(url: &str) -> bool {
+    url.starts_with("https://") && url.len() <= kobo_sdk::MAX_URL_LEN
 }
 
 /// Finds the digest vouching for `asset` in a `sha256sum` style listing:
@@ -1307,12 +1452,13 @@ fn main() -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::{
-        RadioState, Settings, View, AUTO_APPS, AUTO_COBALT, DEVICE_ACTIONS, MORE, NETWORK_ACTIONS,
-        PREVIOUS, RESCAN,
+        RadioState, Settings, View, AUTO_APPS, AUTO_COBALT, BETA_UPDATES, DEVICE_ACTIONS, MORE,
+        NETWORK_ACTIONS, PREVIOUS, RESCAN,
     };
     use kobo_sdk::{
         action_id, BannerLevel, BatteryDetail, BluetoothDevice, BluetoothDeviceKind, Chrome,
-        DeviceIdentity, Emphasis, Glyph, Node, WifiNetwork, CLARA_BW_METRICS,
+        DeviceIdentity, DeviceRequest, Emphasis, Glyph, Node, UpdateChannel, WifiNetwork,
+        CLARA_BW_METRICS,
     };
 
     fn bluetooth_device(index: usize) -> BluetoothDevice {
@@ -1330,6 +1476,7 @@ mod tests {
         let settings = Settings {
             view: View::Update,
             auto_update: Some((true, false)),
+            update_channel: Some(UpdateChannel::Beta),
             ..Settings::default()
         };
         let screen = settings.update();
@@ -1338,6 +1485,10 @@ mod tests {
         let layout = screen.layout_with(&CLARA_BW_METRICS, &Chrome::with_back(true));
         assert!(layout.rect_of_action(action_id(AUTO_COBALT)).is_some());
         assert!(layout.rect_of_action(action_id(AUTO_APPS)).is_some());
+        assert!(layout.rect_of_action(action_id(BETA_UPDATES)).is_some());
+        let text = text_of(&screen);
+        assert!(text.contains("prerelease Cobalt and Store app updates"));
+        assert!(text.contains("nothing is downgraded"));
     }
 
     #[test]
@@ -1351,6 +1502,43 @@ mod tests {
             .layout_with(&CLARA_BW_METRICS, &Chrome::with_back(true));
         assert!(layout.rect_of_action(action_id(AUTO_COBALT)).is_none());
         assert!(layout.rect_of_action(action_id(AUTO_APPS)).is_none());
+        assert!(layout.rect_of_action(action_id(BETA_UPDATES)).is_none());
+    }
+
+    #[test]
+    fn an_installed_beta_ahead_of_stable_is_not_reported_as_the_stable_version() {
+        let settings = Settings {
+            view: View::Update,
+            update: super::UpdateFlow::Ahead {
+                latest: "0.3.1".to_owned(),
+            },
+            ..Settings::default()
+        };
+        let text = text_of(&settings.update());
+        assert!(text.contains("already running a newer version"));
+        assert!(text.contains("nothing is downgraded"));
+        assert!(!text.contains("it is what this reader is running"));
+    }
+
+    #[test]
+    fn changing_channels_clears_only_status_from_the_previous_channel() {
+        let mut settings = Settings {
+            update: super::UpdateFlow::Ahead {
+                latest: "0.3.1".to_owned(),
+            },
+            ..Settings::default()
+        };
+        settings.took_update_channel(&DeviceRequest::ReadUpdateChannel, UpdateChannel::Stable);
+        assert!(matches!(settings.update, super::UpdateFlow::Ahead { .. }));
+
+        settings.took_update_channel(
+            &DeviceRequest::SetUpdateChannel {
+                channel: UpdateChannel::Beta,
+            },
+            UpdateChannel::Beta,
+        );
+        assert_eq!(settings.update_channel, Some(UpdateChannel::Beta));
+        assert_eq!(settings.update, super::UpdateFlow::Idle);
     }
 
     #[test]
@@ -1633,6 +1821,12 @@ mod tests {
             cobalt: true,
             apps: false,
         }));
+        assert!(super::update_screen_owns(&DeviceRequest::ReadUpdateChannel));
+        assert!(super::update_screen_owns(
+            &DeviceRequest::SetUpdateChannel {
+                channel: UpdateChannel::Beta,
+            }
+        ));
         assert!(
             super::Topic::of(&DeviceRequest::ReadAutoUpdate).is_none(),
             "auto-update trouble may not appear under an unrelated row"
@@ -1659,7 +1853,8 @@ mod tests {
 
     #[test]
     fn a_release_is_read_down_to_the_two_urls_this_reader_needs() {
-        let release = super::latest_release(&release_json("9.9.9", true)).expect("a full release");
+        let release = super::latest_release(&release_json("9.9.9", true), UpdateChannel::Stable)
+            .expect("a full release");
         assert_eq!(release.version, "9.9.9");
         assert_eq!(release.archive, "https://example.test/9.9.9/KoboRoot.tgz");
         assert_eq!(release.digest, "https://example.test/9.9.9/checksums");
@@ -1673,14 +1868,38 @@ mod tests {
 
     #[test]
     fn a_release_without_a_digest_to_verify_against_is_not_offered() {
-        assert!(super::latest_release(&release_json("9.9.9", false))
-            .expect_err("no digest, no offer")
-            .contains("digest"));
+        assert!(
+            super::latest_release(&release_json("9.9.9", false), UpdateChannel::Stable)
+                .expect_err("no digest, no offer")
+                .contains("digest")
+        );
+    }
+
+    #[test]
+    fn beta_release_selection_orders_versions_and_excludes_other_releases() {
+        let body = r#"[
+          {"tag_name":"beta-v9.8.0","draft":false,"prerelease":true,"assets":[
+            {"name":"cobalt-9.8.0-KoboRoot.tgz","browser_download_url":"https://example.test/9.8.0.tgz"},
+            {"name":"cobalt-9.8.0.sha256","browser_download_url":"https://example.test/9.8.0.sha256"}]},
+          {"tag_name":"beta-v9.9.0","draft":true,"prerelease":true,"assets":[
+            {"name":"cobalt-9.9.0-KoboRoot.tgz","browser_download_url":"https://example.test/draft.tgz"},
+            {"name":"cobalt-9.9.0.sha256","browser_download_url":"https://example.test/draft.sha256"}]},
+          {"tag_name":"v10.0.0","draft":false,"prerelease":false,"assets":[]},
+          {"tag_name":"beta-v9.7.0","draft":false,"prerelease":true,"assets":[
+            {"name":"wrong.tgz","browser_download_url":"https://example.test/wrong.tgz"},
+            {"name":"cobalt-9.7.0.sha256","browser_download_url":"https://example.test/9.7.0.sha256"}]}
+        ]"#;
+        let release = super::latest_release(body, UpdateChannel::Beta).expect("highest valid beta");
+        assert_eq!(release.version, "9.8.0");
+        assert_eq!(release.archive, "https://example.test/9.8.0.tgz");
+        assert!(super::latest_release("[]", UpdateChannel::Beta).is_err());
     }
 
     #[test]
     fn the_installed_release_and_an_unreadable_tag_are_both_not_newer() {
-        let same = super::latest_release(&release_json(super::VERSION, true)).expect("release");
+        let same =
+            super::latest_release(&release_json(super::VERSION, true), UpdateChannel::Stable)
+                .expect("release");
         assert!(!same.newer_than(super::VERSION));
         let strange = super::Release {
             version: "nightly".to_owned(),
@@ -1691,6 +1910,12 @@ mod tests {
             !strange.newer_than(super::VERSION),
             "a version that cannot be compared must not be offered as an upgrade"
         );
+        let older = super::Release {
+            version: "0.1.0".to_owned(),
+            archive: String::new(),
+            digest: String::new(),
+        };
+        assert!(older.older_than(super::VERSION));
     }
 
     #[test]
@@ -1719,8 +1944,13 @@ mod tests {
     fn every_stop_on_the_update_journey_fits_the_panel() {
         let flows = [
             super::UpdateFlow::Idle,
-            super::UpdateFlow::Checking,
+            super::UpdateFlow::Checking {
+                channel: UpdateChannel::Stable,
+            },
             super::UpdateFlow::UpToDate {
+                latest: "0.1.0".to_owned(),
+            },
+            super::UpdateFlow::Ahead {
                 latest: "0.1.0".to_owned(),
             },
             super::UpdateFlow::Ready {
@@ -1765,7 +1995,9 @@ mod tests {
 
         let checking = Settings {
             view: super::View::Update,
-            update: super::UpdateFlow::Checking,
+            update: super::UpdateFlow::Checking {
+                channel: UpdateChannel::Stable,
+            },
             ..Settings::default()
         };
         let layout = checking

--- a/tools/app-release-compatible-changes.json
+++ b/tools/app-release-compatible-changes.json
@@ -1,0 +1,26 @@
+{
+  "format_version": 1,
+  "changes": [
+    {
+      "protocol_version": 11,
+      "reason": "Additive protocol-11 update-channel settings used only by the bundled runtime and Settings app",
+      "files": [
+        {
+          "path": "crates/kobo-protocol/src/lib.rs",
+          "base_blob": "8c30366191af89abc121075544635bf871fdfac4",
+          "compatible_blob": "f34528d7b407e542a7836b0348b91de043822274"
+        },
+        {
+          "path": "crates/kobo-policy/src/services.rs",
+          "base_blob": "d0a852942683f396baaf3803830d9c19c9911f18",
+          "compatible_blob": "e5b8617ac601332dd9b5d39c8e6ea83d613e171b"
+        },
+        {
+          "path": "crates/kobo-sdk/src/lib.rs",
+          "base_blob": "52bd17b242beee85f691ebefdd0083fdabbd4550",
+          "compatible_blob": "9a645f3f3d9c8746dda47d858bb3fcd744621df8"
+        }
+      ]
+    }
+  ]
+}

--- a/tools/check-app-versions.mjs
+++ b/tools/check-app-versions.mjs
@@ -11,6 +11,11 @@ const MANIFEST_FIELDS = [
   "minimum_cobalt_version",
   "glyph"
 ];
+const COMPATIBLE_PLATFORM_PATHS = new Set([
+  "crates/kobo-policy/src/services.rs",
+  "crates/kobo-protocol/src/lib.rs",
+  "crates/kobo-sdk/src/lib.rs"
+]);
 
 // Store packages are built from the current SDK and therefore speak its exact
 // wire protocol. A new protocol must add its first compatible Cobalt release
@@ -39,6 +44,93 @@ function normalizedCapabilities(value, label) {
   return [...value].sort();
 }
 
+function changedManifestFields(app, previous) {
+  const changed = [];
+  for (const field of [...MANIFEST_FIELDS, "version"]) {
+    if (app[field] !== previous[field]) changed.push(field);
+  }
+  const currentCapabilities = normalizedCapabilities(app.capabilities, app.id);
+  const previousCapabilities = normalizedCapabilities(previous.capabilities, app.id);
+  if (JSON.stringify(currentCapabilities) !== JSON.stringify(previousCapabilities)) {
+    changed.push("capabilities");
+  }
+  return changed;
+}
+
+function numericVersion(value) {
+  if (typeof value !== "string") return null;
+  const parts = value.split(".");
+  if (parts.some(part => part.length === 0 || !/^\d+$/.test(part))) return null;
+  const numbers = parts.map(BigInt);
+  return numbers.some(part => part > 18446744073709551615n) ? null : numbers;
+}
+
+function numericVersionIsNewer(candidate, installed) {
+  const left = numericVersion(candidate);
+  const right = numericVersion(installed);
+  if (!left || !right) return false;
+  const width = Math.max(left.length, right.length);
+  while (left.length < width) left.push(0n);
+  while (right.length < width) right.push(0n);
+  for (let index = 0; index < width; index += 1) {
+    if (left[index] !== right[index]) return left[index] > right[index];
+  }
+  return false;
+}
+
+// Select only packages whose binary or signed public manifest can differ.
+// Unchanged raw binaries are reused from the previous successful run; the
+// current trusted tool verifies them again before signing the new catalog.
+export function packagesToBuild(registry, published, affectedPackages) {
+  if (!Array.isArray(registry.apps) || !Array.isArray(published.entries)) {
+    throw new Error("registry apps and published catalog entries must be arrays");
+  }
+  const previousById = new Map(
+    published.entries.map(entry => [entry?.manifest?.id, entry?.manifest])
+  );
+  return registry.apps
+    .filter(app => {
+      const previous = previousById.get(app.id);
+      return (
+        !previous ||
+        affectedPackages.has(app.package) ||
+        changedManifestFields(app, previous).length > 0
+      );
+    })
+    .map(app => app.package);
+}
+
+export function releaseNeeded(registry, published, affectedPackages) {
+  if (packagesToBuild(registry, published, affectedPackages).length > 0) return true;
+  const currentIds = new Set(registry.apps.map(app => app.id));
+  return published.entries.some(entry => !currentIds.has(entry?.manifest?.id));
+}
+
+export function changedRegistryPackages(previousRegistry, currentRegistry) {
+  if (!Array.isArray(previousRegistry?.apps) || !Array.isArray(currentRegistry?.apps)) {
+    throw new Error("previous and current app registries must contain app arrays");
+  }
+  const previousById = new Map();
+  for (const app of previousRegistry.apps) {
+    if (typeof app?.id !== "string" || typeof app?.package !== "string") {
+      throw new Error("previous app registry has no valid identity or package name");
+    }
+    if (previousById.has(app.id)) throw new Error(`previous app registry repeats ${app.id}`);
+    previousById.set(app.id, app.package);
+  }
+  return new Set(
+    currentRegistry.apps
+      .filter(app => {
+        if (typeof app?.id !== "string" || typeof app?.package !== "string") {
+          throw new Error("current app registry has no valid identity or package name");
+        }
+        const previousPackage = previousById.get(app.id);
+        return previousPackage !== undefined && previousPackage !== app.package;
+      })
+      .map(app => app.package)
+  );
+}
+
 export function checkEntries(registry, published, affectedPackages) {
   if (!Array.isArray(registry.apps) || !Array.isArray(published.entries)) {
     throw new Error("registry apps and published catalog entries must be arrays");
@@ -63,28 +155,23 @@ export function checkEntries(registry, published, affectedPackages) {
     if (typeof app.version !== "string" || typeof previous.version !== "string") {
       throw new Error(`${app.id} has no valid version`);
     }
-    if (app.version !== previous.version) continue;
-
-    const changed = [];
-    if (affectedPackages.has(app.package)) changed.push("release inputs");
-    for (const field of MANIFEST_FIELDS) {
-      if (app[field] !== previous[field]) changed.push(field);
-    }
-    const currentCapabilities = normalizedCapabilities(app.capabilities, app.id);
-    const previousCapabilities = normalizedCapabilities(previous.capabilities, app.id);
-    if (JSON.stringify(currentCapabilities) !== JSON.stringify(previousCapabilities)) {
-      changed.push("capabilities");
-    }
+    const changed = changedManifestFields(app, previous);
+    if (affectedPackages.has(app.package)) changed.unshift("release inputs");
 
     if (changed.length > 0) {
-      failures.push(
-        `${app.id}: package inputs changed (${changed.join(", ")}) but version remains ${app.version}`
-      );
+      if (!numericVersionIsNewer(app.version, previous.version)) {
+        failures.push(
+          `${app.id}: package inputs changed (${changed.join(", ")}) but version ` +
+            `${app.version} is not newer than ${previous.version}`
+        );
+      }
     }
   }
 
   if (failures.length > 0) {
-    throw new Error(`${failures.join("\n")}\nBump each affected version in the app registry.`);
+    throw new Error(
+      `${failures.join("\n")}\nSet each affected app to a strictly newer numeric version.`
+    );
   }
 }
 
@@ -138,6 +225,15 @@ function command(name, arguments_) {
   }
 }
 
+function optionalCommand(name, arguments_) {
+  try {
+    return execFileSync(name, arguments_, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] })
+      .trim();
+  } catch {
+    return null;
+  }
+}
+
 function isInside(path, directory) {
   return path === directory || path.startsWith(`${directory}/`);
 }
@@ -173,20 +269,103 @@ function workspaceMembers(source) {
   };
 }
 
-// Adding a workspace member does not alter an existing app's release binary.
-// Keep every other root-manifest change conservative because workspace
-// dependencies, profiles, and resolver settings can affect all packages.
-export function manifestOnlyAddsWorkspaceMembers(previousSource, currentSource) {
+function normalizeWorkspaceVersion(source) {
+  const lines = source.split("\n");
+  const start = lines.findIndex(line => line.trim() === "[workspace.package]");
+  if (start < 0) return null;
+  const end = lines.findIndex((line, index) => index > start && line.trim().startsWith("["));
+  const stop = end < 0 ? lines.length : end;
+  const versions = [];
+  for (let index = start + 1; index < stop; index += 1) {
+    if (/^version\s*=\s*"[^"]+"\s*$/.test(lines[index])) versions.push(index);
+  }
+  if (versions.length !== 1) return null;
+  lines[versions[0]] = 'version = "<workspace-version>"';
+  return lines.join("\n");
+}
+
+// Workspace member additions and the shared package version do not alter an
+// existing Store app by themselves. Resolver, profile, dependency, or lint
+// changes remain conservative global release inputs.
+export function manifestOnlyChangesWorkspaceMembershipOrVersion(
+  previousSource,
+  currentSource
+) {
   const previous = workspaceMembers(previousSource);
   const current = workspaceMembers(currentSource);
-  if (!previous || !current || previous.remainder !== current.remainder) return false;
+  if (!previous || !current) return false;
 
   const previousMembers = new Set(previous.entries);
   const currentMembers = new Set(current.entries);
+  if (![...previousMembers].every(member => currentMembers.has(member))) return false;
+
+  const previousRemainder = normalizeWorkspaceVersion(previous.remainder);
+  const currentRemainder = normalizeWorkspaceVersion(current.remainder);
   return (
-    currentMembers.size > previousMembers.size &&
-    [...previousMembers].every(member => currentMembers.has(member))
+    previousRemainder !== null &&
+    currentRemainder !== null &&
+    previousRemainder === currentRemainder
   );
+}
+
+export function manifestOnlyChangesPathDependencyVersions(previousSource, currentSource) {
+  const normalize = source =>
+    source
+      .split("\n")
+      .map(line => {
+        if (!line.includes("{") || !/\bpath\s*=/.test(line) || !/\bversion\s*=/.test(line)) {
+          return line;
+        }
+        return line.replace(/\bversion\s*=\s*"[^"]+"/, 'version = "<workspace-version>"');
+      })
+      .join("\n");
+  return normalize(previousSource).trimEnd() === normalize(currentSource).trimEnd();
+}
+
+export function compatibleChangePaths(
+  manifest,
+  protocolVersion,
+  changedPaths,
+  baseBlobOf,
+  currentBlobOf
+) {
+  if (
+    manifest?.format_version !== 1 ||
+    !Array.isArray(manifest.changes) ||
+    manifest.changes.some(
+      change =>
+        !Number.isInteger(change?.protocol_version) ||
+        typeof change?.reason !== "string" ||
+        change.reason.length === 0 ||
+        !Array.isArray(change?.files)
+    )
+  ) {
+    throw new Error("invalid app release compatible-change manifest");
+  }
+
+  const changed = new Set(changedPaths);
+  const compatible = new Set();
+  for (const change of manifest.changes) {
+    if (change.protocol_version !== protocolVersion) continue;
+    for (const file of change.files) {
+      if (
+        typeof file?.path !== "string" ||
+        !COMPATIBLE_PLATFORM_PATHS.has(file.path) ||
+        !/^[0-9a-f]{40}$/.test(file?.base_blob) ||
+        !/^[0-9a-f]{40}$/.test(file?.compatible_blob)
+      ) {
+        throw new Error("invalid app release compatible-change file");
+      }
+      if (
+        changed.has(file.path) &&
+        baseBlobOf(file.path) === file.base_blob &&
+        currentBlobOf(file.path) === file.compatible_blob
+      ) {
+        compatible.add(file.path);
+      }
+    }
+  }
+  return compatible;
 }
 
 function lockfileParts(source) {
@@ -203,9 +382,131 @@ function lockfileParts(source) {
   };
 }
 
-// A new workspace package, and any dependencies used only by it, add complete
-// Cargo.lock package blocks. Existing binaries are unaffected as long as every
-// previous block remains byte-for-byte intact.
+function lockPackage(packageBlock) {
+  const name = /^name = "([^"]+)"$/m.exec(packageBlock)?.[1];
+  const version = /^version = "([^"]+)"$/m.exec(packageBlock)?.[1];
+  if (!name || !version) {
+    throw new Error("Cargo.lock package block has no valid name and version");
+  }
+  const source = /^source = "([^"]+)"$/m.exec(packageBlock)?.[1];
+  return {
+    name,
+    version: source ? version : "<workspace-version>",
+    source: source || "",
+    canonical: source
+      ? packageBlock
+      : packageBlock.replace(/^version = "[^"]+"$/m, 'version = "<workspace-version>"')
+  };
+}
+
+function packageIdentity(name, version, source = "") {
+  return JSON.stringify([name, version, source]);
+}
+
+function lockPackagesByIdentity(source) {
+  const parts = lockfileParts(source);
+  if (!parts) throw new Error("Cargo.lock has no package blocks");
+  const packages = new Map();
+  for (const packageBlock of parts.packages) {
+    const parsed = lockPackage(packageBlock);
+    const identity = packageIdentity(parsed.name, parsed.version, parsed.source);
+    const value = packages.get(identity) || {
+      name: parsed.name,
+      blocks: []
+    };
+    const blocks = value.blocks;
+    blocks.push(parsed.canonical);
+    packages.set(identity, value);
+  }
+  for (const value of packages.values()) value.blocks.sort();
+  return { preamble: parts.preamble, packages };
+}
+
+// Compare exact package identities rather than crate names, so two resolved
+// versions of one crate keep their distinct consumer sets. Local workspace or
+// path package version-only edits are normalized because the shared workspace
+// release number does not by itself change Store app code.
+export function changedLockPackageIdentities(previousSource, currentSource) {
+  const previous = lockPackagesByIdentity(previousSource);
+  const current = lockPackagesByIdentity(currentSource);
+  if (previous.preamble !== current.preamble) {
+    throw new Error("Cargo.lock preamble changed; cannot isolate affected Store apps");
+  }
+
+  const names = new Set([...previous.packages.keys(), ...current.packages.keys()]);
+  return new Set(
+    [...names].filter(identity => {
+      const previousBlocks = previous.packages.get(identity)?.blocks || [];
+      const currentBlocks = current.packages.get(identity)?.blocks || [];
+      return JSON.stringify(previousBlocks) !== JSON.stringify(currentBlocks);
+    })
+  );
+}
+
+export function registeredConsumers(metadata, registeredPackages, changedPackageIdentities) {
+  const packagesByIdentity = new Map();
+  const packageIdsByName = new Map();
+  for (const package_ of metadata.packages) {
+    const identity = packageIdentity(
+      package_.name,
+      package_.source ? package_.version : "<workspace-version>",
+      package_.source || ""
+    );
+    const ids = packagesByIdentity.get(identity) || [];
+    ids.push(package_.id);
+    packagesByIdentity.set(identity, ids);
+    const namedIds = packageIdsByName.get(package_.name) || [];
+    namedIds.push(package_.id);
+    packageIdsByName.set(package_.name, namedIds);
+  }
+
+  const changedIds = new Set();
+  for (const identity of changedPackageIdentities) {
+    const ids = packagesByIdentity.get(identity);
+    if (!ids) {
+      const [name] = JSON.parse(identity);
+      const possibleReplacements = packageIdsByName.get(name);
+      if (!possibleReplacements) {
+        throw new Error(
+          `Cargo.lock changed package ${name}, but current cargo metadata cannot identify its consumers`
+        );
+      }
+      for (const id of possibleReplacements) changedIds.add(id);
+      continue;
+    }
+    for (const id of ids) changedIds.add(id);
+  }
+
+  const dependencies = new Map(
+    metadata.resolve.nodes.map(node => [node.id, releaseDependencyIds(node)])
+  );
+  function dependsOnChanged(id, seen = new Set()) {
+    if (changedIds.has(id)) return true;
+    if (seen.has(id)) return false;
+    const next = new Set(seen);
+    next.add(id);
+    return (dependencies.get(id) || []).some(dependency => dependsOnChanged(dependency, next));
+  }
+
+  const registered = new Set(registeredPackages);
+  return new Set(
+    metadata.packages
+      .filter(package_ => registered.has(package_.name) && dependsOnChanged(package_.id))
+      .map(package_ => package_.name)
+  );
+}
+
+export function releaseDiffArguments(baseRevision) {
+  return [
+    "diff",
+    "--name-only",
+    "--diff-filter=ACDMRT",
+    `${baseRevision}...HEAD`
+  ];
+}
+
+// Kept as a small compatibility helper for callers that only need to know
+// whether an edit consists entirely of unrelated package additions.
 export function lockfileOnlyAddsPackages(previousSource, currentSource) {
   const previous = lockfileParts(previousSource);
   const current = lockfileParts(currentSource);
@@ -224,61 +525,104 @@ export function lockfileOnlyAddsPackages(previousSource, currentSource) {
   return true;
 }
 
-export function affectedWorkspacePackages(baseRevision) {
+export function affectedWorkspacePackages(baseRevision, registry) {
   const metadata = JSON.parse(command("cargo", ["metadata", "--format-version", "1", "--locked"]));
   const workspaceRoot = resolve(metadata.workspace_root);
-  const changedPaths = command("git", [
-    "diff",
-    "--name-only",
-    "--diff-filter=ACMRT",
-    `${baseRevision}...HEAD`
-  ])
+  const changedPaths = command("git", releaseDiffArguments(baseRevision))
     .split("\n")
     .filter(Boolean)
     .map(path => path.split(sep).join("/"));
+  const compatibleManifest = readJson(
+    resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      "app-release-compatible-changes.json"
+    ),
+    "app release compatible changes"
+  );
+  const compatiblePaths = compatibleChangePaths(
+    compatibleManifest,
+    currentProtocolVersion(),
+    changedPaths,
+    path => optionalCommand("git", ["rev-parse", `${baseRevision}:${path}`]),
+    path => command("git", ["hash-object", path])
+  );
 
+  const registeredPackages = registry.apps.map(app => app.package);
   const unconditionalGlobalInputs = new Set(["rust-toolchain", "rust-toolchain.toml"]);
   const changesGlobalInputs =
     changedPaths.some(path => unconditionalGlobalInputs.has(path) || path.startsWith(".cargo/")) ||
     (changedPaths.includes("Cargo.toml") &&
-      !manifestOnlyAddsWorkspaceMembers(
+      !manifestOnlyChangesWorkspaceMembershipOrVersion(
         command("git", ["show", `${baseRevision}:Cargo.toml`]),
         readFileSync(resolve(workspaceRoot, "Cargo.toml"), "utf8")
-      )) ||
-    (changedPaths.includes("Cargo.lock") &&
-      !lockfileOnlyAddsPackages(
-        command("git", ["show", `${baseRevision}:Cargo.lock`]),
-        readFileSync(resolve(workspaceRoot, "Cargo.lock"), "utf8")
       ));
   if (changesGlobalInputs) {
-    return new Set(metadata.packages.map(package_ => package_.name));
+    return new Set(registeredPackages);
   }
 
   const workspaceMembers = new Set(metadata.workspace_members);
   const workspacePackages = metadata.packages.filter(package_ => workspaceMembers.has(package_.id));
-  const changedIds = new Set();
+  const changedIdentities = new Set();
+  const previousRegistry = JSON.parse(
+    command("git", ["show", `${baseRevision}:apps/catalog.json`])
+  );
+  for (const packageName of changedRegistryPackages(previousRegistry, registry)) {
+    const candidates = workspacePackages.filter(package_ => package_.name === packageName);
+    if (candidates.length !== 1) {
+      throw new Error(
+        `app registry package ${packageName} does not name exactly one workspace package`
+      );
+    }
+    const [package_] = candidates;
+    changedIdentities.add(
+      packageIdentity(package_.name, "<workspace-version>", "")
+    );
+  }
   for (const package_ of workspacePackages) {
     const directory = dirname(package_.manifest_path);
     const relativeDirectory = relative(workspaceRoot, directory).split(sep).join("/");
-    if (changedPaths.some(path => isInside(path, relativeDirectory))) changedIds.add(package_.id);
+    const packageChanges = changedPaths.filter(
+      path => isInside(path, relativeDirectory) && !compatiblePaths.has(path)
+    );
+    if (packageChanges.length === 0) continue;
+    const relativeManifest = relative(workspaceRoot, package_.manifest_path).split(sep).join("/");
+    const previousManifest = optionalCommand("git", [
+      "show",
+      `${baseRevision}:${relativeManifest}`
+    ]);
+    if (
+      previousManifest !== null &&
+      packageChanges.every(path => path === relativeManifest) &&
+      manifestOnlyChangesPathDependencyVersions(
+        previousManifest,
+        readFileSync(package_.manifest_path, "utf8")
+      )
+    ) {
+      continue;
+    }
+    changedIdentities.add(
+      packageIdentity(
+        package_.name,
+        package_.source ? package_.version : "<workspace-version>",
+        package_.source || ""
+      )
+    );
   }
 
-  const dependencies = new Map(
-    metadata.resolve.nodes.map(node => [node.id, releaseDependencyIds(node)])
-  );
-  function dependsOnChanged(id, seen = new Set()) {
-    if (changedIds.has(id)) return true;
-    if (seen.has(id)) return false;
-    seen.add(id);
-    return (dependencies.get(id) || []).some(dependency => dependsOnChanged(dependency, seen));
+  if (changedPaths.includes("Cargo.lock")) {
+    const lockChanges = changedLockPackageIdentities(
+      command("git", ["show", `${baseRevision}:Cargo.lock`]),
+      readFileSync(resolve(workspaceRoot, "Cargo.lock"), "utf8")
+    );
+    for (const identity of lockChanges) changedIdentities.add(identity);
   }
 
-  return new Set(
-    workspacePackages.filter(package_ => dependsOnChanged(package_.id)).map(package_ => package_.name)
-  );
+  return registeredConsumers(metadata, registeredPackages, changedIdentities);
 }
 
 function argumentsFrom(argv) {
+  const mode = argv[0] === "--list-packages" || argv[0] === "--publish-needed" ? argv[0] : null;
+  if (mode) argv = argv.slice(1);
   const allowed = ["--registry", "--published-catalog", "--base"];
   const values = new Map();
   for (let index = 0; index < argv.length; index += 2) {
@@ -296,18 +640,24 @@ function argumentsFrom(argv) {
       "usage: node tools/check-app-versions.mjs --registry PATH --published-catalog PATH --base GIT_REVISION"
     );
   }
-  return values;
+  return { values, mode };
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   try {
-    const values = argumentsFrom(process.argv.slice(2));
+    const { values, mode } = argumentsFrom(process.argv.slice(2));
     const registry = readJson(resolve(values.get("--registry")), "app registry");
     const published = readJson(resolve(values.get("--published-catalog")), "published catalog");
-    const affected = affectedWorkspacePackages(values.get("--base"));
+    const affected = affectedWorkspacePackages(values.get("--base"), registry);
     checkProtocolMinimums(registry, currentProtocolVersion());
-    checkEntries(registry, published, affected);
-    console.log("Every changed app package has a new version.");
+    if (mode === "--list-packages") {
+      console.log(JSON.stringify(packagesToBuild(registry, published, affected)));
+    } else if (mode === "--publish-needed") {
+      console.log(releaseNeeded(registry, published, affected) ? "true" : "false");
+    } else {
+      checkEntries(registry, published, affected);
+      console.log("Every changed app package has a new version.");
+    }
   } catch (error) {
     console.error(error.message);
     process.exitCode = 1;

--- a/tools/check-app-versions.test.mjs
+++ b/tools/check-app-versions.test.mjs
@@ -1,10 +1,20 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import {
+  changedLockPackageIdentities,
+  changedRegistryPackages,
   checkEntries,
   checkProtocolMinimums,
+  compatibleChangePaths,
   lockfileOnlyAddsPackages,
-  manifestOnlyAddsWorkspaceMembers,
+  manifestOnlyChangesPathDependencyVersions,
+  manifestOnlyChangesWorkspaceMembershipOrVersion,
+  packagesToBuild,
+  registeredConsumers,
+  releaseDiffArguments,
+  releaseNeeded,
   releaseDependencyIds
 } from "./check-app-versions.mjs";
 
@@ -48,7 +58,7 @@ test("requires a version bump when code or a dependency changes", () => {
   const values = fixture();
   assert.throws(
     () => checkEntries(values.registry, values.published, new Set(["kobo-notes"])),
-    /package inputs changed \(release inputs\).*version remains 1\.0\.0/s
+    /package inputs changed \(release inputs\).*version 1\.0\.0 is not newer than 1\.0\.0/s
   );
 });
 
@@ -56,7 +66,7 @@ test("requires a version bump when public metadata changes", () => {
   const values = fixture({ summary: "New summary" });
   assert.throws(
     () => checkEntries(values.registry, values.published, new Set()),
-    /package inputs changed \(summary\).*version remains 1\.0\.0/s
+    /package inputs changed \(summary\).*version 1\.0\.0 is not newer than 1\.0\.0/s
   );
 });
 
@@ -64,6 +74,91 @@ test("accepts changed content with a new version", () => {
   const values = fixture({ currentVersion: "1.0.1", summary: "New summary" });
   assert.doesNotThrow(() =>
     checkEntries(values.registry, values.published, new Set(["kobo-notes"]))
+  );
+});
+
+test("rejects downgraded and nonnumeric release versions", () => {
+  const downgrade = fixture({ currentVersion: "0.9.0", summary: "New summary" });
+  assert.throws(
+    () => checkEntries(downgrade.registry, downgrade.published, new Set()),
+    /version 0\.9\.0 is not newer than 1\.0\.0/
+  );
+
+  const token = fixture({ currentVersion: "next", summary: "New summary" });
+  assert.throws(
+    () => checkEntries(token.registry, token.published, new Set()),
+    /version next is not newer than 1\.0\.0/
+  );
+});
+
+test("matches runtime numeric version ordering", () => {
+  const values = fixture({ currentVersion: "1.0.0.1", summary: "New summary" });
+  assert.doesNotThrow(() => checkEntries(values.registry, values.published, new Set()));
+
+  values.registry.apps[0].version = "1.0.0.0";
+  assert.throws(
+    () => checkEntries(values.registry, values.published, new Set()),
+    /version 1\.0\.0\.0 is not newer than 1\.0\.0/
+  );
+
+  values.registry.apps[0].version = "18446744073709551615.0";
+  assert.doesNotThrow(() => checkEntries(values.registry, values.published, new Set()));
+
+  values.registry.apps[0].version = "18446744073709551616.0";
+  assert.throws(
+    () => checkEntries(values.registry, values.published, new Set()),
+    /version 18446744073709551616\.0 is not newer than 1\.0\.0/
+  );
+});
+
+test("selective builds include changed binaries manifests and new apps only", () => {
+  const values = fixture();
+  assert.deepEqual(packagesToBuild(values.registry, values.published, new Set()), []);
+  assert.deepEqual(
+    packagesToBuild(values.registry, values.published, new Set(["kobo-notes"])),
+    ["kobo-notes"]
+  );
+
+  values.registry.apps[0].version = "1.0.1";
+  assert.deepEqual(packagesToBuild(values.registry, values.published, new Set()), ["kobo-notes"]);
+
+  values.registry.apps.push({
+    ...values.registry.apps[0],
+    id: "reader",
+    package: "kobo-reader"
+  });
+  assert.deepEqual(packagesToBuild(values.registry, values.published, new Set()), [
+    "kobo-notes",
+    "kobo-reader"
+  ]);
+});
+
+test("catalog removal still requires publication without a build", () => {
+  const values = fixture();
+  values.registry.apps = [];
+  assert.equal(releaseNeeded(values.registry, values.published, new Set()), true);
+});
+
+test("changing an app ID to a different Cargo package is a release input", () => {
+  const previous = {
+    format_version: 1,
+    apps: [{ id: "notes", package: "kobo-notes" }]
+  };
+  const current = {
+    format_version: 1,
+    apps: [{ id: "notes", package: "kobo-reader" }]
+  };
+  assert.deepEqual(changedRegistryPackages(previous, current), new Set(["kobo-reader"]));
+
+  const values = fixture();
+  values.registry.apps[0].package = "kobo-reader";
+  assert.throws(
+    () => checkEntries(values.registry, values.published, new Set(["kobo-reader"])),
+    /package inputs changed \(release inputs\).*version 1\.0\.0 is not newer than 1\.0\.0/s
+  );
+  assert.equal(
+    releaseNeeded(values.registry, values.published, new Set(["kobo-reader"])),
+    true
   );
 });
 
@@ -105,18 +200,129 @@ test("release inputs ignore exclusively dev-only dependency edges", () => {
   assert.deepEqual(dependencies, ["normal", "build", "normal-and-dev", "unspecified"]);
 });
 
-test("a new workspace member does not change existing app release inputs", () => {
-  const previous = `[workspace]\nmembers = [\n    "apps/notes",\n]\nresolver = "2"\n`;
-  const current = `[workspace]\nmembers = [\n    "apps/notes",\n    "apps/reader",\n]\nresolver = "2"\n`;
+test("release input discovery includes deleted paths", () => {
+  assert.deepEqual(releaseDiffArguments("published"), [
+    "diff",
+    "--name-only",
+    "--diff-filter=ACDMRT",
+    "published...HEAD"
+  ]);
+});
 
-  assert.equal(manifestOnlyAddsWorkspaceMembers(previous, current), true);
+test("workspace version and member additions do not change existing app release inputs", () => {
+  const previous = `[workspace]\nmembers = [\n    "apps/notes",\n]\nresolver = "2"\n\n[workspace.package]\nversion = "0.3.1"\nedition = "2021"\n`;
+  const current = `[workspace]\nmembers = [\n    "apps/notes",\n    "apps/reader",\n]\nresolver = "2"\n\n[workspace.package]\nversion = "0.3.2"\nedition = "2021"\n`;
+
+  assert.equal(manifestOnlyChangesWorkspaceMembershipOrVersion(previous, current), true);
 });
 
 test("workspace configuration changes still affect every app", () => {
-  const previous = `[workspace]\nmembers = [\n    "apps/notes",\n]\nresolver = "2"\n`;
-  const current = `[workspace]\nmembers = [\n    "apps/notes",\n    "apps/reader",\n]\nresolver = "3"\n`;
+  const previous = `[workspace]\nmembers = [\n    "apps/notes",\n]\nresolver = "2"\n\n[workspace.package]\nversion = "0.3.1"\n`;
+  const current = `[workspace]\nmembers = [\n    "apps/notes",\n    "apps/reader",\n]\nresolver = "3"\n\n[workspace.package]\nversion = "0.3.2"\n`;
 
-  assert.equal(manifestOnlyAddsWorkspaceMembers(previous, current), false);
+  assert.equal(manifestOnlyChangesWorkspaceMembershipOrVersion(previous, current), false);
+});
+
+test("path dependency version-only manifest edits are not app release inputs", () => {
+  const previous = `[dependencies]\nkobo-sdk = { version = "0.3.1", path = "../kobo-sdk", features = ["text"] }\n`;
+  const current = previous.replace('version = "0.3.1"', 'version = "0.3.2"');
+  assert.equal(manifestOnlyChangesPathDependencyVersions(previous, current), true);
+  assert.equal(
+    manifestOnlyChangesPathDependencyVersions(
+      previous,
+      current.replace('features = ["text"]', 'features = ["runtime-settings"]')
+    ),
+    false
+  );
+});
+
+test("only exact reviewed compatible blobs are excluded from app release inputs", () => {
+  const manifest = {
+    format_version: 1,
+    changes: [
+      {
+        protocol_version: 11,
+        reason: "additive runtime setting",
+        files: [
+          {
+            path: "crates/kobo-protocol/src/lib.rs",
+            base_blob: "a".repeat(40),
+            compatible_blob: "b".repeat(40)
+          }
+        ]
+      }
+    ]
+  };
+  const changed = ["crates/kobo-protocol/src/lib.rs"];
+  assert.deepEqual(
+    compatibleChangePaths(
+      manifest,
+      11,
+      changed,
+      () => "a".repeat(40),
+      () => "b".repeat(40)
+    ),
+    new Set(changed)
+  );
+  assert.deepEqual(
+    compatibleChangePaths(
+      manifest,
+      11,
+      changed,
+      () => "a".repeat(40),
+      () => "c".repeat(40)
+    ),
+    new Set()
+  );
+  assert.deepEqual(
+    compatibleChangePaths(
+      manifest,
+      12,
+      changed,
+      () => "a".repeat(40),
+      () => "b".repeat(40)
+    ),
+    new Set()
+  );
+  assert.throws(
+    () =>
+      compatibleChangePaths(
+        {
+          ...manifest,
+          changes: [
+            {
+              ...manifest.changes[0],
+              files: [
+                {
+                  ...manifest.changes[0].files[0],
+                  path: "apps/arxiv/src/main.rs"
+                }
+              ]
+            }
+          ]
+        },
+        11,
+        ["apps/arxiv/src/main.rs"],
+        () => "a".repeat(40),
+        () => "b".repeat(40)
+      ),
+    /invalid app release compatible-change file/
+  );
+});
+
+test("reviewed compatible-change entries name the exact current files", () => {
+  const manifest = JSON.parse(
+    readFileSync("tools/app-release-compatible-changes.json", "utf8")
+  );
+  for (const change of manifest.changes) {
+    for (const file of change.files) {
+      assert.equal(
+        execFileSync("git", ["hash-object", file.path], { encoding: "utf8" }).trim(),
+        file.compatible_blob,
+        `${file.path} changed without reviewing its Store release impact`
+      );
+    }
+  }
 });
 
 test("new lockfile package blocks do not change existing app release inputs", () => {
@@ -126,9 +332,132 @@ test("new lockfile package blocks do not change existing app release inputs", ()
   assert.equal(lockfileOnlyAddsPackages(previous, current), true);
 });
 
-test("changes to an existing lockfile package remain global release inputs", () => {
-  const previous = `version = 4\n\n[[package]]\nname = "notes"\nversion = "1.0.0"\n`;
-  const current = `version = 4\n\n[[package]]\nname = "notes"\nversion = "1.0.1"\n\n[[package]]\nname = "reader"\nversion = "1.0.0"\n`;
+function metadata() {
+  const workspacePackage = name => ({
+    id: `${name} 1.0.0`,
+    name,
+    version: "0.3.2",
+    source: null
+  });
+  const registryPackage = name => ({
+    id: `${name} 1.0.0`,
+    name,
+    version: "1.0.0",
+    source: "registry+https://example.test/index"
+  });
+  const dependency = pkg => ({ pkg, dep_kinds: [{ kind: null, target: null }] });
+  return {
+    packages: [
+      workspacePackage("notes"),
+      workspacePackage("reader"),
+      workspacePackage("weather"),
+      registryPackage("notes-dep"),
+      registryPackage("shared"),
+      registryPackage("unrelated")
+    ],
+    resolve: {
+      nodes: [
+        { id: "notes 1.0.0", deps: [dependency("notes-dep 1.0.0"), dependency("shared 1.0.0")] },
+        { id: "reader 1.0.0", deps: [dependency("notes 1.0.0")] },
+        { id: "weather 1.0.0", deps: [dependency("shared 1.0.0")] },
+        { id: "notes-dep 1.0.0", deps: [] },
+        { id: "shared 1.0.0", deps: [] },
+        { id: "unrelated 1.0.0", deps: [] }
+      ]
+    }
+  };
+}
 
-  assert.equal(lockfileOnlyAddsPackages(previous, current), false);
+function registryIdentity(name, version = "1.0.0") {
+  return JSON.stringify([name, version, "registry+https://example.test/index"]);
+}
+
+test("an app-local lock change affects that app and its true dependents only", () => {
+  const previous = `version = 4\n\n[[package]]\nname = "notes-dep"\nversion = "1.0.0"\nsource = "registry+https://example.test/index"\nchecksum = "old"\n`;
+  const current = previous.replace('checksum = "old"', 'checksum = "new"');
+  const changed = changedLockPackageIdentities(previous, current);
+  assert.deepEqual(changed, new Set([registryIdentity("notes-dep")]));
+  assert.deepEqual(
+    registeredConsumers(metadata(), ["notes", "reader", "weather"], changed),
+    new Set(["notes", "reader"])
+  );
+});
+
+test("adding a package outside every Store app closure affects no app", () => {
+  const previous = `version = 4\n\n[[package]]\nname = "notes"\nversion = "0.3.1"\n`;
+  const current = `${previous}\n[[package]]\nname = "unrelated"\nversion = "1.0.0"\nsource = "registry+https://example.test/index"\nchecksum = "new"\n`;
+  const changed = changedLockPackageIdentities(previous, current);
+  assert.deepEqual(changed, new Set([registryIdentity("unrelated")]));
+  assert.deepEqual(
+    registeredConsumers(metadata(), ["notes", "reader", "weather"], changed),
+    new Set()
+  );
+});
+
+test("a shared dependency lock change affects every consuming Store app", () => {
+  assert.deepEqual(
+    registeredConsumers(
+      metadata(),
+      ["notes", "reader", "weather"],
+      new Set([registryIdentity("shared")])
+    ),
+    new Set(["notes", "reader", "weather"])
+  );
+});
+
+test("a changed dependency version does not affect consumers of another version", () => {
+  const values = metadata();
+  values.packages.push(
+    {
+      id: "png 0.17.16",
+      name: "png",
+      version: "0.17.16",
+      source: "registry+https://example.test/index"
+    },
+    {
+      id: "png 0.18.1",
+      name: "png",
+      version: "0.18.1",
+      source: "registry+https://example.test/index"
+    }
+  );
+  values.resolve.nodes.find(node => node.id === "notes 1.0.0").deps.push({
+    pkg: "png 0.17.16",
+    dep_kinds: [{ kind: null, target: null }]
+  });
+  values.resolve.nodes.find(node => node.id === "weather 1.0.0").deps.push({
+    pkg: "png 0.18.1",
+    dep_kinds: [{ kind: null, target: null }]
+  });
+  values.resolve.nodes.push(
+    { id: "png 0.17.16", deps: [] },
+    { id: "png 0.18.1", deps: [] }
+  );
+
+  assert.deepEqual(
+    registeredConsumers(
+      values,
+      ["notes", "reader", "weather"],
+      new Set([registryIdentity("png", "0.18.1")])
+    ),
+    new Set(["weather"])
+  );
+});
+
+test("a lock change with no identifiable current package fails closed", () => {
+  assert.throws(
+    () =>
+      registeredConsumers(
+        metadata(),
+        ["notes", "reader", "weather"],
+        new Set([registryIdentity("removed-dependency")])
+      ),
+    /cannot identify its consumers/
+  );
+});
+
+test("workspace package version-only lock changes affect no Store app", () => {
+  const previous = `version = 4\n\n[[package]]\nname = "kobo-sdk"\nversion = "0.3.1"\ndependencies = [\n "shared",\n]\n`;
+  const current = previous.replace('version = "0.3.1"', 'version = "0.3.2"');
+  assert.deepEqual(changedLockPackageIdentities(previous, current), new Set());
 });


### PR DESCRIPTION
Adds an opt-in Beta Updates setting for Cobalt and Store apps.

Keeps stable as the default, isolates signed beta catalogs, supports immutable beta releases and exact-byte promotion, and preserves protocol 11 compatibility.

App publication remains independent and fail-closed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790911203&installation_model_id=20525&pr_number=92&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F92&signature=aa75c8524b2d1843e764d65d755f3f448a044d8d35b82a4ce4abb0dfdfea487e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->