### PR TITLE
Keep MediaTek Wi-Fi working across panel sessions

### DIFF
--- a/crates/kobo-hal/src/network.rs
+++ b/crates/kobo-hal/src/network.rs
@@ -73,8 +73,50 @@ pub enum Restored {
 pub struct Connection {
     /// In start order: the association has to exist before a lease can.
     daemons: Vec<Reader>,
+    /// Executables whose presence could not be established safely.
+    uncertain: Vec<String>,
     /// Whether there was a connection to lose in the first place.
     was_online: bool,
+}
+
+/// Network daemons Cobalt started for the duration of one panel session.
+#[derive(Debug)]
+pub struct SessionConnection {
+    outcome: Restored,
+    started: Vec<Reader>,
+    start_errors: Vec<ReaderError>,
+}
+
+impl SessionConnection {
+    #[must_use]
+    pub fn outcome(&self) -> Restored {
+        self.outcome
+    }
+
+    #[must_use]
+    pub fn start_errors(&self) -> &[ReaderError] {
+        &self.start_errors
+    }
+
+    /// Stops every daemon this session started, even if one stop fails.
+    ///
+    /// # Errors
+    ///
+    /// Returns all stop failures so the caller can choose a clean reboot
+    /// rather than starting Nickel on top of an owner that may still exist.
+    pub fn release(self, within: Duration) -> Result<(), Vec<ReaderError>> {
+        let mut errors = Vec::new();
+        for daemon in self.started.into_iter().rev() {
+            if let Err(error) = daemon.stop(within) {
+                errors.push(error);
+            }
+        }
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
 }
 
 impl Connection {
@@ -85,12 +127,18 @@ impl Connection {
     /// already offline when the session began.
     #[must_use]
     pub fn capture() -> Self {
-        let daemons = [SUPPLICANT_EXECUTABLE, DHCP_EXECUTABLE]
-            .into_iter()
-            .filter_map(|executable| Reader::find_running(executable).ok())
-            .collect();
+        let mut daemons = Vec::new();
+        let mut uncertain = Vec::new();
+        for executable in [SUPPLICANT_EXECUTABLE, DHCP_EXECUTABLE] {
+            match Reader::find_running(executable) {
+                Ok(daemon) => daemons.push(daemon),
+                Err(ReaderError::NotRunning) => {}
+                Err(_) => uncertain.push(executable.to_owned()),
+            }
+        }
         Self {
             daemons,
+            uncertain,
             was_online: is_online(WIRELESS_LINK),
         }
     }
@@ -99,6 +147,39 @@ impl Connection {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.daemons.is_empty()
+    }
+
+    /// Returns whether the reader had a usable route when it was captured.
+    #[must_use]
+    pub fn was_online(&self) -> bool {
+        self.was_online
+    }
+
+    /// Stops one daemon captured before the reader handoff, if it still runs.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the exact captured process cannot be stopped or
+    /// its original presence could not be established.
+    pub fn release_captured(&self, executable: &str, within: Duration) -> Result<(), ReaderError> {
+        let uncertain = self
+            .uncertain
+            .iter()
+            .any(|uncertain| uncertain == executable);
+        let captured = self
+            .daemons
+            .iter()
+            .find(|daemon| daemon.executable() == executable);
+        match Reader::find_running(executable) {
+            Err(ReaderError::NotRunning) => Ok(()),
+            Ok(observed)
+                if !uncertain && captured.is_some_and(|daemon| observed.pid() == daemon.pid()) =>
+            {
+                observed.stop(within)
+            }
+            Ok(observed) => Err(ReaderError::IdentityChanged(observed.pid())),
+            Err(error) => Err(error),
+        }
     }
 
     /// Puts the connection back if it has gone, waiting up to `within`.
@@ -118,9 +199,6 @@ impl Connection {
             return Ok(Restored::Unaffected);
         }
         for daemon in &self.daemons {
-            // Starting a second copy of a daemon that is already running would
-            // leave two of them fighting over one interface, which is worse
-            // than the problem being fixed.
             if Reader::find_running(daemon.executable()).is_ok() {
                 continue;
             }
@@ -131,6 +209,74 @@ impl Connection {
         } else {
             Restored::StillDown
         })
+    }
+
+    /// Restores a dropped connection and records only daemons Cobalt starts.
+    #[must_use]
+    pub fn restore_for_session(&self, within: Duration) -> SessionConnection {
+        let mut start_errors = self
+            .uncertain
+            .iter()
+            .map(|_| ReaderError::DidNotStart)
+            .collect::<Vec<_>>();
+        // A device that was already offline has nothing to put back, and
+        // starting a supplicant it was not running would be inventing state.
+        if !self.was_online {
+            return SessionConnection {
+                outcome: Restored::Unaffected,
+                started: Vec::new(),
+                start_errors,
+            };
+        }
+        if !went_offline(WIRELESS_LINK, SETTLE) {
+            return SessionConnection {
+                outcome: Restored::Unaffected,
+                started: Vec::new(),
+                start_errors,
+            };
+        }
+        let mut started = Vec::new();
+        for daemon in &self.daemons {
+            // Starting a second copy of a daemon that is already running would
+            // leave two of them fighting over one interface, which is worse
+            // than the problem being fixed.
+            match Reader::find_running(daemon.executable()) {
+                Ok(observed) if observed.pid() == daemon.pid() => continue,
+                Ok(observed) => {
+                    start_errors.push(ReaderError::IdentityChanged(observed.pid()));
+                    continue;
+                }
+                Err(ReaderError::NotRunning) => {}
+                Err(error) => {
+                    start_errors.push(error);
+                    continue;
+                }
+            }
+            match daemon.start_captured(within) {
+                Ok(running) => {
+                    let launched_pid = running.pid();
+                    started.push(running);
+                    match Reader::find_running(daemon.executable()) {
+                        Ok(observed) if observed.pid() == launched_pid => {}
+                        Ok(_) | Err(ReaderError::Ambiguous(_)) => {
+                            start_errors.push(ReaderError::Ambiguous(vec![launched_pid]));
+                        }
+                        Err(error) => start_errors.push(error),
+                    }
+                }
+                Err(error) => start_errors.push(error),
+            }
+        }
+        let outcome = if wait_until_online(WIRELESS_LINK, within) {
+            Restored::Restarted
+        } else {
+            Restored::StillDown
+        };
+        SessionConnection {
+            outcome,
+            started,
+            start_errors,
+        }
     }
 }
 
@@ -330,10 +476,12 @@ wlan0\tDestination\tGateway\n";
 
     #[test]
     fn capturing_on_a_host_without_those_daemons_records_nothing() {
+        let connection = Connection::capture();
         assert!(
-            Connection::capture().is_empty(),
+            connection.is_empty(),
             "capture must never fail when the daemons are absent"
         );
+        assert!(!connection.was_online());
     }
 }
 

--- a/crates/kobo-hal/src/network.rs
+++ b/crates/kobo-hal/src/network.rs
@@ -85,6 +85,7 @@ pub struct SessionConnection {
     outcome: Restored,
     started: Vec<Reader>,
     start_errors: Vec<ReaderError>,
+    uncertain_executables: Vec<String>,
 }
 
 impl SessionConnection {
@@ -96,6 +97,11 @@ impl SessionConnection {
     #[must_use]
     pub fn start_errors(&self) -> &[ReaderError] {
         &self.start_errors
+    }
+
+    #[must_use]
+    pub fn uncertain_executables(&self) -> &[String] {
+        &self.uncertain_executables
     }
 
     /// Stops every daemon this session started, even if one stop fails.
@@ -143,7 +149,7 @@ impl Connection {
         }
     }
 
-    /// Returns whether anything was recorded.
+    /// Returns whether any daemon identity was captured.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.daemons.is_empty()
@@ -214,11 +220,8 @@ impl Connection {
     /// Restores a dropped connection and records only daemons Cobalt starts.
     #[must_use]
     pub fn restore_for_session(&self, within: Duration) -> SessionConnection {
-        let mut start_errors = self
-            .uncertain
-            .iter()
-            .map(|_| ReaderError::DidNotStart)
-            .collect::<Vec<_>>();
+        let mut start_errors = Vec::new();
+        let uncertain_executables = self.uncertain.clone();
         // A device that was already offline has nothing to put back, and
         // starting a supplicant it was not running would be inventing state.
         if !self.was_online {
@@ -226,6 +229,7 @@ impl Connection {
                 outcome: Restored::Unaffected,
                 started: Vec::new(),
                 start_errors,
+                uncertain_executables,
             };
         }
         if !went_offline(WIRELESS_LINK, SETTLE) {
@@ -233,6 +237,7 @@ impl Connection {
                 outcome: Restored::Unaffected,
                 started: Vec::new(),
                 start_errors,
+                uncertain_executables,
             };
         }
         let mut started = Vec::new();
@@ -276,6 +281,7 @@ impl Connection {
             outcome,
             started,
             start_errors,
+            uncertain_executables,
         }
     }
 }

--- a/crates/kobo-hal/src/reader.rs
+++ b/crates/kobo-hal/src/reader.rs
@@ -55,6 +55,10 @@ pub const SUPERVISOR_EXECUTABLE: &str = "/usr/local/Kobo/sickel";
 /// How often to check whether a stopped reader has actually exited.
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
+/// A daemon launched with `-B` briefly leaves its pre-fork process visible.
+/// Requiring an unchanged process set avoids capturing that transient parent.
+const START_CAPTURE_SETTLE: Duration = Duration::from_millis(500);
+
 #[derive(Debug)]
 pub enum ReaderError {
     /// No process is running the reader executable.
@@ -206,30 +210,7 @@ impl Reader {
         executable: &str,
         identity: Identity,
     ) -> Result<Self, ReaderError> {
-        let mut matches = Vec::new();
-        for entry in fs::read_dir(proc_root)? {
-            let entry = entry?;
-            let Some(pid) = entry
-                .file_name()
-                .to_str()
-                .and_then(|name| name.parse::<i32>().ok())
-            else {
-                continue;
-            };
-            if pid <= 1 {
-                continue;
-            }
-            let identified = match identity {
-                Identity::ZerothArgument => read_argv(proc_root, pid)
-                    .is_some_and(|argv| argv.first().is_some_and(|first| first == executable)),
-                Identity::Executable => fs::read_link(proc_root.join(pid.to_string()).join("exe"))
-                    .is_ok_and(|target| target == Path::new(executable)),
-            };
-            if identified {
-                matches.push(pid);
-            }
-        }
-        matches.sort_unstable();
+        let matches = matching_pids_in(proc_root, executable, identity)?;
         let pid = match matches.as_slice() {
             [] => return Err(ReaderError::NotRunning),
             [only] => *only,
@@ -370,32 +351,33 @@ impl Reader {
     /// Returns an error when the process cannot be spawned or never appears
     /// with the same identity mode that originally found it.
     pub fn start_captured(&self, appear_within: Duration) -> Result<Self, ReaderError> {
-        let mut command = Command::new("/bin/sh");
-        command
-            .arg("-c")
-            .arg(r#"nohup "$0" "$@" >/dev/null 2>&1 & printf '%s\n' "$!""#)
-            .arg(&self.executable)
-            .args(&self.arguments)
-            .current_dir(&self.working_directory)
-            .env_clear()
-            .envs(&self.environment)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null());
-        let output = command.output()?;
-        if !output.status.success() {
+        let proc_root = Path::new("/proc");
+        let before = matching_pids_in(proc_root, &self.executable, self.identity)?;
+        let status = self.start_command().status()?;
+        if !status.success() {
             return Err(ReaderError::DidNotStart);
         }
-        let pid = String::from_utf8_lossy(&output.stdout)
-            .trim()
-            .parse::<i32>()
-            .map_err(|_| ReaderError::DidNotStart)?;
         let deadline = Instant::now() + appear_within;
+        let mut last_started = Vec::new();
+        let mut unchanged_since = Instant::now();
         loop {
-            if let Ok(reader) =
-                Self::capture_pid_in(Path::new("/proc"), &self.executable, pid, self.identity)
-            {
-                return Ok(reader);
+            let running = matching_pids_in(proc_root, &self.executable, self.identity)?;
+            let started = newly_started_pids(&before, &running);
+            if started != last_started {
+                last_started = started;
+                unchanged_since = Instant::now();
+            } else if !started.is_empty() && unchanged_since.elapsed() >= START_CAPTURE_SETTLE {
+                match started.as_slice() {
+                    [pid] => {
+                        return Self::capture_pid_in(
+                            proc_root,
+                            &self.executable,
+                            *pid,
+                            self.identity,
+                        );
+                    }
+                    several => return Err(ReaderError::Ambiguous(several.to_vec())),
+                }
             }
             if Instant::now() >= deadline {
                 return Err(ReaderError::DidNotStart);
@@ -482,6 +464,46 @@ impl Reader {
             identity: Identity::ZerothArgument,
         })
     }
+}
+
+fn matching_pids_in(
+    proc_root: &Path,
+    executable: &str,
+    identity: Identity,
+) -> Result<Vec<i32>, ReaderError> {
+    let mut matches = Vec::new();
+    for entry in fs::read_dir(proc_root)? {
+        let entry = entry?;
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<i32>().ok())
+        else {
+            continue;
+        };
+        if pid <= 1 {
+            continue;
+        }
+        let identified = match identity {
+            Identity::ZerothArgument => read_argv(proc_root, pid)
+                .is_some_and(|argv| argv.first().is_some_and(|first| first == executable)),
+            Identity::Executable => fs::read_link(proc_root.join(pid.to_string()).join("exe"))
+                .is_ok_and(|target| target == Path::new(executable)),
+        };
+        if identified {
+            matches.push(pid);
+        }
+    }
+    matches.sort_unstable();
+    Ok(matches)
+}
+
+fn newly_started_pids(before: &[i32], running: &[i32]) -> Vec<i32> {
+    running
+        .iter()
+        .copied()
+        .filter(|pid| !before.contains(pid))
+        .collect()
 }
 
 /// A detached process that restarts the reader if we do not.
@@ -672,8 +694,8 @@ fn read_environment(proc_root: &Path, pid: i32) -> io::Result<BTreeMap<OsString,
 #[cfg(test)]
 mod tests {
     use super::{
-        read_argv, read_environment, sibling, watchdog_script, Reader, ReaderError,
-        READER_EXECUTABLE,
+        newly_started_pids, read_argv, read_environment, sibling, watchdog_script, Reader,
+        ReaderError, READER_EXECUTABLE,
     };
     use std::ffi::OsString;
     use std::fs;
@@ -810,6 +832,12 @@ mod tests {
         fs::remove_file(root.join("500").join("exe")).expect("remove exe link");
         assert!(!daemon.still_running_in(&root));
         let _ignored = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn detached_start_capture_ignores_processes_that_predate_the_launch() {
+        assert_eq!(newly_started_pids(&[400], &[400, 402]), vec![402]);
+        assert_eq!(newly_started_pids(&[400], &[402, 403]), vec![402, 403]);
     }
 
     #[test]

--- a/crates/kobo-hal/src/reader.rs
+++ b/crates/kobo-hal/src/reader.rs
@@ -235,7 +235,24 @@ impl Reader {
             [only] => *only,
             several => return Err(ReaderError::Ambiguous(several.to_vec())),
         };
+        Self::capture_pid_in(proc_root, executable, pid, identity)
+    }
 
+    fn capture_pid_in(
+        proc_root: &Path,
+        executable: &str,
+        pid: i32,
+        identity: Identity,
+    ) -> Result<Self, ReaderError> {
+        let identified = match identity {
+            Identity::ZerothArgument => read_argv(proc_root, pid)
+                .is_some_and(|argv| argv.first().is_some_and(|first| first == executable)),
+            Identity::Executable => fs::read_link(proc_root.join(pid.to_string()).join("exe"))
+                .is_ok_and(|target| target == Path::new(executable)),
+        };
+        if !identified {
+            return Err(ReaderError::IdentityChanged(pid));
+        }
         let argv = read_argv(proc_root, pid).ok_or(ReaderError::IdentityChanged(pid))?;
         let arguments = argv
             .into_iter()
@@ -343,14 +360,42 @@ impl Reader {
     /// Returns an error when the reader cannot be spawned or never appears in
     /// the process table.
     pub fn start(&self, appear_within: Duration) -> Result<i32, ReaderError> {
-        let status = self.start_command().status()?;
-        if !status.success() {
+        self.start_captured(appear_within).map(|reader| reader.pid)
+    }
+
+    /// Starts an identical process and returns its newly captured identity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the process cannot be spawned or never appears
+    /// with the same identity mode that originally found it.
+    pub fn start_captured(&self, appear_within: Duration) -> Result<Self, ReaderError> {
+        let mut command = Command::new("/bin/sh");
+        command
+            .arg("-c")
+            .arg(r#"nohup "$0" "$@" >/dev/null 2>&1 & printf '%s\n' "$!""#)
+            .arg(&self.executable)
+            .args(&self.arguments)
+            .current_dir(&self.working_directory)
+            .env_clear()
+            .envs(&self.environment)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        let output = command.output()?;
+        if !output.status.success() {
             return Err(ReaderError::DidNotStart);
         }
+        let pid = String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .parse::<i32>()
+            .map_err(|_| ReaderError::DidNotStart)?;
         let deadline = Instant::now() + appear_within;
         loop {
-            if let Ok(reader) = Self::find_executable_in(Path::new("/proc"), &self.executable) {
-                return Ok(reader.pid);
+            if let Ok(reader) =
+                Self::capture_pid_in(Path::new("/proc"), &self.executable, pid, self.identity)
+            {
+                return Ok(reader);
             }
             if Instant::now() >= deadline {
                 return Err(ReaderError::DidNotStart);

--- a/crates/kobo-hal/src/wifi.rs
+++ b/crates/kobo-hal/src/wifi.rs
@@ -58,6 +58,49 @@ impl Wifi {
         }
     }
 
+    /// Returns whether the firmware supplicant has completed association.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the supplicant control socket cannot be queried.
+    pub fn associated(&self) -> Result<bool, DeviceError> {
+        self.command(["status"])
+            .map(|status| value(&status, "wpa_state").is_some_and(|state| state == "COMPLETED"))
+    }
+
+    /// Asks the existing firmware supplicant to reconnect.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the control socket rejects or cannot receive the
+    /// request.
+    pub fn reconnect(&self) -> Result<(), DeviceError> {
+        self.command(["reconnect"]).map(|_| ())
+    }
+
+    /// Reproduces the stock reader's network-screen recovery without changing
+    /// saved networks or starting another supplicant.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the interface cannot be raised or the existing
+    /// firmware supplicant rejects one of the recovery commands.
+    pub fn recover_association(&self) -> Result<(), DeviceError> {
+        if !set_interface(true) {
+            return Err(DeviceError::Backend);
+        }
+        if self.associated()? {
+            return Ok(());
+        }
+        for command in association_recovery_commands() {
+            self.command(command)?;
+            if self.associated()? {
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
+
     #[must_use]
     pub fn set_enabled(&self, enabled: bool) -> DeviceResult {
         if enabled {
@@ -219,6 +262,10 @@ fn set_interface(enabled: bool) -> bool {
     false
 }
 
+fn association_recovery_commands() -> [[&'static str; 1]; 3] {
+    [["scan"], ["reassociate"], ["reconnect"]]
+}
+
 fn parse_scan_results(output: &str, connected: Option<&str>) -> Vec<WifiNetwork> {
     let mut networks = Vec::new();
     for line in output
@@ -291,7 +338,17 @@ fn quote(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_scan_results, quote, valid_credentials, value};
+    use super::{
+        association_recovery_commands, parse_scan_results, quote, valid_credentials, value,
+    };
+
+    #[test]
+    fn association_recovery_matches_the_stock_network_screen_sequence() {
+        assert_eq!(
+            association_recovery_commands(),
+            [["scan"], ["reassociate"], ["reconnect"]]
+        );
+    }
 
     #[test]
     fn a_wpa_scan_is_sorted_and_deduplicated() {

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -290,9 +290,10 @@ pub const CLARA_BW_391: DeviceProfile = DeviceProfile {
     write_ready: true,
     // Measured on the device on 2026-09-02: preserving Nickel's detached
     // supplicant kept SSH alive throughout Cobalt's panel session, but the
-    // restarted reader launched a replacement and Wi-Fi then stayed down
-    // until the owner reconnected it. Reaping the exact captured process
-    // before Nickel returns prevents the two-owner handoff.
+    // restarted reader launched a replacement. Reaping the exact captured
+    // process prevents the two-owner handoff; the runtime then reproduces the
+    // stock network screen's scan/reassociate sequence and waits for the
+    // replacement to complete association because a stale route can linger.
     reap_nickel_supplicant: true,
 };
 

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -288,7 +288,12 @@ pub const CLARA_BW_391: DeviceProfile = DeviceProfile {
     firmware_versions: &["4.45.23697"],
     kernel_release: "4.9.77",
     write_ready: true,
-    reap_nickel_supplicant: false,
+    // Measured on the device on 2026-09-02: preserving Nickel's detached
+    // supplicant kept SSH alive throughout Cobalt's panel session, but the
+    // restarted reader launched a replacement and Wi-Fi then stayed down
+    // until the owner reconnected it. Reaping the exact captured process
+    // before Nickel returns prevents the two-owner handoff.
+    reap_nickel_supplicant: true,
 };
 
 /// The 2025 P365 hardware refresh of the Clara BW. Kobo lists N365 and P365
@@ -1728,7 +1733,7 @@ mod tests {
         assert_eq!(
             declared,
             [
-                ("clara-bw-391", false),
+                ("clara-bw-391", true),
                 ("clara-bw-395", false),
                 ("clara-hd-376", false),
                 ("clara-colour-393", false),

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -790,6 +790,19 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
     // path, so Nickel is never started on top of an unproven network owner.
     trace("reader restart returned, waiting for it to feed the freeze watchdog");
     println!("waiting for the reader to feed the freeze watchdog");
+    let reader_wifi = restore_reader_wifi(network.was_online(), Duration::from_secs(45));
+    if !reader_wifi {
+        trace("the reader did not complete Wi-Fi association; requesting a clean reboot");
+        watchdog.disarm();
+        drop(teardown);
+        let _ignored = fs::remove_dir_all(&state);
+        let summary = outcome.unwrap_or_else(|error| format!("application ended: {error}"));
+        return request_clean_reboot().map(|()| {
+            format!(
+                "{summary}; typeface {typeface}; the reader did not reclaim Wi-Fi, so a clean reboot was requested"
+            )
+        });
+    }
     // Resumed only once the reader is feeding it again. Resuming the moment
     // the process exists lights a ten second fuse that a still-starting reader
     // cannot feed, which is what rebooted the device at the end of a session.
@@ -831,6 +844,44 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
             "{summary}; typeface {typeface}; the screen could not be restored ({error}), but {reader_state} and repaints its own screen"
         )),
         (Err(error), _) => Err(format!("{error}; {reader_state}")),
+    }
+}
+
+fn restore_reader_wifi(was_online: bool, within: Duration) -> bool {
+    if !was_online {
+        return true;
+    }
+    let deadline = Instant::now() + within;
+    let mut retry_at = Instant::now();
+    let mut healthy_since = None;
+    loop {
+        if let Some(wifi) = kobo_hal::wifi::Wifi::open() {
+            let associated = wifi.associated().unwrap_or(false);
+            let healthy =
+                associated && kobo_hal::network::is_online(kobo_hal::network::WIRELESS_LINK);
+            if healthy {
+                let since = healthy_since.get_or_insert_with(Instant::now);
+                if since.elapsed() >= Duration::from_secs(10) {
+                    return true;
+                }
+            } else {
+                healthy_since = None;
+                if !associated && Instant::now() >= retry_at {
+                    if let Err(error) = wifi.recover_association() {
+                        trace(&format!(
+                            "the reader Wi-Fi recovery sequence was not accepted: {error:?}"
+                        ));
+                    }
+                    retry_at = Instant::now() + Duration::from_secs(5);
+                }
+            }
+        } else {
+            healthy_since = None;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(500));
     }
 }
 

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -525,6 +525,7 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
 
     // Everything that can fail happens before the reader is stopped.
     let reader = Reader::find().map_err(|error| error.to_string())?;
+    let network = kobo_hal::network::Connection::capture();
     let state = PathBuf::from(format!("/tmp/kobo-session-{}", std::process::id()));
     reader
         .save(&state)
@@ -606,6 +607,25 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
         .stop(STOP_GRACE)
         .map_err(|error| format!("stop the reader: {error}"))?;
 
+    // Nickel owns Wi-Fi while it runs, but its supplicant and DHCP client are
+    // detached processes. Capture them before the handoff and restore exactly
+    // those processes if stopping Nickel drops the route. Cobalt never invents
+    // a network or starts a daemon that was not already serving the owner.
+    if network.was_online() {
+        if let Some(wifi) = kobo_hal::wifi::Wifi::open() {
+            let reconnected = wifi.set_enabled(true);
+            trace(&format!(
+                "asked the captured Wi-Fi owner to reconnect: {reconnected:?}"
+            ));
+        }
+    }
+    let session_network = network.restore_for_session(Duration::from_secs(30));
+    trace(&format!(
+        "session network: {:?}; start errors: {:?}",
+        session_network.outcome(),
+        session_network.start_errors()
+    ));
+
     // One reader thread on the touch descriptor for the whole panel session,
     // started here rather than per application.
     let taps = TouchSink::default();
@@ -668,12 +688,60 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
     // Without this the recovery watchdog would conclude the runtime had died
     // and restart a reader that is already starting.
     let teardown = KeepBeating::start(&watchdog);
+    let captured_supplicant_release_failed = if profile.reap_nickel_supplicant {
+        trace("stopping the captured leftover supplicant before the reader returns");
+        if let Err(error) =
+            network.release_captured(kobo_hal::network::SUPPLICANT_EXECUTABLE, STOP_GRACE)
+        {
+            trace(&format!("the leftover supplicant would not stop: {error}"));
+            true
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+    let network_start_uncertain = !session_network.start_errors().is_empty();
+    let network_release_failed = match session_network.release(STOP_GRACE) {
+        Ok(()) => false,
+        Err(errors) => {
+            trace(&format!(
+                "session network would not stop cleanly: {errors:?}"
+            ));
+            true
+        }
+    };
     // Asked once, before the panel is given up, because the answer decides
     // whether the owner is owed an explanation and the display is gone by the
     // time the reboot itself is requested.
-    let rebooting = kobo_hal::bluetooth::requires_reboot_after_use();
+    let bluetooth_reboot = kobo_hal::bluetooth::requires_reboot_after_use();
+    let reboot_reason = if bluetooth_reboot {
+        Some((
+            kobo_ui::Glyph::Bluetooth,
+            "Bluetooth shares one radio with Wi-Fi here, and that radio can only be \
+             started once per boot. Restarting is the only way to hand it back working. \
+             This is expected, it is not a crash, and everything you have saved is \
+             already on the disk.",
+            "Bluetooth used the shared MediaTek radio",
+        ))
+    } else if network_start_uncertain
+        || network_release_failed
+        || captured_supplicant_release_failed
+    {
+        Some((
+            kobo_ui::Glyph::Wifi,
+            "Cobalt could not prove that its temporary network processes stopped. \
+             Restarting avoids giving Wi-Fi to two owners at once. This is expected, \
+             it is not a crash, and everything you have saved is already on the disk.",
+            "the temporary session network could not be released safely",
+        ))
+    } else {
+        None
+    };
+    let rebooting = reboot_reason.is_some();
     if rebooting {
-        if let Err(error) = announce_reboot(&display, whole_screen) {
+        let (glyph, summary, _) = reboot_reason.expect("reboot reason");
+        if let Err(error) = announce_reboot(&display, whole_screen, glyph, summary) {
             // Not fatal. Failing to explain the reboot is worse than not
             // rebooting, but it is not a reason to leave the radio broken.
             trace(&format!("could not show the restart notice: {error}"));
@@ -699,59 +767,27 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
     // the only proven hand-back: it returns directly to the stock reader with
     // a pristine shared Wi-Fi/Bluetooth driver state.
     if rebooting {
-        trace("MediaTek Bluetooth was used; rebooting cleanly instead of restarting the reader");
-        println!("Bluetooth changed; rebooting cleanly back to the reader");
+        let (_, _, detail) = reboot_reason.expect("reboot reason");
+        trace(&format!(
+            "{detail}; rebooting cleanly instead of restarting the reader"
+        ));
+        println!("shared hardware needs a clean handoff; rebooting back to the reader");
         watchdog.disarm();
         drop(teardown);
         let _ignored = fs::remove_dir_all(&state);
         let summary = outcome.unwrap_or_else(|error| format!("application ended: {error}"));
         return request_clean_reboot().map(|()| {
             format!(
-                "{summary}; typeface {typeface}; Bluetooth used the shared MediaTek radio, so a clean reboot was requested before returning to the stock reader"
+                "{summary}; typeface {typeface}; {detail}, so a clean reboot was requested before returning to the stock reader"
             )
         });
-    }
-    // Nickel launches its supplicant detached, so stopping the reader never
-    // took it down and it has been running for the whole session. A restarted
-    // Nickel starts a supplicant of its own on top of it, the two fight over
-    // the interface, and Wi-Fi stays down until a reboot. On the profiles
-    // that declare it, the leftover one is stopped here, after the panel is
-    // given up and before the reader returns, so the new Nickel comes up
-    // alone. This is a reap, not radio configuration: the interface, the
-    // association and the choice to reconnect stay Nickel's.
-    //
-    // Nothing here is fatal. A supplicant that is absent, ambiguous, or will
-    // not die leaves the owner exactly where every session left them before
-    // this existed: reconnecting by hand or rebooting.
-    if profile.reap_nickel_supplicant {
-        match Reader::find_running(kobo_hal::network::SUPPLICANT_EXECUTABLE) {
-            Ok(supplicant) => {
-                trace("stopping the leftover supplicant before the reader returns");
-                if let Err(error) = supplicant.stop(STOP_GRACE) {
-                    trace(&format!("the leftover supplicant would not stop: {error}"));
-                }
-            }
-            Err(error) => trace(&format!("no leftover supplicant to stop: {error}")),
-        }
     }
     trace("panel and touch released, restarting the reader");
     println!("panel released, restarting the reader");
     let restarted = reader.start(START_GRACE);
-    // The connection is never put back, and there is no longer a way to ask
-    // for it. Restoring it meant starting a supplicant and a DHCP client on
-    // `wlan0` while the reader we had just restarted drives that same radio
-    // itself, from inside libnickel, with no way to be told what we did. Two
-    // owners of one radio is the mistake the display is careful to avoid
-    // twelve lines above, and it had the same shape here.
-    //
-    // It existed as a convenience for working on a device over Wi-Fi, where
-    // losing the link costs a reboot. It is gone because that convenience was
-    // the first link in the chain that erased a device: the reader came up
-    // owning a radio it had not configured, never reached its first watchdog
-    // ping, and the watchdog was armed against it anyway. The second link is
-    // fixed in `resume_once_fed`, which now arms nothing without evidence, but
-    // a developer's reboot was never worth being one fault away from a
-    // stranger's library.
+    // Any daemon Cobalt started for the session was stopped by exact captured
+    // identity above. A stop or capture uncertainty takes the clean-reboot
+    // path, so Nickel is never started on top of an unproven network owner.
     trace("reader restart returned, waiting for it to feed the freeze watchdog");
     println!("waiting for the reader to feed the freeze watchdog");
     // Resumed only once the reader is feeding it again. Resuming the moment
@@ -848,18 +884,19 @@ fn describe(limit: Duration) -> String {
 /// It exists because the reboot below was silent. The only warning was a line
 /// on a developer's terminal, so from the owner's chair a Bluetooth connection
 /// simply killed the device, which is exactly how it was reported.
-fn announce_reboot(display: &DisplaySession, whole_screen: Rect) -> Result<(), String> {
+fn announce_reboot(
+    display: &DisplaySession,
+    whole_screen: Rect,
+    glyph: kobo_ui::Glyph,
+    summary: &str,
+) -> Result<(), String> {
     let screen = Screen::new(
         0,
         vec![kobo_ui::Node::Splash {
             id: kobo_ui::NodeId(1),
-            glyph: Some(kobo_ui::Glyph::Bluetooth),
+            glyph: Some(glyph),
             title: "Restarting your reader".to_owned(),
-            summary: "Bluetooth shares one radio with Wi-Fi here, and that radio can only be \
-                      started once per boot. Restarting is the only way to hand it back working. \
-                      This is expected, it is not a crash, and everything you have saved is \
-                      already on the disk."
-                .to_owned(),
+            summary: summary.to_owned(),
         }],
     );
     let mut surface = Surface::new(

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -621,8 +621,9 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
     }
     let session_network = network.restore_for_session(Duration::from_secs(30));
     trace(&format!(
-        "session network: {:?}; start errors: {:?}",
+        "session network: {:?}; uncertain captures: {:?}; start errors: {:?}",
         session_network.outcome(),
+        session_network.uncertain_executables(),
         session_network.start_errors()
     ));
 
@@ -701,7 +702,8 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
     } else {
         false
     };
-    let network_start_uncertain = !session_network.start_errors().is_empty();
+    let network_start_uncertain = !session_network.start_errors().is_empty()
+        || !session_network.uncertain_executables().is_empty();
     let network_release_failed = match session_network.release(STOP_GRACE) {
         Ok(()) => false,
         Err(errors) => {
@@ -730,10 +732,10 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
     {
         Some((
             kobo_ui::Glyph::Wifi,
-            "Cobalt could not prove that its temporary network processes stopped. \
-             Restarting avoids giving Wi-Fi to two owners at once. This is expected, \
-             it is not a crash, and everything you have saved is already on the disk.",
-            "the temporary session network could not be released safely",
+            "Cobalt could not prove that Wi-Fi has exactly one owner. Restarting avoids \
+             handing the radio to competing processes. This is expected, it is not a \
+             crash, and everything you have saved is already on the disk.",
+            "Wi-Fi ownership could not be handed back safely",
         ))
     } else {
         None
@@ -784,7 +786,23 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
     }
     trace("panel and touch released, restarting the reader");
     println!("panel released, restarting the reader");
-    let restarted = reader.start(START_GRACE);
+    let restarted = match reader.start(START_GRACE) {
+        Ok(pid) => pid,
+        Err(error) => {
+            trace(&format!(
+                "the reader did not restart ({error}); requesting a clean reboot"
+            ));
+            watchdog.disarm();
+            drop(teardown);
+            let _ignored = fs::remove_dir_all(&state);
+            let summary = outcome.unwrap_or_else(|error| format!("application ended: {error}"));
+            return request_clean_reboot().map(|()| {
+                format!(
+                    "{summary}; typeface {typeface}; the reader did not restart ({error}), so a clean reboot was requested"
+                )
+            });
+        }
+    };
     // Any daemon Cobalt started for the session was stopped by exact captured
     // identity above. A stop or capture uncertainty takes the clean-reboot
     // path, so Nickel is never started on top of an unproven network owner.
@@ -816,15 +834,12 @@ pub fn present(application: &Path, limits: Limits) -> Result<String, String> {
     drop(teardown);
     let _ignored = fs::remove_dir_all(&state);
 
-    let reader_state = match (restarted, resumed) {
-        (Ok(pid), Ok(after)) => {
-            format!("the reader is running again as pid {pid}, and the freeze watchdog was resumed {after}")
+    let reader_state = match resumed {
+        Ok(after) => {
+            format!("the reader is running again as pid {restarted}, and the freeze watchdog was resumed {after}")
         }
-        (Ok(pid), Err(error)) => format!(
-            "the reader is running again as pid {pid}, but the freeze watchdog could not be resumed ({error}); it returns on the next reboot"
-        ),
-        (Err(error), _) => format!(
-            "THE READER DID NOT COME BACK ({error}). Power cycle the device; it always boots the stock reader"
+        Err(error) => format!(
+            "the reader is running again as pid {restarted}, but the freeze watchdog could not be resumed ({error}); it returns on the next reboot"
         ),
     };
     let reader_state =


### PR DESCRIPTION
## Summary
- preserve exact Wi-Fi process ownership while Cobalt owns the panel
- restart detached firmware daemons by capturing their stable post-fork PID
- reproduce Nickel network recovery with bounded scan/reassociation and a ten-second association/route stability gate
- request a clean reboot when ownership or recovery cannot be proven safe

## Validation
- 64 kobo-hal tests and 67 kobod tests pass
- strict host and ARM target Clippy pass
- static ARM device daemon built with `device-write`
- Kobo Clara BW N365: two consecutive 150-second Todo sessions returned to Nickel without reboot
- each successful handoff retained one supplicant owner and remained associated, routed, and SSH-reachable for more than three minutes
- official Beta daemon restored byte-for-byte after device testing

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790940413&installation_model_id=20525&pr_number=94&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F94&signature=3ee438c03084a4cacada268bfcc5b429f50e5a2a22a2a74a9a6408363d6e64ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->