### PR TITLE
Add signed prebuilt host installer

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -57,7 +57,6 @@ jobs:
             `cobalt-${version}-KoboRoot.tgz`,
             `cobalt-${version}.sha256`,
             "THIRD-PARTY.md",
-            "install.sh",
             "cobalt-host-manifest.txt",
             "cobalt-host-manifest.txt.sig",
             "cobalt-host-manifest.txt.sshsig",
@@ -76,6 +75,8 @@ jobs:
             git cat-file -e "${tag_sha}^{commit}"
             git merge-base --is-ancestor "$tag_sha" "$GITHUB_SHA"
             published="$RUNNER_TEMP/published-$tag"
+            bootstrap="$RUNNER_TEMP/install-$tag.sh"
+            git show "${tag_sha}:install.sh" > "$bootstrap"
             mkdir "$published"
             gh release download "$tag" --dir "$published"
             cd "$published"
@@ -115,8 +116,15 @@ jobs:
           NODE
             while read -r kind first second third fourth; do
               case "$kind" in
-                device|bootstrap)
+                device)
                   name=$first
+                  bytes=$second
+                  checksum=$third
+                  test -z "${fourth:-}"
+                  ;;
+                bootstrap)
+                  test "$first" = install.sh
+                  name=$bootstrap
                   bytes=$second
                   checksum=$third
                   test -z "${fourth:-}"
@@ -273,6 +281,7 @@ jobs:
             --seed "$seed" \
             --signature dist/cobalt-host-manifest.txt.sig \
             --ssh-signature dist/cobalt-host-manifest.txt.sshsig
+          rm dist/install.sh
       - name: Create the immutable isolated prerelease
         env:
           GH_TOKEN: ${{ github.token }}
@@ -288,7 +297,7 @@ jobs:
             --field "ref=refs/tags/${tag}" --field "sha=${GITHUB_SHA}" \
             --jq '.object.sha' | grep -Fx "$GITHUB_SHA"
           find dist -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} +
-          test "$(find dist -maxdepth 1 -type f | wc -l)" -eq 13
+          test "$(find dist -maxdepth 1 -type f | wc -l)" -eq 12
           gh release create "$tag" dist/* \
             --title "Cobalt ${VERSION} beta" \
             --notes "Immutable prerelease built from the beta branch at ${GITHUB_SHA}." \

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -13,231 +13,282 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  package:
+  prepare:
     if: github.ref == 'refs/heads/beta'
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      publish: ${{ steps.release.outputs.publish }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
-        with:
-          toolchain: 1.85.1
-          targets: armv7-unknown-linux-musleabihf
-      - name: Install the ring C cross-compiler
-        run: sudo apt-get update && sudo apt-get install --yes gcc-arm-linux-gnueabihf
       - name: Read the workspace version
         id: version
         run: |
           version="$(sed -n 's/^version = "\([0-9][0-9.]*\)"$/\1/p' Cargo.toml)"
-          test -n "$version"
-          test "$(printf '%s\n' "$version" | wc -l)" -eq 1
+          printf '%s\n' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'
           echo "version=$version" >> "$GITHUB_OUTPUT"
-      - name: Decide whether this version needs publishing
+      - name: Enforce immutable beta versions
         id: release
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          set -o pipefail
-          api_get() {
-            output="$1"
-            endpoint="$2"
-            if ! status="$(curl --silent --show-error --location \
-              --retry 3 --retry-all-errors \
-              --header "Authorization: Bearer $GH_TOKEN" \
-              --header "Accept: application/vnd.github+json" \
-              --header "X-GitHub-Api-Version: 2022-11-28" \
-              --output "$output" --write-out '%{http_code}' \
-              "https://api.github.com/${endpoint}")"
-            then
-              echo "GitHub API request failed for $endpoint" >&2
-              return 2
-            fi
-            case "$status" in
-              200) return 0 ;;
-              404)
-                rm -f "$output"
-                return 1
-                ;;
-              *)
-                echo "GitHub API request for $endpoint returned HTTP $status" >&2
-                return 2
-                ;;
-            esac
-          }
           tag="beta-v${VERSION}"
-          tag_present=false
-          release_present=false
-          if api_get "$RUNNER_TEMP/tag.json" \
-            "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}"
-          then
-            tag_present=true
-          else
-            status=$?
-            test "$status" -eq 1
-          fi
-          if api_get "$RUNNER_TEMP/release.json" \
-            "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}"
-          then
-            release_present=true
-          else
-            status=$?
-            test "$status" -eq 1
-          fi
-          if [ "$tag_present" != "$release_present" ]; then
+          tag_count="$(git ls-remote --tags origin "refs/tags/$tag" | wc -l)"
+          release_count="$(gh release list --limit 100 --json tagName \
+            --jq '[.[] | select(.tagName == "'"$tag"'")] | length')"
+          if [ "$tag_count" != "$release_count" ]; then
             echo "$tag has an incomplete tag/release pair; refusing to continue" >&2
             exit 1
           fi
-          if [ "$tag_present" = true ]; then
-            # shellcheck disable=SC2016
-            node -e '
-              const release = require(process.argv[1]);
-              const expected = [
-                `cobalt-${process.argv[3]}-ClaraBW-KoboRoot.tgz`,
-                `cobalt-${process.argv[3]}-ClaraBW.sha256`,
-                `cobalt-${process.argv[3]}-KoboRoot.tgz`,
-                `cobalt-${process.argv[3]}.sha256`,
-                "THIRD-PARTY.md",
-              ].sort();
-              const assets = release.assets.map(asset => asset.name).sort();
-              if (
-                release.tag_name !== process.argv[2] ||
-                release.draft !== false ||
-                release.prerelease !== true ||
-                JSON.stringify(assets) !== JSON.stringify(expected)
-              ) process.exit(1);
-            ' "$RUNNER_TEMP/release.json" "$tag" "$VERSION"
-            tag_sha="$(
-              # shellcheck disable=SC2016
-              node -e '
-                const tag = require(process.argv[1]);
-                if (
-                  tag.object.type !== "commit" ||
-                  !/^[0-9a-f]{40}$/.test(tag.object.sha)
-                ) process.exit(1);
-                process.stdout.write(tag.object.sha);
-              ' "$RUNNER_TEMP/tag.json"
-            )"
+          if [ "$tag_count" -eq 1 ]; then
+            release="$RUNNER_TEMP/release.json"
+            gh release view "$tag" --json tagName,isDraft,isPrerelease,assets,targetCommitish \
+              > "$release"
+            node - "$release" "$tag" "$VERSION" <<'NODE'
+          const fs = require("fs");
+          const release = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+          const version = process.argv[4];
+          const expected = [
+            `cobalt-${version}-ClaraBW-KoboRoot.tgz`,
+            `cobalt-${version}-ClaraBW.sha256`,
+            `cobalt-${version}-KoboRoot.tgz`,
+            `cobalt-${version}.sha256`,
+            "THIRD-PARTY.md",
+            "install.sh",
+            "cobalt-host-manifest.txt",
+            "cobalt-host-manifest.txt.sig",
+            "cobalt-host-manifest.txt.sshsig",
+            ...["macos-x86_64", "macos-arm64", "linux-x86_64", "linux-arm64"]
+              .map(platform => `kobo-${version}-${platform}.tar.gz`),
+          ].sort();
+          const assets = release.assets.map(asset => asset.name).sort();
+          if (
+            release.tagName !== process.argv[3] ||
+            release.isDraft ||
+            !release.isPrerelease ||
+            JSON.stringify(assets) !== JSON.stringify(expected)
+          ) process.exit(1);
+          NODE
+            tag_sha="$(git ls-remote --tags origin "refs/tags/$tag" | awk '{print $1}')"
             git cat-file -e "${tag_sha}^{commit}"
             git merge-base --is-ancestor "$tag_sha" "$GITHUB_SHA"
             published="$RUNNER_TEMP/published-$tag"
-            mkdir -p "$published"
+            mkdir "$published"
             gh release download "$tag" --dir "$published"
-            test "$(find "$published" -maxdepth 1 -type f | wc -l)" -eq 5
             cd "$published"
-            cmp \
-              "cobalt-${VERSION}.sha256" \
-              "cobalt-${VERSION}-ClaraBW.sha256"
-            cmp \
-              "cobalt-${VERSION}-KoboRoot.tgz" \
-              "cobalt-${VERSION}-ClaraBW-KoboRoot.tgz"
             sha256sum --check "cobalt-${VERSION}.sha256"
+            cmp "cobalt-${VERSION}.sha256" "cobalt-${VERSION}-ClaraBW.sha256"
+            cmp "cobalt-${VERSION}-KoboRoot.tgz" \
+              "cobalt-${VERSION}-ClaraBW-KoboRoot.tgz"
+            grep -Fx "version ${VERSION}" cobalt-host-manifest.txt
+            grep -Fx "channels stable,beta" cobalt-host-manifest.txt
+            grep -Fx "source ${tag_sha}" cobalt-host-manifest.txt
+            printf '%s\n' \
+              'cobalt-release ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL7XUR3p+tvPgftO/kRbigc8gagzP2RBDG3tWIu/1KXe' \
+              > allowed_signers
+            ssh-keygen -Y verify -q \
+              -f allowed_signers -I cobalt-release -n cobalt-host-release \
+              -s cobalt-host-manifest.txt.sshsig < cobalt-host-manifest.txt
+            node - <<'NODE'
+          const crypto = require("crypto");
+          const fs = require("fs");
+          const publicKey = Buffer.from(
+            "302a300506032b6570032100bed7511de9fadbcf81fb4efe445b8a073c81a8333f64410c6ded588bbfd4a5de",
+            "hex",
+          );
+          const signature = Buffer.from(
+            fs.readFileSync("cobalt-host-manifest.txt.sig", "utf8").trim(),
+            "hex",
+          );
+          if (
+            signature.length !== 64 ||
+            !crypto.verify(
+              null,
+              fs.readFileSync("cobalt-host-manifest.txt"),
+              {key: publicKey, format: "der", type: "spki"},
+              signature,
+            )
+          ) process.exit(1);
+          NODE
+            while read -r kind first second third fourth; do
+              case "$kind" in
+                device|bootstrap)
+                  name=$first
+                  bytes=$second
+                  checksum=$third
+                  test -z "${fourth:-}"
+                  ;;
+                host)
+                  name=$second
+                  bytes=$third
+                  checksum=$fourth
+                  ;;
+                *) continue ;;
+              esac
+              test -f "$name"
+              test "$(wc -c < "$name" | tr -d ' ')" = "$bytes"
+              test "$(sha256sum "$name" | cut -d' ' -f1)" = "$checksum"
+            done < cobalt-host-manifest.txt
             cd "$GITHUB_WORKSPACE"
             echo "publish=false" >> "$GITHUB_OUTPUT"
-            echo "$tag is already immutable; this beta push does not need a platform release."
             exit 0
           fi
-          latest="$(gh api --paginate \
-            "repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/beta-v?per_page=100" \
-            --jq '.[].ref' |
+          latest="$(git ls-remote --tags origin 'refs/tags/beta-v*' |
             sed -n 's#.*refs/tags/beta-v\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)$#\1#p' |
-            sort -V |
-            tail -n 1)"
+            sort -V | tail -n 1)"
           if [ -n "$latest" ]; then
-            node -e '
-              const current = process.argv[1].split(".").map(Number);
-              const latest = process.argv[2].split(".").map(Number);
-              for (let index = 0; index < 3; index += 1) {
-                if (current[index] > latest[index]) process.exit(0);
-                if (current[index] < latest[index]) process.exit(1);
-              }
-              process.exit(1);
-            ' "$VERSION" "$latest" || {
-              echo "beta-v${VERSION} is not newer than beta-v${latest}. Bump the workspace version." >&2
-              exit 1
-            }
+            test "$(printf '%s\n%s\n' "$latest" "$VERSION" | sort -V | tail -n 1)" = "$VERSION"
+            test "$latest" != "$VERSION"
           fi
           echo "publish=true" >> "$GITHUB_OUTPUT"
-      - name: Build the device package once
-        if: steps.release.outputs.publish == 'true'
-        run: cargo run --locked -p kobo-cli -- package --out dist/KoboRoot.tgz
+
+  device:
+    needs: prepare
+    if: needs.prepare.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: 1.85.1
+          targets: armv7-unknown-linux-musleabihf
+      - name: Install the ARM cross-compiler
+        run: sudo apt-get update && sudo apt-get install --yes gcc-arm-linux-gnueabihf
+      - name: Build the deterministic device package
         env:
+          VERSION: ${{ needs.prepare.outputs.version }}
           CC_armv7_unknown_linux_musleabihf: arm-linux-gnueabihf-gcc
           CFLAGS_armv7_unknown_linux_musleabihf: -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
-      - name: Name deterministic assets and checksums
-        if: steps.release.outputs.publish == 'true'
+        run: cargo run --locked -p kobo-cli -- package --out "dist/cobalt-${VERSION}-KoboRoot.tgz"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: device-package
+          path: dist/cobalt-*-KoboRoot.tgz
+          if-no-files-found: error
+
+  host:
+    needs: prepare
+    if: needs.prepare.outputs.publish == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-x86_64
+            runner: macos-15-intel
+            target: x86_64-apple-darwin
+            cc: ""
+          - platform: macos-arm64
+            runner: macos-14
+            target: aarch64-apple-darwin
+            cc: ""
+          - platform: linux-x86_64
+            runner: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+            cc: musl-gcc
+          - platform: linux-arm64
+            runner: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-musl
+            cc: musl-gcc
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: 1.85.1
+          targets: ${{ matrix.target }}
+      - name: Install Linux cross tools
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install --yes musl-tools
+      - name: Build the host kobo command
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          CC_x86_64_unknown_linux_musl: ${{ matrix.cc }}
+          CC_aarch64_unknown_linux_musl: ${{ matrix.cc }}
+        run: cargo build --locked --release -p kobo-cli --target "${{ matrix.target }}"
+      - name: Stage the host binary
         run: |
-          asset="cobalt-${VERSION}-KoboRoot.tgz"
-          legacy_asset="cobalt-${VERSION}-ClaraBW-KoboRoot.tgz"
-          digest="cobalt-${VERSION}.sha256"
-          legacy_digest="cobalt-${VERSION}-ClaraBW.sha256"
-          mv dist/KoboRoot.tgz "dist/$asset"
-          cp "dist/$asset" "dist/$legacy_asset"
+          mkdir -p host
+          cp "target/${{ matrix.target }}/release/kobo" host/kobo
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: host-${{ matrix.platform }}
+          path: host/kobo
+          if-no-files-found: error
+
+  publish:
+    needs: [prepare, device, host]
+    if: needs.prepare.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: 1.85.1
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: device-package
+          path: dist
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: host-*
+          path: dist/host-binaries
+      - name: Arrange matrix artifacts
+        run: |
+          for platform in macos-x86_64 macos-arm64 linux-x86_64 linux-arm64; do
+            test -f "dist/host-binaries/host-${platform}/kobo"
+            mkdir -p "dist/host-binaries/${platform}"
+            mv "dist/host-binaries/host-${platform}/kobo" \
+              "dist/host-binaries/${platform}/kobo"
+          done
+      - name: Build deterministic host release assets
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          chmod +x tools/build-host-release.sh
+          tools/build-host-release.sh "$VERSION" beta "$GITHUB_SHA" dist
+          cp "dist/cobalt-${VERSION}-KoboRoot.tgz" \
+            "dist/cobalt-${VERSION}-ClaraBW-KoboRoot.tgz"
           cp THIRD-PARTY.md dist/
           cd dist
-          sha256sum THIRD-PARTY.md "$asset" "$legacy_asset" > "$digest"
-          cp "$digest" "$legacy_digest"
+          sha256sum THIRD-PARTY.md \
+            "cobalt-${VERSION}-KoboRoot.tgz" \
+            "cobalt-${VERSION}-ClaraBW-KoboRoot.tgz" > "cobalt-${VERSION}.sha256"
+          cp "cobalt-${VERSION}.sha256" "cobalt-${VERSION}-ClaraBW.sha256"
+      - name: Sign the release manifest
+        env:
+          COBALT_APP_SIGNING_SEED: ${{ secrets.COBALT_APP_SIGNING_SEED }}
+        run: |
+          test -n "$COBALT_APP_SIGNING_SEED" || {
+            echo "COBALT_APP_SIGNING_SEED is not configured" >&2
+            exit 1
+          }
+          seed="$RUNNER_TEMP/cobalt-release-seed"
+          trap 'rm -f "$seed"' EXIT
+          printf '%s' "$COBALT_APP_SIGNING_SEED" > "$seed"
+          chmod 600 "$seed"
+          cargo run --locked -p kobo-cli -- host-release-sign \
+            --manifest dist/cobalt-host-manifest.txt \
+            --seed "$seed" \
+            --signature dist/cobalt-host-manifest.txt.sig \
+            --ssh-signature dist/cobalt-host-manifest.txt.sshsig
       - name: Create the immutable isolated prerelease
-        if: steps.release.outputs.publish == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          api_get() {
-            output="$1"
-            endpoint="$2"
-            if ! status="$(curl --silent --show-error --location \
-              --retry 3 --retry-all-errors \
-              --header "Authorization: Bearer $GH_TOKEN" \
-              --header "Accept: application/vnd.github+json" \
-              --header "X-GitHub-Api-Version: 2022-11-28" \
-              --output "$output" --write-out '%{http_code}' \
-              "https://api.github.com/${endpoint}")"
-            then
-              echo "GitHub API request failed for $endpoint" >&2
-              return 2
-            fi
-            case "$status" in
-              200) return 0 ;;
-              404)
-                rm -f "$output"
-                return 1
-                ;;
-              *)
-                echo "GitHub API request for $endpoint returned HTTP $status" >&2
-                return 2
-                ;;
-            esac
-          }
-          require_absent() {
-            label="$1"
-            endpoint="$2"
-            state="$RUNNER_TEMP/${label}.json"
-            if api_get "$state" "$endpoint"; then
-              echo "$label already exists. Refusing to publish assets for an existing beta version." >&2
-              exit 1
-            else
-              lookup_status=$?
-              if [ "$lookup_status" -ne 1 ]; then
-                exit 1
-              fi
-            fi
-          }
           tag="beta-v${VERSION}"
-          require_absent "$tag tag" \
-            "repos/${GITHUB_REPOSITORY}/git/ref/tags/${tag}"
-          require_absent "$tag release" \
-            "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}"
-          created_sha="$(gh api \
-            --method POST \
-            "repos/${GITHUB_REPOSITORY}/git/refs" \
-            --field "ref=refs/tags/${tag}" \
-            --field "sha=${GITHUB_SHA}" \
-            --jq '.object.sha')"
-          test "$created_sha" = "$GITHUB_SHA"
+          test -z "$(git ls-remote --tags origin "refs/tags/$tag")"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "$tag already exists; refusing replacement" >&2
+            exit 1
+          fi
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+            --field "ref=refs/tags/${tag}" --field "sha=${GITHUB_SHA}" \
+            --jq '.object.sha' | grep -Fx "$GITHUB_SHA"
+          find dist -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} +
+          test "$(find dist -maxdepth 1 -type f | wc -l)" -eq 13
           gh release create "$tag" dist/* \
             --title "Cobalt ${VERSION} beta" \
             --notes "Immutable prerelease built from the beta branch at ${GITHUB_SHA}." \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - run: cargo fmt --all -- --check
       - name: Test the POSIX host installer
         run: |
-          sh -n install.sh tools/installer-test.sh tools/build-host-release.sh
+          sh -n install.sh docs/install.sh tools/installer-test.sh tools/build-host-release.sh
           tools/installer-test.sh
       - run: node --test tools/*.test.mjs
       - name: Require current generated app pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Install the ARM cross-compiler the packaging tests look for
         run: sudo apt-get update && sudo apt-get install --yes gcc-arm-linux-gnueabihf
       - run: cargo fmt --all -- --check
+      - name: Test the POSIX host installer
+        run: |
+          sh -n install.sh tools/installer-test.sh tools/build-host-release.sh
+          tools/installer-test.sh
       - run: node --test tools/*.test.mjs
       - name: Require current generated app pages
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,46 @@ jobs:
             --published-catalog published-state/cobalt-app-catalog.json \
             --base "$published_sha"
 
+  host-release-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-x86_64
+            runner: macos-15-intel
+            target: x86_64-apple-darwin
+            cc: ""
+          - platform: macos-arm64
+            runner: macos-14
+            target: aarch64-apple-darwin
+            cc: ""
+          - platform: linux-x86_64
+            runner: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+            cc: musl-gcc
+          - platform: linux-arm64
+            runner: ubuntu-22.04-arm
+            target: aarch64-unknown-linux-musl
+            cc: musl-gcc
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: 1.85.1
+          targets: ${{ matrix.target }}
+      - name: Install Linux host tools
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install --yes musl-tools
+      - name: Build release host binary
+        env:
+          CC_x86_64_unknown_linux_musl: ${{ matrix.cc }}
+          CC_aarch64_unknown_linux_musl: ${{ matrix.cc }}
+        run: |
+          cargo build --locked --release -p kobo-cli --target "${{ matrix.target }}"
+          test -x "target/${{ matrix.target }}/release/kobo"
+          echo "built ${{ matrix.platform }}"
+
   advisories:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/promote-beta.yml
+++ b/.github/workflows/promote-beta.yml
@@ -151,6 +151,8 @@ jobs:
             "$beta_ref"
           test "$(resolve_ref_commit "$beta_ref")" = "$TESTED_COMMIT"
           git cat-file -e "${TESTED_COMMIT}^{commit}"
+          git cat-file -e "${TESTED_COMMIT}:install.sh"
+          git cat-file -e "${TESTED_COMMIT}:docs/install.sh"
           git merge-base --is-ancestor "$TESTED_COMMIT" HEAD
           stable_tag="v${VERSION}"
           require_absent "$stable_tag tag" \
@@ -181,14 +183,13 @@ jobs:
           test -f "$digest"
           test -f "cobalt-${VERSION}-ClaraBW.sha256"
           test -f THIRD-PARTY.md
-          test -f install.sh
           test -f cobalt-host-manifest.txt
           test -f cobalt-host-manifest.txt.sig
           test -f cobalt-host-manifest.txt.sshsig
           for platform in macos-x86_64 macos-arm64 linux-x86_64 linux-arm64; do
             test -f "kobo-${VERSION}-${platform}.tar.gz"
           done
-          test "$(find . -maxdepth 1 -type f | wc -l)" -eq 13
+          test "$(find . -maxdepth 1 -type f | wc -l)" -eq 12
           grep -Eq "^[0-9a-f]{64}  ${asset}$" "$digest"
           grep -Eq "^[0-9a-f]{64}  ${legacy_asset}$" "$digest"
           cmp "$digest" "cobalt-${VERSION}-ClaraBW.sha256"
@@ -211,6 +212,7 @@ jobs:
             -s cobalt-host-manifest.txt.sshsig \
             < cobalt-host-manifest.txt
           rm allowed_signers
+          git show "${TESTED_COMMIT}:install.sh" > install.sh
           while read -r kind first second third fourth; do
             case "$kind" in
               device)
@@ -236,6 +238,7 @@ jobs:
             test "$(wc -c < "$name" | tr -d ' ')" = "$bytes"
             test "$(sha256sum "$name" | cut -d' ' -f1)" = "$checksum"
           done < cobalt-host-manifest.txt
+          test "$(find . -maxdepth 1 -type f | wc -l)" -eq 13
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           toolchain: 1.85.1
@@ -306,5 +309,5 @@ jobs:
           test "$created_sha" = "$TESTED_COMMIT"
           gh release create "$tag" dist/* \
             --title "Cobalt ${VERSION}" \
-            --notes "Promoted unchanged from tested beta-v${VERSION}." \
+            --notes "Promoted verified artifacts from tested beta-v${VERSION}." \
             --latest

--- a/.github/workflows/promote-beta.yml
+++ b/.github/workflows/promote-beta.yml
@@ -170,6 +170,7 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           EXPECTED_ARCHIVE_SHA256: ${{ inputs.expected_archive_sha256 }}
+          TESTED_COMMIT: ${{ inputs.tested_commit }}
         run: |
           cd dist
           asset="cobalt-${VERSION}-KoboRoot.tgz"
@@ -180,7 +181,14 @@ jobs:
           test -f "$digest"
           test -f "cobalt-${VERSION}-ClaraBW.sha256"
           test -f THIRD-PARTY.md
-          test "$(find . -maxdepth 1 -type f | wc -l)" -eq 5
+          test -f install.sh
+          test -f cobalt-host-manifest.txt
+          test -f cobalt-host-manifest.txt.sig
+          test -f cobalt-host-manifest.txt.sshsig
+          for platform in macos-x86_64 macos-arm64 linux-x86_64 linux-arm64; do
+            test -f "kobo-${VERSION}-${platform}.tar.gz"
+          done
+          test "$(find . -maxdepth 1 -type f | wc -l)" -eq 13
           grep -Eq "^[0-9a-f]{64}  ${asset}$" "$digest"
           grep -Eq "^[0-9a-f]{64}  ${legacy_asset}$" "$digest"
           cmp "$digest" "cobalt-${VERSION}-ClaraBW.sha256"
@@ -189,6 +197,53 @@ jobs:
           test "$primary_digest" = "$EXPECTED_ARCHIVE_SHA256"
           sha256sum --check "$digest"
           sha256sum --check "cobalt-${VERSION}-ClaraBW.sha256"
+          test "$(sed -n '1p' cobalt-host-manifest.txt)" = "cobalt-host-release 1"
+          grep -Fx "version ${VERSION}" cobalt-host-manifest.txt
+          grep -Fx "channels stable,beta" cobalt-host-manifest.txt
+          grep -Fx "source ${TESTED_COMMIT}" cobalt-host-manifest.txt
+          printf '%s\n' \
+            'cobalt-release ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL7XUR3p+tvPgftO/kRbigc8gagzP2RBDG3tWIu/1KXe' \
+            > allowed_signers
+          ssh-keygen -Y verify -q \
+            -f allowed_signers \
+            -I cobalt-release \
+            -n cobalt-host-release \
+            -s cobalt-host-manifest.txt.sshsig \
+            < cobalt-host-manifest.txt
+          rm allowed_signers
+          while read -r kind first second third fourth; do
+            case "$kind" in
+              device)
+                name=$first
+                bytes=$second
+                checksum=$third
+                test -z "${fourth:-}"
+                ;;
+              bootstrap)
+                name=$first
+                bytes=$second
+                checksum=$third
+                test -z "${fourth:-}"
+                ;;
+              host)
+                name=$second
+                bytes=$third
+                checksum=$fourth
+                ;;
+              *) continue ;;
+            esac
+            test -f "$name"
+            test "$(wc -c < "$name" | tr -d ' ')" = "$bytes"
+            test "$(sha256sum "$name" | cut -d' ' -f1)" = "$checksum"
+          done < cobalt-host-manifest.txt
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: 1.85.1
+      - name: Verify the in-process release signature
+        run: |
+          cargo run --locked -p kobo-cli -- host-release-verify \
+            --manifest dist/cobalt-host-manifest.txt \
+            --signature dist/cobalt-host-manifest.txt.sig
       - name: Publish the exact verified bytes as stable
         env:
           GH_TOKEN: ${{ github.token }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "icon-import"
-version = "0.3.3"
+version = "0.3.4"
 
 [[package]]
 name = "image"
@@ -548,14 +548,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-abi"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "kobo-app-store"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-arxiv"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-audiobook"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-doc",
  "kobo-json",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-bookview"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-brief"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-chat"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -614,25 +614,27 @@ dependencies = [
 
 [[package]]
 name = "kobo-cli"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-app-store",
  "kobo-image",
  "kobo-json",
  "kobo-net",
+ "kobo-profile",
  "kobo-sim",
+ "ring",
 ]
 
 [[package]]
 name = "kobo-dict"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "unicode-normalization",
 ]
 
 [[package]]
 name = "kobo-doc"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-html",
  "miniz_oxide 0.9.1",
@@ -641,7 +643,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doctor"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -649,14 +651,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-gallery"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-guard"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -664,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gutenbird"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -677,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-hal"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-abi",
  "kobo-doc",
@@ -688,21 +690,21 @@ dependencies = [
 
 [[package]]
 name = "kobo-handoff"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-hello"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-hn"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -712,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-html"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "ratex-layout",
  "ratex-parser",
@@ -722,18 +724,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-image"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "image",
 ]
 
 [[package]]
 name = "kobo-json"
-version = "0.3.3"
+version = "0.3.4"
 
 [[package]]
 name = "kobo-launcher"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -741,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-magnet"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -749,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-morse"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -757,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-net"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "http",
  "httparse",
@@ -769,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-opds"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-json",
  "kobo-xml",
@@ -777,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-policy"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-abi",
  "kobo-dict",
@@ -787,18 +789,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-profile"
-version = "0.3.3"
+version = "0.3.4"
 
 [[package]]
 name = "kobo-protocol"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-ui",
 ]
 
 [[package]]
 name = "kobo-read"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -811,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-rss"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -822,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sdk"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-policy",
  "kobo-protocol",
@@ -832,7 +834,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-settings"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -840,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-shell"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-abi",
  "kobo-policy",
@@ -849,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekick"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -858,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekickd"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -866,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sim"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-net",
  "kobo-policy",
@@ -879,14 +881,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-smoke"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-store"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -895,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sudoku"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -903,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tap"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -912,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-term"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-ui",
  "vt100",
@@ -920,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-terminal"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-policy",
  "kobo-sdk",
@@ -931,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-text"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "fontdue",
  "kobo-ui",
@@ -941,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tictactoe"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -949,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-todo"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -957,18 +959,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-ui"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "kobo-xml"
-version = "0.3.3"
+version = "0.3.4"
 
 [[package]]
 name = "kobo-zotero-reader"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -979,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "kobod"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64",
  "kobo-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,6 +836,7 @@ dependencies = [
 name = "kobo-settings"
 version = "0.3.4"
 dependencies = [
+ "kobo-app-store",
  "kobo-json",
  "kobo-sdk",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 rust-version = "1.85.1"
 license = "AGPL-3.0-only"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -19,8 +19,8 @@ exist in the registry at the same version.
 Runtime binaries, CLI tools and examples are distributed from this repository,
 not as library crates. The beta workflow builds the device package and the
 `kobo` host command for macOS x86_64/arm64 and Linux x86_64/arm64. Host archives
-carry the project license, dependency terms, third-party notices, and exact
-source commit.
+carry the command, the verified updater used by `kobo update`, the project
+license, dependency terms, third-party notices, and exact source commit.
 
 ## Stable and beta platform channels
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -57,4 +57,8 @@ The long-lived `beta` branch is the only source for beta publishing:
   targeting the tested commit. It never rebuilds or replaces a tag or release.
 
 Promotion is never automatic. Merge the tested beta commit to main first so
-the main workspace version matches the artifact being promoted.
+the main workspace version matches the artifact being promoted. GitHub Pages
+continues to publish `main:/docs`; after that merge, `docs/install.sh` becomes
+the canonical stable discovery URL at
+`https://bandarlabs.github.io/Cobalt/install.sh`. The first beta must use its
+exact `beta-vX.Y.Z` release asset because beta does not publish Pages.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -37,8 +37,8 @@ The long-lived `beta` branch is the only source for beta publishing:
   must advance the workspace version for every published test build; an
   existing beta tag or release is never moved or replaced. Assets retain the
   stable deterministic names, including `cobalt-X.Y.Z-KoboRoot.tgz` and
-  `cobalt-X.Y.Z.sha256`. It also publishes `install.sh`, four
-  `kobo-X.Y.Z-<platform>.tar.gz` archives, and a versioned host manifest.
+  `cobalt-X.Y.Z.sha256`. It also publishes four
+  `kobo-X.Y.Z-<platform>.tar.gz` archives and a versioned host manifest.
   The manifest fixes every host/device asset name, size, SHA-256, version, and
   source commit. The protected `COBALT_APP_SIGNING_SEED` signs it twice with
   the repository's existing Ed25519 release key: raw detached form for
@@ -53,12 +53,14 @@ The long-lived `beta` branch is the only source for beta publishing:
   prerelease tag to target that commit, requires the commit to be in current
   main, enforces the workspace version, verifies the downloaded checksum
   files, both manifest signatures, all host/device manifest entries, and the
-  expected archive digest, then publishes those exact bytes as `vX.Y.Z`
-  targeting the tested commit. It never rebuilds or replaces a tag or release.
+  expected archive digest. It takes `install.sh` from the exact tested commit,
+  verifies it against the signed bootstrap manifest entry, and publishes the
+  stable release without rebuilding any binary. It never replaces a tag or
+  release.
 
 Promotion is never automatic. Merge the tested beta commit to main first so
 the main workspace version matches the artifact being promoted. GitHub Pages
 continues to publish `main:/docs`; after that merge, `docs/install.sh` becomes
 the canonical stable discovery URL at
-`https://bandarlabs.github.io/Cobalt/install.sh`. The first beta must use its
-exact `beta-vX.Y.Z` release asset because beta does not publish Pages.
+`https://bandarlabs.github.io/Cobalt/install.sh`. Beta does not publish a
+public host bootstrap; owners opt into beta later through Cobalt Settings.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -44,7 +44,9 @@ The long-lived `beta` branch is the only source for beta publishing:
   the repository's existing Ed25519 release key: raw detached form for
   in-process verification and standard OpenSSH SSHSIG form for the POSIX
   bootstrap. Pull-request tests use disposable fixture keys and never require
-  the protected seed.
+  the protected seed. Cobalt Settings and background platform updates verify
+  the raw signature for both Stable and Beta before accepting the device
+  archive digest.
 - `.github/workflows/apps.yml` publishes beta branch apps only to
   `app-catalog-beta`; main continues to publish only to `app-catalog`.
 - `.github/workflows/promote-beta.yml` is a manual, guarded promotion. Supply

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -17,11 +17,10 @@ packaging, so `kobo-sdk` cannot complete its dry run until the preceding crates
 exist in the registry at the same version.
 
 Runtime binaries, CLI tools and examples are distributed from this repository,
-not as library crates. Pushing a tag `vX.Y.Z` from a clean commit runs the
-[release workflow](.github/workflows/release.yml), which checks the tag against
-the workspace version, builds the device package per profile, and publishes a
-GitHub release with assets named `cobalt-X.Y.Z-<device>-KoboRoot.tgz` alongside
-their checksums and third-party notices.
+not as library crates. The beta workflow builds the device package and the
+`kobo` host command for macOS x86_64/arm64 and Linux x86_64/arm64. Host archives
+carry the project license, dependency terms, third-party notices, and exact
+source commit.
 
 ## Stable and beta platform channels
 
@@ -38,7 +37,14 @@ The long-lived `beta` branch is the only source for beta publishing:
   must advance the workspace version for every published test build; an
   existing beta tag or release is never moved or replaced. Assets retain the
   stable deterministic names, including `cobalt-X.Y.Z-KoboRoot.tgz` and
-  `cobalt-X.Y.Z.sha256`.
+  `cobalt-X.Y.Z.sha256`. It also publishes `install.sh`, four
+  `kobo-X.Y.Z-<platform>.tar.gz` archives, and a versioned host manifest.
+  The manifest fixes every host/device asset name, size, SHA-256, version, and
+  source commit. The protected `COBALT_APP_SIGNING_SEED` signs it twice with
+  the repository's existing Ed25519 release key: raw detached form for
+  in-process verification and standard OpenSSH SSHSIG form for the POSIX
+  bootstrap. Pull-request tests use disposable fixture keys and never require
+  the protected seed.
 - `.github/workflows/apps.yml` publishes beta branch apps only to
   `app-catalog-beta`; main continues to publish only to `app-catalog`.
 - `.github/workflows/promote-beta.yml` is a manual, guarded promotion. Supply
@@ -46,9 +52,9 @@ The long-lived `beta` branch is the only source for beta publishing:
   SHA-256, and the exact confirmation `promote-beta-vX.Y.Z`. It requires the
   prerelease tag to target that commit, requires the commit to be in current
   main, enforces the workspace version, verifies the downloaded checksum
-  files and expected archive digest, and publishes those exact bytes as
-  `vX.Y.Z` targeting the tested commit. It never rebuilds or replaces a tag or
-  release.
+  files, both manifest signatures, all host/device manifest entries, and the
+  expected archive digest, then publishes those exact bytes as `vX.Y.Z`
+  targeting the tested commit. It never rebuilds or replaces a tag or release.
 
 Promotion is never automatic. Merge the tested beta commit to main first so
 the main workspace version matches the artifact being promoted.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -46,7 +46,9 @@ The long-lived `beta` branch is the only source for beta publishing:
   bootstrap. Pull-request tests use disposable fixture keys and never require
   the protected seed. Cobalt Settings and background platform updates verify
   the raw signature for both Stable and Beta before accepting the device
-  archive digest.
+  archive digest. The same host packages support `kobo update`; its default is
+  Stable and its Beta host channel is explicit and independent from the
+  in-product platform channel.
 - `.github/workflows/apps.yml` publishes beta branch apps only to
   `app-catalog-beta`; main continues to publish only to `app-catalog`.
 - `.github/workflows/promote-beta.yml` is a manual, guarded promotion. Supply

--- a/README.md
+++ b/README.md
@@ -144,11 +144,22 @@ of `install.sh`, use the recommended
 [signed-bootstrap procedure](docs/INSTALL.md#high-assurance-signed-bootstrap).
 
 The installer supports macOS Intel and Apple Silicon, and Linux x86_64 and
-arm64. It installs stable Cobalt only. Beta participation is enabled later in
-Cobalt Settings, or through the developer/source workflow. Settings shows the
-installed version and current channel, confirms channel changes explicitly,
-and verifies signed Beta platform metadata. Returning to Stable needs no USB
-connection and preserves installed apps, state, and secrets.
+arm64. It installs the stable Kobo platform only. The platform Beta channel is
+enabled exclusively in Cobalt Settings after first launch, or through the
+developer/source workflow. Settings shows the installed version and current
+channel, confirms channel changes explicitly, and verifies signed Beta
+platform metadata. Returning to Stable needs no USB connection and preserves
+installed apps, state, and secrets.
+
+Update the installed host command independently:
+
+```sh
+kobo update
+kobo update --channel beta   # explicit host CLI beta; never writes to a reader
+```
+
+The host CLI channel does not select the Kobo platform channel. Device Beta
+updates remain an explicit choice in Cobalt Settings.
 
 Rerun the same command to update. Restart the reader, wait one minute for
 NickelMenu's failsafe, then open **Cobalt** from Kobo's menu. Future

--- a/README.md
+++ b/README.md
@@ -135,16 +135,22 @@ On macOS or Linux, install the stable release:
 curl -fsSL https://github.com/BandarLabs/Cobalt/releases/latest/download/install.sh | sh
 ```
 
-The installer verifies the signed release manifest and SHA-256 checksums,
-installs the `kobo` command without sudo, then guides the USB setup. It supports
-macOS Intel and Apple Silicon, and Linux x86_64 and arm64.
+This convenience command trusts GitHub HTTPS for the bootstrap script itself.
+After it starts, every downloaded executable and device package is covered by
+the signed release manifest and SHA-256 checks. For pre-execution verification
+of `install.sh`, use the recommended
+[signed-bootstrap procedure](docs/INSTALL.md#high-assurance-signed-bootstrap).
 
-Beta is explicit:
+The first beta installer is available from its exact beta release; it does not
+depend on a stable release already containing `install.sh`:
 
 ```sh
-curl -fsSL https://github.com/BandarLabs/Cobalt/releases/latest/download/install.sh |
-  sh -s -- --beta
+curl -fsSL https://github.com/BandarLabs/Cobalt/releases/download/beta-v0.3.4/install.sh |
+  sh -s -- --beta --version 0.3.4
 ```
+
+The installer supports macOS Intel and Apple Silicon, and Linux x86_64 and
+arm64. Stable remains the default; beta is explicit.
 
 Rerun the same command to update. Restart the reader, wait one minute for
 NickelMenu's failsafe, then open **Cobalt** from Kobo's menu. Future

--- a/README.md
+++ b/README.md
@@ -132,10 +132,12 @@ the [app request thread](https://github.com/BandarLabs/Cobalt/issues/41).
 On macOS or Linux, install the stable release:
 
 ```sh
-curl -fsSL https://github.com/BandarLabs/Cobalt/releases/latest/download/install.sh | sh
+curl -fsSL https://bandarlabs.github.io/Cobalt/install.sh | sh
 ```
 
-This convenience command trusts GitHub HTTPS for the bootstrap script itself.
+This canonical discovery URL is published by GitHub Pages from stable
+`main:/docs`; it becomes available with the first stable promotion containing
+the installer. It trusts GitHub Pages HTTPS for the bootstrap script itself.
 After it starts, every downloaded executable and device package is covered by
 the signed release manifest and SHA-256 checks. For pre-execution verification
 of `install.sh`, use the recommended
@@ -150,7 +152,8 @@ curl -fsSL https://github.com/BandarLabs/Cobalt/releases/download/beta-v0.3.4/in
 ```
 
 The installer supports macOS Intel and Apple Silicon, and Linux x86_64 and
-arm64. Stable remains the default; beta is explicit.
+arm64. The Pages bootstrap is channel-agnostic and accepts `--beta`, but the
+first beta must use the exact release URL above because Pages is stable-only.
 
 Rerun the same command to update. Restart the reader, wait one minute for
 NickelMenu's failsafe, then open **Cobalt** from Kobo's menu. Future

--- a/README.md
+++ b/README.md
@@ -129,29 +129,32 @@ the [app request thread](https://github.com/BandarLabs/Cobalt/issues/41).
 
 ## Install
 
-Install [rustup](https://rustup.rs), let it install the stable Rust toolchain,
-then add the ARM target and connect a charged, fully supported reader over USB.
-You do not need a separate operating-system `rust` package; rustup supplies
-`rustc` and `cargo`:
+On macOS or Linux, install the stable release:
 
 ```sh
-rustup toolchain install stable
-git clone https://github.com/BandarLabs/Cobalt.git
-cd Cobalt
-rustup override set stable
-rustup target add armv7-unknown-linux-musleabihf
-cargo run -p kobo-cli -- setup
+curl -fsSL https://github.com/BandarLabs/Cobalt/releases/latest/download/install.sh | sh
 ```
 
-Restart the reader and open **Cobalt** from Kobo's menu. Future applications
-are installed from **Store** over Wi-Fi. Full Cobalt updates remain under
-**Settings**.
+The installer verifies the signed release manifest and SHA-256 checksums,
+installs the `kobo` command without sudo, then guides the USB setup. It supports
+macOS Intel and Apple Silicon, and Linux x86_64 and arm64.
+
+Beta is explicit:
+
+```sh
+curl -fsSL https://github.com/BandarLabs/Cobalt/releases/latest/download/install.sh |
+  sh -s -- --beta
+```
+
+Rerun the same command to update. Restart the reader, wait one minute for
+NickelMenu's failsafe, then open **Cobalt** from Kobo's menu. Future
+applications are installed from **Store** over Wi-Fi.
 
 If you already use NickelMenu, Cobalt is added to it; existing entries are
 left alone.
 
 See [docs/INSTALL.md](docs/INSTALL.md) for the complete walkthrough and
-recovery steps.
+recovery, uninstall, and source-build instructions.
 
 ## App Store
 

--- a/README.md
+++ b/README.md
@@ -143,17 +143,9 @@ the signed release manifest and SHA-256 checks. For pre-execution verification
 of `install.sh`, use the recommended
 [signed-bootstrap procedure](docs/INSTALL.md#high-assurance-signed-bootstrap).
 
-The first beta installer is available from its exact beta release; it does not
-depend on a stable release already containing `install.sh`:
-
-```sh
-curl -fsSL https://github.com/BandarLabs/Cobalt/releases/download/beta-v0.3.4/install.sh |
-  sh -s -- --beta --version 0.3.4
-```
-
 The installer supports macOS Intel and Apple Silicon, and Linux x86_64 and
-arm64. The Pages bootstrap is channel-agnostic and accepts `--beta`, but the
-first beta must use the exact release URL above because Pages is stable-only.
+arm64. It installs stable Cobalt only. Beta participation is enabled later in
+Cobalt Settings, or through the developer/source workflow.
 
 Rerun the same command to update. Restart the reader, wait one minute for
 NickelMenu's failsafe, then open **Cobalt** from Kobo's menu. Future

--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ of `install.sh`, use the recommended
 
 The installer supports macOS Intel and Apple Silicon, and Linux x86_64 and
 arm64. It installs stable Cobalt only. Beta participation is enabled later in
-Cobalt Settings, or through the developer/source workflow.
+Cobalt Settings, or through the developer/source workflow. Settings shows the
+installed version and current channel, confirms channel changes explicitly,
+and verifies signed Beta platform metadata. Returning to Stable needs no USB
+connection and preserves installed apps, state, and secrets.
 
 Rerun the same command to update. Restart the reader, wait one minute for
 NickelMenu's failsafe, then open **Cobalt** from Kobo's menu. Future

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,9 @@ only its public key belongs in the repository.
 
 The canonical one-line `curl | sh` route trusts GitHub Pages HTTPS for the
 discovery bootstrap itself; it is not protected retroactively by the manifest
-it later downloads. Pages fixes stable discovery, not self-verification.
+it later downloads. Pages fixes stable discovery, not self-verification. The
+public bootstrap installs stable only; beta remains an authenticated
+in-product update-channel choice after installation.
 The installation guide therefore provides a recommended high-assurance route
 that downloads `install.sh` as data and verifies its signed-manifest entry
 before execution using an out-of-band pinned OpenSSH Ed25519 key.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,6 +44,13 @@ release manifest before accepting the device archive digest; background
 updates use the same signed metadata. Returning to Stable changes only the
 persisted preference and never removes or downgrades apps or owner data.
 
+`kobo update` is a host-only operation using the verified updater stored by the
+stable installer. It reuses the installer lock, platform detection, SSHSIG
+manifest verification, archive length/SHA-256 checks, conflict checks, and
+atomic binary replacement. Stable is the default; `--channel beta` is explicit
+and changes only the host CLI. It does not discover or write mounted readers,
+and the cached USB setup package remains Stable.
+
 After either bootstrap starts, it verifies the signed versioned manifest before
 parsing it, then checks the selected host archive and device package against
 the manifest's exact byte lengths and SHA-256 digests. `kobo setup`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,9 +47,16 @@ persisted preference and never removes or downgrades apps or owner data.
 `kobo update` is a host-only operation using the verified updater stored by the
 stable installer. It reuses the installer lock, platform detection, SSHSIG
 manifest verification, archive length/SHA-256 checks, conflict checks, and
-atomic binary replacement. Stable is the default; `--channel beta` is explicit
-and changes only the host CLI. It does not discover or write mounted readers,
-and the cached USB setup package remains Stable.
+atomic activation. Stable is the default; `--channel beta` is explicit and
+changes only the host CLI. It does not discover or write mounted readers, and
+the cached USB setup package remains Stable.
+
+Host packages are installed into immutable version/channel/platform directories
+containing the CLI and its verified next updater. One atomically replaced
+`current` selector file selects the complete pair; the public `kobo` command
+link and stable setup state do not change during host updates. An interruption
+before the selector leaves the old pair live, and an interruption after it
+leaves the complete new pair live.
 
 After either bootstrap starts, it verifies the signed versioned manifest before
 parsing it, then checks the selected host archive and device package against

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,8 +28,9 @@ built-in `store` application. Full Cobalt replacement is a distinct
 Settings-only operation. The public signing seed is release infrastructure:
 only its public key belongs in the repository.
 
-The one-line `curl | sh` route trusts GitHub HTTPS for the bootstrap script
-itself; it is not protected retroactively by the manifest it later downloads.
+The canonical one-line `curl | sh` route trusts GitHub Pages HTTPS for the
+discovery bootstrap itself; it is not protected retroactively by the manifest
+it later downloads. Pages fixes stable discovery, not self-verification.
 The installation guide therefore provides a recommended high-assurance route
 that downloads `install.sh` as data and verifies its signed-manifest entry
 before execution using an out-of-band pinned OpenSSH Ed25519 key.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,6 +37,13 @@ The installation guide therefore provides a recommended high-assurance route
 that downloads `install.sh` as data and verifies its signed-manifest entry
 before execution using an out-of-band pinned OpenSSH Ed25519 key.
 
+Cobalt Settings shows the installed version and persisted update channel before
+offering a change. Channel changes require a separate confirmation screen.
+Stable and Beta platform checks both require the raw Ed25519 signature over the
+release manifest before accepting the device archive digest; background
+updates use the same signed metadata. Returning to Stable changes only the
+persisted preference and never removes or downgrades apps or owner data.
+
 After either bootstrap starts, it verifies the signed versioned manifest before
 parsing it, then checks the selected host archive and device package against
 the manifest's exact byte lengths and SHA-256 digests. `kobo setup`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,10 +28,17 @@ built-in `store` application. Full Cobalt replacement is a distinct
 Settings-only operation. The public signing seed is release infrastructure:
 only its public key belongs in the repository.
 
-The host bootstrap uses the same Ed25519 trust root through OpenSSH's SSHSIG
-format. It verifies the signed versioned manifest before parsing it, then
-checks the selected host archive and device package against the manifest's
-exact byte lengths and SHA-256 digests. `kobo setup` independently verifies the
-raw detached manifest signature with its pinned public key before accepting a
-prebuilt device package. Downloads are staged under the user's cache; the host
-binary and release directory are activated by same-filesystem renames.
+The one-line `curl | sh` route trusts GitHub HTTPS for the bootstrap script
+itself; it is not protected retroactively by the manifest it later downloads.
+The installation guide therefore provides a recommended high-assurance route
+that downloads `install.sh` as data and verifies its signed-manifest entry
+before execution using an out-of-band pinned OpenSSH Ed25519 key.
+
+After either bootstrap starts, it verifies the signed versioned manifest before
+parsing it, then checks the selected host archive and device package against
+the manifest's exact byte lengths and SHA-256 digests. `kobo setup`
+independently verifies the raw detached manifest signature with its pinned
+public key before accepting a prebuilt device package. USB activation stages
+and verifies a complete managed directory, swaps whole directories with a
+previous-copy rollback, and recovers interrupted swaps before a rerun. Mutable
+owner folders are carried separately and never accepted from a release.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,3 +27,11 @@ Store catalog refresh, app install and app removal are accepted only from the
 built-in `store` application. Full Cobalt replacement is a distinct
 Settings-only operation. The public signing seed is release infrastructure:
 only its public key belongs in the repository.
+
+The host bootstrap uses the same Ed25519 trust root through OpenSSH's SSHSIG
+format. It verifies the signed versioned manifest before parsing it, then
+checks the selected host archive and device package against the manifest's
+exact byte lengths and SHA-256 digests. `kobo setup` independently verifies the
+raw detached manifest signature with its pinned public key before accepting a
+prebuilt device package. Downloads are staged under the user's cache; the host
+binary and release directory are activated by same-filesystem renames.

--- a/crates/kobo-app-store/src/lib.rs
+++ b/crates/kobo-app-store/src/lib.rs
@@ -10,6 +10,7 @@
 mod bundle;
 mod error;
 mod model;
+mod release;
 mod signing;
 
 pub use bundle::{build_bundle, parse_bundle, parse_public_bundle, ParsedBundle};
@@ -18,6 +19,7 @@ pub use model::{
     cobalt_version_at_least, is_public_glyph, is_public_reserved_app_id, public_reserved_app_ids,
     Catalog, CatalogEntry, CatalogEntryInput, Manifest, ManifestInput, Sha256Digest,
 };
+pub use release::{verify_release_manifest, ReleaseAsset, ReleaseManifest};
 pub use signing::{derive_public_key, sign, verify, DetachedSignature, Ed25519PublicKey};
 
 /// JSON schema version understood by this crate.

--- a/crates/kobo-app-store/src/release.rs
+++ b/crates/kobo-app-store/src/release.rs
@@ -1,0 +1,209 @@
+use crate::{verify, DetachedSignature, Ed25519PublicKey, PUBLIC_RELEASE_KEY_HEX};
+
+const MAX_RELEASE_MANIFEST_BYTES: usize = 64 * 1024;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReleaseAsset {
+    pub kind: String,
+    pub platform: Option<String>,
+    pub name: String,
+    pub bytes: u64,
+    pub sha256: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReleaseManifest {
+    pub version: String,
+    pub channels: Vec<String>,
+    pub source: String,
+    pub assets: Vec<ReleaseAsset>,
+}
+
+impl ReleaseManifest {
+    /// Parses the canonical host/platform release manifest.
+    ///
+    /// # Errors
+    ///
+    /// Returns a description of the first malformed or missing field.
+    pub fn parse(bytes: &[u8]) -> Result<Self, String> {
+        if bytes.len() > MAX_RELEASE_MANIFEST_BYTES {
+            return Err("release manifest is too large".to_owned());
+        }
+        let text =
+            std::str::from_utf8(bytes).map_err(|_| "release manifest is not UTF-8".to_owned())?;
+        if !text.ends_with('\n') {
+            return Err("release manifest must end with a newline".to_owned());
+        }
+        let mut lines = text.lines();
+        if lines.next() != Some("cobalt-host-release 1") {
+            return Err("unsupported release manifest format".to_owned());
+        }
+        let version = field(lines.next(), "version")?;
+        if !valid_version(&version) {
+            return Err("release manifest has an invalid version".to_owned());
+        }
+        let channel_text = lines
+            .next()
+            .and_then(|line| line.strip_prefix("channels "))
+            .ok_or_else(|| "release manifest has no channels".to_owned())?
+            .to_owned();
+        let channels = channel_text
+            .split(',')
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+        if channels != ["stable", "beta"] {
+            return Err(
+                "release manifest must be promotable unchanged from beta to stable".to_owned(),
+            );
+        }
+        let source = field(lines.next(), "source")?;
+        if source.len() != 40 || !source.bytes().all(is_lower_hex) {
+            return Err("release manifest has an invalid source commit".to_owned());
+        }
+
+        let mut assets = Vec::new();
+        for line in lines {
+            let fields = line.split(' ').collect::<Vec<_>>();
+            let (kind, platform, name, byte_text, sha256) = match fields.as_slice() {
+                ["device", name, bytes, sha256] => ("device", None, *name, *bytes, *sha256),
+                ["bootstrap", name, bytes, sha256] => ("bootstrap", None, *name, *bytes, *sha256),
+                ["host", platform, name, bytes, sha256] => {
+                    ("host", Some((*platform).to_owned()), *name, *bytes, *sha256)
+                }
+                _ => return Err(format!("invalid release manifest line {line:?}")),
+            };
+            if !safe_token(name) || sha256.len() != 64 || !sha256.bytes().all(is_lower_hex) {
+                return Err(format!("invalid release asset line {line:?}"));
+            }
+            let bytes = byte_text
+                .parse::<u64>()
+                .map_err(|_| format!("invalid release asset size in {line:?}"))?;
+            if bytes == 0 {
+                return Err(format!("empty release asset in {line:?}"));
+            }
+            assets.push(ReleaseAsset {
+                kind: kind.to_owned(),
+                platform,
+                name: name.to_owned(),
+                bytes,
+                sha256: sha256.to_owned(),
+            });
+        }
+        if assets.iter().filter(|asset| asset.kind == "device").count() != 1 {
+            return Err("release manifest must name exactly one device package".to_owned());
+        }
+        if assets
+            .iter()
+            .filter(|asset| asset.kind == "bootstrap" && asset.name == "install.sh")
+            .count()
+            != 1
+        {
+            return Err("release manifest must name exactly one install.sh bootstrap".to_owned());
+        }
+        for platform in ["macos-x86_64", "macos-arm64", "linux-x86_64", "linux-arm64"] {
+            if assets
+                .iter()
+                .filter(|asset| asset.platform.as_deref() == Some(platform))
+                .count()
+                != 1
+            {
+                return Err(format!(
+                    "release manifest must name exactly one {platform} host package"
+                ));
+            }
+        }
+        Ok(Self {
+            version,
+            channels,
+            source,
+            assets,
+        })
+    }
+
+    #[must_use]
+    pub fn device(&self) -> Option<&ReleaseAsset> {
+        self.assets.iter().find(|asset| asset.kind == "device")
+    }
+
+    #[must_use]
+    pub fn allows_channel(&self, channel: &str) -> bool {
+        self.channels.iter().any(|allowed| allowed == channel)
+    }
+}
+
+/// Verifies and parses a raw detached Ed25519 release-manifest signature.
+///
+/// # Errors
+///
+/// Returns an error for malformed signatures, verification failure, or an
+/// invalid manifest.
+pub fn verify_release_manifest(
+    bytes: &[u8],
+    signature_hex: &str,
+) -> Result<ReleaseManifest, String> {
+    let signature = DetachedSignature::from_hex(signature_hex.trim())
+        .map_err(|error| format!("invalid release signature: {error}"))?;
+    let public = Ed25519PublicKey::from_hex(PUBLIC_RELEASE_KEY_HEX)
+        .map_err(|error| format!("invalid built-in release key: {error}"))?;
+    verify(bytes, &signature, &public)
+        .map_err(|_| "release manifest signature verification failed".to_owned())?;
+    ReleaseManifest::parse(bytes)
+}
+
+fn field(line: Option<&str>, name: &str) -> Result<String, String> {
+    let line = line.ok_or_else(|| format!("release manifest has no {name}"))?;
+    let prefix = format!("{name} ");
+    let value = line
+        .strip_prefix(&prefix)
+        .ok_or_else(|| format!("release manifest has no {name}"))?;
+    if !safe_token(value) {
+        return Err(format!("release manifest has an invalid {name}"));
+    }
+    Ok(value.to_owned())
+}
+
+fn valid_version(value: &str) -> bool {
+    let parts = value.split('.').collect::<Vec<_>>();
+    parts.len() == 3
+        && parts
+            .iter()
+            .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+fn safe_token(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
+fn is_lower_hex(byte: u8) -> bool {
+    byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest() -> Vec<u8> {
+        b"cobalt-host-release 1\nversion 0.3.4\nchannels stable,beta\nsource 0123456789abcdef0123456789abcdef01234567\ndevice cobalt-0.3.4-KoboRoot.tgz 12 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nbootstrap install.sh 13 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\nhost macos-x86_64 kobo-0.3.4-macos-x86_64.tar.gz 14 cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\nhost macos-arm64 kobo-0.3.4-macos-arm64.tar.gz 15 dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\nhost linux-x86_64 kobo-0.3.4-linux-x86_64.tar.gz 16 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\nhost linux-arm64 kobo-0.3.4-linux-arm64.tar.gz 17 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\n".to_vec()
+    }
+
+    #[test]
+    fn release_manifest_binds_both_channels_and_the_device_digest() {
+        let parsed = ReleaseManifest::parse(&manifest()).expect("manifest");
+        assert!(parsed.allows_channel("stable"));
+        assert!(parsed.allows_channel("beta"));
+        let device = parsed.device().expect("device");
+        assert_eq!(device.name, "cobalt-0.3.4-KoboRoot.tgz");
+        assert_eq!(device.sha256, "a".repeat(64));
+    }
+
+    #[test]
+    fn unsigned_or_malformed_release_metadata_is_refused() {
+        assert!(verify_release_manifest(&manifest(), &"0".repeat(128)).is_err());
+        let mut malformed = manifest();
+        malformed.extend_from_slice(b"version 9.9.9\n");
+        assert!(ReleaseManifest::parse(&malformed).is_err());
+    }
+}

--- a/crates/kobo-cli/Cargo.toml
+++ b/crates/kobo-cli/Cargo.toml
@@ -16,6 +16,8 @@ kobo-sim = { path = "../kobo-sim" }
 kobo-image = { path = "../kobo-image" }
 kobo-json = { path = "../kobo-json" }
 kobo-net = { path = "../kobo-net" }
+kobo-profile = { path = "../kobo-profile" }
+ring = "0.17"
 
 [features]
 default = []

--- a/crates/kobo-cli/src/host_release.rs
+++ b/crates/kobo-cli/src/host_release.rs
@@ -1,0 +1,365 @@
+//! Host release manifests and OpenSSH-compatible release signatures.
+//!
+//! Cobalt already uses one protected Ed25519 release key for the public app
+//! catalog. Host releases use the same established trust root. The raw
+//! detached signature is consumed by `kobo setup`; the SSHSIG spelling lets a
+//! bootstrap shell verify the same manifest with the `ssh-keygen` shipped by
+//! macOS and mainstream Linux distributions before it executes the download.
+
+use std::fmt::Write as _;
+
+use ring::digest::{digest, SHA512};
+
+pub const SIGNING_NAMESPACE: &str = "cobalt-host-release";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Asset {
+    pub kind: String,
+    pub platform: Option<String>,
+    pub name: String,
+    pub bytes: u64,
+    pub sha256: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Manifest {
+    pub version: String,
+    pub channels: Vec<String>,
+    pub source: String,
+    pub assets: Vec<Asset>,
+}
+
+impl Manifest {
+    pub fn parse(bytes: &[u8]) -> Result<Self, String> {
+        let text =
+            std::str::from_utf8(bytes).map_err(|_| "release manifest is not UTF-8".to_owned())?;
+        if !text.ends_with('\n') {
+            return Err("release manifest must end with a newline".to_owned());
+        }
+        let mut lines = text.lines();
+        if lines.next() != Some("cobalt-host-release 1") {
+            return Err("unsupported release manifest format".to_owned());
+        }
+        let version = field(lines.next(), "version")?;
+        if !valid_version(&version) {
+            return Err("release manifest has an invalid version".to_owned());
+        }
+        let channel_text = lines
+            .next()
+            .and_then(|line| line.strip_prefix("channels "))
+            .ok_or_else(|| "release manifest has no channels".to_owned())?
+            .to_owned();
+        let channels = channel_text
+            .split(',')
+            .map(ToOwned::to_owned)
+            .collect::<Vec<_>>();
+        if channels != ["stable", "beta"] {
+            return Err(
+                "release manifest must be promotable unchanged from beta to stable".to_owned(),
+            );
+        }
+        let source = field(lines.next(), "source")?;
+        if source.len() != 40 || !source.bytes().all(is_lower_hex) {
+            return Err("release manifest has an invalid source commit".to_owned());
+        }
+
+        let mut assets = Vec::new();
+        for line in lines {
+            let fields = line.split(' ').collect::<Vec<_>>();
+            let (kind, platform, name, byte_text, sha256) = match fields.as_slice() {
+                ["device", name, bytes, sha256] => ("device", None, *name, *bytes, *sha256),
+                ["bootstrap", name, bytes, sha256] => ("bootstrap", None, *name, *bytes, *sha256),
+                ["host", platform, name, bytes, sha256] => {
+                    ("host", Some((*platform).to_owned()), *name, *bytes, *sha256)
+                }
+                _ => return Err(format!("invalid release manifest line {line:?}")),
+            };
+            if !safe_token(name) || sha256.len() != 64 || !sha256.bytes().all(is_lower_hex) {
+                return Err(format!("invalid release asset line {line:?}"));
+            }
+            let bytes = byte_text
+                .parse::<u64>()
+                .map_err(|_| format!("invalid release asset size in {line:?}"))?;
+            if bytes == 0 {
+                return Err(format!("empty release asset in {line:?}"));
+            }
+            assets.push(Asset {
+                kind: kind.to_owned(),
+                platform,
+                name: name.to_owned(),
+                bytes,
+                sha256: sha256.to_owned(),
+            });
+        }
+        if assets.iter().filter(|asset| asset.kind == "device").count() != 1 {
+            return Err("release manifest must name exactly one device package".to_owned());
+        }
+        if assets
+            .iter()
+            .filter(|asset| asset.kind == "bootstrap" && asset.name == "install.sh")
+            .count()
+            != 1
+        {
+            return Err("release manifest must name exactly one install.sh bootstrap".to_owned());
+        }
+        for platform in ["macos-x86_64", "macos-arm64", "linux-x86_64", "linux-arm64"] {
+            if assets
+                .iter()
+                .filter(|asset| asset.platform.as_deref() == Some(platform))
+                .count()
+                != 1
+            {
+                return Err(format!(
+                    "release manifest must name exactly one {platform} host package"
+                ));
+            }
+        }
+        Ok(Self {
+            version,
+            channels,
+            source,
+            assets,
+        })
+    }
+
+    pub fn device(&self) -> &Asset {
+        self.assets
+            .iter()
+            .find(|asset| asset.kind == "device")
+            .expect("parse requires one device asset")
+    }
+
+    pub fn allows_channel(&self, channel: &str) -> bool {
+        self.channels.iter().any(|allowed| allowed == channel)
+    }
+}
+
+fn field(line: Option<&str>, name: &str) -> Result<String, String> {
+    let line = line.ok_or_else(|| format!("release manifest has no {name}"))?;
+    let prefix = format!("{name} ");
+    let value = line
+        .strip_prefix(&prefix)
+        .ok_or_else(|| format!("release manifest has no {name}"))?;
+    if !safe_token(value) {
+        return Err(format!("release manifest has an invalid {name}"));
+    }
+    Ok(value.to_owned())
+}
+
+fn valid_version(value: &str) -> bool {
+    let parts = value.split('.').collect::<Vec<_>>();
+    parts.len() == 3
+        && parts
+            .iter()
+            .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
+}
+
+fn safe_token(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
+fn is_lower_hex(byte: u8) -> bool {
+    byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)
+}
+
+pub fn verify_manifest(bytes: &[u8], signature_hex: &str) -> Result<Manifest, String> {
+    let signature = kobo_app_store::DetachedSignature::from_hex(signature_hex.trim())
+        .map_err(|error| format!("invalid release signature: {error}"))?;
+    let public = kobo_app_store::Ed25519PublicKey::from_hex(kobo_app_store::PUBLIC_RELEASE_KEY_HEX)
+        .map_err(|error| format!("invalid built-in release key: {error}"))?;
+    kobo_app_store::verify(bytes, &signature, &public)
+        .map_err(|_| "release manifest signature verification failed".to_owned())?;
+    Manifest::parse(bytes)
+}
+
+pub fn sign(
+    bytes: &[u8],
+    seed: &[u8; 32],
+) -> Result<(kobo_app_store::DetachedSignature, String), String> {
+    let signature =
+        kobo_app_store::sign(bytes, seed).map_err(|error| format!("sign manifest: {error}"))?;
+    Ok((signature, ssh_signature(bytes, seed)?))
+}
+
+fn ssh_signature(bytes: &[u8], seed: &[u8; 32]) -> Result<String, String> {
+    let public = kobo_app_store::derive_public_key(seed)
+        .map_err(|error| format!("derive release key: {error}"))?;
+    let mut public_blob = Vec::new();
+    push_string(&mut public_blob, b"ssh-ed25519");
+    push_string(&mut public_blob, public.as_bytes());
+
+    let message_hash = digest(&SHA512, bytes);
+    let mut signed = Vec::new();
+    signed.extend_from_slice(b"SSHSIG");
+    push_string(&mut signed, SIGNING_NAMESPACE.as_bytes());
+    push_string(&mut signed, b"");
+    push_string(&mut signed, b"sha512");
+    push_string(&mut signed, message_hash.as_ref());
+    let signature = kobo_app_store::sign(&signed, seed)
+        .map_err(|error| format!("sign SSH manifest: {error}"))?;
+
+    let mut signature_blob = Vec::new();
+    push_string(&mut signature_blob, b"ssh-ed25519");
+    push_string(&mut signature_blob, signature.as_bytes());
+
+    let mut sshsig = Vec::new();
+    sshsig.extend_from_slice(b"SSHSIG");
+    sshsig.extend_from_slice(&1_u32.to_be_bytes());
+    push_string(&mut sshsig, &public_blob);
+    push_string(&mut sshsig, SIGNING_NAMESPACE.as_bytes());
+    push_string(&mut sshsig, b"");
+    push_string(&mut sshsig, b"sha512");
+    push_string(&mut sshsig, &signature_blob);
+
+    let encoded = base64(&sshsig);
+    let mut armored = String::from("-----BEGIN SSH SIGNATURE-----\n");
+    for line in encoded.as_bytes().chunks(70) {
+        let _ = writeln!(armored, "{}", String::from_utf8_lossy(line));
+    }
+    armored.push_str("-----END SSH SIGNATURE-----\n");
+    Ok(armored)
+}
+
+#[cfg(test)]
+fn allowed_signer(public: &kobo_app_store::Ed25519PublicKey, identity: &str) -> String {
+    let mut public_blob = Vec::new();
+    push_string(&mut public_blob, b"ssh-ed25519");
+    push_string(&mut public_blob, public.as_bytes());
+    format!("{identity} ssh-ed25519 {}", base64(&public_blob))
+}
+
+fn push_string(out: &mut Vec<u8>, value: &[u8]) {
+    let length = u32::try_from(value.len()).expect("SSHSIG field fits u32");
+    out.extend_from_slice(&length.to_be_bytes());
+    out.extend_from_slice(value);
+}
+
+fn base64(bytes: &[u8]) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
+    for chunk in bytes.chunks(3) {
+        let first = u32::from(chunk[0]);
+        let second = u32::from(*chunk.get(1).unwrap_or(&0));
+        let third = u32::from(*chunk.get(2).unwrap_or(&0));
+        let value = (first << 16) | (second << 8) | third;
+        out.push(char::from(TABLE[((value >> 18) & 0x3f) as usize]));
+        out.push(char::from(TABLE[((value >> 12) & 0x3f) as usize]));
+        out.push(if chunk.len() > 1 {
+            char::from(TABLE[((value >> 6) & 0x3f) as usize])
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            char::from(TABLE[(value & 0x3f) as usize])
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest() -> Vec<u8> {
+        b"cobalt-host-release 1\nversion 0.3.3\nchannels stable,beta\nsource 0123456789abcdef0123456789abcdef01234567\ndevice cobalt-0.3.3-KoboRoot.tgz 12 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nbootstrap install.sh 11 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\nhost macos-x86_64 kobo-0.3.3-macos-x86_64.tar.gz 13 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\nhost macos-arm64 kobo-0.3.3-macos-arm64.tar.gz 14 cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\nhost linux-x86_64 kobo-0.3.3-linux-x86_64.tar.gz 15 dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\nhost linux-arm64 kobo-0.3.3-linux-arm64.tar.gz 16 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\n".to_vec()
+    }
+
+    #[test]
+    fn strict_manifest_names_every_supported_host_and_one_device() {
+        let parsed = Manifest::parse(&manifest()).expect("manifest");
+        assert_eq!(parsed.version, "0.3.3");
+        assert!(parsed.allows_channel("stable"));
+        assert!(parsed.allows_channel("beta"));
+        assert_eq!(parsed.device().bytes, 12);
+        let mut missing = manifest();
+        let start = String::from_utf8(missing.clone())
+            .expect("text")
+            .find("host linux-arm64")
+            .expect("line");
+        missing.truncate(start);
+        assert!(Manifest::parse(&missing)
+            .expect_err("missing platform")
+            .contains("linux-arm64"));
+    }
+
+    #[test]
+    fn raw_signature_verifies_and_detects_changes() {
+        let bytes = manifest();
+        let seed = [7_u8; 32];
+        let public = kobo_app_store::derive_public_key(&seed).expect("key");
+        let signature = kobo_app_store::sign(&bytes, &seed).expect("signature");
+        kobo_app_store::verify(&bytes, &signature, &public).expect("verify");
+        let mut changed = bytes;
+        changed[30] ^= 1;
+        assert!(kobo_app_store::verify(&changed, &signature, &public).is_err());
+        assert!(verify_manifest(&manifest(), &"00".repeat(64))
+            .expect_err("wrong release signature")
+            .contains("verification failed"));
+    }
+
+    #[test]
+    fn ssh_signature_is_armored_and_deterministic() {
+        let first = ssh_signature(&manifest(), &[7_u8; 32]).expect("signature");
+        let second = ssh_signature(&manifest(), &[7_u8; 32]).expect("signature");
+        assert_eq!(first, second);
+        assert!(first.starts_with("-----BEGIN SSH SIGNATURE-----\n"));
+        assert!(first.ends_with("-----END SSH SIGNATURE-----\n"));
+    }
+
+    #[test]
+    fn ssh_keygen_accepts_the_generated_signature() {
+        use std::fs;
+        use std::process::{Command, Stdio};
+
+        let seed = [7_u8; 32];
+        let public = kobo_app_store::derive_public_key(&seed).expect("key");
+        let root = std::env::temp_dir().join(format!(
+            "cobalt-sshsig-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).expect("directory");
+        let manifest_path = root.join("manifest");
+        let signature_path = root.join("manifest.sshsig");
+        let signers_path = root.join("allowed_signers");
+        fs::write(&manifest_path, manifest()).expect("manifest");
+        fs::write(
+            &signature_path,
+            ssh_signature(&manifest(), &seed).expect("signature"),
+        )
+        .expect("signature file");
+        fs::write(
+            &signers_path,
+            format!("{}\n", allowed_signer(&public, SIGNING_IDENTITY_FOR_TEST)),
+        )
+        .expect("allowed signers");
+        let input = fs::File::open(&manifest_path).expect("manifest input");
+        let status = Command::new("ssh-keygen")
+            .args([
+                "-Y",
+                "verify",
+                "-q",
+                "-f",
+                signers_path.to_str().expect("path"),
+                "-I",
+                SIGNING_IDENTITY_FOR_TEST,
+                "-n",
+                SIGNING_NAMESPACE,
+                "-s",
+                signature_path.to_str().expect("path"),
+            ])
+            .stdin(Stdio::from(input))
+            .status()
+            .expect("ssh-keygen");
+        let _ = fs::remove_dir_all(&root);
+        assert!(status.success());
+    }
+
+    const SIGNING_IDENTITY_FOR_TEST: &str = "cobalt-release";
+}

--- a/crates/kobo-cli/src/host_release.rs
+++ b/crates/kobo-cli/src/host_release.rs
@@ -11,168 +11,12 @@ use std::fmt::Write as _;
 use ring::digest::{digest, SHA512};
 
 pub const SIGNING_NAMESPACE: &str = "cobalt-host-release";
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Asset {
-    pub kind: String,
-    pub platform: Option<String>,
-    pub name: String,
-    pub bytes: u64,
-    pub sha256: String,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Manifest {
-    pub version: String,
-    pub channels: Vec<String>,
-    pub source: String,
-    pub assets: Vec<Asset>,
-}
-
-impl Manifest {
-    pub fn parse(bytes: &[u8]) -> Result<Self, String> {
-        let text =
-            std::str::from_utf8(bytes).map_err(|_| "release manifest is not UTF-8".to_owned())?;
-        if !text.ends_with('\n') {
-            return Err("release manifest must end with a newline".to_owned());
-        }
-        let mut lines = text.lines();
-        if lines.next() != Some("cobalt-host-release 1") {
-            return Err("unsupported release manifest format".to_owned());
-        }
-        let version = field(lines.next(), "version")?;
-        if !valid_version(&version) {
-            return Err("release manifest has an invalid version".to_owned());
-        }
-        let channel_text = lines
-            .next()
-            .and_then(|line| line.strip_prefix("channels "))
-            .ok_or_else(|| "release manifest has no channels".to_owned())?
-            .to_owned();
-        let channels = channel_text
-            .split(',')
-            .map(ToOwned::to_owned)
-            .collect::<Vec<_>>();
-        if channels != ["stable", "beta"] {
-            return Err(
-                "release manifest must be promotable unchanged from beta to stable".to_owned(),
-            );
-        }
-        let source = field(lines.next(), "source")?;
-        if source.len() != 40 || !source.bytes().all(is_lower_hex) {
-            return Err("release manifest has an invalid source commit".to_owned());
-        }
-
-        let mut assets = Vec::new();
-        for line in lines {
-            let fields = line.split(' ').collect::<Vec<_>>();
-            let (kind, platform, name, byte_text, sha256) = match fields.as_slice() {
-                ["device", name, bytes, sha256] => ("device", None, *name, *bytes, *sha256),
-                ["bootstrap", name, bytes, sha256] => ("bootstrap", None, *name, *bytes, *sha256),
-                ["host", platform, name, bytes, sha256] => {
-                    ("host", Some((*platform).to_owned()), *name, *bytes, *sha256)
-                }
-                _ => return Err(format!("invalid release manifest line {line:?}")),
-            };
-            if !safe_token(name) || sha256.len() != 64 || !sha256.bytes().all(is_lower_hex) {
-                return Err(format!("invalid release asset line {line:?}"));
-            }
-            let bytes = byte_text
-                .parse::<u64>()
-                .map_err(|_| format!("invalid release asset size in {line:?}"))?;
-            if bytes == 0 {
-                return Err(format!("empty release asset in {line:?}"));
-            }
-            assets.push(Asset {
-                kind: kind.to_owned(),
-                platform,
-                name: name.to_owned(),
-                bytes,
-                sha256: sha256.to_owned(),
-            });
-        }
-        if assets.iter().filter(|asset| asset.kind == "device").count() != 1 {
-            return Err("release manifest must name exactly one device package".to_owned());
-        }
-        if assets
-            .iter()
-            .filter(|asset| asset.kind == "bootstrap" && asset.name == "install.sh")
-            .count()
-            != 1
-        {
-            return Err("release manifest must name exactly one install.sh bootstrap".to_owned());
-        }
-        for platform in ["macos-x86_64", "macos-arm64", "linux-x86_64", "linux-arm64"] {
-            if assets
-                .iter()
-                .filter(|asset| asset.platform.as_deref() == Some(platform))
-                .count()
-                != 1
-            {
-                return Err(format!(
-                    "release manifest must name exactly one {platform} host package"
-                ));
-            }
-        }
-        Ok(Self {
-            version,
-            channels,
-            source,
-            assets,
-        })
-    }
-
-    pub fn device(&self) -> &Asset {
-        self.assets
-            .iter()
-            .find(|asset| asset.kind == "device")
-            .expect("parse requires one device asset")
-    }
-
-    pub fn allows_channel(&self, channel: &str) -> bool {
-        self.channels.iter().any(|allowed| allowed == channel)
-    }
-}
-
-fn field(line: Option<&str>, name: &str) -> Result<String, String> {
-    let line = line.ok_or_else(|| format!("release manifest has no {name}"))?;
-    let prefix = format!("{name} ");
-    let value = line
-        .strip_prefix(&prefix)
-        .ok_or_else(|| format!("release manifest has no {name}"))?;
-    if !safe_token(value) {
-        return Err(format!("release manifest has an invalid {name}"));
-    }
-    Ok(value.to_owned())
-}
-
-fn valid_version(value: &str) -> bool {
-    let parts = value.split('.').collect::<Vec<_>>();
-    parts.len() == 3
-        && parts
-            .iter()
-            .all(|part| !part.is_empty() && part.bytes().all(|byte| byte.is_ascii_digit()))
-}
-
-fn safe_token(value: &str) -> bool {
-    !value.is_empty()
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
-}
-
-fn is_lower_hex(byte: u8) -> bool {
-    byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)
-}
+#[cfg(test)]
+pub use kobo_app_store::ReleaseAsset as Asset;
+pub use kobo_app_store::ReleaseManifest as Manifest;
 
 pub fn verify_manifest(bytes: &[u8], signature_hex: &str) -> Result<Manifest, String> {
-    let signature = kobo_app_store::DetachedSignature::from_hex(signature_hex.trim())
-        .map_err(|error| format!("invalid release signature: {error}"))?;
-    let public = kobo_app_store::Ed25519PublicKey::from_hex(kobo_app_store::PUBLIC_RELEASE_KEY_HEX)
-        .map_err(|error| format!("invalid built-in release key: {error}"))?;
-    kobo_app_store::verify(bytes, &signature, &public)
-        .map_err(|_| "release manifest signature verification failed".to_owned())?;
-    Manifest::parse(bytes)
+    kobo_app_store::verify_release_manifest(bytes, signature_hex)
 }
 
 pub fn sign(
@@ -275,7 +119,7 @@ mod tests {
         assert_eq!(parsed.version, "0.3.3");
         assert!(parsed.allows_channel("stable"));
         assert!(parsed.allows_channel("beta"));
-        assert_eq!(parsed.device().bytes, 12);
+        assert_eq!(parsed.device().expect("device").bytes, 12);
         let mut missing = manifest();
         let start = String::from_utf8(missing.clone())
             .expect("text")

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -3349,15 +3349,21 @@ fn load_release_package_from_manifest(
                 env!("CARGO_PKG_VERSION")
             ));
     }
-    let asset = manifest.device();
+    let asset = manifest
+        .device()
+        .ok_or("signed release manifest has no device package")?;
     let channel = fs::read_to_string(directory.join("channel"))
         .map_err(|error| format!("read release channel: {error}"))?
         .trim()
         .to_owned();
-    if !manifest.allows_channel(&channel) {
-        return Err(format!(
-            "signed release manifest does not allow channel {channel:?}"
-        ));
+    if channel != "stable" {
+        return Err(
+            "kobo setup installs stable releases only; enable Beta updates later in Cobalt Settings"
+                .to_owned(),
+        );
+    }
+    if !manifest.allows_channel("stable") {
+        return Err("signed release manifest does not allow stable installation".to_owned());
     }
     let package_path = directory.join(&asset.name);
     let compressed = fs::read(&package_path)
@@ -7171,7 +7177,7 @@ mod tests {
         #[test]
         fn a_verified_prebuilt_device_package_becomes_direct_writer_members() {
             let release = TempVolume::new("prebuilt");
-            std::fs::write(release.path.join("channel"), "beta\n").expect("channel");
+            std::fs::write(release.path.join("channel"), "stable\n").expect("channel");
             let members = vec![
                 crate::package::Member {
                     path: format!("{}/bin/kobod", crate::package::INSTALL_ROOT),
@@ -7210,11 +7216,29 @@ mod tests {
                 load_release_package_from_manifest(&release.path, manifest).expect("prebuilt");
             match payload {
                 SetupPayload::Prebuilt { built, channel, .. } => {
-                    assert_eq!(channel, "beta");
+                    assert_eq!(channel, "stable");
                     assert_eq!(built.members, members);
                 }
                 SetupPayload::Source => panic!("prebuilt became source build"),
             }
+
+            std::fs::write(release.path.join("channel"), "beta\n").expect("channel");
+            let manifest = crate::host_release::Manifest {
+                version: env!("CARGO_PKG_VERSION").to_owned(),
+                channels: vec!["stable".to_owned(), "beta".to_owned()],
+                source: "0123456789abcdef0123456789abcdef01234567".to_owned(),
+                assets: vec![crate::host_release::Asset {
+                    kind: "device".to_owned(),
+                    platform: None,
+                    name: format!("cobalt-{}-KoboRoot.tgz", env!("CARGO_PKG_VERSION")),
+                    bytes: compressed.len() as u64,
+                    sha256: crate::sha256::hex_digest(&compressed),
+                }],
+            };
+            let Err(error) = load_release_package_from_manifest(&release.path, manifest) else {
+                panic!("beta USB package was accepted");
+            };
+            assert!(error.contains("stable releases only"), "{error}");
         }
 
         #[test]

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -14,6 +14,7 @@ mod authorize;
 mod connect;
 mod devsession;
 mod drive;
+mod host_release;
 mod menu;
 mod package;
 // Only the `device-write` build dispatches to this, but its tests decide what
@@ -240,6 +241,10 @@ enum SmokeStage {
     WaitTiming,
 }
 
+fn confirmation_answer(answer: &str) -> bool {
+    matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+}
+
 #[cfg(feature = "device-write")]
 impl SmokeStage {
     const CONFIRM_DISPLAY_ONLY: &'static str = "DISPLAY_ONLY_GC16";
@@ -412,6 +417,8 @@ fn run(arguments: &[String]) -> Result<(), String> {
         "app-list" => app_list(&arguments[1..]),
         "app-check" => app_check(&arguments[1..]),
         "app-release" => app_release(&arguments[1..]),
+        "host-release-sign" => host_release_sign(&arguments[1..]),
+        "host-release-verify" => host_release_verify(&arguments[1..]),
         "setup" => setup_device(&arguments[1..]),
         "deploy" => deploy_package(&arguments[1..]),
         "secret" => secret_command(&arguments[1..]),
@@ -434,6 +441,53 @@ fn run(arguments: &[String]) -> Result<(), String> {
         }
         unknown => Err(format!("unknown command '{unknown}'")),
     }
+}
+
+fn host_release_sign(arguments: &[String]) -> Result<(), String> {
+    const USAGE: &str = "usage: kobo host-release-sign --manifest PATH --seed PATH \
+                         --signature PATH --ssh-signature PATH";
+    let manifest_path = single_path_flag(arguments, "--manifest", USAGE)?;
+    let seed_path = single_path_flag(arguments, "--seed", USAGE)?;
+    let signature_path = single_path_flag(arguments, "--signature", USAGE)?;
+    let ssh_signature_path = single_path_flag(arguments, "--ssh-signature", USAGE)?;
+    ensure_only_flags(
+        arguments,
+        &["--manifest", "--seed", "--signature", "--ssh-signature"],
+        USAGE,
+    )?;
+    let manifest = fs::read(&manifest_path)
+        .map_err(|error| format!("read {}: {error}", manifest_path.display()))?;
+    host_release::Manifest::parse(&manifest)?;
+    let seed = read_signing_seed(&seed_path)?;
+    let public = kobo_app_store::derive_public_key(&seed).map_err(|error| error.to_string())?;
+    if public.to_hex() != kobo_app_store::PUBLIC_RELEASE_KEY_HEX {
+        return Err("host release seed does not match the public release key".to_owned());
+    }
+    let (signature, ssh_signature) = host_release::sign(&manifest, &seed)?;
+    fs::write(&signature_path, format!("{signature}\n"))
+        .map_err(|error| format!("write {}: {error}", signature_path.display()))?;
+    fs::write(&ssh_signature_path, ssh_signature)
+        .map_err(|error| format!("write {}: {error}", ssh_signature_path.display()))?;
+    println!("created {}", signature_path.display());
+    println!("created {}", ssh_signature_path.display());
+    Ok(())
+}
+
+fn host_release_verify(arguments: &[String]) -> Result<(), String> {
+    const USAGE: &str = "usage: kobo host-release-verify --manifest PATH --signature PATH";
+    let manifest_path = single_path_flag(arguments, "--manifest", USAGE)?;
+    let signature_path = single_path_flag(arguments, "--signature", USAGE)?;
+    ensure_only_flags(arguments, &["--manifest", "--signature"], USAGE)?;
+    let manifest = fs::read(&manifest_path)
+        .map_err(|error| format!("read {}: {error}", manifest_path.display()))?;
+    let signature = fs::read_to_string(&signature_path)
+        .map_err(|error| format!("read {}: {error}", signature_path.display()))?;
+    let parsed = host_release::verify_manifest(&manifest, &signature)?;
+    println!(
+        "verified Cobalt {} host release from {}",
+        parsed.version, parsed.source
+    );
+    Ok(())
 }
 
 fn app_key(arguments: &[String]) -> Result<(), String> {
@@ -3108,10 +3162,15 @@ enum MenuEntry {
 #[allow(clippy::struct_excessive_bools)]
 struct SetupOptions {
     volume: Option<PathBuf>,
+    release_dir: Option<PathBuf>,
+    source: bool,
     mode: SetupMode,
     menu: MenuEntry,
     eject: bool,
     dry_run: bool,
+    yes: bool,
+    non_interactive: bool,
+    wait_for_reader: bool,
     wait: bool,
     enable_ssh: bool,
     /// Whether this machine's key is installed alongside the SSH server.
@@ -3125,10 +3184,15 @@ struct SetupOptions {
 fn parse_setup(arguments: &[String]) -> Result<SetupOptions, String> {
     let mut options = SetupOptions {
         volume: None,
+        release_dir: None,
+        source: false,
         mode: SetupMode::Install,
         menu: MenuEntry::Add,
         eject: true,
         dry_run: false,
+        yes: false,
+        non_interactive: false,
+        wait_for_reader: false,
         wait: true,
         enable_ssh: false,
         authorize_key: true,
@@ -3144,6 +3208,17 @@ fn parse_setup(arguments: &[String]) -> Result<SetupOptions, String> {
                 index += 1;
             }
             "--undo" => options.mode = SetupMode::Undo,
+            "--release-dir" => {
+                let value = arguments
+                    .get(index + 1)
+                    .ok_or("--release-dir needs a verified release directory")?;
+                options.release_dir = Some(PathBuf::from(value));
+                index += 1;
+            }
+            "--source" => options.source = true,
+            "--yes" => options.yes = true,
+            "--non-interactive" => options.non_interactive = true,
+            "--wait-for-reader" => options.wait_for_reader = true,
             "--no-eject" => options.eject = false,
             "--no-wait" => options.wait = false,
             "--no-menu" => options.menu = MenuEntry::Skip,
@@ -3155,11 +3230,18 @@ fn parse_setup(arguments: &[String]) -> Result<SetupOptions, String> {
                 return Err(format!(
                     "unknown option '{other}'\n\
                      usage: kobo setup [--volume PATH] [--undo] [--enable-ssh] [--no-key] \
-                     [--no-eject] [--no-wait] [--menu] [--no-menu] [--dry-run]"
+                     [--no-eject] [--no-wait] [--menu] [--no-menu] [--dry-run] [--yes] \
+                     [--non-interactive] [--wait-for-reader] [--release-dir PATH] [--source]"
                 ))
             }
         }
         index += 1;
+    }
+    if options.source && options.release_dir.is_some() {
+        return Err("--source and --release-dir are mutually exclusive".to_owned());
+    }
+    if options.non_interactive && !options.yes && !options.dry_run {
+        return Err("--non-interactive requires --yes for any change".to_owned());
     }
     Ok(options)
 }
@@ -3175,7 +3257,261 @@ fn chosen_reader(volume: Option<&Path>) -> Result<setup::Mounted, String> {
             )
         });
     }
-    let mut found = setup::mounted_readers();
+    choose_discovered_reader()
+}
+
+fn wait_for_mounted_reader(volume: Option<&Path>, wait: bool) -> Result<setup::Mounted, String> {
+    if !wait {
+        return chosen_reader(volume);
+    }
+    println!(
+        "Connect a charged Kobo with a data-capable USB cable, tap Connect on the reader,\n\
+             and leave the mounted volume connected. Waiting up to 10 minutes..."
+    );
+    let deadline = Instant::now() + Duration::from_secs(600);
+    loop {
+        match chosen_reader(volume) {
+            Ok(reader) => return Ok(reader),
+            Err(error) if error.starts_with("No mounted reader found.") => {
+                if Instant::now() >= deadline {
+                    return Err(error);
+                }
+                thread::sleep(Duration::from_secs(2));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+enum SetupPayload {
+    Source,
+    Prebuilt {
+        built: BuiltPackage,
+        version: String,
+        channel: String,
+    },
+}
+
+impl SetupPayload {
+    fn description(&self) -> String {
+        match self {
+            Self::Source => format!(
+                "Cobalt {} from this source checkout",
+                env!("CARGO_PKG_VERSION")
+            ),
+            Self::Prebuilt {
+                version, channel, ..
+            } => format!("Cobalt {version} ({channel})"),
+        }
+    }
+
+    fn into_built(self) -> Result<BuiltPackage, String> {
+        match self {
+            Self::Source => build_package_bytes(),
+            Self::Prebuilt { built, .. } => Ok(built),
+        }
+    }
+}
+
+fn setup_payload(options: &SetupOptions) -> Result<SetupPayload, String> {
+    if options.source {
+        return Ok(SetupPayload::Source);
+    }
+    if let Some(directory) = options
+        .release_dir
+        .clone()
+        .or_else(managed_release_directory)
+    {
+        return load_release_package(&directory);
+    }
+    Ok(SetupPayload::Source)
+}
+
+fn load_release_package(directory: &Path) -> Result<SetupPayload, String> {
+    let manifest_path = directory.join("cobalt-host-manifest.txt");
+    let signature_path = directory.join("cobalt-host-manifest.txt.sig");
+    let manifest_bytes = fs::read(&manifest_path)
+        .map_err(|error| format!("read {}: {error}", manifest_path.display()))?;
+    let signature = fs::read_to_string(&signature_path)
+        .map_err(|error| format!("read {}: {error}", signature_path.display()))?;
+    let manifest = host_release::verify_manifest(&manifest_bytes, &signature)?;
+    load_release_package_from_manifest(directory, manifest)
+}
+
+fn load_release_package_from_manifest(
+    directory: &Path,
+    manifest: host_release::Manifest,
+) -> Result<SetupPayload, String> {
+    if manifest.version != env!("CARGO_PKG_VERSION") {
+        return Err(format!(
+                "release metadata is for Cobalt {}, but this kobo is {}; reinstall the matching host package",
+                manifest.version,
+                env!("CARGO_PKG_VERSION")
+            ));
+    }
+    let asset = manifest.device();
+    let channel = fs::read_to_string(directory.join("channel"))
+        .map_err(|error| format!("read release channel: {error}"))?
+        .trim()
+        .to_owned();
+    if !manifest.allows_channel(&channel) {
+        return Err(format!(
+            "signed release manifest does not allow channel {channel:?}"
+        ));
+    }
+    let package_path = directory.join(&asset.name);
+    let compressed = fs::read(&package_path)
+        .map_err(|error| format!("read {}: {error}", package_path.display()))?;
+    let actual_bytes =
+        u64::try_from(compressed.len()).map_err(|_| "device package is too large".to_owned())?;
+    if actual_bytes != asset.bytes {
+        return Err(format!(
+            "{} is truncated: manifest says {} bytes, found {actual_bytes}",
+            package_path.display(),
+            asset.bytes
+        ));
+    }
+    let actual_digest = sha256::hex_digest(&compressed);
+    if actual_digest != asset.sha256 {
+        return Err(format!(
+            "{} checksum failed: expected {}, found {actual_digest}",
+            package_path.display(),
+            asset.sha256
+        ));
+    }
+    gzip_test(&compressed)?;
+    let archive = gunzip(&compressed)?;
+    let members = package::members(&archive)?;
+    let listed = package::list(&archive)?;
+    let outside = members_outside_install_root(&listed);
+    if !outside.is_empty() {
+        return Err(format!(
+            "refusing prebuilt package: {} would be written outside {}",
+            outside.join(", "),
+            package::INSTALL_ROOT
+        ));
+    }
+    let expected_version = format!("{}\n", manifest.version);
+    let packaged_version = members
+        .iter()
+        .find(|member| member.path == format!("{}/VERSION", package::INSTALL_ROOT))
+        .ok_or("prebuilt package has no VERSION file")?;
+    if packaged_version.bytes != expected_version.as_bytes() {
+        return Err("prebuilt package VERSION does not match its signed manifest".to_owned());
+    }
+    Ok(SetupPayload::Prebuilt {
+        built: BuiltPackage {
+            members,
+            listed,
+            compressed,
+        },
+        version: manifest.version,
+        channel,
+    })
+}
+
+fn managed_release_directory() -> Option<PathBuf> {
+    let home = env::var_os("HOME")?;
+    let data = env::var_os("XDG_DATA_HOME")
+        .map_or_else(|| Path::new(&home).join(".local/share"), PathBuf::from);
+    let state = fs::read_to_string(data.join("kobo/install-state")).ok()?;
+    let mut binary = None;
+    let mut release = None;
+    let mut channel = None;
+    for line in state.lines() {
+        if line == "cobalt-kobo-install 1" {
+            continue;
+        }
+        if let Some(value) = line.strip_prefix("binary ") {
+            binary = Some(PathBuf::from(value));
+        } else if let Some(value) = line.strip_prefix("release ") {
+            release = Some(PathBuf::from(value));
+        } else if let Some(value) = line.strip_prefix("channel ") {
+            channel = Some(value.to_owned());
+        }
+    }
+    let current = env::current_exe().ok()?.canonicalize().ok()?;
+    let installed = binary?.canonicalize().ok()?;
+    if current != installed {
+        return None;
+    }
+    let derived =
+        data.join("kobo/releases")
+            .join(format!("{}-{}", env!("CARGO_PKG_VERSION"), channel?));
+    Some(if derived.is_dir() { derived } else { release? })
+}
+
+fn reader_still_connected(expected: &setup::Mounted) -> Result<(), String> {
+    let current = setup::read_reader(&expected.volume).ok_or_else(|| {
+        format!(
+            "{} was unmounted or is no longer a Kobo; nothing was written",
+            expected.volume.display()
+        )
+    })?;
+    if current.serial != expected.serial || current.firmware != expected.firmware {
+        return Err(format!(
+            "the reader at {} changed after confirmation; nothing was written",
+            expected.volume.display()
+        ));
+    }
+    Ok(())
+}
+
+fn confirmed_setup(
+    options: &SetupOptions,
+    reader: &setup::Mounted,
+    profile: &kobo_profile::DeviceProfile,
+    payload: &SetupPayload,
+) -> Result<bool, String> {
+    println!(
+            "\nReady to {}:\n  Model: {} (device code {}, profile {})\n  Firmware: {}\n  Mount: {}\n  Release: {}\n  Changes: {}\n",
+            if options.mode == SetupMode::Undo {
+                "remove Cobalt"
+            } else {
+                "install Cobalt"
+            },
+            profile.model,
+            profile.device_code,
+            profile.id,
+            reader.firmware,
+            reader.volume.display(),
+            payload.description(),
+            if options.mode == SetupMode::Undo {
+                "remove .adds/cobalt and revert only Cobalt-managed settings/menu/SSH markers"
+            } else {
+                "update Cobalt program files in .adds/cobalt, preserve app data, secrets, owner files and unrelated NickelMenu entries"
+            }
+        );
+    if options.yes {
+        return Ok(true);
+    }
+    if options.non_interactive {
+        return Err("noninteractive setup was not explicitly confirmed with --yes".to_owned());
+    }
+    let tty = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/tty")
+            .map_err(|error| format!("open /dev/tty for confirmation: {error}; pass --yes only after reviewing --dry-run"))?;
+    let mut writer = &tty;
+    writer
+        .write_all(b"Continue? [y/N] ")
+        .map_err(|error| format!("write confirmation prompt: {error}"))?;
+    writer
+        .flush()
+        .map_err(|error| format!("flush confirmation prompt: {error}"))?;
+    let mut reader_tty = std::io::BufReader::new(tty);
+    let mut answer = String::new();
+    std::io::BufRead::read_line(&mut reader_tty, &mut answer)
+        .map_err(|error| format!("read confirmation: {error}"))?;
+    Ok(confirmation_answer(&answer))
+}
+
+fn choose_discovered_reader() -> Result<setup::Mounted, String> {
+    choose_reader_list(setup::mounted_readers())
+}
+
+fn choose_reader_list(mut found: Vec<setup::Mounted>) -> Result<setup::Mounted, String> {
     match found.len() {
         0 => Err(NO_READER_FOUND.to_owned()),
         1 => Ok(found.remove(0)),
@@ -3200,23 +3536,60 @@ fn chosen_reader(volume: Option<&Path>) -> Result<setup::Mounted, String> {
 /// SSH server, and the setting that keeps the radio up. Everything after this
 /// happens over Wi-Fi, so everything before it has to happen here.
 fn setup_device(arguments: &[String]) -> Result<(), String> {
+    setup_device_with_confirmation(arguments, confirmed_setup)
+}
+
+fn setup_device_with_confirmation(
+    arguments: &[String],
+    confirm: impl FnOnce(
+        &SetupOptions,
+        &setup::Mounted,
+        &kobo_profile::DeviceProfile,
+        &SetupPayload,
+    ) -> Result<bool, String>,
+) -> Result<(), String> {
     let options = parse_setup(arguments)?;
-    let reader = chosen_reader(options.volume.as_deref())?;
-    println!("found {}", reader.summary());
+    let reader = wait_for_mounted_reader(options.volume.as_deref(), options.wait_for_reader)?;
+    let profile = setup::install_profile(&reader)?;
+    let payload = if options.mode == SetupMode::Undo {
+        SetupPayload::Source
+    } else {
+        setup_payload(&options)?
+    };
+    println!(
+        "found {} ({}, profile {}, device code {}) at {} · firmware {}",
+        profile.model,
+        reader.model_code(),
+        profile.id,
+        profile.device_code,
+        reader.volume.display(),
+        reader.firmware
+    );
 
     if options.dry_run {
-        println!("{}", dry_run_plan(&options, &reader));
+        println!(
+            "{}\nrelease: {}",
+            dry_run_plan(&options, &reader),
+            payload.description()
+        );
         return Ok(());
     }
+    if !confirm(&options, &reader, profile, &payload)? {
+        println!("Declined; nothing was written.");
+        return Ok(());
+    }
+    reader_still_connected(&reader)?;
     if options.mode == SetupMode::Undo {
         return undo_setup(&reader, options.eject);
     }
 
-    // Built before anything is written, so a build that fails leaves the
-    // reader exactly as it was rather than half set up.
-    let built = build_package_bytes()?;
+    // Built or fully verified before anything is written, so a failure leaves
+    // the reader exactly as it was rather than half set up.
+    let built = payload.into_built()?;
+    reader_still_connected(&reader)?;
     let installed = setup::write_payload(&built.members, &reader.volume)?;
     setup::verify_payload(&built.members, &reader.volume)?;
+    reader_still_connected(&reader)?;
     let ssh = options
         .enable_ssh
         .then(|| setup::enable_ssh(&reader.volume))
@@ -3252,7 +3625,7 @@ fn setup_device(arguments: &[String]) -> Result<(), String> {
             ejected,
             waiting,
         }
-        .describe(&reader.volume)
+        .describe_for(&reader)
     );
     if waiting {
         let subnet = subnet.unwrap_or_default();
@@ -5322,9 +5695,14 @@ fn print_help() {
                                    Build and verify every registered Store app\n\
            app-release --registry PATH --seed PATH --out PATH --base-url HTTPS_URL [--prebuilt-dir PATH | --artifact-dir PATH]\n\
                                    Build and sign every registered Store app\n\
-           setup [--volume PATH] [--undo] [--enable-ssh] [--no-key]  Prepare a reader\n\
-                                   over USB; root SSH is an explicit opt-in, and it\n\
-                                   installs this machine's key unless --no-key\n\
+           host-release-sign --manifest PATH --seed PATH --signature PATH --ssh-signature PATH\n\
+                                   Sign host release metadata for publishing\n\
+           host-release-verify --manifest PATH --signature PATH\n\
+                                   Verify signed host release metadata\n\
+           setup [--volume PATH] [--undo] [--enable-ssh] [--no-key] [--dry-run]\n\
+                 [--yes] [--non-interactive] [--release-dir PATH | --source]\n\
+                                   Prepare a reader over USB after default-no confirmation;\n\
+                                   installed builds use their verified prebuilt device package\n\
            deploy --device IP [--package PATH]   Install over Wi-Fi, no reboot\n\
            secret set <name> [--from PATH] --device IP   Install a credential an app can name\n\
            secret list --device IP   Name the installed credentials, never their values\n\
@@ -6652,7 +7030,11 @@ mod tests {
     }
 
     mod preparing {
-        use super::super::{dry_run_plan, parse_setup, setup, SetupMode};
+        use super::super::{
+            choose_reader_list, confirmation_answer, dry_run_plan, gzip,
+            load_release_package_from_manifest, parse_setup, setup, setup_device_with_confirmation,
+            SetupMode, SetupPayload,
+        };
         use std::path::PathBuf;
 
         fn arguments(values: &[&str]) -> Vec<String> {
@@ -6724,6 +7106,115 @@ mod tests {
             assert!(parsed.wait);
             assert!(!parsed.dry_run);
             assert!(!parsed.enable_ssh);
+            assert!(!parsed.yes);
+            assert!(!parsed.non_interactive);
+        }
+
+        #[test]
+        fn automation_requires_an_explicit_confirmation() {
+            let error =
+                parse_setup(&arguments(&["--non-interactive"])).expect_err("confirmation required");
+            assert!(error.contains("--yes"), "{error}");
+            let parsed =
+                parse_setup(&arguments(&["--non-interactive", "--yes"])).expect("confirmed");
+            assert!(parsed.non_interactive);
+            assert!(parsed.yes);
+            for declined in ["", "n", "no", "later"] {
+                assert!(!confirmation_answer(declined));
+            }
+            assert!(confirmation_answer("yes\n"));
+        }
+
+        #[test]
+        fn declined_confirmation_writes_nothing() {
+            let volume = TempVolume::new("declined");
+            let system = volume.path.join(".kobo");
+            std::fs::create_dir_all(&system).expect("system folder");
+            std::fs::write(
+                system.join("version"),
+                "N365410043013,4.9.77,4.45.23697,4.9.77\n",
+            )
+            .expect("version");
+            setup_device_with_confirmation(
+                &arguments(&[
+                    "--volume",
+                    volume.path.to_str().expect("path"),
+                    "--source",
+                    "--no-eject",
+                ]),
+                |_, _, _, _| Ok(false),
+            )
+            .expect("declined cleanly");
+            assert!(!volume.path.join(setup::INSTALL_FOLDER).exists());
+            assert!(!volume.path.join(setup::SETTINGS).exists());
+        }
+
+        #[test]
+        fn several_readers_are_refused_without_printing_full_serials() {
+            let first = mounted(PathBuf::from("/Volumes/ONE"));
+            let mut second = mounted(PathBuf::from("/Volumes/TWO"));
+            second.serial = "N418999999999".to_owned();
+            let error = choose_reader_list(vec![first, second]).expect_err("ambiguous");
+            assert!(error.contains("2 readers"), "{error}");
+            assert!(error.contains("/Volumes/ONE"), "{error}");
+            assert!(!error.contains("N365410043013"), "{error}");
+            assert!(!error.contains("N418999999999"), "{error}");
+        }
+
+        #[test]
+        fn source_build_setup_remains_an_explicit_supported_path() {
+            let parsed = parse_setup(&arguments(&["--source", "--dry-run"])).expect("source");
+            assert!(parsed.source);
+            assert!(parse_setup(&arguments(&["--source", "--release-dir", "release"])).is_err());
+        }
+
+        #[test]
+        fn a_verified_prebuilt_device_package_becomes_direct_writer_members() {
+            let release = TempVolume::new("prebuilt");
+            std::fs::write(release.path.join("channel"), "beta\n").expect("channel");
+            let members = vec![
+                crate::package::Member {
+                    path: format!("{}/bin/kobod", crate::package::INSTALL_ROOT),
+                    bytes: b"prebuilt binary".to_vec(),
+                    program: true,
+                },
+                crate::package::Member {
+                    path: format!("{}/VERSION", crate::package::INSTALL_ROOT),
+                    bytes: format!("{}\n", env!("CARGO_PKG_VERSION")).into_bytes(),
+                    program: false,
+                },
+            ];
+            let archive = crate::package::tar(&members).expect("archive");
+            let compressed = gzip(&archive).expect("gzip");
+            let asset_name = format!("cobalt-{}-KoboRoot.tgz", env!("CARGO_PKG_VERSION"));
+            std::fs::write(release.path.join(&asset_name), &compressed).expect("package");
+            let manifest = crate::host_release::Manifest {
+                version: env!("CARGO_PKG_VERSION").to_owned(),
+                channels: vec!["stable".to_owned(), "beta".to_owned()],
+                source: "0123456789abcdef0123456789abcdef01234567".to_owned(),
+                assets: vec![crate::host_release::Asset {
+                    kind: "device".to_owned(),
+                    platform: None,
+                    name: asset_name,
+                    bytes: compressed.len() as u64,
+                    sha256: crate::sha256::hex_digest(&compressed),
+                }],
+            };
+            let mut damaged = manifest.clone();
+            damaged.assets[0].sha256 = "0".repeat(64);
+            let Err(error) = load_release_package_from_manifest(&release.path, damaged) else {
+                panic!("bad checksum was accepted");
+            };
+            assert!(error.contains("checksum failed"), "{error}");
+            let payload =
+                load_release_package_from_manifest(&release.path, manifest).expect("prebuilt");
+            match payload {
+                SetupPayload::Prebuilt { built, channel, .. } => {
+                    assert_eq!(channel, "beta");
+                    assert_eq!(built.members, members);
+                }
+                SetupPayload::Source => panic!("prebuilt became source build"),
+            }
         }
 
         #[test]

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -419,6 +419,7 @@ fn run(arguments: &[String]) -> Result<(), String> {
         "app-release" => app_release(&arguments[1..]),
         "host-release-sign" => host_release_sign(&arguments[1..]),
         "host-release-verify" => host_release_verify(&arguments[1..]),
+        "update" => update_host(&arguments[1..]),
         "setup" => setup_device(&arguments[1..]),
         "deploy" => deploy_package(&arguments[1..]),
         "secret" => secret_command(&arguments[1..]),
@@ -440,6 +441,83 @@ fn run(arguments: &[String]) -> Result<(), String> {
             Ok(())
         }
         unknown => Err(format!("unknown command '{unknown}'")),
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HostUpdateChannel {
+    Stable,
+    Beta,
+}
+
+impl HostUpdateChannel {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Stable => "stable",
+            Self::Beta => "beta",
+        }
+    }
+}
+
+fn parse_host_update(arguments: &[String]) -> Result<HostUpdateChannel, String> {
+    match arguments {
+        [] => Ok(HostUpdateChannel::Stable),
+        [flag, channel] if flag == "--channel" => match channel.as_str() {
+            "stable" => Ok(HostUpdateChannel::Stable),
+            "beta" => Ok(HostUpdateChannel::Beta),
+            _ => Err("usage: kobo update [--channel stable|beta]".to_owned()),
+        },
+        _ => Err("usage: kobo update [--channel stable|beta]".to_owned()),
+    }
+}
+
+fn update_host(arguments: &[String]) -> Result<(), String> {
+    let channel = parse_host_update(arguments)?;
+    let home = env::var_os("HOME").ok_or("HOME is not set")?;
+    let data = env::var_os("XDG_DATA_HOME")
+        .map_or_else(|| Path::new(&home).join(".local/share"), PathBuf::from);
+    let root = data.join("kobo");
+    let state_path = root.join("install-state");
+    let state = fs::read_to_string(&state_path).map_err(|error| {
+        format!(
+            "kobo update requires a managed host installation (read {}: {error})",
+            state_path.display()
+        )
+    })?;
+    let binary = state
+        .lines()
+        .find_map(|line| line.strip_prefix("binary "))
+        .map(PathBuf::from)
+        .ok_or("managed installation state has no binary path")?;
+    let current = env::current_exe()
+        .and_then(|path| path.canonicalize())
+        .map_err(|error| format!("locate running kobo: {error}"))?;
+    let installed = binary
+        .canonicalize()
+        .map_err(|error| format!("locate managed kobo {}: {error}", binary.display()))?;
+    if current != installed {
+        return Err(
+            "kobo update is available only from the host command installed by Cobalt; \
+             source checkouts use git and cargo"
+                .to_owned(),
+        );
+    }
+    let updater = root.join("updater/install.sh");
+    if !updater.is_file() {
+        return Err(format!(
+            "verified host updater is missing at {}; rerun the stable installer",
+            updater.display()
+        ));
+    }
+    let status = Command::new("sh")
+        .arg(&updater)
+        .args(["--host-update", "--channel", channel.name()])
+        .status()
+        .map_err(|error| format!("run verified host updater: {error}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!("host update exited with {status}"))
     }
 }
 
@@ -3342,12 +3420,12 @@ fn load_release_package_from_manifest(
     directory: &Path,
     manifest: host_release::Manifest,
 ) -> Result<SetupPayload, String> {
-    if manifest.version != env!("CARGO_PKG_VERSION") {
+    if !kobo_app_store::cobalt_version_at_least(env!("CARGO_PKG_VERSION"), &manifest.version) {
         return Err(format!(
-                "release metadata is for Cobalt {}, but this kobo is {}; reinstall the matching host package",
-                manifest.version,
-                env!("CARGO_PKG_VERSION")
-            ));
+            "stable setup package {} is newer than this kobo {}; update the host command first",
+            manifest.version,
+            env!("CARGO_PKG_VERSION")
+        ));
     }
     let asset = manifest
         .device()
@@ -5705,6 +5783,8 @@ fn print_help() {
                                    Sign host release metadata for publishing\n\
            host-release-verify --manifest PATH --signature PATH\n\
                                    Verify signed host release metadata\n\
+           update [--channel stable|beta]\n\
+                                   Update only the installed host kobo command; Stable is default\n\
            setup [--volume PATH] [--undo] [--enable-ssh] [--no-key] [--dry-run]\n\
                  [--yes] [--non-interactive] [--release-dir PATH | --source]\n\
                                    Prepare a reader over USB after default-no confirmation;\n\
@@ -5739,7 +5819,28 @@ mod tests {
             raw.extend_from_slice(&millis.to_le_bytes());
             raw.extend(std::iter::repeat_n(*fill, (width * height) as usize));
         }
+
         raw
+    }
+
+    #[test]
+    fn host_update_defaults_stable_and_requires_explicit_beta() {
+        let arguments = |values: &[&str]| {
+            values
+                .iter()
+                .map(|value| (*value).to_owned())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            super::parse_host_update(&arguments(&[])),
+            Ok(super::HostUpdateChannel::Stable)
+        );
+        assert_eq!(
+            super::parse_host_update(&arguments(&["--channel", "beta"])),
+            Ok(super::HostUpdateChannel::Beta)
+        );
+        assert!(super::parse_host_update(&arguments(&["--beta"])).is_err());
+        assert!(super::parse_host_update(&arguments(&["--channel", "nightly"])).is_err());
     }
 
     #[test]

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -489,12 +489,20 @@ fn update_host(arguments: &[String]) -> Result<(), String> {
         .find_map(|line| line.strip_prefix("binary "))
         .map(PathBuf::from)
         .ok_or("managed installation state has no binary path")?;
+    if !binary.exists() {
+        return Err(format!(
+            "managed kobo command is missing at {}",
+            binary.display()
+        ));
+    }
+    let host = managed_host_directory(&root)?;
     let current = env::current_exe()
         .and_then(|path| path.canonicalize())
         .map_err(|error| format!("locate running kobo: {error}"))?;
-    let installed = binary
+    let installed = host
+        .join("kobo")
         .canonicalize()
-        .map_err(|error| format!("locate managed kobo {}: {error}", binary.display()))?;
+        .map_err(|error| format!("locate selected host kobo: {error}"))?;
     if current != installed {
         return Err(
             "kobo update is available only from the host command installed by Cobalt; \
@@ -502,7 +510,7 @@ fn update_host(arguments: &[String]) -> Result<(), String> {
                 .to_owned(),
         );
     }
-    let updater = root.join("updater/install.sh");
+    let updater = host.join("updater.sh");
     if !updater.is_file() {
         return Err(format!(
             "verified host updater is missing at {}; rerun the stable installer",
@@ -519,6 +527,21 @@ fn update_host(arguments: &[String]) -> Result<(), String> {
     } else {
         Err(format!("host update exited with {status}"))
     }
+}
+
+fn managed_host_directory(root: &Path) -> Result<PathBuf, String> {
+    let selector = root.join("current");
+    let selected = fs::read_to_string(&selector)
+        .map_err(|error| format!("read host selector {}: {error}", selector.display()))?;
+    let selected = selected.trim();
+    if selected.is_empty()
+        || !selected
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+    {
+        return Err("managed host selector is invalid".to_owned());
+    }
+    Ok(root.join("hosts").join(selected))
 }
 
 fn host_release_sign(arguments: &[String]) -> Result<(), String> {
@@ -3516,7 +3539,11 @@ fn managed_release_directory() -> Option<PathBuf> {
     }
     let current = env::current_exe().ok()?.canonicalize().ok()?;
     let installed = binary?.canonicalize().ok()?;
-    if current != installed {
+    let root = data.join("kobo");
+    let selected = managed_host_directory(&root)
+        .ok()
+        .and_then(|directory| directory.join("kobo").canonicalize().ok());
+    if current != installed && selected.as_ref() != Some(&current) {
         return None;
     }
     let derived =

--- a/crates/kobo-cli/src/package.rs
+++ b/crates/kobo-cli/src/package.rs
@@ -45,6 +45,7 @@ use std::path::{Path, PathBuf};
 /// Relative, because a tar member path must be, and because a leading slash is
 /// exactly the thing that would let a tarball escape.
 pub const INSTALL_ROOT: &str = "mnt/onboard/.adds/cobalt";
+pub const INSTALL_ROOT_PREFIX: &str = "mnt/onboard/.adds/cobalt/";
 
 /// The largest member this builder will write.
 ///
@@ -479,6 +480,7 @@ mod tests {
     /// project's safety argument is void.
     #[test]
     fn nothing_outside_the_install_root_can_be_packaged() {
+        assert_eq!(super::INSTALL_ROOT_PREFIX, format!("{INSTALL_ROOT}/"));
         for path in [
             "etc/init.d/rcS",
             "usr/local/Kobo/nickel",

--- a/crates/kobo-cli/src/package.rs
+++ b/crates/kobo-cli/src/package.rs
@@ -325,6 +325,51 @@ pub fn list(archive: &[u8]) -> Result<Vec<Listed>, String> {
     Ok(entries)
 }
 
+/// Reads regular files from a checked package archive.
+///
+/// This is the inverse of [`tar`] used by the prebuilt host installer. It
+/// first applies the same archive checks as [`list`], then returns only plain
+/// files as [`Member`] values suitable for the direct-folder USB writer.
+///
+/// # Errors
+///
+/// Returns an error for any archive [`list`] refuses or for a member list that
+/// does not satisfy [`check`].
+pub fn members(archive: &[u8]) -> Result<Vec<Member>, String> {
+    let listed = list(archive)?;
+    let mut offset = 0usize;
+    let mut members = Vec::new();
+    for entry in listed {
+        let payload_offset = offset
+            .checked_add(BLOCK)
+            .ok_or_else(|| format!("{:?} has an overflowing offset", entry.path))?;
+        if entry.kind == b'0' {
+            let payload_end = payload_offset
+                .checked_add(entry.size)
+                .ok_or_else(|| format!("{:?} has an overflowing size", entry.path))?;
+            let bytes = archive
+                .get(payload_offset..payload_end)
+                .ok_or_else(|| format!("{:?} is truncated", entry.path))?
+                .to_vec();
+            members.push(Member {
+                path: entry.path.clone(),
+                bytes,
+                program: entry.mode & 0o111 != 0,
+            });
+        }
+        let payload = if entry.kind == b'5' { 0 } else { entry.size };
+        offset = offset
+            .checked_add(BLOCK)
+            .and_then(|value| value.checked_add(payload.div_ceil(BLOCK) * BLOCK))
+            .ok_or_else(|| format!("{:?} has an overflowing offset", entry.path))?;
+    }
+    check(&members)?;
+    if members.is_empty() {
+        return Err("the archive contains no files".to_owned());
+    }
+    Ok(members)
+}
+
 fn verify_checksum(block: &[u8]) -> Result<(), String> {
     let stated = read_octal(&block[148..156])?;
     let computed: u32 = block
@@ -424,6 +469,7 @@ mod tests {
         assert_eq!(files[0].size, 6);
         assert_eq!(files[0].mode, 0o755);
         assert_eq!(files[1].mode, 0o644);
+        assert_eq!(super::members(&archive).expect("member bytes"), members);
     }
 
     /// The property the whole design rests on.

--- a/crates/kobo-cli/src/setup.rs
+++ b/crates/kobo-cli/src/setup.rs
@@ -107,12 +107,72 @@ impl Mounted {
     #[must_use]
     pub fn summary(&self) -> String {
         format!(
-            "{} at {} · serial {} · firmware {}",
+            "{} at {} · firmware {}",
             self.model_code(),
             self.volume.display(),
-            self.serial,
             self.firmware
         )
+    }
+}
+
+/// Resolves USB-visible identity through the shared device profile table.
+///
+/// A mounted book partition exposes only the serial prefix and firmware. That
+/// is enough to select one reviewed profile because those pairs are unique in
+/// [`kobo_profile::SUPPORTED_PROFILES`]. Panel geometry and kernel identity are
+/// checked again by the runtime before it can write to a display.
+///
+/// # Errors
+///
+/// Returns a hardware- or firmware-specific refusal, or an ambiguity error if
+/// profile data ever stops being unique.
+pub fn install_profile(reader: &Mounted) -> Result<&'static kobo_profile::DeviceProfile, String> {
+    let hardware = kobo_profile::SUPPORTED_PROFILES
+        .iter()
+        .copied()
+        .filter(|profile| profile.serial_prefix == reader.model_code())
+        .collect::<Vec<_>>();
+    if hardware.is_empty() {
+        return Err(format!(
+            "unsupported Kobo hardware: model code {} has no reviewed Cobalt profile",
+            reader.model_code()
+        ));
+    }
+    let matching = hardware
+        .iter()
+        .copied()
+        .filter(|profile| {
+            profile
+                .firmware_versions
+                .contains(&reader.firmware.as_str())
+        })
+        .collect::<Vec<_>>();
+    match matching.as_slice() {
+        [profile] if profile.write_ready => Ok(*profile),
+        [profile] => Err(format!(
+            "{} ({}) is not enabled for installation: {}",
+            profile.model,
+            profile.id,
+            kobo_profile::WRITE_EVIDENCE_PENDING
+        )),
+        [] => {
+            let supported = hardware
+                .iter()
+                .flat_map(|profile| profile.firmware_versions.iter().copied())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(format!(
+                "unsupported firmware {} on {}; reviewed firmware: {}",
+                reader.firmware, hardware[0].model, supported
+            ))
+        }
+        _ => Err(format!(
+            "ambiguous device profiles for {} on firmware {}; refusing to guess",
+            reader.model_code(),
+            reader.firmware
+        )),
     }
 }
 
@@ -508,8 +568,35 @@ fn edit_settings<'a>(
 /// When a member lies outside the install root, or the volume cannot be
 /// written to.
 pub fn write_payload(members: &[crate::package::Member], volume: &Path) -> Result<usize, String> {
+    crate::package::check(members)?;
+    let adds = volume.join(".adds");
+    fs::create_dir_all(&adds).map_err(|error| format!("{}: {error}", adds.display()))?;
+    let stage = adds.join(format!(".cobalt-stage-{}", std::process::id()));
+    if stage.exists() {
+        fs::remove_dir_all(&stage).map_err(|error| format!("{}: {error}", stage.display()))?;
+    }
+    crate::package::write_folder(members, &stage)?;
+    verify_payload_at(members, &stage)?;
+
     let destination = volume.join(INSTALL_FOLDER);
-    crate::package::write_folder(members, &destination)?;
+    for member in members {
+        let relative = member_relative(member)?;
+        let staged = stage.join(relative);
+        let installed = destination.join(relative);
+        let parent = installed
+            .parent()
+            .ok_or_else(|| format!("{} has no parent", installed.display()))?;
+        fs::create_dir_all(parent).map_err(|error| format!("{}: {error}", parent.display()))?;
+        if let Err(error) = fs::rename(&staged, &installed) {
+            let _ = fs::remove_dir_all(&stage);
+            return Err(format!(
+                "replace {} atomically from {}: {error}",
+                installed.display(),
+                staged.display()
+            ));
+        }
+    }
+    fs::remove_dir_all(&stage).map_err(|error| format!("{}: {error}", stage.display()))?;
     Ok(members.len())
 }
 
@@ -527,13 +614,13 @@ pub fn write_payload(members: &[crate::package::Member], volume: &Path) -> Resul
 /// When a file is missing, short, or different, naming which, because the
 /// answer determines whether to run setup again or replace the cable.
 pub fn verify_payload(members: &[crate::package::Member], volume: &Path) -> Result<(), String> {
-    let prefix = format!("{}/", crate::package::INSTALL_ROOT);
     let destination = volume.join(INSTALL_FOLDER);
+    verify_payload_at(members, &destination)
+}
+
+fn verify_payload_at(members: &[crate::package::Member], destination: &Path) -> Result<(), String> {
     for member in members {
-        let relative = member
-            .path
-            .strip_prefix(&prefix)
-            .ok_or_else(|| format!("{:?} is outside the install root", member.path))?;
+        let relative = member_relative(member)?;
         let path = destination.join(relative);
         let written =
             fs::read(&path).map_err(|error| format!("read back {}: {error}", path.display()))?;
@@ -553,6 +640,13 @@ pub fn verify_payload(members: &[crate::package::Member], volume: &Path) -> Resu
         }
     }
     Ok(())
+}
+
+fn member_relative(member: &crate::package::Member) -> Result<&str, String> {
+    member
+        .path
+        .strip_prefix(&format!("{}/", crate::package::INSTALL_ROOT))
+        .ok_or_else(|| format!("{:?} is outside the install root", member.path))
 }
 
 /// Removes an installed Cobalt from a mounted reader.
@@ -582,12 +676,20 @@ pub fn remove_payload(volume: &Path) -> Result<bool, String> {
 /// still sitting in a directory on the volume.
 pub fn eject(volume: &Path) -> Result<(), String> {
     let _ = Command::new("sync").status();
+    if is_wsl() {
+        return Err(format!(
+            "{} is mounted through WSL. Close files using it, then use Windows \
+             'Safely Remove Hardware' or eject the Kobo in File Explorer; WSL did not eject it",
+            volume.display()
+        ));
+    }
     if !cfg!(target_os = "macos") {
         return Err(format!(
             "eject {} yourself, then restart the reader",
             volume.display()
         ));
     }
+
     let output = Command::new("diskutil")
         .arg("eject")
         .arg(volume)
@@ -601,6 +703,14 @@ pub fn eject(volume: &Path) -> Result<(), String> {
         volume.display(),
         String::from_utf8_lossy(&output.stderr).trim()
     ))
+}
+
+#[must_use]
+pub fn is_wsl() -> bool {
+    std::env::var_os("WSL_INTEROP").is_some()
+        || fs::read_to_string("/proc/sys/kernel/osrelease")
+            .or_else(|_| fs::read_to_string("/proc/version"))
+            .is_ok_and(|value| value.to_ascii_lowercase().contains("microsoft"))
 }
 
 /// What a completed setup did, in the order it did it.
@@ -627,7 +737,18 @@ pub struct Report {
 impl Report {
     /// The whole of what happened, and how to undo each part of it.
     #[must_use]
+    #[cfg(test)]
     pub fn describe(&self, volume: &Path) -> String {
+        self.describe_with_firmware(volume, None)
+    }
+
+    /// The completed report with the menu location for the mounted firmware.
+    #[must_use]
+    pub fn describe_for(&self, reader: &Mounted) -> String {
+        self.describe_with_firmware(&reader.volume, Some(&reader.firmware))
+    }
+
+    fn describe_with_firmware(&self, volume: &Path, firmware: Option<&str>) -> String {
         let mut text = String::new();
         let _ = writeln!(text, "\nSet up {}:", volume.display());
         let _ = writeln!(
@@ -681,7 +802,17 @@ impl Report {
                 "volume left mounted"
             }
         );
-        text.push_str(&next_steps(self.waiting, self.staged_an_archive()));
+        if !self.ejected {
+            let _ = writeln!(
+                text,
+                "  · safely eject it from the host before disconnecting the USB cable"
+            );
+        }
+        text.push_str(&next_steps_for(
+            self.waiting,
+            self.staged_an_archive(),
+            firmware,
+        ));
         text
     }
 
@@ -734,18 +865,42 @@ fn describe_key(key: crate::authorize::Key, staged: crate::authorize::Staged) ->
 /// Telling somebody to run `kobo devices` and then running it for them reads
 /// as though one of the two did not happen.
 #[must_use]
+#[cfg(test)]
 pub fn next_steps(waiting: bool, staged: Staged) -> String {
+    next_steps_for(waiting, staged, None)
+}
+
+fn next_steps_for(waiting: bool, staged: Staged, firmware: Option<&str>) -> String {
     let finding = if waiting {
-        "  3. This command is waiting for it, and will print its address when it\n\
+        "  4. This command is waiting for it, and will print its address when it\n\
          \x20    appears. Ctrl-C stops the wait; nothing on the reader depends on it."
     } else {
-        "  3. Find it with 'kobo devices', then 'kobo deploy' works from here on."
+        "  4. Find it with 'kobo devices', then 'kobo deploy' works from here on."
     };
+    let menu = firmware.map_or_else(
+        || "Open the Kobo menu and choose Cobalt.".to_owned(),
+        |version| {
+            if firmware_at_least(version, [4, 23, 15_505]) {
+                "Open the bottom-right Kobo menu and choose Cobalt.".to_owned()
+            } else {
+                "Open the top-left Kobo menu and choose Cobalt.".to_owned()
+            }
+        },
+    );
     format!(
-        "{}{}{finding}{NEXT_STEPS_TAIL}",
+        "{}{}{finding}\n  5. {menu}{NEXT_STEPS_TAIL}",
         staged.scope(),
         staged.restart()
     )
+}
+
+fn firmware_at_least(value: &str, minimum: [u64; 3]) -> bool {
+    let parts = value
+        .split('.')
+        .take(3)
+        .map(|part| part.parse::<u64>().unwrap_or(0))
+        .collect::<Vec<_>>();
+    parts.len() == 3 && [parts[0], parts[1], parts[2]] >= minimum
 }
 
 /// What ended up in the single archive the firmware extracts as root.
@@ -834,9 +989,10 @@ unable to boot. To undo all of it: 'kobo setup --undo'.
 const RESTART_BY_HAND: &str = "
 Next, on the reader:
 
-  1. Restart it. Hold the power button until it powers off, then press it
+  1. After the host has safely ejected it, disconnect the USB cable.
+  2. Restart it. Hold the power button until it powers off, then press it
      again. The SSH server only starts at boot.
-  2. Join it to Wi-Fi if it is not already.
+  3. Join it to Wi-Fi if it is not already.
 ";
 
 /// The same, for a reader that was left an archive.
@@ -848,10 +1004,11 @@ Next, on the reader:
 const RESTARTS_ITSELF: &str = "
 Next, on the reader:
 
-  1. Nothing. It restarts by itself: ejecting leaves the archive where the
-     firmware looks, so it shows its Updating screen, takes it, and reboots.
-     The SSH server starts with that boot.
-  2. Join it to Wi-Fi if it is not already.
+  1. After the host has safely ejected it, disconnect the USB cable.
+  2. It restarts by itself: ejecting leaves the archive where the firmware
+     looks, so it shows its Updating screen, takes it, and reboots. The SSH
+     server starts with that boot.
+  3. Join it to Wi-Fi if it is not already.
 ";
 
 /// Everything below it.
@@ -860,6 +1017,10 @@ const NEXT_STEPS_TAIL: &str = "
 Cobalt itself is started from the Cobalt entry in the reader's own menu, or
 from .adds/cobalt/start.sh. Starting it stops the reader and takes the screen;
 a restart always returns to the stock reader.
+
+After a restart, leave the home screen alone for one minute before opening the
+menu. NickelMenu uses that window as a boot-loop failsafe and disables itself
+after an interrupted startup.
 
 The reader is also set to stay awake for ninety minutes rather than a few, so
 that it is still reachable when you come back to it. That costs battery. The
@@ -971,10 +1132,12 @@ pub fn wait_for_reader(
 
 #[cfg(test)]
 mod tests {
+    #[cfg(target_os = "linux")]
+    use super::mount_roots;
     use super::{
-        carry_trust_from, clear_setting, is_kobo_serial, next_steps, parse_version, set_setting,
-        wait_for_reader, Arrival, Mounted, Report, Ssh, Staged, Verdict, INSTALL_FOLDER,
-        SETTINGS_APPLIED, SSH_DISABLED, SSH_ENABLED,
+        carry_trust_from, clear_setting, install_profile, is_kobo_serial, next_steps,
+        next_steps_for, parse_version, set_setting, wait_for_reader, Arrival, Mounted, Report, Ssh,
+        Staged, Verdict, INSTALL_FOLDER, SETTINGS_APPLIED, SSH_DISABLED, SSH_ENABLED,
     };
     use std::net::Ipv4Addr;
     use std::path::PathBuf;
@@ -1207,8 +1370,19 @@ mod tests {
             assert!(text.contains("restarts by itself"), "{text}");
             assert!(!text.contains("Hold the power button"), "{text}");
         }
+
         let untouched = next_steps(false, Staged::Nothing);
         assert!(untouched.contains("Hold the power button"), "{untouched}");
+    }
+
+    #[test]
+    fn menu_instructions_follow_the_firmware_generation() {
+        assert!(next_steps_for(false, Staged::Nothing, Some("4.45.23697"))
+            .contains("bottom-right Kobo menu"));
+        assert!(next_steps_for(false, Staged::Nothing, Some("4.22.15190"))
+            .contains("top-left Kobo menu"));
+        assert!(next_steps_for(false, Staged::Nothing, Some("4.45.23697"))
+            .contains("leave the home screen alone for one minute"));
     }
 
     #[test]
@@ -1220,7 +1394,10 @@ mod tests {
         // about the archive that exists.
         let key_only = next_steps(false, Staged::Key);
         assert!(key_only.contains("authorized_keys"), "{key_only}");
-        assert!(!key_only.contains("NickelMenu"), "{key_only}");
+        assert!(
+            !key_only.contains("NickelMenu, checked first"),
+            "{key_only}"
+        );
 
         let plugin_only = next_steps(false, Staged::Plugin);
         assert!(plugin_only.contains("NickelMenu"), "{plugin_only}");
@@ -1297,6 +1474,34 @@ mod tests {
     }
 
     #[test]
+    fn usb_identity_resolves_through_the_shared_profile_table() {
+        let reader = Mounted {
+            volume: PathBuf::from("/Volumes/KOBOeReader"),
+            serial: "N365410043013".to_owned(),
+            firmware: "4.45.23697".to_owned(),
+        };
+        let profile = install_profile(&reader).expect("supported");
+        assert_eq!(profile.model, "Kobo Clara BW");
+        assert_eq!(profile.device_code, 391);
+        assert_eq!(profile.id, "clara-bw-391");
+    }
+
+    #[test]
+    fn unsupported_hardware_and_firmware_are_refused_before_writes() {
+        let reader = |serial: &str, firmware: &str| Mounted {
+            volume: PathBuf::from("/Volumes/KOBOeReader"),
+            serial: serial.to_owned(),
+            firmware: firmware.to_owned(),
+        };
+        assert!(install_profile(&reader("N999000000000", "4.45.23697"))
+            .expect_err("hardware")
+            .contains("unsupported Kobo hardware"));
+        assert!(install_profile(&reader("N365000000000", "9.9.9"))
+            .expect_err("firmware")
+            .contains("unsupported firmware"));
+    }
+
+    #[test]
     fn a_truncated_version_line_is_not_an_error() {
         let (serial, firmware) = parse_version("N365410043013");
         assert_eq!(serial, "N365410043013");
@@ -1312,6 +1517,12 @@ mod tests {
         assert!(!is_kobo_serial("NABC410043013"));
         assert!(!is_kobo_serial("PABC410043013"));
         assert!(!is_kobo_serial("Q365410043013"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_mount_discovery_includes_wsl_drive_roots() {
+        assert!(mount_roots().contains(&PathBuf::from("/mnt")));
     }
 
     #[test]
@@ -1606,6 +1817,15 @@ mod tests {
 
         assert_eq!(write_payload(&members, &root).expect("write"), 1);
         verify_payload(&members, &root).expect("what was written reads back");
+        let owner_state = root.join(INSTALL_FOLDER).join("apps/state.db");
+        std::fs::create_dir_all(owner_state.parent().expect("parent")).expect("state folder");
+        std::fs::write(&owner_state, b"owner state").expect("state");
+        assert_eq!(write_payload(&members, &root).expect("rerun"), 1);
+        assert_eq!(
+            std::fs::read(&owner_state).expect("preserved"),
+            b"owner state",
+            "files outside the signed platform member list survive updates"
+        );
 
         let installed = root.join(INSTALL_FOLDER).join("bin/kobod");
         std::fs::write(&installed, b"a whole").expect("truncate");
@@ -1625,5 +1845,6 @@ mod tests {
         assert_eq!(reader.model_code(), "N365");
         assert!(reader.summary().contains("/Volumes/KOBOeReader"));
         assert!(reader.summary().contains("4.45.23697"));
+        assert!(!reader.summary().contains("N365410043013"));
     }
 }

--- a/crates/kobo-cli/src/setup.rs
+++ b/crates/kobo-cli/src/setup.rs
@@ -645,7 +645,7 @@ fn verify_payload_at(members: &[crate::package::Member], destination: &Path) -> 
 fn member_relative(member: &crate::package::Member) -> Result<&str, String> {
     member
         .path
-        .strip_prefix(&format!("{}/", crate::package::INSTALL_ROOT))
+        .strip_prefix(crate::package::INSTALL_ROOT_PREFIX)
         .ok_or_else(|| format!("{:?} is outside the install root", member.path))
 }
 

--- a/crates/kobo-cli/src/setup.rs
+++ b/crates/kobo-cli/src/setup.rs
@@ -46,6 +46,14 @@ pub const SYSTEM_FOLDER: &str = ".kobo";
 
 /// Where Cobalt is installed, relative to the mounted volume.
 pub const INSTALL_FOLDER: &str = ".adds/cobalt";
+// The current/next/previous names and owner-folder list deliberately match
+// kobod's OTA transaction. USB setup can therefore recover the same directory
+// swap states instead of inventing a parallel layout.
+const STAGING_FOLDER: &str = ".adds/cobalt.next";
+const PREVIOUS_FOLDER: &str = ".adds/cobalt.prev";
+const OWNER_HOLD_FOLDER: &str = ".adds/cobalt.owner";
+const TRANSACTION_MARKER: &str = ".managed-complete";
+const OWNER_FOLDERS: &[&str] = &["secrets", "trust", "state", "data", "apps", "store"];
 
 /// The firmware's own marker for a disabled SSH server.
 ///
@@ -569,35 +577,335 @@ fn edit_settings<'a>(
 /// written to.
 pub fn write_payload(members: &[crate::package::Member], volume: &Path) -> Result<usize, String> {
     crate::package::check(members)?;
+    refuse_managed_owner_folders(members)?;
+    recover_payload_transaction(volume)?;
     let adds = volume.join(".adds");
     fs::create_dir_all(&adds).map_err(|error| format!("{}: {error}", adds.display()))?;
-    let stage = adds.join(format!(".cobalt-stage-{}", std::process::id()));
+    let stage = volume.join(STAGING_FOLDER);
     if stage.exists() {
         fs::remove_dir_all(&stage).map_err(|error| format!("{}: {error}", stage.display()))?;
     }
     crate::package::write_folder(members, &stage)?;
     verify_payload_at(members, &stage)?;
+    fs::write(stage.join(TRANSACTION_MARKER), b"complete\n")
+        .map_err(|error| format!("write transaction marker: {error}"))?;
+    activate_staged(&adds, &mut |_| Ok(()))?;
+    if let Err(error) = verify_payload(members, volume) {
+        let rollback = rollback_activation(&adds, &mut |_| Ok(()));
+        return Err(with_rollback(&error, rollback));
+    }
+    let previous = volume.join(PREVIOUS_FOLDER);
+    if previous.exists() {
+        fs::remove_dir_all(&previous).map_err(|error| {
+            format!(
+                "remove verified previous payload {}: {error}",
+                previous.display()
+            )
+        })?;
+    }
+    Ok(members.len())
+}
 
-    let destination = volume.join(INSTALL_FOLDER);
+fn refuse_managed_owner_folders(members: &[crate::package::Member]) -> Result<(), String> {
     for member in members {
         let relative = member_relative(member)?;
-        let staged = stage.join(relative);
-        let installed = destination.join(relative);
-        let parent = installed
-            .parent()
-            .ok_or_else(|| format!("{} has no parent", installed.display()))?;
-        fs::create_dir_all(parent).map_err(|error| format!("{}: {error}", parent.display()))?;
-        if let Err(error) = fs::rename(&staged, &installed) {
-            let _ = fs::remove_dir_all(&stage);
+        let first = relative.split('/').next().unwrap_or_default();
+        if OWNER_FOLDERS.contains(&first) {
             return Err(format!(
-                "replace {} atomically from {}: {error}",
-                installed.display(),
-                staged.display()
+                "release member {:?} overlaps owner-managed folder {first:?}",
+                member.path
             ));
         }
     }
-    fs::remove_dir_all(&stage).map_err(|error| format!("{}: {error}", stage.display()))?;
-    Ok(members.len())
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ActivationStep {
+    HoldOwner(&'static str),
+    RemovePrevious,
+    RetireCurrent,
+    ActivateStaged,
+    RestoreOwner(&'static str),
+    RollbackNew,
+    RollbackPrevious,
+    RollbackOwner(&'static str),
+}
+
+fn activate_staged(
+    adds: &Path,
+    step: &mut impl FnMut(ActivationStep) -> Result<(), String>,
+) -> Result<(), String> {
+    let current = adds.join("cobalt");
+    let staging = adds.join("cobalt.next");
+    let previous = adds.join("cobalt.prev");
+    let holder = adds.join("cobalt.owner");
+    if !staging.join(TRANSACTION_MARKER).is_file() {
+        return Err("staged Cobalt payload is incomplete".to_owned());
+    }
+    if holder.exists() {
+        return Err(format!(
+            "{} still holds an interrupted owner-data transaction",
+            holder.display()
+        ));
+    }
+    fs::create_dir(&holder).map_err(|error| format!("{}: {error}", holder.display()))?;
+
+    if current.exists() {
+        for &folder in OWNER_FOLDERS {
+            let source = current.join(folder);
+            if source.exists() {
+                if let Err(error) = rename_step(
+                    &source,
+                    &holder.join(folder),
+                    ActivationStep::HoldOwner(folder),
+                    step,
+                ) {
+                    let rollback = restore_owner_folders(
+                        &holder,
+                        &current,
+                        ActivationStep::RollbackOwner,
+                        step,
+                    );
+                    return Err(with_rollback(&error, rollback));
+                }
+            }
+        }
+        if previous.exists() {
+            if let Err(error) = step(ActivationStep::RemovePrevious) {
+                let rollback =
+                    restore_owner_folders(&holder, &current, ActivationStep::RollbackOwner, step);
+                return Err(with_rollback(&error, rollback));
+            }
+            if let Err(error) = fs::remove_dir_all(&previous)
+                .map_err(|error| format!("remove {}: {error}", previous.display()))
+            {
+                let rollback =
+                    restore_owner_folders(&holder, &current, ActivationStep::RollbackOwner, step);
+                return Err(with_rollback(&error, rollback));
+            }
+        }
+        if let Err(error) = rename_step(&current, &previous, ActivationStep::RetireCurrent, step) {
+            let rollback =
+                restore_owner_folders(&holder, &current, ActivationStep::RollbackOwner, step);
+            return Err(with_rollback(&error, rollback));
+        }
+    }
+
+    if let Err(error) = rename_step(&staging, &current, ActivationStep::ActivateStaged, step) {
+        let rollback = rollback_activation(adds, step);
+        return Err(with_rollback(&error, rollback));
+    }
+
+    if let Err(error) = restore_owner_folders(&holder, &current, ActivationStep::RestoreOwner, step)
+    {
+        let rollback = rollback_activation(adds, step);
+        return Err(with_rollback(&error, rollback));
+    }
+    remove_empty_directory(&holder)?;
+    Ok(())
+}
+
+fn rollback_activation(
+    adds: &Path,
+    step: &mut impl FnMut(ActivationStep) -> Result<(), String>,
+) -> Result<(), String> {
+    let current = adds.join("cobalt");
+    let staging = adds.join("cobalt.next");
+    let previous = adds.join("cobalt.prev");
+    let holder = adds.join("cobalt.owner");
+    if current.exists() && current.join(TRANSACTION_MARKER).is_file() {
+        restore_owner_folders(&current, &holder, ActivationStep::RollbackOwner, step)?;
+        rename_step(&current, &staging, ActivationStep::RollbackNew, step)?;
+    }
+    if !current.exists() && previous.exists() {
+        rename_step(&previous, &current, ActivationStep::RollbackPrevious, step)?;
+    }
+    restore_owner_folders(&holder, &current, ActivationStep::RollbackOwner, step)?;
+    remove_empty_directory(&holder)
+}
+
+fn rename_step(
+    source: &Path,
+    destination: &Path,
+    operation: ActivationStep,
+    step: &mut impl FnMut(ActivationStep) -> Result<(), String>,
+) -> Result<(), String> {
+    step(operation)?;
+    fs::rename(source, destination).map_err(|error| {
+        format!(
+            "rename {} to {}: {error}",
+            source.display(),
+            destination.display()
+        )
+    })
+}
+
+fn restore_owner_folders(
+    source_root: &Path,
+    destination_root: &Path,
+    operation: fn(&'static str) -> ActivationStep,
+    step: &mut impl FnMut(ActivationStep) -> Result<(), String>,
+) -> Result<(), String> {
+    if !source_root.exists() {
+        return Ok(());
+    }
+    fs::create_dir_all(destination_root)
+        .map_err(|error| format!("{}: {error}", destination_root.display()))?;
+    for &folder in OWNER_FOLDERS {
+        let source = source_root.join(folder);
+        if !source.exists() {
+            continue;
+        }
+        let destination = destination_root.join(folder);
+        if destination.exists() {
+            merge_owner_tree(&source, &destination)?;
+        } else {
+            rename_step(&source, &destination, operation(folder), step)?;
+        }
+    }
+    Ok(())
+}
+
+fn merge_owner_tree(source: &Path, destination: &Path) -> Result<(), String> {
+    let source_type = fs::symlink_metadata(source)
+        .map_err(|error| format!("inspect {}: {error}", source.display()))?
+        .file_type();
+    if source_type.is_symlink() {
+        return Err(format!(
+            "owner data {} is a symbolic link; refusing to follow it",
+            source.display()
+        ));
+    }
+    let destination_type = fs::symlink_metadata(destination)
+        .ok()
+        .map(|value| value.file_type());
+    if destination_type.is_some_and(|kind| kind.is_symlink()) {
+        return Err(format!(
+            "owner data destination {} is a symbolic link; refusing to follow it",
+            destination.display()
+        ));
+    }
+    if source_type.is_dir() && destination_type.is_some_and(|kind| kind.is_dir()) {
+        for entry in
+            fs::read_dir(source).map_err(|error| format!("read {}: {error}", source.display()))?
+        {
+            let entry = entry.map_err(|error| format!("read {}: {error}", source.display()))?;
+            merge_owner_tree(&entry.path(), &destination.join(entry.file_name()))?;
+        }
+        remove_empty_directory(source)
+    } else if source_type.is_file() && destination_type.is_some_and(|kind| kind.is_file()) {
+        let source_bytes =
+            fs::read(source).map_err(|error| format!("read {}: {error}", source.display()))?;
+        let destination_bytes = fs::read(destination)
+            .map_err(|error| format!("read {}: {error}", destination.display()))?;
+        if source_bytes != destination_bytes {
+            return Err(format!(
+                "owner data exists with different bytes at {} and {}; refusing to overwrite either",
+                source.display(),
+                destination.display()
+            ));
+        }
+        fs::remove_file(source).map_err(|error| format!("remove {}: {error}", source.display()))
+    } else if !destination.exists() {
+        fs::rename(source, destination).map_err(|error| {
+            format!(
+                "move owner data {} to {}: {error}",
+                source.display(),
+                destination.display()
+            )
+        })
+    } else {
+        Err(format!(
+            "owner data has conflicting file types at {} and {}",
+            source.display(),
+            destination.display()
+        ))
+    }
+}
+
+fn remove_empty_directory(path: &Path) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let mut entries =
+        fs::read_dir(path).map_err(|error| format!("read {}: {error}", path.display()))?;
+    if entries.next().is_some() {
+        return Err(format!(
+            "{} still contains owner data; leaving it for recovery",
+            path.display()
+        ));
+    }
+    fs::remove_dir(path).map_err(|error| format!("remove {}: {error}", path.display()))
+}
+
+fn with_rollback(error: &str, rollback: Result<(), String>) -> String {
+    match rollback {
+        Ok(()) => format!("{error}; activation rolled back"),
+        Err(rollback) => format!(
+            "{error}; rollback was incomplete ({rollback}); rerun setup to recover before writing"
+        ),
+    }
+}
+
+/// Recovers any interrupted directory transaction before a new USB setup.
+///
+/// The current installation is always preferred when present. If the commit
+/// window left it absent, the complete previous installation is restored
+/// before a staged first install is considered. Owner folders are merged
+/// without overwriting differing bytes.
+pub fn recover_payload_transaction(volume: &Path) -> Result<(), String> {
+    let adds = volume.join(".adds");
+    let current = volume.join(INSTALL_FOLDER);
+    let staging = volume.join(STAGING_FOLDER);
+    let previous = volume.join(PREVIOUS_FOLDER);
+    let holder = volume.join(OWNER_HOLD_FOLDER);
+    if !adds.exists() {
+        return Ok(());
+    }
+    if !current.exists() {
+        if previous.exists() {
+            fs::rename(&previous, &current).map_err(|error| {
+                format!(
+                    "recover {} as {}: {error}",
+                    previous.display(),
+                    current.display()
+                )
+            })?;
+        } else if staging.join(TRANSACTION_MARKER).is_file() {
+            fs::rename(&staging, &current).map_err(|error| {
+                format!(
+                    "recover {} as {}: {error}",
+                    staging.display(),
+                    current.display()
+                )
+            })?;
+        }
+    }
+    if current.exists() {
+        restore_owner_folders(
+            &holder,
+            &current,
+            ActivationStep::RollbackOwner,
+            &mut |_| Ok(()),
+        )?;
+        if previous.exists() {
+            restore_owner_folders(
+                &previous,
+                &current,
+                ActivationStep::RollbackOwner,
+                &mut |_| Ok(()),
+            )?;
+        }
+        if staging.exists() {
+            fs::remove_dir_all(&staging)
+                .map_err(|error| format!("remove {}: {error}", staging.display()))?;
+        }
+    }
+    if holder.exists() {
+        remove_empty_directory(&holder)?;
+    }
+    Ok(())
 }
 
 /// Reads back everything that was written and compares it byte for byte.
@@ -655,13 +963,21 @@ fn member_relative(member: &crate::package::Member) -> Result<&str, String> {
 ///
 /// When the folder exists but cannot be removed.
 pub fn remove_payload(volume: &Path) -> Result<bool, String> {
-    let installed = volume.join(INSTALL_FOLDER);
-    if !installed.exists() {
-        return Ok(false);
+    let folders = [
+        volume.join(INSTALL_FOLDER),
+        volume.join(STAGING_FOLDER),
+        volume.join(PREVIOUS_FOLDER),
+        volume.join(OWNER_HOLD_FOLDER),
+    ];
+    let mut removed = false;
+    for installed in folders {
+        if installed.exists() {
+            fs::remove_dir_all(&installed)
+                .map_err(|error| format!("remove {}: {error}", installed.display()))?;
+            removed = true;
+        }
     }
-    fs::remove_dir_all(&installed)
-        .map_err(|error| format!("remove {}: {error}", installed.display()))?;
-    Ok(true)
+    Ok(removed)
 }
 
 /// Flushes the volume and ejects it, so the reader remounts its own storage.
@@ -1140,7 +1456,7 @@ mod tests {
         Staged, Verdict, INSTALL_FOLDER, SETTINGS_APPLIED, SSH_DISABLED, SSH_ENABLED,
     };
     use std::net::Ipv4Addr;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     #[test]
     fn the_machines_trust_roots_ride_along_with_a_setup() {
@@ -1821,6 +2137,7 @@ mod tests {
         std::fs::create_dir_all(owner_state.parent().expect("parent")).expect("state folder");
         std::fs::write(&owner_state, b"owner state").expect("state");
         assert_eq!(write_payload(&members, &root).expect("rerun"), 1);
+        assert!(!root.join(super::PREVIOUS_FOLDER).exists());
         assert_eq!(
             std::fs::read(&owner_state).expect("preserved"),
             b"owner state",
@@ -1833,6 +2150,168 @@ mod tests {
         assert!(error.contains("written short"), "{error}");
 
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    fn transaction_fixture(name: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "kobo-setup-transaction-{name}-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let adds = root.join(".adds");
+        std::fs::create_dir_all(adds.join("cobalt/state")).expect("old state");
+        std::fs::create_dir_all(adds.join("cobalt/apps/example")).expect("old app");
+        std::fs::write(adds.join("cobalt/start.sh"), b"old managed").expect("old managed");
+        std::fs::write(adds.join("cobalt/state/settings"), b"owner state").expect("state");
+        std::fs::write(adds.join("cobalt/apps/example/data"), b"owner app").expect("app");
+        std::fs::create_dir_all(adds.join("cobalt.prev")).expect("previous");
+        std::fs::write(adds.join("cobalt.prev/start.sh"), b"older managed").expect("previous");
+        std::fs::create_dir_all(adds.join("cobalt.next")).expect("staging");
+        std::fs::write(adds.join("cobalt.next/start.sh"), b"new managed").expect("new managed");
+        std::fs::write(
+            adds.join("cobalt.next").join(super::TRANSACTION_MARKER),
+            b"complete\n",
+        )
+        .expect("marker");
+        root
+    }
+
+    fn assert_owner_data(root: &Path) {
+        assert_eq!(
+            std::fs::read(root.join(INSTALL_FOLDER).join("state/settings")).expect("state"),
+            b"owner state"
+        );
+        assert_eq!(
+            std::fs::read(root.join(INSTALL_FOLDER).join("apps/example/data")).expect("app"),
+            b"owner app"
+        );
+    }
+
+    #[test]
+    fn every_activation_failure_rolls_back_without_mixing_managed_files() {
+        use super::ActivationStep;
+
+        let failures = [
+            ActivationStep::HoldOwner("state"),
+            ActivationStep::RemovePrevious,
+            ActivationStep::RetireCurrent,
+            ActivationStep::ActivateStaged,
+            ActivationStep::RestoreOwner("apps"),
+        ];
+        for failure in failures {
+            let root = transaction_fixture(&format!("{failure:?}"));
+            let adds = root.join(".adds");
+            let mut failed = false;
+            let error = super::activate_staged(&adds, &mut |step| {
+                if !failed && step == failure {
+                    failed = true;
+                    Err(format!("injected failure at {step:?}"))
+                } else {
+                    Ok(())
+                }
+            })
+            .expect_err("activation fails");
+            assert!(error.contains("activation rolled back"), "{error}");
+            super::recover_payload_transaction(&root).expect("recovery");
+            assert_eq!(
+                std::fs::read(root.join(INSTALL_FOLDER).join("start.sh")).expect("managed"),
+                b"old managed",
+                "failure at {failure:?} mixed managed versions"
+            );
+            assert_owner_data(&root);
+
+            let staging = root.join(super::STAGING_FOLDER);
+            std::fs::create_dir_all(&staging).expect("restage");
+            std::fs::write(staging.join("start.sh"), b"new managed").expect("new managed");
+            std::fs::write(staging.join(super::TRANSACTION_MARKER), b"complete\n").expect("marker");
+            super::activate_staged(&adds, &mut |_| Ok(())).expect("safe rerun");
+            assert_eq!(
+                std::fs::read(root.join(INSTALL_FOLDER).join("start.sh")).expect("managed"),
+                b"new managed"
+            );
+            assert_owner_data(&root);
+            let _ = std::fs::remove_dir_all(root);
+        }
+    }
+
+    #[test]
+    fn failed_rollback_is_recovered_on_the_next_run() {
+        use super::ActivationStep;
+
+        let root = transaction_fixture("rollback-previous");
+        let adds = root.join(".adds");
+        let error = super::activate_staged(&adds, &mut |step| {
+            if matches!(
+                step,
+                ActivationStep::ActivateStaged | ActivationStep::RollbackPrevious
+            ) {
+                Err(format!("injected failure at {step:?}"))
+            } else {
+                Ok(())
+            }
+        })
+        .expect_err("rollback fails");
+        assert!(error.contains("rollback was incomplete"), "{error}");
+        assert!(!root.join(INSTALL_FOLDER).exists());
+        super::recover_payload_transaction(&root).expect("rerun recovery");
+        assert_eq!(
+            std::fs::read(root.join(INSTALL_FOLDER).join("start.sh")).expect("managed"),
+            b"old managed"
+        );
+        assert_owner_data(&root);
+        let _ = std::fs::remove_dir_all(root);
+
+        let root = transaction_fixture("rollback-new");
+        let adds = root.join(".adds");
+        let error = super::activate_staged(&adds, &mut |step| {
+            if matches!(
+                step,
+                ActivationStep::RestoreOwner("apps") | ActivationStep::RollbackNew
+            ) {
+                Err(format!("injected failure at {step:?}"))
+            } else {
+                Ok(())
+            }
+        })
+        .expect_err("rollback fails");
+        assert!(error.contains("rollback was incomplete"), "{error}");
+        super::recover_payload_transaction(&root).expect("rerun completes committed transaction");
+        assert_eq!(
+            std::fs::read(root.join(INSTALL_FOLDER).join("start.sh")).expect("managed"),
+            b"new managed"
+        );
+        assert_owner_data(&root);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn post_activation_verification_failure_can_restore_the_previous_tree() {
+        let root = transaction_fixture("post-verify");
+        let adds = root.join(".adds");
+        super::activate_staged(&adds, &mut |_| Ok(())).expect("activate new");
+        assert_eq!(
+            std::fs::read(root.join(INSTALL_FOLDER).join("start.sh")).expect("new"),
+            b"new managed"
+        );
+        super::rollback_activation(&adds, &mut |_| Ok(())).expect("rollback after readback");
+        assert_eq!(
+            std::fs::read(root.join(INSTALL_FOLDER).join("start.sh")).expect("old"),
+            b"old managed"
+        );
+        assert_owner_data(&root);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn a_release_cannot_claim_owner_managed_folders() {
+        let member = crate::package::Member {
+            path: format!("{}/state/settings", crate::package::INSTALL_ROOT),
+            bytes: b"replacement".to_vec(),
+            program: false,
+        };
+        assert!(super::refuse_managed_owner_folders(&[member])
+            .expect_err("owner overlap")
+            .contains("owner-managed"));
     }
 
     #[test]

--- a/crates/kobod/src/autoupdate.rs
+++ b/crates/kobod/src/autoupdate.rs
@@ -27,8 +27,8 @@ const BETA_RELEASES: &str = "https://api.github.com/repos/BandarLabs/Cobalt/rele
 /// kilobytes; a reply a thousand times that size is not a release description.
 const RELEASE_LIMIT: u32 = 1024 * 1024;
 
-/// The most a digest listing is allowed to be: a few lines of hex and names.
-const DIGEST_LIMIT: u32 = 16 * 1024;
+const MANIFEST_LIMIT: u32 = 64 * 1024;
+const SIGNATURE_LIMIT: u32 = 1024;
 
 /// The file holding the owner's two choices, under `root/state`.
 const STATE_FILE: &str = "auto-update";
@@ -195,9 +195,8 @@ fn stale_apps(root: &Path, channel: UpdateChannel) -> Vec<String> {
     )
 }
 
-/// A strictly newer published release, with its digest already fetched, or
-/// nothing. All-or-nothing on purpose: a release that cannot be verified is
-/// not an update, it is a download.
+/// A strictly newer published release, with its signed manifest verified, or
+/// nothing. All-or-nothing on purpose: unsigned metadata is not an update.
 fn platform_update(installed: &str, channel: UpdateChannel) -> Option<PlatformUpdate> {
     let endpoint = match channel {
         UpdateChannel::Stable => STABLE_RELEASES,
@@ -205,46 +204,69 @@ fn platform_update(installed: &str, channel: UpdateChannel) -> Option<PlatformUp
     };
     let body = kobo_net::fetch(endpoint, RELEASE_LIMIT).ok()?;
     let body = String::from_utf8(body).ok()?;
-    let (version, archive, digest_url) = match channel {
+    let release = match channel {
         UpdateChannel::Stable => release_from(&body),
         UpdateChannel::Beta => beta_release_from(&body),
     }?;
-    if !newer(&version, installed) {
+    if !newer(&release.version, installed) {
         return None;
     }
-    let listing = kobo_net::fetch(&digest_url, DIGEST_LIMIT).ok()?;
-    let listing = String::from_utf8(listing).ok()?;
-    let sha256 = digest_from(&listing, &archive_file(&version))?;
+    let manifest = kobo_net::fetch(&release.manifest, MANIFEST_LIMIT).ok()?;
+    let signature = kobo_net::fetch(&release.signature, SIGNATURE_LIMIT).ok()?;
+    let signature = String::from_utf8(signature).ok()?;
+    let manifest = kobo_app_store::verify_release_manifest(&manifest, &signature).ok()?;
+    platform_from_manifest(release, &manifest)
+}
+
+fn platform_from_manifest(
+    release: Release,
+    manifest: &kobo_app_store::ReleaseManifest,
+) -> Option<PlatformUpdate> {
+    if manifest.version != release.version {
+        return None;
+    }
+    let device = manifest.device()?;
+    if device.name != archive_file(&release.version) {
+        return None;
+    }
     Some(PlatformUpdate {
-        version,
-        url: archive,
-        sha256,
+        version: release.version,
+        url: release.archive,
+        sha256: device.sha256.clone(),
     })
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Release {
+    version: String,
+    archive: String,
+    manifest: String,
+    signature: String,
 }
 
 /// Reads the GitHub "latest release" reply down to the version, the archive
 /// URL and the digest URL this device needs.
-fn release_from(body: &str) -> Option<(String, String, String)> {
+fn release_from(body: &str) -> Option<Release> {
     let value = kobo_json::parse(body).ok()?;
     release_value(&value, "v", false)
 }
 
 /// Selects the highest valid beta prerelease, independent of GitHub's reply
 /// order. Drafts, stable releases and malformed beta entries are skipped.
-fn beta_release_from(body: &str) -> Option<(String, String, String)> {
+fn beta_release_from(body: &str) -> Option<Release> {
     let value = kobo_json::parse(body).ok()?;
     value
         .as_array()?
         .iter()
         .filter_map(|release| release_value(release, "beta-v", true))
-        .max_by_key(|(version, _, _)| numbers(version))
+        .max_by_key(|release| numbers(&release.version))
 }
 
 fn release_value(
     value: &kobo_json::Value,
     tag_prefix: &str,
     require_prerelease: bool,
-) -> Option<(String, String, String)> {
+) -> Option<Release> {
     if value
         .get("draft")
         .and_then(kobo_json::Value::as_bool)
@@ -271,8 +293,14 @@ fn release_value(
             .map(str::to_owned)
     };
     let archive = url_of(&archive_file(&version))?;
-    let digest = url_of(&format!("cobalt-{version}.sha256"))?;
-    Some((version, archive, digest))
+    let manifest = url_of("cobalt-host-manifest.txt")?;
+    let signature = url_of("cobalt-host-manifest.txt.sig")?;
+    Some(Release {
+        version,
+        archive,
+        manifest,
+        signature,
+    })
 }
 
 fn valid_release_url(url: &str) -> bool {
@@ -300,27 +328,14 @@ fn numbers(version: &str) -> Option<(u64, u64, u64)> {
     }
 }
 
-/// Finds the digest vouching for `asset` in a `sha256sum` style listing:
-/// sixty-four hex characters, whitespace, a file name per line.
-fn digest_from(listing: &str, asset: &str) -> Option<String> {
-    listing.lines().find_map(|line| {
-        let (digest, name) = line.split_once(char::is_whitespace)?;
-        let named = name.trim_start().trim_start_matches('*') == asset;
-        let plausible = digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
-        (named && plausible).then(|| digest.to_owned())
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
-        beta_release_from, digest_from, newer, parse, plan_with, preferences, release_from, render,
-        set_preferences, PlatformUpdate, Preferences,
+        beta_release_from, newer, parse, plan_with, platform_from_manifest, preferences,
+        release_from, render, set_preferences, PlatformUpdate, Preferences,
     };
     use kobo_protocol::UpdateChannel;
+    use std::fs;
 
     #[test]
     fn a_reader_who_chose_nothing_gets_both_updates() {
@@ -388,6 +403,41 @@ mod tests {
     }
 
     #[test]
+    fn returning_to_stable_changes_only_persisted_preferences() {
+        let root =
+            std::env::temp_dir().join(format!("cobalt-stable-channel-{}", std::process::id()));
+        let _ignored = std::fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("apps/example")).expect("app");
+        fs::create_dir_all(root.join("secrets")).expect("secrets");
+        fs::write(root.join("apps/example/state"), b"app state").expect("app state");
+        fs::write(root.join("secrets/service"), b"secret").expect("secret");
+        let beta = Preferences {
+            cobalt: true,
+            apps: true,
+            channel: UpdateChannel::Beta,
+        };
+        set_preferences(&root, beta).expect("choose beta");
+        set_preferences(
+            &root,
+            Preferences {
+                channel: UpdateChannel::Stable,
+                ..beta
+            },
+        )
+        .expect("return stable");
+        assert_eq!(preferences(&root).channel, UpdateChannel::Stable);
+        assert_eq!(
+            fs::read(root.join("apps/example/state")).expect("app state"),
+            b"app state"
+        );
+        assert_eq!(
+            fs::read(root.join("secrets/service")).expect("secret"),
+            b"secret"
+        );
+        let _ignored = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn only_a_strictly_newer_triple_counts() {
         assert!(newer("0.4.0", "0.3.0"));
         assert!(!newer("0.3.0", "0.3.0"));
@@ -397,7 +447,7 @@ mod tests {
     }
 
     #[test]
-    fn a_release_is_read_down_to_its_three_facts() {
+    fn a_release_is_read_down_to_its_signed_metadata() {
         let body = r#"{
             "tag_name": "v0.4.0",
             "draft": false,
@@ -405,14 +455,20 @@ mod tests {
             "assets": [
                 {"name": "cobalt-0.4.0-KoboRoot.tgz",
                  "browser_download_url": "https://example.test/cobalt-0.4.0-KoboRoot.tgz"},
-                {"name": "cobalt-0.4.0.sha256",
-                 "browser_download_url": "https://example.test/cobalt-0.4.0.sha256"}
+                {"name": "cobalt-host-manifest.txt",
+                 "browser_download_url": "https://example.test/manifest"},
+                {"name": "cobalt-host-manifest.txt.sig",
+                 "browser_download_url": "https://example.test/manifest.sig"}
             ]
         }"#;
-        let (version, archive, digest) = release_from(body).expect("release");
-        assert_eq!(version, "0.4.0");
-        assert_eq!(archive, "https://example.test/cobalt-0.4.0-KoboRoot.tgz");
-        assert_eq!(digest, "https://example.test/cobalt-0.4.0.sha256");
+        let release = release_from(body).expect("release");
+        assert_eq!(release.version, "0.4.0");
+        assert_eq!(
+            release.archive,
+            "https://example.test/cobalt-0.4.0-KoboRoot.tgz"
+        );
+        assert_eq!(release.manifest, "https://example.test/manifest");
+        assert_eq!(release.signature, "https://example.test/manifest.sig");
     }
 
     #[test]
@@ -429,22 +485,26 @@ mod tests {
         let body = r#"[
           {"tag_name":"beta-v0.4.0","draft":false,"prerelease":true,"assets":[
             {"name":"cobalt-0.4.0-KoboRoot.tgz","browser_download_url":"https://example.test/0.4.0.tgz"},
-            {"name":"cobalt-0.4.0.sha256","browser_download_url":"https://example.test/0.4.0.sha256"}]},
+            {"name":"cobalt-host-manifest.txt","browser_download_url":"https://example.test/0.4.0.manifest"},
+            {"name":"cobalt-host-manifest.txt.sig","browser_download_url":"https://example.test/0.4.0.sig"}]},
           {"tag_name":"beta-v0.6.0","draft":true,"prerelease":true,"assets":[
             {"name":"cobalt-0.6.0-KoboRoot.tgz","browser_download_url":"https://example.test/0.6.0.tgz"},
-            {"name":"cobalt-0.6.0.sha256","browser_download_url":"https://example.test/0.6.0.sha256"}]},
+            {"name":"cobalt-host-manifest.txt","browser_download_url":"https://example.test/0.6.0.manifest"},
+            {"name":"cobalt-host-manifest.txt.sig","browser_download_url":"https://example.test/0.6.0.sig"}]},
           {"tag_name":"v0.7.0","draft":false,"prerelease":false,"assets":[]},
           {"tag_name":"beta-v0.8.0","draft":false,"prerelease":true,"assets":[
             {"name":"KoboRoot.tgz","browser_download_url":"https://example.test/wrong.tgz"},
-            {"name":"cobalt-0.8.0.sha256","browser_download_url":"https://example.test/0.8.0.sha256"}]},
+            {"name":"cobalt-host-manifest.txt","browser_download_url":"https://example.test/0.8.0.manifest"},
+            {"name":"cobalt-host-manifest.txt.sig","browser_download_url":"https://example.test/0.8.0.sig"}]},
           {"tag_name":"beta-v0.5.0","draft":false,"prerelease":true,"assets":[
             {"name":"cobalt-0.5.0-KoboRoot.tgz","browser_download_url":"https://example.test/0.5.0.tgz"},
-            {"name":"cobalt-0.5.0.sha256","browser_download_url":"https://example.test/0.5.0.sha256"}]}
+            {"name":"cobalt-host-manifest.txt","browser_download_url":"https://example.test/0.5.0.manifest"},
+            {"name":"cobalt-host-manifest.txt.sig","browser_download_url":"https://example.test/0.5.0.sig"}]}
         ]"#;
-        let (version, archive, digest) = beta_release_from(body).expect("beta release");
-        assert_eq!(version, "0.5.0");
-        assert_eq!(archive, "https://example.test/0.5.0.tgz");
-        assert_eq!(digest, "https://example.test/0.5.0.sha256");
+        let release = beta_release_from(body).expect("beta release");
+        assert_eq!(release.version, "0.5.0");
+        assert_eq!(release.archive, "https://example.test/0.5.0.tgz");
+        assert_eq!(release.manifest, "https://example.test/0.5.0.manifest");
     }
 
     #[test]
@@ -462,24 +522,36 @@ mod tests {
     }
 
     #[test]
-    fn the_digest_listing_is_matched_by_name_and_shape() {
-        let listing = format!(
-            "{}  cobalt-0.4.0-KoboRoot.tgz\n{}  something-else.tgz\n",
-            "a".repeat(64),
-            "b".repeat(64)
-        );
+    fn signed_metadata_binds_the_beta_platform_digest() {
+        let release = super::Release {
+            version: "0.4.0".to_owned(),
+            archive: "https://example.test/0.4.0.tgz".to_owned(),
+            manifest: "https://example.test/0.4.0.manifest".to_owned(),
+            signature: "https://example.test/0.4.0.sig".to_owned(),
+        };
+        let manifest = kobo_app_store::ReleaseManifest {
+            version: "0.4.0".to_owned(),
+            channels: vec!["stable".to_owned(), "beta".to_owned()],
+            source: "0123456789abcdef0123456789abcdef01234567".to_owned(),
+            assets: vec![kobo_app_store::ReleaseAsset {
+                kind: "device".to_owned(),
+                platform: None,
+                name: "cobalt-0.4.0-KoboRoot.tgz".to_owned(),
+                bytes: 123,
+                sha256: "a".repeat(64),
+            }],
+        };
         assert_eq!(
-            digest_from(&listing, "cobalt-0.4.0-KoboRoot.tgz"),
-            Some("a".repeat(64))
+            platform_from_manifest(release.clone(), &manifest),
+            Some(PlatformUpdate {
+                version: "0.4.0".to_owned(),
+                url: "https://example.test/0.4.0.tgz".to_owned(),
+                sha256: "a".repeat(64),
+            })
         );
-        assert_eq!(digest_from(&listing, "cobalt-0.5.0-KoboRoot.tgz"), None);
-        assert_eq!(
-            digest_from(
-                "tooshort  cobalt-0.4.0-KoboRoot.tgz",
-                "cobalt-0.4.0-KoboRoot.tgz"
-            ),
-            None
-        );
+        let mut wrong = manifest;
+        wrong.version = "0.4.1".to_owned();
+        assert!(platform_from_manifest(release, &wrong).is_none());
     }
 
     #[test]

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -53,12 +53,13 @@ and device artifact.
 
 To install an exact immutable release, add `--version X.Y.Z`. For CI, use
 `--non-interactive --yes`; add `--no-setup` when no physical reader is
-attached. The public bootstrap installs stable only. Enable **Beta updates** in
-Cobalt Settings after a normal stable installation, or use the source workflow
-for development. Settings shows the installed version and channel, requires a
-separate confirmation before changing it, persists the choice, and verifies
-the signed platform manifest. Returning to Stable changes future platform and
-Store checks without USB, downgrading, or deleting apps, state, or secrets.
+attached. The public bootstrap and prebuilt `kobo setup` install the stable
+platform only. Enable **Beta updates** exclusively in Cobalt Settings after a
+normal stable installation, or use the source workflow for development.
+Settings shows the installed version and channel, requires a separate
+confirmation before changing it, persists the choice, and verifies the signed
+platform manifest. Returning to Stable changes future platform and Store
+checks without USB, downgrading, or deleting apps, state, or secrets.
 
 ### High-assurance signed bootstrap
 
@@ -230,6 +231,20 @@ Rerun the stable installer command to update. The host binary and verified
 release directory are replaced atomically; an interrupted download is never
 activated. Running it again at the same version is safe. Beta platform updates
 remain inside Cobalt Settings and do not require USB.
+
+After the first installation, update only the host command with:
+
+```sh
+kobo update
+kobo update --channel beta
+```
+
+Stable is the default. Host Beta requires the explicit selector and changes
+only the installed `kobo` executable; it never scans, mounts, ejects, or writes
+an attached reader. Returning from a Beta host CLI to the latest Stable CLI is
+`kobo update`. An already-current command reports that result without replacing
+the binary. The stable setup package remains separate, so `kobo setup` never
+turns into a Beta USB installation.
 
 The installer lock fails closed. If an interrupted process leaves
 `~/.local/share/kobo/install.lock`, first verify that no installer is still

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -243,8 +243,11 @@ Stable is the default. Host Beta requires the explicit selector and changes
 only the installed `kobo` executable; it never scans, mounts, ejects, or writes
 an attached reader. Returning from a Beta host CLI to the latest Stable CLI is
 `kobo update`. An already-current command reports that result without replacing
-the binary. The stable setup package remains separate, so `kobo setup` never
-turns into a Beta USB installation.
+the binary. The stable setup package and its signed metadata remain
+byte-for-byte unchanged, so `kobo setup` never turns into a Beta USB
+installation. Each host release keeps `kobo` and its next updater together in
+an immutable directory; one atomic selector changes the live pair while the
+public command link stays fixed.
 
 The installer lock fails closed. If an interrupted process leaves
 `~/.local/share/kobo/install.lock`, first verify that no installer is still

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -28,38 +28,38 @@ at.
 - A **USB cable** that carries data. Charge-only cables are common and they
   look identical; if the reader charges but never offers to connect, suspect
   the cable before anything else.
-- **An internet connection**, and **`curl`** on your path. Setup downloads
-  NickelMenu v0.6.0 (the one piece that cannot live on the book partition) and
-  checks it against a recorded SHA-256.
-- [**rustup**](https://rustup.rs) with its stable Rust toolchain. You do not
-  need a separate operating-system `rust` package: rustup supplies `rustc` and
-  `cargo`. If stable is not installed, run `rustup toolchain install stable`;
-  the next section selects it only for this checkout.
-- An **ARM cross-compiler**, because the TLS stack carries C and assembly that
-  is built from source. Everything else is linked by `rust-lld`, which the Rust
-  toolchain already ships.
+- An internet connection, `curl` or `wget`, `tar`, and OpenSSH `ssh-keygen`.
+  These are included with current macOS and mainstream Linux distributions.
 
-  ```sh
-  # macOS
-  brew install messense/macos-cross-toolchains/armv7-unknown-linux-musleabihf
-  # Debian or Ubuntu
-  sudo apt-get install gcc-arm-linux-gnueabihf
-  ```
+No Rust toolchain, Git checkout, or ARM cross-compiler is needed for the
+prebuilt installer.
 
-  Cobalt finds it under any of its usual names, and tells you which package to
-  install if it is missing.
+## 1. Install the host command
 
-## 1. Get the code and the cross-compilation target
+Stable is the default:
 
 ```sh
-rustup toolchain install stable
-git clone https://github.com/BandarLabs/Cobalt
-cd Cobalt
-rustup override set stable
-rustup target add armv7-unknown-linux-musleabihf
+curl -fsSL https://github.com/BandarLabs/Cobalt/releases/latest/download/install.sh | sh
 ```
 
-## 2. Connect the reader over USB
+The script selects macOS Intel/Apple Silicon or Linux x86_64/arm64, verifies an
+OpenSSH Ed25519 signature over the versioned release manifest, verifies the
+host and device package sizes and SHA-256 digests, and installs `kobo` under
+`~/.local/bin` without sudo. It prompts through `/dev/tty`, so piping the
+script does not consume its answers.
+
+For the current beta candidate:
+
+```sh
+curl -fsSL https://github.com/BandarLabs/Cobalt/releases/latest/download/install.sh |
+  sh -s -- --beta
+```
+
+To install an exact immutable release, add `--version X.Y.Z`. For CI, use
+`--non-interactive --yes`; add `--no-setup` when no physical reader is
+attached. Beta is never selected implicitly.
+
+## 2. Connect and confirm the reader
 
 This is the step people get stuck on, so in full:
 
@@ -72,28 +72,26 @@ This is the step people get stuck on, so in full:
    volume is the reader's book partition, and it is the only thing Cobalt
    writes to.
 
-Leave it mounted. Setup ejects it for you when it is finished.
+The installer waits for the volume, resolves its friendly model and support
+status through Cobalt's device profiles, then shows the model, device code,
+profile, firmware, mount point, release version/channel, and intended changes.
+It does not print the full serial. The write requires an explicit default-no
+confirmation. Unsupported or changed devices, unsupported firmware, and
+multiple mounted readers are refused.
 
-## 3. Run setup
-
-```sh
-cargo run -p kobo-cli -- setup
-```
-
-That one command builds every device-side program, finds the mounted reader,
-copies Cobalt into `.adds/cobalt`, reads every file back to prove it arrived
-intact, sets the reader's own `ForceWifiOn` and `AutoSleepMinutes` settings,
-stages the **Cobalt** menu entry, and ejects. It builds before it writes
-anything, so a build that fails leaves the reader untouched. It leaves the
-firmware's root SSH server disabled.
-
-The first run takes a while, because it builds the whole workspace for ARM.
+Setup copies the verified prebuilt package directly into `.adds/cobalt`, reads
+every file back byte for byte, preserves installed apps, app state, secrets,
+owner files, and unrelated NickelMenu entries, then ejects where supported.
+Under WSL it tells you to eject from Windows and does not claim WSL ejected it.
+The firmware's root SSH server remains disabled unless `--enable-ssh` is
+explicitly supplied.
 
 The binaries are statically linked, so nothing has to be installed on the
 reader to support them.
 
-Not sure? Add `--dry-run` and it prints every step it would take and touches
-nothing.
+Not sure? Run `kobo setup --dry-run`. If installation was deferred with
+`--no-setup`, run `kobo setup`; the installed command automatically reuses its
+signed prebuilt package.
 
 ## 4. Restart the reader
 
@@ -158,14 +156,14 @@ if an install fails, the previous installed copy remains in place.
   was installed.** A firmware update removes the plugin but leaves its files
   on the book partition, so setup believes NickelMenu is still there and
   stages nothing. Setup says so when it notices the dates disagree. Run
-  `cargo run -p kobo-cli -- setup --menu` to stage NickelMenu again; that
-  keeps every menu entry already on the reader.
+  `kobo setup --menu` to stage NickelMenu again; that keeps every menu entry
+  already on the reader.
 - **The Cobalt entry was there and then vanished.** That is NickelMenu's
   failsafe, which reads any unexpected restart of the reader software as a
   crash and disables itself rather than risk a boot loop. You can confirm it:
   the plugin is left beside itself as `libnm.so.failsafe`. Run
-  `cargo run -p kobo-cli -- setup` again and restart, and this time let the
-  reader sit on its home screen for a minute before touching it.
+  `kobo setup` again and restart, and this time let the reader sit on its home
+  screen for a minute before touching it.
 - **Setup refused to do something.** Read what it printed. It refuses rather
   than guesses, and it names the reason: an unrecognised volume, a menu slot
   another mod is already using, or a file that did not read back byte for byte.
@@ -180,15 +178,43 @@ the firmware's own SSH server so that `kobo deploy` can install without a
 reboot. That is a developer path with its own trade-offs, and it is described
 under [Connecting a device](DEVICES.md#connecting-a-device).
 
+## Updating or building from source
+
+Rerun the same stable or beta installer command to update. The host binary and
+verified release directory are replaced atomically; an interrupted download is
+never activated. Running it again at the same version is safe.
+
+Developers can keep the original source-build path:
+
+```sh
+rustup toolchain install stable
+git clone https://github.com/BandarLabs/Cobalt.git
+cd Cobalt
+rustup override set stable
+rustup target add armv7-unknown-linux-musleabihf
+# macOS: brew install messense/macos-cross-toolchains/armv7-unknown-linux-musleabihf
+# Debian/Ubuntu: sudo apt-get install gcc-arm-linux-gnueabihf
+cargo run -p kobo-cli -- setup --source
+```
+
+`--source` builds the device package before writing. The direct-folder writer,
+profile checks, confirmation, preservation rules, and byte-for-byte readback
+are the same as the prebuilt path.
+
 ## Removing it
 
 Cobalt never writes to the root filesystem, the bootloader, the kernel, a
 partition table or any startup script, so removing it is deleting a folder:
 
 ```sh
-cargo run -p kobo-cli -- setup --undo
+kobo setup --undo
 ```
 
 Or, with no tooling at all, plug the reader in and delete `.adds/cobalt` from
 it. That is the entire uninstall. If you used `--enable-ssh`, `--undo` also
 switches the SSH server back off.
+
+To remove the host command, read `~/.local/share/kobo/install-state`, remove
+only the `binary` path named there and `~/.local/share/kobo`, then remove the
+clearly delimited `Cobalt kobo installer` block from the shell startup file the
+installer reported. Do not delete another `kobo` command at a different path.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -39,14 +39,17 @@ prebuilt installer.
 Stable is the default:
 
 ```sh
-curl -fsSL https://github.com/BandarLabs/Cobalt/releases/latest/download/install.sh | sh
+curl -fsSL https://bandarlabs.github.io/Cobalt/install.sh | sh
 ```
 
-This one-line convenience route trusts GitHub HTTPS for `install.sh`, because a
-script cannot verify itself before the shell executes it. Once running, it
-verifies an OpenSSH Ed25519 signature over the versioned release manifest and
-checks every subsequently executed/downloaded host and device artifact by
-length and SHA-256. It installs `kobo` under `~/.local/bin` without sudo.
+This canonical stable discovery path is served by GitHub Pages from
+`main:/docs` after stable promotion. It fixes discovery and avoids depending on
+a particular stable release asset name; it does not solve self-verification.
+The one-line route trusts GitHub Pages HTTPS for the bootstrap because a script
+cannot verify itself before the shell executes it. Once running, the small
+Pages bootstrap verifies the signed release manifest and the full release
+installer before executing it. The release installer then verifies every host
+and device artifact.
 
 For the first beta candidate, use its exact beta release URL; no stable
 installer asset is required:
@@ -103,6 +106,11 @@ sh ./install.sh --beta --version "$version"
 For stable, use `tag=v$version` and omit `--beta`. Keep the pinned signer line
 from this repository or another out-of-band trusted copy, not from the release
 being checked.
+
+After the first stable promotion, the Pages discovery bootstrap is
+channel-agnostic, so `https://bandarlabs.github.io/Cobalt/install.sh` may also
+be run with `sh -s -- --beta`. The exact beta URL remains the first-beta and
+exact-version route.
 
 ## 2. Connect and confirm the reader
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -55,7 +55,10 @@ To install an exact immutable release, add `--version X.Y.Z`. For CI, use
 `--non-interactive --yes`; add `--no-setup` when no physical reader is
 attached. The public bootstrap installs stable only. Enable **Beta updates** in
 Cobalt Settings after a normal stable installation, or use the source workflow
-for development.
+for development. Settings shows the installed version and channel, requires a
+separate confirmation before changing it, persists the choice, and verifies
+the signed platform manifest. Returning to Stable changes future platform and
+Store checks without USB, downgrading, or deleting apps, state, or secrets.
 
 ### High-assurance signed bootstrap
 
@@ -223,9 +226,10 @@ under [Connecting a device](DEVICES.md#connecting-a-device).
 
 ## Updating or building from source
 
-Rerun the same stable or beta installer command to update. The host binary and
-verified release directory are replaced atomically; an interrupted download is
-never activated. Running it again at the same version is safe.
+Rerun the stable installer command to update. The host binary and verified
+release directory are replaced atomically; an interrupted download is never
+activated. Running it again at the same version is safe. Beta platform updates
+remain inside Cobalt Settings and do not require USB.
 
 The installer lock fails closed. If an interrupted process leaves
 `~/.local/share/kobo/install.lock`, first verify that no installer is still

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -51,17 +51,11 @@ Pages bootstrap verifies the signed release manifest and the full release
 installer before executing it. The release installer then verifies every host
 and device artifact.
 
-For the first beta candidate, use its exact beta release URL; no stable
-installer asset is required:
-
-```sh
-curl -fsSL https://github.com/BandarLabs/Cobalt/releases/download/beta-v0.3.4/install.sh |
-  sh -s -- --beta --version 0.3.4
-```
-
 To install an exact immutable release, add `--version X.Y.Z`. For CI, use
 `--non-interactive --yes`; add `--no-setup` when no physical reader is
-attached. Beta is never selected implicitly.
+attached. The public bootstrap installs stable only. Enable **Beta updates** in
+Cobalt Settings after a normal stable installation, or use the source workflow
+for development.
 
 ### High-assurance signed bootstrap
 
@@ -75,7 +69,7 @@ repository; its SHA-256 fingerprint is
 
 ```sh
 version=0.3.4
-tag=beta-v$version                 # use v$version after stable promotion
+tag=v$version
 base=https://github.com/BandarLabs/Cobalt/releases/download/$tag
 dir=cobalt-installer-$version
 (umask 077 && mkdir "$dir") || exit
@@ -100,17 +94,11 @@ else
   actual=$(shasum -a 256 install.sh | awk '{print $1}')
 fi
 test "$actual" = "$2"
-sh ./install.sh --beta --version "$version"
+sh ./install.sh --version "$version"
 ```
 
-For stable, use `tag=v$version` and omit `--beta`. Keep the pinned signer line
-from this repository or another out-of-band trusted copy, not from the release
-being checked.
-
-After the first stable promotion, the Pages discovery bootstrap is
-channel-agnostic, so `https://bandarlabs.github.io/Cobalt/install.sh` may also
-be run with `sh -s -- --beta`. The exact beta URL remains the first-beta and
-exact-version route.
+Keep the pinned signer line from this repository or another out-of-band trusted
+copy, not from the release being checked.
 
 ## 2. Connect and confirm the reader
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -42,22 +42,67 @@ Stable is the default:
 curl -fsSL https://github.com/BandarLabs/Cobalt/releases/latest/download/install.sh | sh
 ```
 
-The script selects macOS Intel/Apple Silicon or Linux x86_64/arm64, verifies an
-OpenSSH Ed25519 signature over the versioned release manifest, verifies the
-host and device package sizes and SHA-256 digests, and installs `kobo` under
-`~/.local/bin` without sudo. It prompts through `/dev/tty`, so piping the
-script does not consume its answers.
+This one-line convenience route trusts GitHub HTTPS for `install.sh`, because a
+script cannot verify itself before the shell executes it. Once running, it
+verifies an OpenSSH Ed25519 signature over the versioned release manifest and
+checks every subsequently executed/downloaded host and device artifact by
+length and SHA-256. It installs `kobo` under `~/.local/bin` without sudo.
 
-For the current beta candidate:
+For the first beta candidate, use its exact beta release URL; no stable
+installer asset is required:
 
 ```sh
-curl -fsSL https://github.com/BandarLabs/Cobalt/releases/latest/download/install.sh |
-  sh -s -- --beta
+curl -fsSL https://github.com/BandarLabs/Cobalt/releases/download/beta-v0.3.4/install.sh |
+  sh -s -- --beta --version 0.3.4
 ```
 
 To install an exact immutable release, add `--version X.Y.Z`. For CI, use
 `--non-interactive --yes`; add `--no-setup` when no physical reader is
 attached. Beta is never selected implicitly.
+
+### High-assurance signed bootstrap
+
+The recommended route when GitHub HTTPS alone is not sufficient verifies
+`install.sh` before execution. Choose an exact immutable release, download the
+manifest, SSHSIG, and script as data, verify the manifest with the pinned
+release key below, then verify the script against the signed `bootstrap`
+entry. Obtain this signer line from a separately trusted copy of this guide or
+repository; its SHA-256 fingerprint is
+`SHA256:ufJnWeLeZxeWlrY7KXb1MadhxMHYZdHSmk21Nmovgbo`.
+
+```sh
+version=0.3.4
+tag=beta-v$version                 # use v$version after stable promotion
+base=https://github.com/BandarLabs/Cobalt/releases/download/$tag
+dir=cobalt-installer-$version
+(umask 077 && mkdir "$dir") || exit
+cd "$dir"
+curl -fsSLO "$base/cobalt-host-manifest.txt"
+curl -fsSLO "$base/cobalt-host-manifest.txt.sshsig"
+curl -fsSLO "$base/install.sh"
+printf '%s\n' \
+  'cobalt-release ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL7XUR3p+tvPgftO/kRbigc8gagzP2RBDG3tWIu/1KXe' \
+  > allowed_signers
+ssh-keygen -Y verify -q -f allowed_signers -I cobalt-release \
+  -n cobalt-host-release -s cobalt-host-manifest.txt.sshsig \
+  < cobalt-host-manifest.txt
+set -- $(awk '$1 == "bootstrap" && $2 == "install.sh" && NF == 4 {
+  print $3, $4
+}' cobalt-host-manifest.txt)
+test "$#" -eq 2
+test "$(wc -c < install.sh | tr -d ' ')" = "$1"
+if command -v sha256sum >/dev/null 2>&1; then
+  actual=$(sha256sum install.sh | awk '{print $1}')
+else
+  actual=$(shasum -a 256 install.sh | awk '{print $1}')
+fi
+test "$actual" = "$2"
+sh ./install.sh --beta --version "$version"
+```
+
+For stable, use `tag=v$version` and omit `--beta`. Keep the pinned signer line
+from this repository or another out-of-band trusted copy, not from the release
+being checked.
 
 ## 2. Connect and confirm the reader
 
@@ -79,12 +124,14 @@ It does not print the full serial. The write requires an explicit default-no
 confirmation. Unsupported or changed devices, unsupported firmware, and
 multiple mounted readers are refused.
 
-Setup copies the verified prebuilt package directly into `.adds/cobalt`, reads
-every file back byte for byte, preserves installed apps, app state, secrets,
-owner files, and unrelated NickelMenu entries, then ejects where supported.
-Under WSL it tells you to eject from Windows and does not claim WSL ejected it.
-The firmware's root SSH server remains disabled unless `--enable-ssh` is
-explicitly supplied.
+Setup writes the complete verified managed payload into `.adds/cobalt.next`
+and reads every file back byte for byte before activation. It temporarily
+holds the known mutable owner folders, retires the complete old payload as
+`.adds/cobalt.prev`, activates the complete new directory, and restores owner
+data. A failed swap rolls back; an interrupted rollback is recovered on the
+next run without mixing managed versions. Installed apps, app state, secrets,
+owner data, and unrelated NickelMenu entries are preserved. Under WSL setup
+instructs Windows eject and does not claim WSL ejected the reader.
 
 The binaries are statically linked, so nothing has to be installed on the
 reader to support them.
@@ -183,6 +230,11 @@ under [Connecting a device](DEVICES.md#connecting-a-device).
 Rerun the same stable or beta installer command to update. The host binary and
 verified release directory are replaced atomically; an interrupted download is
 never activated. Running it again at the same version is safe.
+
+The installer lock fails closed. If an interrupted process leaves
+`~/.local/share/kobo/install.lock`, first verify that no installer is still
+running, then remove that exact directory manually and rerun. The script never
+guesses that a lock is stale or races another process to reclaim it.
 
 Developers can keep the original source-build path:
 

--- a/docs/RELEASE-TRAIN.md
+++ b/docs/RELEASE-TRAIN.md
@@ -33,7 +33,7 @@ artifacts are promoted from beta rather than rebuilt.
    installer, manifest, and signatures as `vX.Y.Z` without rebuilding.
    The `docs/install.sh` merged to main is then available from the canonical
    GitHub Pages stable discovery URL. Beta itself never changes the live Pages
-   source and uses exact `beta-vX.Y.Z` release URLs.
+   source or publishes a public host bootstrap.
 
 Direct stable publication from `main` is intentionally disabled for Store
 applications. A successful build is necessary but does not replace physical

--- a/docs/RELEASE-TRAIN.md
+++ b/docs/RELEASE-TRAIN.md
@@ -22,13 +22,15 @@ artifacts are promoted from beta rather than rebuilt.
 
 1. Merge platform pull requests into `beta`.
 2. Bump the workspace version once when cutting a beta candidate. The first
-   push of that version publishes immutable `beta-vX.Y.Z` assets. Later
-   app-only pushes at the same version leave that platform release unchanged.
+   push of that version publishes immutable `beta-vX.Y.Z` device and host
+   assets, their signed manifest, and the bootstrap installer. Later app-only
+   pushes at the same version leave that platform release unchanged.
 3. Install the beta release through Software Update and record the tested
    commit and archive SHA-256.
 4. Merge `beta` into `main` without squashing away the tested commit.
 5. Run **Promote tested beta** from `main`. The workflow tags the tested commit
-   and publishes the already-tested archive bytes as `vX.Y.Z`.
+   and publishes the already-tested device package, four host packages,
+   installer, manifest, and signatures as `vX.Y.Z` without rebuilding.
 
 Direct stable publication from `main` is intentionally disabled for Store
 applications. A successful build is necessary but does not replace physical

--- a/docs/RELEASE-TRAIN.md
+++ b/docs/RELEASE-TRAIN.md
@@ -31,6 +31,9 @@ artifacts are promoted from beta rather than rebuilt.
 5. Run **Promote tested beta** from `main`. The workflow tags the tested commit
    and publishes the already-tested device package, four host packages,
    installer, manifest, and signatures as `vX.Y.Z` without rebuilding.
+   The `docs/install.sh` merged to main is then available from the canonical
+   GitHub Pages stable discovery URL. Beta itself never changes the live Pages
+   source and uses exact `beta-vX.Y.Z` release URLs.
 
 Direct stable publication from `main` is intentionally disabled for Store
 applications. A successful build is necessary but does not replace physical

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -7,7 +7,6 @@
 set -eu
 
 REPOSITORY=${KOBO_INSTALLER_REPOSITORY:-BandarLabs/Cobalt}
-CHANNEL=stable
 VERSION=
 VERSION_EXPLICIT=false
 EXPECT_VERSION=false
@@ -33,8 +32,10 @@ for argument in "$@"; do
         continue
     fi
     case "$argument" in
-        --stable) CHANNEL=stable ;;
-        --beta) CHANNEL=beta ;;
+        --stable) ;;
+        --beta)
+            fail "the public bootstrap installs stable only; enable Beta updates in Cobalt Settings after installation"
+            ;;
         --version) EXPECT_VERSION=true ;;
     esac
 done
@@ -96,21 +97,8 @@ file_size() {
     wc -c < "$1" | tr -d ' '
 }
 
-if [ "$CHANNEL" = beta ] && [ -z "$VERSION" ]; then
-    beta_manifest=$STAGE/Cargo.toml
-    download "https://raw.githubusercontent.com/$REPOSITORY/beta/Cargo.toml" \
-        "$beta_manifest"
-    VERSION=$(sed -n 's/^version = "\([0-9][0-9.]*\)"$/\1/p' "$beta_manifest")
-    printf '%s\n' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' ||
-        fail "beta branch does not declare one workspace version"
-fi
-
 if [ -n "$VERSION" ]; then
-    if [ "$CHANNEL" = beta ]; then
-        tag=beta-v$VERSION
-    else
-        tag=v$VERSION
-    fi
+    tag=v$VERSION
     BASE_URL=https://github.com/$REPOSITORY/releases/download/$tag
 else
     BASE_URL=https://github.com/$REPOSITORY/releases/latest/download
@@ -145,8 +133,8 @@ manifest_field() {
 manifest_version=$(manifest_field version)
 manifest_channels=$(manifest_field channels)
 case ",$manifest_channels," in
-    *,"$CHANNEL",*) ;;
-    *) fail "signed manifest does not allow the requested $CHANNEL channel" ;;
+    *,stable,*) ;;
+    *) fail "signed manifest does not allow stable installation" ;;
 esac
 if [ "$VERSION_EXPLICIT" = true ] && [ "$manifest_version" != "$VERSION" ]; then
     fail "requested version $VERSION, but the signed manifest is $manifest_version"

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -32,7 +32,6 @@ for argument in "$@"; do
         continue
     fi
     case "$argument" in
-        --stable) ;;
         --beta)
             fail "the public bootstrap installs stable only; enable Beta updates in Cobalt Settings after installation"
             ;;

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -1,0 +1,179 @@
+#!/bin/sh
+# Stable discovery bootstrap served by GitHub Pages after stable promotion.
+#
+# This file is trusted through GitHub Pages HTTPS. It verifies the signed
+# release manifest and the release's full installer before executing that
+# installer; it cannot cryptographically verify its own already-running bytes.
+set -eu
+
+REPOSITORY=${KOBO_INSTALLER_REPOSITORY:-BandarLabs/Cobalt}
+CHANNEL=stable
+VERSION=
+VERSION_EXPLICIT=false
+EXPECT_VERSION=false
+STAGE=
+
+fail() {
+    printf 'kobo bootstrap: %s\n' "$*" >&2
+    exit 1
+}
+
+cleanup() {
+    if [ -n "$STAGE" ] && [ -d "$STAGE" ]; then
+        rm -rf "$STAGE"
+    fi
+}
+trap cleanup EXIT HUP INT TERM
+
+for argument in "$@"; do
+    if [ "$EXPECT_VERSION" = true ]; then
+        VERSION=$argument
+        VERSION_EXPLICIT=true
+        EXPECT_VERSION=false
+        continue
+    fi
+    case "$argument" in
+        --stable) CHANNEL=stable ;;
+        --beta) CHANNEL=beta ;;
+        --version) EXPECT_VERSION=true ;;
+    esac
+done
+[ "$EXPECT_VERSION" = false ] || fail "--version needs X.Y.Z"
+case "$VERSION" in
+    '') ;;
+    *[!0-9.]*|.*|*..*|*.) fail "version must be X.Y.Z" ;;
+esac
+if [ -n "$VERSION" ] &&
+    [ "$(printf '%s' "$VERSION" | awk -F. '{print NF}')" -ne 3 ]; then
+    fail "version must be X.Y.Z"
+fi
+
+CACHE_HOME=${XDG_CACHE_HOME:-"$HOME/.cache"}
+case "$CACHE_HOME" in
+    /*) ;;
+    *) fail "XDG_CACHE_HOME must be an absolute path" ;;
+esac
+case "$CACHE_HOME" in
+    *'
+'*) fail "cache path must not contain newlines" ;;
+esac
+mkdir -p "$CACHE_HOME/kobo"
+chmod 700 "$CACHE_HOME/kobo" 2>/dev/null || true
+STAGE=$CACHE_HOME/kobo/pages-bootstrap.$$
+rm -rf "$STAGE"
+(umask 077 && mkdir "$STAGE") || fail "cannot create bootstrap staging directory"
+
+download() {
+    url=$1
+    output=$2
+    case "$url" in
+        https://*) ;;
+        *) fail "bootstrap downloads must use HTTPS" ;;
+    esac
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL --retry 3 --retry-delay 1 --connect-timeout 10 --max-time 300 \
+            -o "$output" -- "$url"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q --https-only --timeout=20 --tries=3 -O "$output" -- "$url"
+    else
+        fail "curl or wget is required"
+    fi
+}
+
+sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    elif command -v openssl >/dev/null 2>&1; then
+        openssl dgst -sha256 "$1" | awk '{print $NF}'
+    else
+        fail "sha256sum, shasum, or openssl is required"
+    fi
+}
+
+file_size() {
+    wc -c < "$1" | tr -d ' '
+}
+
+if [ "$CHANNEL" = beta ] && [ -z "$VERSION" ]; then
+    beta_manifest=$STAGE/Cargo.toml
+    download "https://raw.githubusercontent.com/$REPOSITORY/beta/Cargo.toml" \
+        "$beta_manifest"
+    VERSION=$(sed -n 's/^version = "\([0-9][0-9.]*\)"$/\1/p' "$beta_manifest")
+    printf '%s\n' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' ||
+        fail "beta branch does not declare one workspace version"
+fi
+
+if [ -n "$VERSION" ]; then
+    if [ "$CHANNEL" = beta ]; then
+        tag=beta-v$VERSION
+    else
+        tag=v$VERSION
+    fi
+    BASE_URL=https://github.com/$REPOSITORY/releases/download/$tag
+else
+    BASE_URL=https://github.com/$REPOSITORY/releases/latest/download
+fi
+
+MANIFEST=$STAGE/cobalt-host-manifest.txt
+SIGNATURE=$STAGE/cobalt-host-manifest.txt.sshsig
+INSTALLER=$STAGE/install.sh
+download "$BASE_URL/cobalt-host-manifest.txt" "$MANIFEST"
+download "$BASE_URL/cobalt-host-manifest.txt.sshsig" "$SIGNATURE"
+
+command -v ssh-keygen >/dev/null 2>&1 ||
+    fail "OpenSSH ssh-keygen with -Y signature verification is required"
+printf '%s\n' \
+    'cobalt-release ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL7XUR3p+tvPgftO/kRbigc8gagzP2RBDG3tWIu/1KXe' \
+    > "$STAGE/allowed_signers"
+ssh-keygen -Y verify -q \
+    -f "$STAGE/allowed_signers" \
+    -I cobalt-release \
+    -n cobalt-host-release \
+    -s "$SIGNATURE" < "$MANIFEST" >/dev/null 2>&1 ||
+    fail "release manifest signature verification failed"
+
+manifest_field() {
+    field=$1
+    count=$(awk -v field="$field" '$1 == field && NF == 2 {count++} END {print count + 0}' \
+        "$MANIFEST")
+    [ "$count" -eq 1 ] ||
+        fail "signed manifest must contain exactly one $field field"
+    awk -v field="$field" '$1 == field && NF == 2 {print $2}' "$MANIFEST"
+}
+manifest_version=$(manifest_field version)
+manifest_channels=$(manifest_field channels)
+case ",$manifest_channels," in
+    *,"$CHANNEL",*) ;;
+    *) fail "signed manifest does not allow the requested $CHANNEL channel" ;;
+esac
+if [ "$VERSION_EXPLICIT" = true ] && [ "$manifest_version" != "$VERSION" ]; then
+    fail "requested version $VERSION, but the signed manifest is $manifest_version"
+fi
+VERSION=$manifest_version
+
+bootstrap_line=$(awk \
+    '$1 == "bootstrap" && $2 == "install.sh" && NF == 4 {print $3 " " $4}' \
+    "$MANIFEST")
+[ "$(printf '%s\n' "$bootstrap_line" | wc -l | tr -d ' ')" -eq 1 ] &&
+    [ -n "$bootstrap_line" ] ||
+    fail "signed manifest does not contain exactly one install.sh bootstrap"
+IFS=' ' read -r expected_bytes expected_sha256 <<EOF
+$bootstrap_line
+EOF
+
+download "$BASE_URL/install.sh" "$INSTALLER"
+[ "$(file_size "$INSTALLER")" = "$expected_bytes" ] ||
+    fail "release install.sh length does not match the signed manifest"
+[ "$(sha256_file "$INSTALLER")" = "$expected_sha256" ] ||
+    fail "release install.sh checksum does not match the signed manifest"
+chmod 700 "$INSTALLER"
+
+printf '%s\n' \
+    "GitHub Pages supplied discovery; signed release metadata verified install.sh $VERSION."
+if [ "$VERSION_EXPLICIT" = true ]; then
+    sh "$INSTALLER" "$@"
+else
+    sh "$INSTALLER" "$@" --version "$VERSION"
+fi

--- a/examples/settings/Cargo.toml
+++ b/examples/settings/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
+kobo-app-store = { path = "../../crates/kobo-app-store" }
 kobo-json = { path = "../../crates/kobo-json" }
 # The settings screen is the one application the runtime answers automatic
 # update requests for, so it is the one that turns that feature on.

--- a/examples/settings/src/main.rs
+++ b/examples/settings/src/main.rs
@@ -21,6 +21,8 @@ const TOGGLE: &str = "toggle";
 const AUTO_COBALT: &str = "auto-cobalt";
 const AUTO_APPS: &str = "auto-apps";
 const BETA_UPDATES: &str = "beta-updates";
+const CONFIRM_CHANNEL: &str = "confirm-channel";
+const CANCEL_CHANNEL: &str = "cancel-channel";
 const RESCAN: &str = "rescan";
 const MORE: &str = "more";
 const PREVIOUS: &str = "previous";
@@ -40,6 +42,20 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 const RELEASES: &str = "https://api.github.com/repos/BandarLabs/Cobalt/releases/latest";
 const BETA_RELEASES: &str = "https://api.github.com/repos/BandarLabs/Cobalt/releases?per_page=100";
 
+const fn channel_name(channel: UpdateChannel) -> &'static str {
+    match channel {
+        UpdateChannel::Stable => "Stable",
+        UpdateChannel::Beta => "Beta",
+    }
+}
+
+const fn opposite_channel(channel: UpdateChannel) -> UpdateChannel {
+    match channel {
+        UpdateChannel::Stable => UpdateChannel::Beta,
+        UpdateChannel::Beta => UpdateChannel::Stable,
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 enum View {
     #[default]
@@ -50,6 +66,7 @@ enum View {
     Battery,
     About,
     Update,
+    UpdateChannelConfirm,
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -82,7 +99,7 @@ enum Pending {
 }
 
 /// Where the software update stands. One journey, told left to right:
-/// nothing asked, asking GitHub, reading the digest file, ready to install,
+/// nothing asked, asking GitHub, verifying signed metadata, ready to install,
 /// installing, installed, or stopped with a reason.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 enum UpdateFlow {
@@ -97,11 +114,14 @@ enum UpdateFlow {
     Ahead {
         latest: String,
     },
-    /// The release is newer; its digest file is being fetched so the
-    /// download can be verified before it is installed.
-    Digest {
-        version: String,
-        url: String,
+    /// The release is newer; its signed canonical manifest is being fetched.
+    Manifest {
+        release: Release,
+    },
+    /// The manifest bytes are held while their detached signature is fetched.
+    ManifestSignature {
+        release: Release,
+        manifest: Vec<u8>,
     },
     Ready {
         version: String,
@@ -212,6 +232,7 @@ impl Settings {
             View::Battery => self.battery(),
             View::About => self.about(),
             View::Update => self.update(),
+            View::UpdateChannelConfirm => self.update_channel_confirmation(),
         };
         context.set_screen(screen);
     }
@@ -304,7 +325,9 @@ impl Settings {
     fn update_summary(&self) -> String {
         match &self.update {
             UpdateFlow::Idle => format!("Cobalt {VERSION}"),
-            UpdateFlow::Checking { .. } | UpdateFlow::Digest { .. } => "Checking".to_owned(),
+            UpdateFlow::Checking { .. }
+            | UpdateFlow::Manifest { .. }
+            | UpdateFlow::ManifestSignature { .. } => "Checking".to_owned(),
             UpdateFlow::UpToDate { .. } => "Up to date".to_owned(),
             UpdateFlow::Ahead { .. } => "Newer than this channel".to_owned(),
             UpdateFlow::Ready { version, .. } => format!("{version} available"),
@@ -325,7 +348,9 @@ impl Settings {
                     .text("Checking asks GitHub for the newest published release. Nothing is downloaded until you choose to install it.")
                     .button(CHECK, "Check for updates");
             }
-            UpdateFlow::Checking { .. } | UpdateFlow::Digest { .. } => {
+            UpdateFlow::Checking { .. }
+            | UpdateFlow::Manifest { .. }
+            | UpdateFlow::ManifestSignature { .. } => {
                 screen = screen
                     .section_with_value("Installed", VERSION)
                     .text("Checking for the newest release.");
@@ -398,20 +423,16 @@ impl Settings {
         };
         screen = screen
             .section_with_value(
-                "Beta updates",
-                if channel == UpdateChannel::Beta {
-                    "On"
-                } else {
-                    "Off"
-                },
+                "Update channel",
+                format!("{} · Cobalt {VERSION}", channel_name(channel)),
             )
-            .text("Gets prerelease Cobalt and Store app updates. Turning it off uses stable for future checks; installed apps stay and nothing is downgraded.")
+            .text("Beta is selected only here, after stable installation. Changing back to Stable needs no USB cable and preserves installed apps, state, and secrets.")
             .button(
                 BETA_UPDATES,
                 if channel == UpdateChannel::Beta {
-                    "Use stable updates"
+                    "Change to Stable"
                 } else {
-                    "Get beta updates"
+                    "Change to Beta"
                 },
             )
             .section_with_value(
@@ -439,6 +460,34 @@ impl Settings {
                 },
             );
         screen
+    }
+
+    fn update_channel_confirmation(&self) -> Screen {
+        let current = self.update_channel.unwrap_or_default();
+        let chosen = opposite_channel(current);
+        let explanation = match chosen {
+            UpdateChannel::Beta => {
+                "Beta checks signed prerelease platform metadata and the signed Beta Store catalog. It may be less stable. Apps, state, and secrets are preserved."
+            }
+            UpdateChannel::Stable => {
+                "Stable becomes the source for future platform and Store checks. Nothing is downgraded, and apps, state, and secrets are preserved."
+            }
+        };
+        ScreenBuilder::new("settings-update-channel-confirm")
+            .top_bar("Confirm update channel")
+            .owns_back(true)
+            .facts([
+                ("Installed", format!("Cobalt {VERSION}")),
+                ("Current channel", channel_name(current).to_owned()),
+                ("New channel", channel_name(chosen).to_owned()),
+            ])
+            .text(explanation)
+            .primary_button(
+                CONFIRM_CHANNEL,
+                format!("Use {} updates", channel_name(chosen)),
+            )
+            .button(CANCEL_CHANNEL, "Cancel")
+            .build()
     }
 
     fn bluetooth(&self) -> Screen {
@@ -794,17 +843,35 @@ impl Settings {
             match choice {
                 AUTO_COBALT => context.device().set_auto_update(!cobalt, apps),
                 AUTO_APPS => context.device().set_auto_update(cobalt, !apps),
-                BETA_UPDATES => {
-                    if let Some(channel) = self.update_channel {
-                        context.device().set_update_channel(match channel {
-                            UpdateChannel::Stable => UpdateChannel::Beta,
-                            UpdateChannel::Beta => UpdateChannel::Stable,
-                        });
-                    }
-                }
                 _ => {}
             }
         }
+    }
+
+    fn update_channel_action(&mut self, context: &mut Context, action: ActionId) -> bool {
+        if action == action_id(BETA_UPDATES) {
+            if self.update_channel.is_some() {
+                self.view = View::UpdateChannelConfirm;
+                self.show(context);
+            }
+            return true;
+        }
+        if action == action_id(CONFIRM_CHANNEL) && self.view == View::UpdateChannelConfirm {
+            if let Some(channel) = self.update_channel {
+                self.view = View::Update;
+                context
+                    .device()
+                    .set_update_channel(opposite_channel(channel));
+                self.show(context);
+            }
+            return true;
+        }
+        if action == action_id(CANCEL_CHANNEL) && self.view == View::UpdateChannelConfirm {
+            self.view = View::Update;
+            self.show(context);
+            return true;
+        }
+        false
     }
 
     fn install_update(&mut self, context: &mut Context) {
@@ -830,8 +897,7 @@ impl Settings {
     }
 
     /// Takes the reply to whichever update fetch was in flight: the release
-    /// description first, then the digest file that lets the download be
-    /// verified.
+    /// description, signed manifest, then detached signature.
     fn took_update_reply(&mut self, context: &mut Context, bytes: &[u8]) {
         let body = String::from_utf8_lossy(bytes);
         match self.update.clone() {
@@ -839,19 +905,16 @@ impl Settings {
                 Err(reason) => self.update = UpdateFlow::Failed(reason),
                 Ok(release) if release.newer_than(VERSION) => {
                     self.update_task = context.spawn(Task::Fetch {
-                        url: release.digest,
+                        url: release.manifest.clone(),
                         offset: 0,
-                        max_bytes: 16 * 1024,
+                        max_bytes: 64 * 1024,
                         credential: None,
                         headers: Vec::new(),
                     });
                     self.update = if self.update_task.is_none() {
                         UpdateFlow::Failed("This build was refused the network.".to_owned())
                     } else {
-                        UpdateFlow::Digest {
-                            version: release.version,
-                            url: release.archive,
-                        }
+                        UpdateFlow::Manifest { release }
                     };
                 }
                 Ok(release) if release.older_than(VERSION) => {
@@ -865,15 +928,32 @@ impl Settings {
                     };
                 }
             },
-            UpdateFlow::Digest { version, url } => {
-                self.update = match digest_for(&body, &archive_name(&version)) {
+            UpdateFlow::Manifest { release } => {
+                self.update_task = context.spawn(Task::Fetch {
+                    url: release.signature.clone(),
+                    offset: 0,
+                    max_bytes: 1024,
+                    credential: None,
+                    headers: Vec::new(),
+                });
+                self.update = if self.update_task.is_none() {
+                    UpdateFlow::Failed("This build was refused the network.".to_owned())
+                } else {
+                    UpdateFlow::ManifestSignature {
+                        release,
+                        manifest: bytes.to_vec(),
+                    }
+                };
+            }
+            UpdateFlow::ManifestSignature { release, manifest } => {
+                self.update = match verified_device_digest(&release, &manifest, &body) {
                     Some(sha256) => UpdateFlow::Ready {
-                        version,
-                        url,
+                        version: release.version,
+                        url: release.archive,
                         sha256,
                     },
                     None => UpdateFlow::Failed(
-                        "The release does not publish a digest for this reader's download."
+                        "The release metadata signature or device package entry is invalid."
                             .to_owned(),
                     ),
                 };
@@ -911,7 +991,12 @@ impl Settings {
         let (page, pages) = match self.view {
             View::Bluetooth => (&mut self.bluetooth_page, page_count(self.devices.len())),
             View::Wifi => (&mut self.wifi_page, page_count(self.networks.len())),
-            View::Home | View::WifiPassword | View::Battery | View::About | View::Update => return,
+            View::Home
+            | View::WifiPassword
+            | View::Battery
+            | View::About
+            | View::Update
+            | View::UpdateChannelConfirm => return,
         };
         *page = if forward {
             (*page + 1).min(pages - 1)
@@ -1005,8 +1090,15 @@ impl KoboApp for Settings {
             self.password_action(context, action);
             return;
         }
+        if self.update_channel_action(context, action) {
+            return;
+        }
         if action == ActionId::BACK {
-            self.view = View::Home;
+            self.view = if self.view == View::UpdateChannelConfirm {
+                View::Update
+            } else {
+                View::Home
+            };
             self.show(context);
         } else if action == action_id(BLUETOOTH) {
             self.view = View::Bluetooth;
@@ -1036,8 +1128,6 @@ impl KoboApp for Settings {
             self.flip_auto_update(context, AUTO_COBALT);
         } else if action == action_id(AUTO_APPS) {
             self.flip_auto_update(context, AUTO_APPS);
-        } else if action == action_id(BETA_UPDATES) {
-            self.flip_auto_update(context, BETA_UPDATES);
         } else if action == action_id(CLOSE) && matches!(self.update, UpdateFlow::Installed { .. })
         {
             context.exit();
@@ -1047,7 +1137,12 @@ impl KoboApp for Settings {
                     .device()
                     .set_bluetooth(!self.bluetooth_state.enabled()),
                 View::Wifi => context.device().set_wifi(!self.wifi_state.enabled()),
-                View::Home | View::WifiPassword | View::Battery | View::About | View::Update => {}
+                View::Home
+                | View::WifiPassword
+                | View::Battery
+                | View::About
+                | View::Update
+                | View::UpdateChannelConfirm => {}
             }
         } else if action == action_id(RESCAN) {
             match self.view {
@@ -1063,7 +1158,7 @@ impl KoboApp for Settings {
                 }
                 View::Battery => context.device().read_battery_detail(),
                 View::About => context.device().read_identity(),
-                View::Home | View::WifiPassword | View::Update => {}
+                View::Home | View::WifiPassword | View::Update | View::UpdateChannelConfirm => {}
             }
             self.show(context);
         } else if action == action_id(MORE) {
@@ -1259,13 +1354,15 @@ fn page_count(items: usize) -> usize {
 }
 
 /// The newest published release, as its assets name this device's download.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct Release {
     version: String,
     /// Where the installable archive is.
     archive: String,
-    /// Where the digest file that vouches for it is.
-    digest: String,
+    /// Where the signed canonical release manifest is.
+    manifest: String,
+    /// Where the manifest's raw detached Ed25519 signature is.
+    signature: String,
 }
 
 impl Release {
@@ -1343,12 +1440,15 @@ fn stable_release(value: &Value) -> Result<Release, String> {
     };
     let archive = url_of(&archive_name(&version))
         .ok_or_else(|| "The newest release has no download for this reader.".to_owned())?;
-    let digest = url_of(&format!("cobalt-{version}.sha256"))
-        .ok_or_else(|| "The newest release publishes no digest to verify against.".to_owned())?;
+    let manifest = url_of("cobalt-host-manifest.txt")
+        .ok_or_else(|| "The newest release publishes no signed metadata.".to_owned())?;
+    let signature = url_of("cobalt-host-manifest.txt.sig")
+        .ok_or_else(|| "The newest release publishes no metadata signature.".to_owned())?;
     Ok(Release {
         version,
         archive,
-        digest,
+        manifest,
+        signature,
     })
 }
 
@@ -1380,7 +1480,8 @@ fn release_value(value: &Value, tag_prefix: &str, prerelease: bool) -> Option<Re
     };
     Some(Release {
         archive: url_of(&archive_name(&version))?,
-        digest: url_of(&format!("cobalt-{version}.sha256"))?,
+        manifest: url_of("cobalt-host-manifest.txt")?,
+        signature: url_of("cobalt-host-manifest.txt.sig")?,
         version,
     })
 }
@@ -1389,18 +1490,20 @@ fn valid_release_url(url: &str) -> bool {
     url.starts_with("https://") && url.len() <= kobo_sdk::MAX_URL_LEN
 }
 
-/// Finds the digest vouching for `asset` in a `sha256sum` style listing:
-/// sixty-four hex characters, whitespace, a file name per line.
-fn digest_for(listing: &str, asset: &str) -> Option<String> {
-    listing.lines().find_map(|line| {
-        let (digest, name) = line.split_once(char::is_whitespace)?;
-        let named = name.trim_start().trim_start_matches('*') == asset;
-        let plausible = digest.len() == 64
-            && digest
-                .bytes()
-                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
-        (named && plausible).then(|| digest.to_owned())
-    })
+fn verified_device_digest(release: &Release, manifest: &[u8], signature: &str) -> Option<String> {
+    let manifest = kobo_app_store::verify_release_manifest(manifest, signature).ok()?;
+    device_digest_from_manifest(release, &manifest)
+}
+
+fn device_digest_from_manifest(
+    release: &Release,
+    manifest: &kobo_app_store::ReleaseManifest,
+) -> Option<String> {
+    if manifest.version != release.version {
+        return None;
+    }
+    let device = manifest.device()?;
+    (device.name == archive_name(&release.version)).then(|| device.sha256.clone())
 }
 
 /// Hours and minutes, because "412 minutes" is arithmetic a reader should not
@@ -1452,8 +1555,8 @@ fn main() -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::{
-        RadioState, Settings, View, AUTO_APPS, AUTO_COBALT, BETA_UPDATES, DEVICE_ACTIONS, MORE,
-        NETWORK_ACTIONS, PREVIOUS, RESCAN,
+        RadioState, Settings, View, AUTO_APPS, AUTO_COBALT, BETA_UPDATES, CANCEL_CHANNEL,
+        CONFIRM_CHANNEL, DEVICE_ACTIONS, MORE, NETWORK_ACTIONS, PREVIOUS, RESCAN, VERSION,
     };
     use kobo_sdk::{
         action_id, BannerLevel, BatteryDetail, BluetoothDevice, BluetoothDeviceKind, Chrome,
@@ -1487,8 +1590,37 @@ mod tests {
         assert!(layout.rect_of_action(action_id(AUTO_APPS)).is_some());
         assert!(layout.rect_of_action(action_id(BETA_UPDATES)).is_some());
         let text = text_of(&screen);
-        assert!(text.contains("prerelease Cobalt and Store app updates"));
-        assert!(text.contains("nothing is downgraded"));
+        assert!(
+            facts_of(&screen).contains(&format!("Beta · Cobalt {VERSION}")),
+            "{:?}",
+            screen.nodes
+        );
+        assert!(text.contains("selected only here"), "{text}");
+        assert!(text.contains("preserves installed apps, state, and secrets"));
+    }
+
+    #[test]
+    fn changing_update_channels_has_an_explicit_confirmation_screen() {
+        for (current, chosen) in [
+            (UpdateChannel::Stable, "Beta"),
+            (UpdateChannel::Beta, "Stable"),
+        ] {
+            let settings = Settings {
+                view: View::UpdateChannelConfirm,
+                update_channel: Some(current),
+                ..Settings::default()
+            };
+            let screen = settings.update_channel_confirmation();
+            let issues = screen.validate(&CLARA_BW_METRICS);
+            assert!(issues.is_empty(), "{issues:?}");
+            let layout = screen.layout_with(&CLARA_BW_METRICS, &Chrome::with_back(true));
+            assert!(layout.rect_of_action(action_id(CONFIRM_CHANNEL)).is_some());
+            assert!(layout.rect_of_action(action_id(CANCEL_CHANNEL)).is_some());
+            let text = text_of(&screen);
+            assert!(facts_of(&screen).contains(&format!("Cobalt {VERSION}")));
+            assert!(text.contains(chosen), "{text}");
+            assert!(text.contains("preserved"), "{text}");
+        }
     }
 
     #[test]
@@ -1639,6 +1771,29 @@ mod tests {
             .iter()
             .filter_map(|node| match node {
                 kobo_sdk::Node::Text { text, .. } => Some(text.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    fn facts_of(screen: &kobo_sdk::Screen) -> String {
+        screen
+            .nodes
+            .iter()
+            .filter_map(|node| match node {
+                kobo_sdk::Node::Facts { entries, .. } => Some(
+                    entries
+                        .iter()
+                        .flat_map(|(label, value)| [label.as_str(), value.as_str()])
+                        .collect::<Vec<_>>()
+                        .join(" "),
+                ),
+                kobo_sdk::Node::Section { title, value, .. } => Some(format!(
+                    "{} {}",
+                    title,
+                    value.as_deref().unwrap_or_default()
+                )),
                 _ => None,
             })
             .collect::<Vec<_>>()
@@ -1837,27 +1992,28 @@ mod tests {
         );
     }
 
-    fn release_json(version: &str, with_digest: bool) -> String {
+    fn release_json(version: &str, with_metadata: bool) -> String {
         let archive = format!(
             r#"{{"name":"cobalt-{version}-KoboRoot.tgz","browser_download_url":"https://example.test/{version}/KoboRoot.tgz"}}"#
         );
-        let digest = if with_digest {
+        let metadata = if with_metadata {
             format!(
-                r#",{{"name":"cobalt-{version}.sha256","browser_download_url":"https://example.test/{version}/checksums"}}"#
+                r#",{{"name":"cobalt-host-manifest.txt","browser_download_url":"https://example.test/{version}/manifest"}},{{"name":"cobalt-host-manifest.txt.sig","browser_download_url":"https://example.test/{version}/manifest.sig"}}"#
             )
         } else {
             String::new()
         };
-        format!(r#"{{"tag_name":"v{version}","assets":[{archive}{digest}]}}"#)
+        format!(r#"{{"tag_name":"v{version}","assets":[{archive}{metadata}]}}"#)
     }
 
     #[test]
-    fn a_release_is_read_down_to_the_two_urls_this_reader_needs() {
+    fn a_release_is_read_down_to_the_signed_metadata_urls_this_reader_needs() {
         let release = super::latest_release(&release_json("9.9.9", true), UpdateChannel::Stable)
             .expect("a full release");
         assert_eq!(release.version, "9.9.9");
         assert_eq!(release.archive, "https://example.test/9.9.9/KoboRoot.tgz");
-        assert_eq!(release.digest, "https://example.test/9.9.9/checksums");
+        assert_eq!(release.manifest, "https://example.test/9.9.9/manifest");
+        assert_eq!(release.signature, "https://example.test/9.9.9/manifest.sig");
         assert!(release.newer_than(super::VERSION));
     }
 
@@ -1867,11 +2023,11 @@ mod tests {
     }
 
     #[test]
-    fn a_release_without_a_digest_to_verify_against_is_not_offered() {
+    fn a_release_without_signed_metadata_is_not_offered() {
         assert!(
             super::latest_release(&release_json("9.9.9", false), UpdateChannel::Stable)
-                .expect_err("no digest, no offer")
-                .contains("digest")
+                .expect_err("no signed metadata, no offer")
+                .contains("signed metadata")
         );
     }
 
@@ -1880,14 +2036,17 @@ mod tests {
         let body = r#"[
           {"tag_name":"beta-v9.8.0","draft":false,"prerelease":true,"assets":[
             {"name":"cobalt-9.8.0-KoboRoot.tgz","browser_download_url":"https://example.test/9.8.0.tgz"},
-            {"name":"cobalt-9.8.0.sha256","browser_download_url":"https://example.test/9.8.0.sha256"}]},
+            {"name":"cobalt-host-manifest.txt","browser_download_url":"https://example.test/9.8.0.manifest"},
+            {"name":"cobalt-host-manifest.txt.sig","browser_download_url":"https://example.test/9.8.0.sig"}]},
           {"tag_name":"beta-v9.9.0","draft":true,"prerelease":true,"assets":[
             {"name":"cobalt-9.9.0-KoboRoot.tgz","browser_download_url":"https://example.test/draft.tgz"},
-            {"name":"cobalt-9.9.0.sha256","browser_download_url":"https://example.test/draft.sha256"}]},
+            {"name":"cobalt-host-manifest.txt","browser_download_url":"https://example.test/draft.manifest"},
+            {"name":"cobalt-host-manifest.txt.sig","browser_download_url":"https://example.test/draft.sig"}]},
           {"tag_name":"v10.0.0","draft":false,"prerelease":false,"assets":[]},
           {"tag_name":"beta-v9.7.0","draft":false,"prerelease":true,"assets":[
             {"name":"wrong.tgz","browser_download_url":"https://example.test/wrong.tgz"},
-            {"name":"cobalt-9.7.0.sha256","browser_download_url":"https://example.test/9.7.0.sha256"}]}
+            {"name":"cobalt-host-manifest.txt","browser_download_url":"https://example.test/9.7.0.manifest"},
+            {"name":"cobalt-host-manifest.txt.sig","browser_download_url":"https://example.test/9.7.0.sig"}]}
         ]"#;
         let release = super::latest_release(body, UpdateChannel::Beta).expect("highest valid beta");
         assert_eq!(release.version, "9.8.0");
@@ -1904,7 +2063,8 @@ mod tests {
         let strange = super::Release {
             version: "nightly".to_owned(),
             archive: String::new(),
-            digest: String::new(),
+            manifest: String::new(),
+            signature: String::new(),
         };
         assert!(
             !strange.newer_than(super::VERSION),
@@ -1913,30 +2073,37 @@ mod tests {
         let older = super::Release {
             version: "0.1.0".to_owned(),
             archive: String::new(),
-            digest: String::new(),
+            manifest: String::new(),
+            signature: String::new(),
         };
         assert!(older.older_than(super::VERSION));
     }
 
     #[test]
-    fn the_digest_is_found_beside_the_other_files_in_the_listing() {
-        let digest = "a".repeat(64);
-        let listing = format!(
-            "{}  THIRD-PARTY.md\n{digest}  cobalt-9.9.9-KoboRoot.tgz\n",
-            "b".repeat(64)
-        );
+    fn verified_metadata_binds_the_version_and_device_archive_digest() {
+        let release = super::latest_release(&release_json("9.9.9", true), UpdateChannel::Stable)
+            .expect("release");
+        let manifest = kobo_app_store::ReleaseManifest {
+            version: "9.9.9".to_owned(),
+            channels: vec!["stable".to_owned(), "beta".to_owned()],
+            source: "0123456789abcdef0123456789abcdef01234567".to_owned(),
+            assets: vec![kobo_app_store::ReleaseAsset {
+                kind: "device".to_owned(),
+                platform: None,
+                name: "cobalt-9.9.9-KoboRoot.tgz".to_owned(),
+                bytes: 123,
+                sha256: "a".repeat(64),
+            }],
+        };
         assert_eq!(
-            super::digest_for(&listing, "cobalt-9.9.9-KoboRoot.tgz"),
-            Some(digest)
+            super::device_digest_from_manifest(&release, &manifest),
+            Some("a".repeat(64))
         );
-        assert_eq!(
-            super::digest_for(&listing, "cobalt-9.9.9-ClaraBW-KoboRoot.tgz"),
-            None,
-            "a digest for a different file vouches for nothing"
-        );
-        assert_eq!(
-            super::digest_for("not a listing", "cobalt-9.9.9-KoboRoot.tgz"),
-            None
+        let mut wrong = manifest;
+        wrong.version = "9.9.8".to_owned();
+        assert_eq!(super::device_digest_from_manifest(&release, &wrong), None);
+        assert!(
+            super::verified_device_digest(&release, b"not a manifest", &"0".repeat(128)).is_none()
         );
     }
 
@@ -1946,6 +2113,15 @@ mod tests {
             super::UpdateFlow::Idle,
             super::UpdateFlow::Checking {
                 channel: UpdateChannel::Stable,
+            },
+            super::UpdateFlow::Manifest {
+                release: super::latest_release(&release_json("9.9.9", true), UpdateChannel::Stable)
+                    .expect("release"),
+            },
+            super::UpdateFlow::ManifestSignature {
+                release: super::latest_release(&release_json("9.9.9", true), UpdateChannel::Stable)
+                    .expect("release"),
+                manifest: b"manifest".to_vec(),
             },
             super::UpdateFlow::UpToDate {
                 latest: "0.1.0".to_owned(),

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,447 @@
+#!/bin/sh
+# Installs the prebuilt kobo host CLI and its verified Cobalt device package.
+set -eu
+
+REPOSITORY=${KOBO_INSTALLER_REPOSITORY:-BandarLabs/Cobalt}
+CHANNEL=stable
+VERSION=
+VERSION_EXPLICIT=false
+INSTALL_DIR=${KOBO_INSTALL_DIR:-"$HOME/.local/bin"}
+NO_SETUP=false
+NO_PATH=false
+YES=false
+NONINTERACTIVE=false
+FORCE_CONFLICT=false
+BASE_URL=${KOBO_INSTALLER_BASE_URL:-}
+PLATFORM=
+LOCK=
+LOCK_HELD=false
+STAGE=
+
+fail() {
+    printf 'kobo installer: %s\n' "$*" >&2
+    exit 1
+}
+
+say() {
+    printf '%s\n' "$*"
+}
+
+cleanup() {
+    if [ -n "$STAGE" ] && [ -d "$STAGE" ]; then
+        rm -rf "$STAGE"
+    fi
+    if [ "$LOCK_HELD" = true ] && [ -n "$LOCK" ] && [ -d "$LOCK" ]; then
+        rm -rf "$LOCK"
+    fi
+}
+trap cleanup EXIT HUP INT TERM
+
+usage() {
+    cat <<'EOF'
+usage: install.sh [--stable|--beta] [--version X.Y.Z] [--yes]
+                  [--non-interactive] [--no-setup] [--no-path]
+                  [--install-dir PATH] [--force-conflict]
+
+Stable is the default. Beta must be selected explicitly.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --stable) CHANNEL=stable ;;
+        --beta) CHANNEL=beta ;;
+        --version)
+            [ "$#" -ge 2 ] || fail "--version needs X.Y.Z"
+            VERSION=$2
+            VERSION_EXPLICIT=true
+            shift
+            ;;
+        --install-dir)
+            [ "$#" -ge 2 ] || fail "--install-dir needs a path"
+            INSTALL_DIR=$2
+            shift
+            ;;
+        --yes) YES=true ;;
+        --non-interactive) NONINTERACTIVE=true ;;
+        --no-setup) NO_SETUP=true ;;
+        --no-path) NO_PATH=true ;;
+        --force-conflict) FORCE_CONFLICT=true ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --platform)
+            [ "${KOBO_INSTALLER_TESTING:-0}" = 1 ] ||
+                fail "--platform is reserved for installer tests"
+            [ "$#" -ge 2 ] || fail "--platform needs a value"
+            PLATFORM=$2
+            shift
+            ;;
+        *) fail "unknown option $1" ;;
+    esac
+    shift
+done
+
+case "$VERSION" in
+    '') ;;
+    *[!0-9.]*|.*|*..*|*.) fail "version must be X.Y.Z" ;;
+esac
+if [ -n "$VERSION" ] && [ "$(printf '%s' "$VERSION" | awk -F. '{print NF}')" -ne 3 ]; then
+    fail "version must be X.Y.Z"
+fi
+if [ "$NONINTERACTIVE" = true ] && [ "$YES" != true ]; then
+    fail "--non-interactive requires --yes"
+fi
+
+uname_s=${KOBO_TEST_UNAME_S:-$(uname -s)}
+uname_m=${KOBO_TEST_UNAME_M:-$(uname -m)}
+WSL=false
+case "$uname_s" in
+    Darwin)
+        rosetta=${KOBO_TEST_ROSETTA:-0}
+        if [ "$rosetta" = 0 ] && command -v sysctl >/dev/null 2>&1; then
+            rosetta=$(sysctl -in sysctl.proc_translated 2>/dev/null || printf 0)
+        fi
+        if [ "$rosetta" = 1 ]; then
+            uname_m=arm64
+            say "Rosetta detected; selecting the native Apple Silicon package."
+        fi
+        case "$uname_m" in
+            x86_64) detected=macos-x86_64 ;;
+            arm64|aarch64) detected=macos-arm64 ;;
+            *) fail "unsupported macOS architecture: $uname_m" ;;
+        esac
+        ;;
+    Linux)
+        if [ "${KOBO_TEST_WSL:-0}" = 1 ] ||
+            [ -n "${WSL_INTEROP:-}" ] ||
+            { [ -r /proc/sys/kernel/osrelease ] &&
+              grep -qi microsoft /proc/sys/kernel/osrelease; }; then
+            WSL=true
+        fi
+        case "$uname_m" in
+            x86_64|amd64) detected=linux-x86_64 ;;
+            aarch64|arm64) detected=linux-arm64 ;;
+            *) fail "unsupported Linux architecture: $uname_m" ;;
+        esac
+        ;;
+    *) fail "unsupported operating system: $uname_s" ;;
+esac
+[ -n "$PLATFORM" ] || PLATFORM=$detected
+case "$PLATFORM" in
+    macos-x86_64|macos-arm64|linux-x86_64|linux-arm64) ;;
+    *) fail "unsupported platform selection: $PLATFORM" ;;
+esac
+
+DATA_HOME=${XDG_DATA_HOME:-"$HOME/.local/share"}
+CACHE_HOME=${XDG_CACHE_HOME:-"$HOME/.cache"}
+case "$INSTALL_DIR:$DATA_HOME:$CACHE_HOME" in
+    *'
+'*) fail "installation paths must not contain newlines" ;;
+esac
+for directory in "$INSTALL_DIR" "$DATA_HOME" "$CACHE_HOME"; do
+    case "$directory" in
+        /*) ;;
+        *) fail "installation paths must be absolute: $directory" ;;
+    esac
+done
+ROOT=$DATA_HOME/kobo
+mkdir -p "$ROOT" "$CACHE_HOME/kobo" "$INSTALL_DIR"
+chmod 700 "$ROOT" "$CACHE_HOME/kobo" 2>/dev/null || true
+
+LOCK=$ROOT/install.lock
+if ! mkdir "$LOCK" 2>/dev/null; then
+    lock_pid=$(cat "$LOCK/pid" 2>/dev/null || true)
+    if [ -n "$lock_pid" ] && kill -0 "$lock_pid" 2>/dev/null; then
+        fail "another installer is running (pid $lock_pid)"
+    fi
+    rm -rf "$LOCK"
+    mkdir "$LOCK" || fail "cannot replace stale installation lock"
+fi
+LOCK_HELD=true
+printf '%s\n' "$$" > "$LOCK/pid"
+rm -rf "$CACHE_HOME/kobo"/install.* "$ROOT/releases"/.new-*
+rm -f "$INSTALL_DIR"/.kobo.new.*
+
+STAGE=$CACHE_HOME/kobo/install.$$
+rm -rf "$STAGE"
+(umask 077 && mkdir "$STAGE") || fail "cannot create staging directory"
+
+download() {
+    url=$1
+    output=$2
+    case "$url" in
+        https://*) ;;
+        file://*)
+            [ "${KOBO_INSTALLER_TESTING:-0}" = 1 ] ||
+                fail "release downloads must use HTTPS"
+            ;;
+        *) fail "release downloads must use HTTPS" ;;
+    esac
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL --retry 3 --retry-delay 1 --connect-timeout 10 --max-time 300 \
+            -o "$output" -- "$url"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q --https-only --timeout=20 --tries=3 -O "$output" -- "$url"
+    else
+        fail "curl or wget is required"
+    fi
+}
+
+sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    elif command -v openssl >/dev/null 2>&1; then
+        openssl dgst -sha256 "$1" | awk '{print $NF}'
+    else
+        fail "sha256sum, shasum, or openssl is required"
+    fi
+}
+
+file_size() {
+    wc -c < "$1" | tr -d ' '
+}
+
+if [ -z "$BASE_URL" ]; then
+    if [ "$CHANNEL" = beta ] && [ -z "$VERSION" ]; then
+        beta_manifest=$STAGE/Cargo.toml
+        download "https://raw.githubusercontent.com/$REPOSITORY/beta/Cargo.toml" "$beta_manifest" ||
+            fail "cannot discover the current beta version"
+        VERSION=$(sed -n 's/^version = "\([0-9][0-9.]*\)"$/\1/p' "$beta_manifest")
+        [ -n "$VERSION" ] || fail "beta branch does not declare one workspace version"
+    fi
+    if [ -n "$VERSION" ]; then
+        if [ "$CHANNEL" = beta ]; then tag=beta-v$VERSION; else tag=v$VERSION; fi
+        BASE_URL=https://github.com/$REPOSITORY/releases/download/$tag
+    else
+        BASE_URL=https://github.com/$REPOSITORY/releases/latest/download
+    fi
+fi
+
+MANIFEST=$STAGE/cobalt-host-manifest.txt
+SSH_SIGNATURE=$STAGE/cobalt-host-manifest.txt.sshsig
+RAW_SIGNATURE=$STAGE/cobalt-host-manifest.txt.sig
+download "$BASE_URL/cobalt-host-manifest.txt" "$MANIFEST" ||
+    fail "cannot download the release manifest"
+download "$BASE_URL/cobalt-host-manifest.txt.sshsig" "$SSH_SIGNATURE" ||
+    fail "cannot download the release signature"
+
+command -v ssh-keygen >/dev/null 2>&1 ||
+    fail "OpenSSH ssh-keygen with -Y signature verification is required"
+ALLOWED_SIGNER="cobalt-release ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL7XUR3p+tvPgftO/kRbigc8gagzP2RBDG3tWIu/1KXe"
+printf '%s\n' "$ALLOWED_SIGNER" > "$STAGE/allowed_signers"
+if ! ssh-keygen -Y verify -q \
+    -f "$STAGE/allowed_signers" \
+    -I cobalt-release \
+    -n cobalt-host-release \
+    -s "$SSH_SIGNATURE" < "$MANIFEST" >/dev/null 2>&1; then
+    fail "release manifest signature verification failed"
+fi
+
+[ "$(sed -n '1p' "$MANIFEST")" = "cobalt-host-release 1" ] ||
+    fail "unsupported release manifest format"
+manifest_version=$(awk '$1 == "version" && NF == 2 {print $2}' "$MANIFEST")
+manifest_channels=$(awk '$1 == "channels" && NF == 2 {print $2}' "$MANIFEST")
+manifest_source=$(awk '$1 == "source" && NF == 2 {print $2}' "$MANIFEST")
+case ",$manifest_channels," in
+    *,"$CHANNEL",*) ;;
+    *) fail "signed manifest does not allow the requested $CHANNEL channel" ;;
+esac
+if [ -n "$VERSION" ] && [ "$manifest_version" != "$VERSION" ]; then
+    fail "requested version $VERSION, but the signed manifest is $manifest_version"
+fi
+VERSION=$manifest_version
+printf '%s\n' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' ||
+    fail "signed manifest has an invalid version"
+printf '%s\n' "$manifest_source" | grep -Eq '^[0-9a-f]{40}$' ||
+    fail "signed manifest has an invalid source commit"
+installed_version=$(sed -n 's/^version //p' "$ROOT/install-state" 2>/dev/null || true)
+if [ -n "$installed_version" ] && [ "$VERSION_EXPLICIT" != true ]; then
+    if ! awk -v old="$installed_version" -v new="$VERSION" 'BEGIN {
+        split(old, a, "."); split(new, b, ".");
+        for (i = 1; i <= 3; i++) {
+            if ((b[i] + 0) > (a[i] + 0)) exit 0;
+            if ((b[i] + 0) < (a[i] + 0)) exit 1;
+        }
+        exit 0;
+    }'; then
+        fail "refusing automatic downgrade from $installed_version to $VERSION; use --version $VERSION explicitly"
+    fi
+fi
+
+host_line=$(awk -v platform="$PLATFORM" \
+    '$1 == "host" && $2 == platform && NF == 5 {print $3 " " $4 " " $5}' \
+    "$MANIFEST")
+device_line=$(awk '$1 == "device" && NF == 4 {print $2 " " $3 " " $4}' "$MANIFEST")
+[ "$(printf '%s\n' "$host_line" | wc -l | tr -d ' ')" -eq 1 ] && [ -n "$host_line" ] ||
+    fail "signed manifest does not contain exactly one $PLATFORM host package"
+[ "$(printf '%s\n' "$device_line" | wc -l | tr -d ' ')" -eq 1 ] && [ -n "$device_line" ] ||
+    fail "signed manifest does not contain exactly one device package"
+IFS=' ' read -r HOST_ASSET HOST_BYTES HOST_SHA <<EOF
+$host_line
+EOF
+IFS=' ' read -r DEVICE_ASSET DEVICE_BYTES DEVICE_SHA <<EOF
+$device_line
+EOF
+case "$HOST_ASSET:$DEVICE_ASSET" in
+    *[!A-Za-z0-9._:-]*) fail "signed manifest contains an unsafe asset name" ;;
+esac
+
+HOST_ARCHIVE=$STAGE/$HOST_ASSET
+DEVICE_ARCHIVE=$STAGE/$DEVICE_ASSET
+download "$BASE_URL/$HOST_ASSET" "$HOST_ARCHIVE" ||
+    fail "cannot download $HOST_ASSET"
+download "$BASE_URL/$DEVICE_ASSET" "$DEVICE_ARCHIVE" ||
+    fail "cannot download $DEVICE_ASSET"
+download "$BASE_URL/cobalt-host-manifest.txt.sig" "$RAW_SIGNATURE" ||
+    fail "cannot download the setup signature"
+
+verify_asset() {
+    path=$1
+    expected_bytes=$2
+    expected_sha=$3
+    actual_bytes=$(file_size "$path")
+    [ "$actual_bytes" = "$expected_bytes" ] ||
+        fail "$(basename "$path") is truncated: expected $expected_bytes bytes, found $actual_bytes"
+    actual_sha=$(sha256_file "$path")
+    [ "$actual_sha" = "$expected_sha" ] ||
+        fail "$(basename "$path") checksum failed"
+}
+verify_asset "$HOST_ARCHIVE" "$HOST_BYTES" "$HOST_SHA"
+verify_asset "$DEVICE_ARCHIVE" "$DEVICE_BYTES" "$DEVICE_SHA"
+
+PACKAGE=$STAGE/host
+mkdir "$PACKAGE"
+tar -tzf "$HOST_ARCHIVE" > "$STAGE/host-files" ||
+    fail "$HOST_ASSET is not a readable host package"
+LC_ALL=C sort "$STAGE/host-files" > "$STAGE/host-files.sorted"
+cat > "$STAGE/host-files.expected" <<'EOF'
+./
+./LICENSE
+./SOURCE.txt
+./THIRD-PARTY.md
+./kobo
+./licenses/
+./licenses/LICENSE-Rust-dependencies.txt
+EOF
+if ! cmp "$STAGE/host-files.expected" "$STAGE/host-files.sorted" >/dev/null 2>&1; then
+    fail "$HOST_ASSET contains an unexpected path"
+fi
+tar -xzf "$HOST_ARCHIVE" -C "$PACKAGE" ||
+    fail "$HOST_ASSET is not a readable host package"
+for required in kobo LICENSE THIRD-PARTY.md licenses/LICENSE-Rust-dependencies.txt SOURCE.txt; do
+    [ -f "$PACKAGE/$required" ] || fail "$HOST_ASSET is missing $required"
+    [ ! -L "$PACKAGE/$required" ] || fail "$HOST_ASSET contains a symbolic link"
+done
+[ -x "$PACKAGE/kobo" ] || chmod 755 "$PACKAGE/kobo"
+
+TARGET=$INSTALL_DIR/kobo
+STATE=$ROOT/install-state
+managed_binary=$(sed -n 's/^binary //p' "$STATE" 2>/dev/null || true)
+if [ -e "$TARGET" ] && [ "$managed_binary" != "$TARGET" ] && [ "$FORCE_CONFLICT" != true ]; then
+    fail "$TARGET already exists and is not managed by this installer; use --force-conflict to replace it"
+fi
+existing=$(command -v kobo 2>/dev/null || true)
+if [ -n "$existing" ] && [ "$existing" != "$TARGET" ] &&
+    [ "$managed_binary" != "$existing" ] && [ "$FORCE_CONFLICT" != true ]; then
+    fail "another kobo command is already on PATH at $existing; refusing to shadow it"
+fi
+
+say ""
+say "Install Cobalt $VERSION ($CHANNEL)"
+say "  Platform: $PLATFORM"
+say "  Host command: $TARGET"
+say "  Device package: $DEVICE_ASSET"
+say "  Source commit: $manifest_source"
+if [ "$YES" != true ]; then
+    [ "$NONINTERACTIVE" != true ] || fail "noninteractive install was not confirmed"
+    [ -r /dev/tty ] || fail "no terminal is available for confirmation; use --yes after review"
+    printf 'Continue? [y/N] ' > /dev/tty
+    IFS= read -r answer < /dev/tty || answer=
+    case "$answer" in y|Y|yes|YES|Yes) ;; *) say "Declined; nothing was installed."; exit 0 ;; esac
+fi
+
+RELEASE=$ROOT/releases/$VERSION-$CHANNEL
+RELEASE_NEW=$ROOT/releases/.new-$VERSION-$CHANNEL-$$
+mkdir -p "$ROOT/releases"
+rm -rf "$RELEASE_NEW"
+mkdir "$RELEASE_NEW"
+cp "$MANIFEST" "$RELEASE_NEW/cobalt-host-manifest.txt"
+cp "$RAW_SIGNATURE" "$RELEASE_NEW/cobalt-host-manifest.txt.sig"
+cp "$SSH_SIGNATURE" "$RELEASE_NEW/cobalt-host-manifest.txt.sshsig"
+cp "$DEVICE_ARCHIVE" "$RELEASE_NEW/$DEVICE_ASSET"
+printf '%s\n' "$CHANNEL" > "$RELEASE_NEW/channel"
+if [ -d "$RELEASE" ]; then
+    for file in cobalt-host-manifest.txt cobalt-host-manifest.txt.sig \
+        cobalt-host-manifest.txt.sshsig "$DEVICE_ASSET" channel; do
+        cmp "$RELEASE/$file" "$RELEASE_NEW/$file" >/dev/null 2>&1 ||
+            fail "installed immutable release $VERSION-$CHANNEL differs from the signed release"
+    done
+    rm -rf "$RELEASE_NEW"
+else
+    mv "$RELEASE_NEW" "$RELEASE" ||
+        fail "cannot activate the verified release package"
+fi
+
+TARGET_NEW=$INSTALL_DIR/.kobo.new.$$
+cp "$PACKAGE/kobo" "$TARGET_NEW"
+chmod 755 "$TARGET_NEW"
+[ "$(sha256_file "$TARGET_NEW")" = "$(sha256_file "$PACKAGE/kobo")" ] ||
+    fail "staged kobo binary changed while copying"
+mv -f "$TARGET_NEW" "$TARGET" || fail "cannot replace $TARGET"
+
+STATE_NEW=$ROOT/install-state.new.$$
+{
+    printf 'cobalt-kobo-install 1\n'
+    printf 'binary %s\n' "$TARGET"
+    printf 'release %s\n' "$RELEASE"
+    printf 'version %s\n' "$VERSION"
+    printf 'channel %s\n' "$CHANNEL"
+    printf 'platform %s\n' "$PLATFORM"
+    printf 'source %s\n' "$manifest_source"
+} > "$STATE_NEW"
+mv "$STATE_NEW" "$STATE"
+
+if [ "$NO_PATH" != true ]; then
+    case ":${PATH:-}:" in
+        *:"$INSTALL_DIR":*) ;;
+        *)
+            shell_name=$(basename "${SHELL:-sh}")
+            case "$shell_name" in
+                zsh) rc=$HOME/.zshrc ;;
+                bash)
+                    if [ "$uname_s" = Darwin ]; then rc=$HOME/.bash_profile; else rc=$HOME/.bashrc; fi
+                    ;;
+                *) rc=$HOME/.profile ;;
+            esac
+            begin='# >>> Cobalt kobo installer >>>'
+            if ! grep -F "$begin" "$rc" >/dev/null 2>&1; then
+                {
+                    printf '\n%s\n' "$begin"
+                    printf '%s\n' "export PATH=\"$INSTALL_DIR:\$PATH\""
+                    printf '%s\n' '# <<< Cobalt kobo installer <<<'
+                } >> "$rc"
+            fi
+            say "Added $INSTALL_DIR to PATH in $rc (idempotent marked block)."
+            say "Open a new shell, or run: export PATH=\"$INSTALL_DIR:\$PATH\""
+            ;;
+    esac
+fi
+
+say "Installed kobo $VERSION at $TARGET."
+if [ "$WSL" = true ]; then
+    say "WSL detected. Kobo drives normally appear below /mnt; eject them from Windows, not WSL."
+fi
+
+if [ "$NO_SETUP" = false ]; then
+    if [ "$NONINTERACTIVE" = true ]; then
+        "$TARGET" setup --release-dir "$RELEASE" --non-interactive --yes
+    else
+        "$TARGET" setup --release-dir "$RELEASE" --wait-for-reader
+    fi
+else
+    say "Run 'kobo setup' later with the charged reader connected by USB."
+fi

--- a/install.sh
+++ b/install.sh
@@ -18,6 +18,9 @@ PLATFORM=
 LOCK=
 LOCK_HELD=false
 STAGE=
+HOST_NEW=
+CURRENT_NEW=
+COMMAND_NEW=
 
 fail() {
     printf 'kobo installer: %s\n' "$*" >&2
@@ -35,6 +38,9 @@ cleanup() {
     if [ "$LOCK_HELD" = true ] && [ -n "$LOCK" ] && [ -d "$LOCK" ]; then
         rm -rf "$LOCK"
     fi
+    [ -z "$HOST_NEW" ] || rm -rf "$HOST_NEW"
+    [ -z "$CURRENT_NEW" ] || rm -f "$CURRENT_NEW"
+    [ -z "$COMMAND_NEW" ] || rm -f "$COMMAND_NEW"
 }
 trap cleanup EXIT HUP INT TERM
 
@@ -188,8 +194,8 @@ remove that exact directory manually and rerun"
 fi
 LOCK_HELD=true
 printf '%s\n' "$$" > "$LOCK/pid"
-rm -rf "$CACHE_HOME/kobo"/install.* "$ROOT/releases"/.new-*
-rm -f "$INSTALL_DIR"/.kobo.new.*
+rm -rf "$CACHE_HOME/kobo"/install.* "$ROOT/releases"/.new-* "$ROOT/hosts"/.new-*
+rm -f "$ROOT"/.current.new.* "$INSTALL_DIR"/.kobo.new.*
 
 STAGE=$CACHE_HOME/kobo/install.$$
 rm -rf "$STAGE"
@@ -230,6 +236,13 @@ sha256_file() {
 
 file_size() {
     wc -c < "$1" | tr -d ' '
+}
+
+fail_point() {
+    if [ "${KOBO_INSTALLER_TESTING:-0}" = 1 ] &&
+        [ "${KOBO_TEST_FAIL_AT:-}" = "$1" ]; then
+        fail "injected failure after $1"
+    fi
 }
 
 if [ -z "$BASE_URL" ]; then
@@ -293,8 +306,17 @@ printf '%s\n' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' ||
     fail "signed manifest has an invalid version"
 printf '%s\n' "$manifest_source" | grep -Eq '^[0-9a-f]{40}$' ||
     fail "signed manifest has an invalid source commit"
-installed_version=$(sed -n 's/^version //p' "$ROOT/install-state" 2>/dev/null || true)
-installed_host_channel=$(sed -n 's/^host-channel //p' "$ROOT/install-state" 2>/dev/null || true)
+if [ "$HOST_UPDATE" = true ] && [ -f "$ROOT/current" ]; then
+    current_host=$(cat "$ROOT/current")
+    case "$current_host" in
+        ''|*[!A-Za-z0-9._-]*) fail "managed host selector is invalid" ;;
+    esac
+    installed_version=$(cat "$ROOT/hosts/$current_host/VERSION" 2>/dev/null || true)
+    installed_host_channel=$(cat "$ROOT/hosts/$current_host/CHANNEL" 2>/dev/null || true)
+else
+    installed_version=$(sed -n 's/^version //p' "$ROOT/install-state" 2>/dev/null || true)
+    installed_host_channel=$(sed -n 's/^host-channel //p' "$ROOT/install-state" 2>/dev/null || true)
+fi
 [ -n "$installed_host_channel" ] || installed_host_channel=stable
 if [ "$HOST_UPDATE" = true ] &&
     [ "$installed_version" = "$VERSION" ] &&
@@ -370,7 +392,7 @@ fi
 HOST_ARCHIVE=$STAGE/$HOST_ASSET
 DEVICE_ARCHIVE=$STAGE/$DEVICE_ASSET
 CACHE_SETUP=true
-if [ "$HOST_UPDATE" = true ] && [ "$CHANNEL" = beta ]; then
+if [ "$HOST_UPDATE" = true ]; then
     CACHE_SETUP=false
 fi
 download "$BASE_URL/$HOST_ASSET" "$HOST_ARCHIVE" ||
@@ -427,7 +449,6 @@ done
     fail "packaged updater length does not match the signed manifest"
 [ "$(sha256_file "$PACKAGE/updater.sh")" = "$BOOTSTRAP_SHA" ] ||
     fail "packaged updater checksum does not match the signed manifest"
-UPDATER_SOURCE=$PACKAGE/updater.sh
 
 TARGET=$INSTALL_DIR/kobo
 STATE=$ROOT/install-state
@@ -439,6 +460,11 @@ existing=$(command -v kobo 2>/dev/null || true)
 if [ -n "$existing" ] && [ "$existing" != "$TARGET" ] &&
     [ "$managed_binary" != "$existing" ] && [ "$FORCE_CONFLICT" != true ]; then
     fail "another kobo command is already on PATH at $existing; refusing to shadow it"
+fi
+COMMAND_DESTINATION=$ROOT/launcher/kobo
+if [ "$HOST_UPDATE" = true ]; then
+    [ -L "$TARGET" ] && [ "$(readlink "$TARGET")" = "$COMMAND_DESTINATION" ] ||
+        fail "managed kobo command link changed; refusing to replace it"
 fi
 
 say ""
@@ -491,32 +517,101 @@ else
         fail "managed installation has no stable setup package"
 fi
 
-TARGET_NEW=$INSTALL_DIR/.kobo.new.$$
-cp "$PACKAGE/kobo" "$TARGET_NEW"
-chmod 755 "$TARGET_NEW"
-[ "$(sha256_file "$TARGET_NEW")" = "$(sha256_file "$PACKAGE/kobo")" ] ||
-    fail "staged kobo binary changed while copying"
-mv -f "$TARGET_NEW" "$TARGET" || fail "cannot replace $TARGET"
+HOST_ID=$VERSION-$CHANNEL-$PLATFORM-$HOST_SHA
+HOST_DIR=$ROOT/hosts/$HOST_ID
+HOST_NEW=$ROOT/hosts/.new-$HOST_ID-$$
+mkdir -p "$ROOT/hosts"
+rm -rf "$HOST_NEW"
+mkdir "$HOST_NEW"
+cp -R "$PACKAGE/." "$HOST_NEW/"
+printf '%s\n' "$VERSION" > "$HOST_NEW/VERSION"
+printf '%s\n' "$CHANNEL" > "$HOST_NEW/CHANNEL"
+printf '%s\n' "$PLATFORM" > "$HOST_NEW/PLATFORM"
+printf '%s\n' "$manifest_source" > "$HOST_NEW/SOURCE_COMMIT"
+printf '%s\n' "$HOST_SHA" > "$HOST_NEW/HOST_ARCHIVE_SHA256"
+fail_point host-directory
+if [ -d "$HOST_DIR" ]; then
+    for file in kobo updater.sh VERSION CHANNEL PLATFORM SOURCE_COMMIT HOST_ARCHIVE_SHA256; do
+        cmp "$HOST_DIR/$file" "$HOST_NEW/$file" >/dev/null 2>&1 ||
+            fail "immutable host release $HOST_ID differs from its verified copy"
+    done
+    rm -rf "$HOST_NEW"
+else
+    mv "$HOST_NEW" "$HOST_DIR" || fail "cannot activate immutable host release $HOST_ID"
+fi
+HOST_NEW=
 
-mkdir -p "$ROOT/updater"
-UPDATER_NEW=$ROOT/updater/install.sh.new.$$
-cp "$UPDATER_SOURCE" "$UPDATER_NEW"
-chmod 700 "$UPDATER_NEW"
-mv -f "$UPDATER_NEW" "$ROOT/updater/install.sh" ||
-    fail "cannot activate the verified host updater"
+if [ "$HOST_UPDATE" != true ]; then
+    LAUNCHER_NEW=$STAGE/launcher
+    mkdir "$LAUNCHER_NEW"
+    printf '%s\n' "$ROOT" > "$LAUNCHER_NEW/root"
+    cat > "$LAUNCHER_NEW/kobo" <<'EOF'
+#!/bin/sh
+set -eu
+target=$0
+while [ -L "$target" ]; do
+    link=$(readlink "$target") || {
+        echo "kobo: managed command link is invalid" >&2
+        exit 1
+    }
+    case "$link" in
+        /*) target=$link ;;
+        *) target=$(dirname "$target")/$link ;;
+    esac
+done
+launcher=$(dirname "$target")
+root=$(cat "$launcher/root")
+selected=$(cat "$root/current")
+case "$selected" in
+    ''|*[!A-Za-z0-9._-]*)
+        echo "kobo: managed host selector is invalid" >&2
+        exit 1
+        ;;
+esac
+exec "$root/hosts/$selected/kobo" "$@"
+EOF
+    chmod 700 "$LAUNCHER_NEW/kobo"
+    if [ -d "$ROOT/launcher" ]; then
+        if ! cmp "$ROOT/launcher/root" "$LAUNCHER_NEW/root" >/dev/null 2>&1 ||
+            ! cmp "$ROOT/launcher/kobo" "$LAUNCHER_NEW/kobo" >/dev/null 2>&1; then
+            fail "managed kobo launcher changed; refusing to replace it"
+        fi
+    else
+        mv "$LAUNCHER_NEW" "$ROOT/launcher" ||
+            fail "cannot activate the stable kobo launcher"
+    fi
+fi
 
-STATE_NEW=$ROOT/install-state.new.$$
-{
-    printf 'cobalt-kobo-install 1\n'
-    printf 'binary %s\n' "$TARGET"
-    printf 'release %s\n' "$RELEASE"
-    printf 'version %s\n' "$VERSION"
-    printf 'channel %s\n' "$SETUP_CHANNEL"
-    printf 'host-channel %s\n' "$CHANNEL"
-    printf 'platform %s\n' "$PLATFORM"
-    printf 'source %s\n' "$manifest_source"
-} > "$STATE_NEW"
-mv "$STATE_NEW" "$STATE"
+CURRENT_NEW=$ROOT/.current.new.$$
+rm -f "$CURRENT_NEW"
+printf '%s\n' "$HOST_ID" > "$CURRENT_NEW"
+fail_point before-selector
+mv -f "$CURRENT_NEW" "$ROOT/current" ||
+    fail "cannot atomically select host release $HOST_ID"
+CURRENT_NEW=
+fail_point after-selector
+
+if [ "$HOST_UPDATE" != true ]; then
+    COMMAND_NEW=$INSTALL_DIR/.kobo.new.$$
+    rm -f "$COMMAND_NEW"
+    ln -s "$COMMAND_DESTINATION" "$COMMAND_NEW" ||
+        fail "cannot stage the kobo command link"
+    mv -f "$COMMAND_NEW" "$TARGET" || fail "cannot activate the kobo command link"
+    COMMAND_NEW=
+
+    STATE_NEW=$ROOT/install-state.new.$$
+    {
+        printf 'cobalt-kobo-install 1\n'
+        printf 'binary %s\n' "$TARGET"
+        printf 'release %s\n' "$RELEASE"
+        printf 'version %s\n' "$VERSION"
+        printf 'channel %s\n' "$SETUP_CHANNEL"
+        printf 'host-channel %s\n' "$CHANNEL"
+        printf 'platform %s\n' "$PLATFORM"
+        printf 'source %s\n' "$manifest_source"
+    } > "$STATE_NEW"
+    mv "$STATE_NEW" "$STATE"
+fi
 
 if [ "$NO_PATH" != true ]; then
     case ":${PATH:-}:" in

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@ set -eu
 
 REPOSITORY=${KOBO_INSTALLER_REPOSITORY:-BandarLabs/Cobalt}
 CHANNEL=stable
+HOST_UPDATE=false
 VERSION=
 VERSION_EXPLICIT=false
 INSTALL_DIR=${KOBO_INSTALL_DIR:-"$HOME/.local/bin"}
@@ -52,6 +53,18 @@ while [ "$#" -gt 0 ]; do
         --beta)
             fail "the host bootstrap installs stable only; enable Beta updates in Cobalt Settings after installation"
             ;;
+        --host-update)
+            HOST_UPDATE=true
+            NO_SETUP=true
+            NO_PATH=true
+            YES=true
+            NONINTERACTIVE=true
+            ;;
+        --channel)
+            [ "$#" -ge 2 ] || fail "--channel needs stable or beta"
+            CHANNEL=$2
+            shift
+            ;;
         --version)
             [ "$#" -ge 2 ] || fail "--version needs X.Y.Z"
             VERSION=$2
@@ -83,6 +96,14 @@ while [ "$#" -gt 0 ]; do
     esac
     shift
 done
+
+if [ "$HOST_UPDATE" != true ] && [ "$CHANNEL" != stable ]; then
+    fail "channel selection is available only through 'kobo update'"
+fi
+case "$CHANNEL" in
+    stable|beta) ;;
+    *) fail "update channel must be stable or beta" ;;
+esac
 
 case "$VERSION" in
     '') ;;
@@ -137,6 +158,14 @@ esac
 
 DATA_HOME=${XDG_DATA_HOME:-"$HOME/.local/share"}
 CACHE_HOME=${XDG_CACHE_HOME:-"$HOME/.cache"}
+ROOT=$DATA_HOME/kobo
+STATE=$ROOT/install-state
+if [ "$HOST_UPDATE" = true ]; then
+    [ -f "$STATE" ] || fail "kobo update requires an installation managed by this installer"
+    managed_binary=$(sed -n 's/^binary //p' "$STATE")
+    [ -n "$managed_binary" ] || fail "managed installation state has no binary path"
+    INSTALL_DIR=$(dirname "$managed_binary")
+fi
 case "$INSTALL_DIR:$DATA_HOME:$CACHE_HOME" in
     *'
 '*) fail "installation paths must not contain newlines" ;;
@@ -147,7 +176,6 @@ for directory in "$INSTALL_DIR" "$DATA_HOME" "$CACHE_HOME"; do
         *) fail "installation paths must be absolute: $directory" ;;
     esac
 done
-ROOT=$DATA_HOME/kobo
 mkdir -p "$ROOT" "$CACHE_HOME/kobo" "$INSTALL_DIR"
 chmod 700 "$ROOT" "$CACHE_HOME/kobo" 2>/dev/null || true
 
@@ -205,8 +233,15 @@ file_size() {
 }
 
 if [ -z "$BASE_URL" ]; then
+    if [ "$HOST_UPDATE" = true ] && [ "$CHANNEL" = beta ] && [ -z "$VERSION" ]; then
+        beta_manifest=$STAGE/Cargo.toml
+        download "https://raw.githubusercontent.com/$REPOSITORY/beta/Cargo.toml" "$beta_manifest" ||
+            fail "cannot discover the current beta version"
+        VERSION=$(sed -n 's/^version = "\([0-9][0-9.]*\)"$/\1/p' "$beta_manifest")
+        [ -n "$VERSION" ] || fail "beta branch does not declare one workspace version"
+    fi
     if [ -n "$VERSION" ]; then
-        tag=v$VERSION
+        if [ "$CHANNEL" = beta ]; then tag=beta-v$VERSION; else tag=v$VERSION; fi
         BASE_URL=https://github.com/$REPOSITORY/releases/download/$tag
     else
         BASE_URL=https://github.com/$REPOSITORY/releases/latest/download
@@ -247,8 +282,8 @@ manifest_version=$(manifest_field version)
 manifest_channels=$(manifest_field channels)
 manifest_source=$(manifest_field source)
 case ",$manifest_channels," in
-    *,stable,*) ;;
-    *) fail "signed manifest does not allow stable installation" ;;
+    *,"$CHANNEL",*) ;;
+    *) fail "signed manifest does not allow $CHANNEL installation" ;;
 esac
 if [ -n "$VERSION" ] && [ "$manifest_version" != "$VERSION" ]; then
     fail "requested version $VERSION, but the signed manifest is $manifest_version"
@@ -259,7 +294,17 @@ printf '%s\n' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' ||
 printf '%s\n' "$manifest_source" | grep -Eq '^[0-9a-f]{40}$' ||
     fail "signed manifest has an invalid source commit"
 installed_version=$(sed -n 's/^version //p' "$ROOT/install-state" 2>/dev/null || true)
-if [ -n "$installed_version" ] && [ "$VERSION_EXPLICIT" != true ]; then
+installed_host_channel=$(sed -n 's/^host-channel //p' "$ROOT/install-state" 2>/dev/null || true)
+[ -n "$installed_host_channel" ] || installed_host_channel=stable
+if [ "$HOST_UPDATE" = true ] &&
+    [ "$installed_version" = "$VERSION" ] &&
+    [ "$installed_host_channel" = "$CHANNEL" ]; then
+    say "kobo $VERSION is already current on the $CHANNEL channel."
+    exit 0
+fi
+if [ -n "$installed_version" ] &&
+    [ "$VERSION_EXPLICIT" != true ] &&
+    { [ "$HOST_UPDATE" != true ] || [ "$installed_host_channel" = "$CHANNEL" ]; }; then
     if ! awk -v old="$installed_version" -v new="$VERSION" 'BEGIN {
         split(old, a, "."); split(new, b, ".");
         for (i = 1; i <= 3; i++) {
@@ -300,27 +345,42 @@ case "$HOST_ASSET:$DEVICE_ASSET" in
     *[!A-Za-z0-9._:-]*) fail "signed manifest contains an unsafe asset name" ;;
 esac
 
-case "$0" in
-    sh|-sh|bash|-bash|dash|-dash|*/sh|*/bash|*/dash)
-        say "Bootstrap note: piped shell input is trusted through HTTPS; downloaded artifacts remain signature-verified."
-        ;;
-    *)
-        [ -f "$0" ] || fail "cannot inspect bootstrap path $0"
-        [ "$(file_size "$0")" = "$BOOTSTRAP_BYTES" ] ||
-            fail "this install.sh does not match the signed bootstrap length"
-        [ "$(sha256_file "$0")" = "$BOOTSTRAP_SHA" ] ||
-            fail "this install.sh does not match the signed bootstrap checksum"
-        ;;
-esac
+BOOTSTRAP_SOURCE=
+if [ "$HOST_UPDATE" != true ]; then
+    BOOTSTRAP_SOURCE=$STAGE/verified-install.sh
+    case "$0" in
+        sh|-sh|bash|-bash|dash|-dash|*/sh|*/bash|*/dash)
+            say "Bootstrap note: piped shell input is trusted through HTTPS; downloaded artifacts remain signature-verified."
+            download "$BASE_URL/install.sh" "$BOOTSTRAP_SOURCE" ||
+                fail "cannot download the stable updater"
+            ;;
+        *)
+            [ -f "$0" ] || fail "cannot inspect bootstrap path $0"
+            cp "$0" "$BOOTSTRAP_SOURCE"
+            ;;
+    esac
+fi
+if [ -n "$BOOTSTRAP_SOURCE" ]; then
+    [ "$(file_size "$BOOTSTRAP_SOURCE")" = "$BOOTSTRAP_BYTES" ] ||
+        fail "install.sh does not match the signed bootstrap length"
+    [ "$(sha256_file "$BOOTSTRAP_SOURCE")" = "$BOOTSTRAP_SHA" ] ||
+        fail "install.sh does not match the signed bootstrap checksum"
+fi
 
 HOST_ARCHIVE=$STAGE/$HOST_ASSET
 DEVICE_ARCHIVE=$STAGE/$DEVICE_ASSET
+CACHE_SETUP=true
+if [ "$HOST_UPDATE" = true ] && [ "$CHANNEL" = beta ]; then
+    CACHE_SETUP=false
+fi
 download "$BASE_URL/$HOST_ASSET" "$HOST_ARCHIVE" ||
     fail "cannot download $HOST_ASSET"
-download "$BASE_URL/$DEVICE_ASSET" "$DEVICE_ARCHIVE" ||
-    fail "cannot download $DEVICE_ASSET"
-download "$BASE_URL/cobalt-host-manifest.txt.sig" "$RAW_SIGNATURE" ||
-    fail "cannot download the raw release-manifest signature"
+if [ "$CACHE_SETUP" = true ]; then
+    download "$BASE_URL/$DEVICE_ASSET" "$DEVICE_ARCHIVE" ||
+        fail "cannot download $DEVICE_ASSET"
+    download "$BASE_URL/cobalt-host-manifest.txt.sig" "$RAW_SIGNATURE" ||
+        fail "cannot download the raw release-manifest signature"
+fi
 
 verify_asset() {
     path=$1
@@ -334,7 +394,9 @@ verify_asset() {
         fail "$(basename "$path") checksum failed"
 }
 verify_asset "$HOST_ARCHIVE" "$HOST_BYTES" "$HOST_SHA"
-verify_asset "$DEVICE_ARCHIVE" "$DEVICE_BYTES" "$DEVICE_SHA"
+if [ "$CACHE_SETUP" = true ]; then
+    verify_asset "$DEVICE_ARCHIVE" "$DEVICE_BYTES" "$DEVICE_SHA"
+fi
 
 PACKAGE=$STAGE/host
 mkdir "$PACKAGE"
@@ -349,17 +411,23 @@ cat > "$STAGE/host-files.expected" <<'EOF'
 ./kobo
 ./licenses/
 ./licenses/LICENSE-Rust-dependencies.txt
+./updater.sh
 EOF
 if ! cmp "$STAGE/host-files.expected" "$STAGE/host-files.sorted" >/dev/null 2>&1; then
     fail "$HOST_ASSET contains an unexpected path"
 fi
 tar -xzf "$HOST_ARCHIVE" -C "$PACKAGE" ||
     fail "$HOST_ASSET is not a readable host package"
-for required in kobo LICENSE THIRD-PARTY.md licenses/LICENSE-Rust-dependencies.txt SOURCE.txt; do
+for required in kobo updater.sh LICENSE THIRD-PARTY.md licenses/LICENSE-Rust-dependencies.txt SOURCE.txt; do
     [ -f "$PACKAGE/$required" ] || fail "$HOST_ASSET is missing $required"
     [ ! -L "$PACKAGE/$required" ] || fail "$HOST_ASSET contains a symbolic link"
 done
 [ -x "$PACKAGE/kobo" ] || chmod 755 "$PACKAGE/kobo"
+[ "$(file_size "$PACKAGE/updater.sh")" = "$BOOTSTRAP_BYTES" ] ||
+    fail "packaged updater length does not match the signed manifest"
+[ "$(sha256_file "$PACKAGE/updater.sh")" = "$BOOTSTRAP_SHA" ] ||
+    fail "packaged updater checksum does not match the signed manifest"
+UPDATER_SOURCE=$PACKAGE/updater.sh
 
 TARGET=$INSTALL_DIR/kobo
 STATE=$ROOT/install-state
@@ -374,10 +442,16 @@ if [ -n "$existing" ] && [ "$existing" != "$TARGET" ] &&
 fi
 
 say ""
-say "Install Cobalt $VERSION ($CHANNEL)"
+if [ "$HOST_UPDATE" = true ]; then
+    say "Update kobo to $VERSION ($CHANNEL)"
+else
+    say "Install Cobalt $VERSION ($CHANNEL)"
+fi
 say "  Platform: $PLATFORM"
 say "  Host command: $TARGET"
-say "  Device package: $DEVICE_ASSET"
+if [ "$CACHE_SETUP" = true ]; then
+    say "  Stable setup package: $DEVICE_ASSET"
+fi
 say "  Source commit: $manifest_source"
 if [ "$YES" != true ]; then
     [ "$NONINTERACTIVE" != true ] || fail "noninteractive install was not confirmed"
@@ -387,26 +461,34 @@ if [ "$YES" != true ]; then
     case "$answer" in y|Y|yes|YES|Yes) ;; *) say "Declined; nothing was installed."; exit 0 ;; esac
 fi
 
-RELEASE=$ROOT/releases/$VERSION-stable
-RELEASE_NEW=$ROOT/releases/.new-$VERSION-stable-$$
-mkdir -p "$ROOT/releases"
-rm -rf "$RELEASE_NEW"
-mkdir "$RELEASE_NEW"
-cp "$MANIFEST" "$RELEASE_NEW/cobalt-host-manifest.txt"
-cp "$RAW_SIGNATURE" "$RELEASE_NEW/cobalt-host-manifest.txt.sig"
-cp "$SSH_SIGNATURE" "$RELEASE_NEW/cobalt-host-manifest.txt.sshsig"
-cp "$DEVICE_ARCHIVE" "$RELEASE_NEW/$DEVICE_ASSET"
-printf '%s\n' "$CHANNEL" > "$RELEASE_NEW/channel"
-if [ -d "$RELEASE" ]; then
-    for file in cobalt-host-manifest.txt cobalt-host-manifest.txt.sig \
-        cobalt-host-manifest.txt.sshsig "$DEVICE_ASSET" channel; do
-        cmp "$RELEASE/$file" "$RELEASE_NEW/$file" >/dev/null 2>&1 ||
-            fail "installed immutable release $VERSION-$CHANNEL differs from the signed release"
-    done
+if [ "$CACHE_SETUP" = true ]; then
+    RELEASE=$ROOT/releases/$VERSION-stable
+    RELEASE_NEW=$ROOT/releases/.new-$VERSION-stable-$$
+    mkdir -p "$ROOT/releases"
     rm -rf "$RELEASE_NEW"
+    mkdir "$RELEASE_NEW"
+    cp "$MANIFEST" "$RELEASE_NEW/cobalt-host-manifest.txt"
+    cp "$RAW_SIGNATURE" "$RELEASE_NEW/cobalt-host-manifest.txt.sig"
+    cp "$SSH_SIGNATURE" "$RELEASE_NEW/cobalt-host-manifest.txt.sshsig"
+    cp "$DEVICE_ARCHIVE" "$RELEASE_NEW/$DEVICE_ASSET"
+    printf '%s\n' stable > "$RELEASE_NEW/channel"
+    if [ -d "$RELEASE" ]; then
+        for file in cobalt-host-manifest.txt cobalt-host-manifest.txt.sig \
+            cobalt-host-manifest.txt.sshsig "$DEVICE_ASSET" channel; do
+            cmp "$RELEASE/$file" "$RELEASE_NEW/$file" >/dev/null 2>&1 ||
+                fail "installed immutable release $VERSION-stable differs from the signed release"
+        done
+        rm -rf "$RELEASE_NEW"
+    else
+        mv "$RELEASE_NEW" "$RELEASE" ||
+            fail "cannot activate the verified release package"
+    fi
+    SETUP_CHANNEL=stable
 else
-    mv "$RELEASE_NEW" "$RELEASE" ||
-        fail "cannot activate the verified release package"
+    RELEASE=$(sed -n 's/^release //p' "$STATE")
+    SETUP_CHANNEL=$(sed -n 's/^channel //p' "$STATE")
+    [ -n "$RELEASE" ] && [ "$SETUP_CHANNEL" = stable ] ||
+        fail "managed installation has no stable setup package"
 fi
 
 TARGET_NEW=$INSTALL_DIR/.kobo.new.$$
@@ -416,13 +498,21 @@ chmod 755 "$TARGET_NEW"
     fail "staged kobo binary changed while copying"
 mv -f "$TARGET_NEW" "$TARGET" || fail "cannot replace $TARGET"
 
+mkdir -p "$ROOT/updater"
+UPDATER_NEW=$ROOT/updater/install.sh.new.$$
+cp "$UPDATER_SOURCE" "$UPDATER_NEW"
+chmod 700 "$UPDATER_NEW"
+mv -f "$UPDATER_NEW" "$ROOT/updater/install.sh" ||
+    fail "cannot activate the verified host updater"
+
 STATE_NEW=$ROOT/install-state.new.$$
 {
     printf 'cobalt-kobo-install 1\n'
     printf 'binary %s\n' "$TARGET"
     printf 'release %s\n' "$RELEASE"
     printf 'version %s\n' "$VERSION"
-    printf 'channel %s\n' "$CHANNEL"
+    printf 'channel %s\n' "$SETUP_CHANNEL"
+    printf 'host-channel %s\n' "$CHANNEL"
     printf 'platform %s\n' "$PLATFORM"
     printf 'source %s\n' "$manifest_source"
 } > "$STATE_NEW"
@@ -454,6 +544,10 @@ if [ "$NO_PATH" != true ]; then
     esac
 fi
 
+if [ "$HOST_UPDATE" = true ]; then
+    say "Updated kobo to $VERSION ($CHANNEL) at $TARGET."
+    exit 0
+fi
 say "Installed kobo $VERSION at $TARGET."
 if [ "$WSL" = true ]; then
     say "WSL detected. Kobo drives normally appear below /mnt; eject them from Windows, not WSL."

--- a/install.sh
+++ b/install.sh
@@ -153,11 +153,9 @@ chmod 700 "$ROOT" "$CACHE_HOME/kobo" 2>/dev/null || true
 LOCK=$ROOT/install.lock
 if ! mkdir "$LOCK" 2>/dev/null; then
     lock_pid=$(cat "$LOCK/pid" 2>/dev/null || true)
-    if [ -n "$lock_pid" ] && kill -0 "$lock_pid" 2>/dev/null; then
-        fail "another installer is running (pid $lock_pid)"
-    fi
-    rm -rf "$LOCK"
-    mkdir "$LOCK" || fail "cannot replace stale installation lock"
+    fail "installation lock already exists${lock_pid:+ (recorded pid $lock_pid)}. \
+Do not remove $LOCK while an installer may be running; if no installer is active, \
+remove that exact directory manually and rerun"
 fi
 LOCK_HELD=true
 printf '%s\n' "$$" > "$LOCK/pid"
@@ -284,18 +282,41 @@ host_line=$(awk -v platform="$PLATFORM" \
     '$1 == "host" && $2 == platform && NF == 5 {print $3 " " $4 " " $5}' \
     "$MANIFEST")
 device_line=$(awk '$1 == "device" && NF == 4 {print $2 " " $3 " " $4}' "$MANIFEST")
+bootstrap_line=$(awk \
+    '$1 == "bootstrap" && $2 == "install.sh" && NF == 4 {print $2 " " $3 " " $4}' \
+    "$MANIFEST")
 [ "$(printf '%s\n' "$host_line" | wc -l | tr -d ' ')" -eq 1 ] && [ -n "$host_line" ] ||
     fail "signed manifest does not contain exactly one $PLATFORM host package"
 [ "$(printf '%s\n' "$device_line" | wc -l | tr -d ' ')" -eq 1 ] && [ -n "$device_line" ] ||
     fail "signed manifest does not contain exactly one device package"
+[ "$(printf '%s\n' "$bootstrap_line" | wc -l | tr -d ' ')" -eq 1 ] &&
+    [ -n "$bootstrap_line" ] ||
+    fail "signed manifest does not contain exactly one install.sh bootstrap"
 IFS=' ' read -r HOST_ASSET HOST_BYTES HOST_SHA <<EOF
 $host_line
 EOF
 IFS=' ' read -r DEVICE_ASSET DEVICE_BYTES DEVICE_SHA <<EOF
 $device_line
 EOF
+IFS=' ' read -r BOOTSTRAP_ASSET BOOTSTRAP_BYTES BOOTSTRAP_SHA <<EOF
+$bootstrap_line
+EOF
+[ "$BOOTSTRAP_ASSET" = install.sh ] || fail "signed bootstrap asset has an invalid name"
 case "$HOST_ASSET:$DEVICE_ASSET" in
     *[!A-Za-z0-9._:-]*) fail "signed manifest contains an unsafe asset name" ;;
+esac
+
+case "$0" in
+    sh|-sh|bash|-bash|dash|-dash|*/sh|*/bash|*/dash)
+        say "Bootstrap note: piped shell input is trusted through HTTPS; downloaded artifacts remain signature-verified."
+        ;;
+    *)
+        [ -f "$0" ] || fail "cannot inspect bootstrap path $0"
+        [ "$(file_size "$0")" = "$BOOTSTRAP_BYTES" ] ||
+            fail "this install.sh does not match the signed bootstrap length"
+        [ "$(sha256_file "$0")" = "$BOOTSTRAP_SHA" ] ||
+            fail "this install.sh does not match the signed bootstrap checksum"
+        ;;
 esac
 
 HOST_ARCHIVE=$STAGE/$HOST_ASSET

--- a/install.sh
+++ b/install.sh
@@ -243,9 +243,17 @@ fi
 
 [ "$(sed -n '1p' "$MANIFEST")" = "cobalt-host-release 1" ] ||
     fail "unsupported release manifest format"
-manifest_version=$(awk '$1 == "version" && NF == 2 {print $2}' "$MANIFEST")
-manifest_channels=$(awk '$1 == "channels" && NF == 2 {print $2}' "$MANIFEST")
-manifest_source=$(awk '$1 == "source" && NF == 2 {print $2}' "$MANIFEST")
+manifest_field() {
+    field=$1
+    count=$(awk -v field="$field" '$1 == field && NF == 2 {count++} END {print count + 0}' \
+        "$MANIFEST")
+    [ "$count" -eq 1 ] ||
+        fail "signed manifest must contain exactly one $field field"
+    awk -v field="$field" '$1 == field && NF == 2 {print $2}' "$MANIFEST"
+}
+manifest_version=$(manifest_field version)
+manifest_channels=$(manifest_field channels)
+manifest_source=$(manifest_field source)
 case ",$manifest_channels," in
     *,"$CHANNEL",*) ;;
     *) fail "signed manifest does not allow the requested $CHANNEL channel" ;;
@@ -297,7 +305,7 @@ download "$BASE_URL/$HOST_ASSET" "$HOST_ARCHIVE" ||
 download "$BASE_URL/$DEVICE_ASSET" "$DEVICE_ARCHIVE" ||
     fail "cannot download $DEVICE_ASSET"
 download "$BASE_URL/cobalt-host-manifest.txt.sig" "$RAW_SIGNATURE" ||
-    fail "cannot download the setup signature"
+    fail "cannot download the raw release-manifest signature"
 
 verify_asset() {
     path=$1

--- a/install.sh
+++ b/install.sh
@@ -49,7 +49,6 @@ EOF
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        --stable) ;;
         --beta)
             fail "the host bootstrap installs stable only; enable Beta updates in Cobalt Settings after installation"
             ;;

--- a/install.sh
+++ b/install.sh
@@ -39,18 +39,20 @@ trap cleanup EXIT HUP INT TERM
 
 usage() {
     cat <<'EOF'
-usage: install.sh [--stable|--beta] [--version X.Y.Z] [--yes]
+usage: install.sh [--version X.Y.Z] [--yes]
                   [--non-interactive] [--no-setup] [--no-path]
                   [--install-dir PATH] [--force-conflict]
 
-Stable is the default. Beta must be selected explicitly.
+This installs stable Cobalt. Beta is selected later in Cobalt Settings.
 EOF
 }
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        --stable) CHANNEL=stable ;;
-        --beta) CHANNEL=beta ;;
+        --stable) ;;
+        --beta)
+            fail "the host bootstrap installs stable only; enable Beta updates in Cobalt Settings after installation"
+            ;;
         --version)
             [ "$#" -ge 2 ] || fail "--version needs X.Y.Z"
             VERSION=$2
@@ -204,15 +206,8 @@ file_size() {
 }
 
 if [ -z "$BASE_URL" ]; then
-    if [ "$CHANNEL" = beta ] && [ -z "$VERSION" ]; then
-        beta_manifest=$STAGE/Cargo.toml
-        download "https://raw.githubusercontent.com/$REPOSITORY/beta/Cargo.toml" "$beta_manifest" ||
-            fail "cannot discover the current beta version"
-        VERSION=$(sed -n 's/^version = "\([0-9][0-9.]*\)"$/\1/p' "$beta_manifest")
-        [ -n "$VERSION" ] || fail "beta branch does not declare one workspace version"
-    fi
     if [ -n "$VERSION" ]; then
-        if [ "$CHANNEL" = beta ]; then tag=beta-v$VERSION; else tag=v$VERSION; fi
+        tag=v$VERSION
         BASE_URL=https://github.com/$REPOSITORY/releases/download/$tag
     else
         BASE_URL=https://github.com/$REPOSITORY/releases/latest/download
@@ -253,8 +248,8 @@ manifest_version=$(manifest_field version)
 manifest_channels=$(manifest_field channels)
 manifest_source=$(manifest_field source)
 case ",$manifest_channels," in
-    *,"$CHANNEL",*) ;;
-    *) fail "signed manifest does not allow the requested $CHANNEL channel" ;;
+    *,stable,*) ;;
+    *) fail "signed manifest does not allow stable installation" ;;
 esac
 if [ -n "$VERSION" ] && [ "$manifest_version" != "$VERSION" ]; then
     fail "requested version $VERSION, but the signed manifest is $manifest_version"
@@ -393,8 +388,8 @@ if [ "$YES" != true ]; then
     case "$answer" in y|Y|yes|YES|Yes) ;; *) say "Declined; nothing was installed."; exit 0 ;; esac
 fi
 
-RELEASE=$ROOT/releases/$VERSION-$CHANNEL
-RELEASE_NEW=$ROOT/releases/.new-$VERSION-$CHANNEL-$$
+RELEASE=$ROOT/releases/$VERSION-stable
+RELEASE_NEW=$ROOT/releases/.new-$VERSION-stable-$$
 mkdir -p "$ROOT/releases"
 rm -rf "$RELEASE_NEW"
 mkdir "$RELEASE_NEW"

--- a/tools/build-host-release.sh
+++ b/tools/build-host-release.sh
@@ -16,7 +16,16 @@ printf '%s\n' "$SOURCE_SHA" | grep -Eq '^[0-9a-f]{40}$'
 [ -d "$DIST" ]
 
 sha256_file() {
-    sha256sum "$1" | awk '{print $1}'
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    elif command -v openssl >/dev/null 2>&1; then
+        openssl dgst -sha256 "$1" | awk '{print $NF}'
+    else
+        echo "sha256sum, shasum, or openssl is required" >&2
+        exit 1
+    fi
 }
 
 size_file() {

--- a/tools/build-host-release.sh
+++ b/tools/build-host-release.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -ne 4 ]; then
+    echo "usage: build-host-release.sh VERSION CHANNEL SOURCE_SHA DIST" >&2
+    exit 2
+fi
+VERSION=$1
+CHANNEL=$2
+SOURCE_SHA=$3
+DIST=$4
+
+printf '%s\n' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'
+case "$CHANNEL" in stable|beta) ;; *) exit 2 ;; esac
+printf '%s\n' "$SOURCE_SHA" | grep -Eq '^[0-9a-f]{40}$'
+[ -d "$DIST" ]
+
+sha256_file() {
+    sha256sum "$1" | awk '{print $1}'
+}
+
+size_file() {
+    wc -c < "$1" | tr -d ' '
+}
+
+device="cobalt-$VERSION-KoboRoot.tgz"
+[ -f "$DIST/$device" ]
+cp install.sh "$DIST/install.sh"
+chmod 755 "$DIST/install.sh"
+
+build_root="$DIST/.host-release-build"
+rm -rf "$build_root"
+mkdir -p "$build_root"
+trap 'rm -rf "$build_root"' EXIT HUP INT TERM
+
+for platform in macos-x86_64 macos-arm64 linux-x86_64 linux-arm64; do
+    binary="$DIST/host-binaries/$platform/kobo"
+    [ -f "$binary" ] || {
+        echo "missing host binary $binary" >&2
+        exit 1
+    }
+    package="$build_root/$platform"
+    mkdir -p "$package/licenses"
+    cp "$binary" "$package/kobo"
+    chmod 755 "$package/kobo"
+    cp LICENSE "$package/LICENSE"
+    cp THIRD-PARTY.md "$package/THIRD-PARTY.md"
+    cp licenses/LICENSE-Rust-dependencies.txt \
+        "$package/licenses/LICENSE-Rust-dependencies.txt"
+    {
+        printf 'Cobalt %s\n' "$VERSION"
+        printf 'source https://github.com/BandarLabs/Cobalt/commit/%s\n' "$SOURCE_SHA"
+        printf 'release train immutable beta candidate, promotable unchanged to stable\n'
+        printf 'host platform %s\n' "$platform"
+        printf 'command kobo\n'
+    } > "$package/SOURCE.txt"
+    asset="$DIST/kobo-$VERSION-$platform.tar.gz"
+    tar --sort=name --mtime='@0' --owner=0 --group=0 --numeric-owner \
+        -cf - -C "$package" . | gzip -n -9 > "$asset"
+done
+
+manifest="$DIST/cobalt-host-manifest.txt"
+{
+    printf 'cobalt-host-release 1\n'
+    printf 'version %s\n' "$VERSION"
+    printf 'channels stable,beta\n'
+    printf 'source %s\n' "$SOURCE_SHA"
+    printf 'device %s %s %s\n' \
+        "$device" "$(size_file "$DIST/$device")" "$(sha256_file "$DIST/$device")"
+    printf 'bootstrap install.sh %s %s\n' \
+        "$(size_file "$DIST/install.sh")" "$(sha256_file "$DIST/install.sh")"
+    for platform in macos-x86_64 macos-arm64 linux-x86_64 linux-arm64; do
+        asset="kobo-$VERSION-$platform.tar.gz"
+        printf 'host %s %s %s %s\n' \
+            "$platform" "$asset" "$(size_file "$DIST/$asset")" \
+            "$(sha256_file "$DIST/$asset")"
+    done
+} > "$manifest"

--- a/tools/build-host-release.sh
+++ b/tools/build-host-release.sh
@@ -52,6 +52,8 @@ for platform in macos-x86_64 macos-arm64 linux-x86_64 linux-arm64; do
     mkdir -p "$package/licenses"
     cp "$binary" "$package/kobo"
     chmod 755 "$package/kobo"
+    cp install.sh "$package/updater.sh"
+    chmod 700 "$package/updater.sh"
     cp LICENSE "$package/LICENSE"
     cp THIRD-PARTY.md "$package/THIRD-PARTY.md"
     cp licenses/LICENSE-Rust-dependencies.txt \

--- a/tools/installer-test.sh
+++ b/tools/installer-test.sh
@@ -1,0 +1,216 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
+WORK=$ROOT/target/installer-tests
+rm -rf "$WORK"
+mkdir -p "$WORK"
+trap 'rm -rf "$WORK"' EXIT HUP INT TERM
+
+sha256_file() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+size_file() {
+    wc -c < "$1" | tr -d ' '
+}
+
+ssh-keygen -q -t ed25519 -N '' -f "$WORK/signing" >/dev/null
+SIGNER="cobalt-release $(cat "$WORK/signing.pub")"
+SIGNER=$(printf '%s\n' "$SIGNER" | awk '{print $1 " " $2 " " $3}')
+INSTALLER=$WORK/install.sh
+sed "s|cobalt-release ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL7XUR3p+tvPgftO/kRbigc8gagzP2RBDG3tWIu/1KXe|$SIGNER|" \
+    "$ROOT/install.sh" > "$INSTALLER"
+
+make_release() {
+    directory=$1
+    version=$2
+    channel=$3
+    marker=$4
+    case "$channel" in stable|beta) ;; *) exit 2 ;; esac
+    mkdir -p "$directory/package/licenses"
+    cat > "$directory/package/kobo" <<EOF
+#!/bin/sh
+printf '%s\n' '$marker'
+EOF
+    chmod 755 "$directory/package/kobo"
+    printf 'license\n' > "$directory/package/LICENSE"
+    printf 'notices\n' > "$directory/package/THIRD-PARTY.md"
+    printf 'dependency terms\n' > "$directory/package/licenses/LICENSE-Rust-dependencies.txt"
+    printf 'source 0123456789abcdef0123456789abcdef01234567\n' > "$directory/package/SOURCE.txt"
+    device="cobalt-$version-KoboRoot.tgz"
+    printf 'device package %s\n' "$marker" > "$directory/$device"
+    printf 'bootstrap\n' > "$directory/install.sh"
+    for platform in macos-x86_64 macos-arm64 linux-x86_64 linux-arm64; do
+        asset="kobo-$version-$platform.tar.gz"
+        tar -czf "$directory/$asset" -C "$directory/package" .
+    done
+    {
+        printf 'cobalt-host-release 1\n'
+        printf 'version %s\n' "$version"
+        printf 'channels stable,beta\n'
+        printf 'source 0123456789abcdef0123456789abcdef01234567\n'
+        printf 'device %s %s %s\n' \
+            "$device" "$(size_file "$directory/$device")" "$(sha256_file "$directory/$device")"
+        printf 'bootstrap install.sh %s %s\n' \
+            "$(size_file "$directory/install.sh")" "$(sha256_file "$directory/install.sh")"
+        for platform in macos-x86_64 macos-arm64 linux-x86_64 linux-arm64; do
+            asset="kobo-$version-$platform.tar.gz"
+            printf 'host %s %s %s %s\n' \
+                "$platform" "$asset" "$(size_file "$directory/$asset")" \
+                "$(sha256_file "$directory/$asset")"
+        done
+    } > "$directory/cobalt-host-manifest.txt"
+    ssh-keygen -q -Y sign -f "$WORK/signing" -n cobalt-host-release \
+        "$directory/cobalt-host-manifest.txt" >/dev/null
+    mv "$directory/cobalt-host-manifest.txt.sig" \
+        "$directory/cobalt-host-manifest.txt.sshsig"
+    printf '%0128d\n' 0 > "$directory/cobalt-host-manifest.txt.sig"
+    rm -rf "$directory/package"
+}
+
+run_install() {
+    home=$1
+    release=$2
+    shift 2
+    mkdir -p "$home"
+    HOME=$home \
+    XDG_DATA_HOME=$home/data \
+    XDG_CACHE_HOME=$home/cache \
+    PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+    KOBO_INSTALLER_TESTING=1 \
+    KOBO_INSTALLER_BASE_URL="file://$release" \
+    sh "$INSTALLER" --yes --no-setup --no-path "$@"
+}
+
+expect_failure() {
+    label=$1
+    shift
+    if "$@" > "$WORK/failure.out" 2>&1; then
+        printf 'expected failure: %s\n' "$label" >&2
+        exit 1
+    fi
+}
+
+stable=$WORK/stable
+beta=$WORK/beta
+make_release "$stable" 0.3.3 stable stable-one
+make_release "$beta" 0.3.4 beta beta-one
+
+# Clean install, update, and idempotent rerun.
+home=$WORK/home-clean
+run_install "$home" "$stable" --platform linux-x86_64
+[ "$("$home/.local/bin/kobo")" = stable-one ]
+run_install "$home" "$stable" --platform linux-x86_64
+[ "$("$home/.local/bin/kobo")" = stable-one ]
+updated=$WORK/updated
+make_release "$updated" 0.3.5 stable stable-two
+run_install "$home" "$updated" --platform linux-x86_64
+[ "$("$home/.local/bin/kobo")" = stable-two ]
+grep -Fx "version 0.3.5" "$home/data/kobo/install-state" >/dev/null
+expect_failure "automatic downgrade" \
+    run_install "$home" "$stable" --platform linux-x86_64
+run_install "$home" "$stable" --version 0.3.3 --platform linux-x86_64 >/dev/null
+
+# PATH configuration is marked and idempotent.
+path_home=$WORK/home-path
+HOME=$path_home XDG_DATA_HOME=$path_home/data XDG_CACHE_HOME=$path_home/cache \
+PATH=/usr/bin:/bin:/usr/sbin:/sbin SHELL=/bin/sh \
+KOBO_INSTALLER_TESTING=1 \
+KOBO_INSTALLER_BASE_URL="file://$stable" \
+sh "$INSTALLER" --yes --no-setup --platform linux-x86_64 >/dev/null
+HOME=$path_home XDG_DATA_HOME=$path_home/data XDG_CACHE_HOME=$path_home/cache \
+PATH=/usr/bin:/bin:/usr/sbin:/sbin SHELL=/bin/sh \
+KOBO_INSTALLER_TESTING=1 \
+KOBO_INSTALLER_BASE_URL="file://$stable" \
+sh "$INSTALLER" --yes --no-setup --platform linux-x86_64 >/dev/null
+[ "$(grep -Fc '# >>> Cobalt kobo installer >>>' "$path_home/.profile")" -eq 1 ]
+
+# A live lock refuses; a stale lock is cleaned up.
+lock_home=$WORK/home-lock
+mkdir -p "$lock_home/data/kobo/install.lock"
+printf '%s\n' "$$" > "$lock_home/data/kobo/install.lock/pid"
+expect_failure "active install lock" \
+    run_install "$lock_home" "$stable" --platform linux-x86_64
+printf '%s\n' 999999 > "$lock_home/data/kobo/install.lock/pid"
+run_install "$lock_home" "$stable" --platform linux-x86_64 >/dev/null
+
+# Stable/beta and explicit version enforcement.
+run_install "$WORK/home-beta" "$beta" --beta --platform linux-arm64
+grep -Fx "channel beta" "$WORK/home-beta/data/kobo/install-state" >/dev/null
+run_install "$WORK/home-version" "$stable" --version 0.3.3 --platform macos-arm64
+expect_failure "wrong explicit version" \
+    run_install "$WORK/home-wrong-version" "$stable" --version 9.9.9 --platform linux-x86_64
+
+# Every supported platform, including an Apple Silicon selection under Rosetta.
+for platform in macos-x86_64 macos-arm64 linux-x86_64 linux-arm64; do
+    run_install "$WORK/home-$platform" "$stable" --platform "$platform"
+    grep -Fx "platform $platform" \
+        "$WORK/home-$platform/data/kobo/install-state" >/dev/null
+done
+HOME=$WORK/home-rosetta \
+XDG_DATA_HOME=$WORK/home-rosetta/data \
+XDG_CACHE_HOME=$WORK/home-rosetta/cache \
+PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+KOBO_INSTALLER_TESTING=1 \
+KOBO_INSTALLER_BASE_URL="file://$stable" \
+KOBO_TEST_UNAME_S=Darwin KOBO_TEST_UNAME_M=x86_64 KOBO_TEST_ROSETTA=1 \
+sh "$INSTALLER" --yes --no-setup --no-path > "$WORK/rosetta.out"
+grep -F "native Apple Silicon" "$WORK/rosetta.out" >/dev/null
+grep -Fx "platform macos-arm64" \
+    "$WORK/home-rosetta/data/kobo/install-state" >/dev/null
+
+# WSL selects Linux and never claims to eject a drive.
+HOME=$WORK/home-wsl \
+XDG_DATA_HOME=$WORK/home-wsl/data \
+XDG_CACHE_HOME=$WORK/home-wsl/cache \
+PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+KOBO_INSTALLER_TESTING=1 \
+KOBO_INSTALLER_BASE_URL="file://$stable" \
+KOBO_TEST_UNAME_S=Linux KOBO_TEST_UNAME_M=x86_64 KOBO_TEST_WSL=1 \
+sh "$INSTALLER" --yes --no-setup --no-path > "$WORK/wsl.out"
+grep -F "eject them from Windows, not WSL" "$WORK/wsl.out" >/dev/null
+if grep -F "volume ejected" "$WORK/wsl.out" >/dev/null; then
+    printf 'WSL output falsely claimed an eject\n' >&2
+    exit 1
+fi
+
+# Existing unrelated command and target conflicts fail closed.
+conflict=$WORK/home-conflict
+mkdir -p "$conflict/.local/bin"
+printf '#!/bin/sh\nexit 0\n' > "$conflict/.local/bin/kobo"
+chmod 755 "$conflict/.local/bin/kobo"
+expect_failure "unmanaged target conflict" \
+    run_install "$conflict" "$stable" --platform linux-x86_64
+path_conflict=$WORK/path-conflict
+mkdir -p "$path_conflict/bin"
+printf '#!/bin/sh\nexit 0\n' > "$path_conflict/bin/kobo"
+chmod 755 "$path_conflict/bin/kobo"
+expect_failure "PATH conflict" env PATH="$path_conflict/bin:$PATH" \
+    HOME="$path_conflict/home" XDG_DATA_HOME="$path_conflict/home/data" \
+    XDG_CACHE_HOME="$path_conflict/home/cache" KOBO_INSTALLER_TESTING=1 \
+    KOBO_INSTALLER_BASE_URL="file://$stable" \
+    sh "$INSTALLER" --yes --no-setup --no-path --platform linux-x86_64
+
+# Truncation, checksum damage, and signature damage are independently refused.
+truncated=$WORK/truncated
+cp -R "$stable" "$truncated"
+printf x >> "$truncated/kobo-0.3.3-linux-x86_64.tar.gz"
+expect_failure "truncated download" \
+    run_install "$WORK/home-truncated" "$truncated" --platform linux-x86_64
+checksum=$WORK/checksum
+cp -R "$stable" "$checksum"
+printf X | dd of="$checksum/kobo-0.3.3-linux-x86_64.tar.gz" bs=1 seek=8 conv=notrunc 2>/dev/null
+expect_failure "checksum failure" \
+    run_install "$WORK/home-checksum" "$checksum" --platform linux-x86_64
+bad_signature=$WORK/bad-signature
+cp -R "$stable" "$bad_signature"
+printf x >> "$bad_signature/cobalt-host-manifest.txt"
+expect_failure "signature failure" \
+    run_install "$WORK/home-signature" "$bad_signature" --platform linux-x86_64
+
+printf 'installer tests passed\n'

--- a/tools/installer-test.sh
+++ b/tools/installer-test.sh
@@ -212,5 +212,15 @@ cp -R "$stable" "$bad_signature"
 printf x >> "$bad_signature/cobalt-host-manifest.txt"
 expect_failure "signature failure" \
     run_install "$WORK/home-signature" "$bad_signature" --platform linux-x86_64
+duplicate=$WORK/duplicate-field
+cp -R "$stable" "$duplicate"
+printf 'version 9.9.9\n' >> "$duplicate/cobalt-host-manifest.txt"
+ssh-keygen -q -Y sign -f "$WORK/signing" -n cobalt-host-release \
+    "$duplicate/cobalt-host-manifest.txt" >/dev/null
+mv "$duplicate/cobalt-host-manifest.txt.sig" \
+    "$duplicate/cobalt-host-manifest.txt.sshsig"
+printf '%0128d\n' 0 > "$duplicate/cobalt-host-manifest.txt.sig"
+expect_failure "duplicate signed manifest field" \
+    run_install "$WORK/home-duplicate" "$duplicate" --platform linux-x86_64
 
 printf 'installer tests passed\n'

--- a/tools/installer-test.sh
+++ b/tools/installer-test.sh
@@ -3,6 +3,7 @@ set -eu
 
 ROOT=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
 WORK=$ROOT/target/installer-tests
+WORKSPACE_VERSION=$(sed -n 's/^version = "\([0-9][0-9.]*\)"$/\1/p' "$ROOT/Cargo.toml")
 rm -rf "$WORK"
 mkdir -p "$WORK"
 trap 'rm -rf "$WORK"' EXIT HUP INT TERM
@@ -44,7 +45,7 @@ EOF
     printf 'source 0123456789abcdef0123456789abcdef01234567\n' > "$directory/package/SOURCE.txt"
     device="cobalt-$version-KoboRoot.tgz"
     printf 'device package %s\n' "$marker" > "$directory/$device"
-    printf 'bootstrap\n' > "$directory/install.sh"
+    cp "$INSTALLER" "$directory/install.sh"
     for platform in macos-x86_64 macos-arm64 linux-x86_64 linux-arm64; do
         asset="kobo-$version-$platform.tar.gz"
         tar -czf "$directory/$asset" -C "$directory/package" .
@@ -99,7 +100,68 @@ expect_failure() {
 stable=$WORK/stable
 beta=$WORK/beta
 make_release "$stable" 0.3.3 stable stable-one
-make_release "$beta" 0.3.4 beta beta-one
+make_release "$beta" "$WORKSPACE_VERSION" beta beta-one
+grep -F \
+    "https://github.com/BandarLabs/Cobalt/releases/download/beta-v${WORKSPACE_VERSION}/install.sh" \
+    "$ROOT/README.md" >/dev/null
+grep -F "sh -s -- --beta --version ${WORKSPACE_VERSION}" "$ROOT/README.md" >/dev/null
+
+# The first beta does not depend on a stable installer asset. An explicit beta
+# version resolves every download against its immutable beta-vX.Y.Z release.
+printf '%s\n' "$SIGNER" > "$WORK/high-assurance-signers"
+ssh-keygen -Y verify -q -f "$WORK/high-assurance-signers" \
+    -I cobalt-release -n cobalt-host-release \
+    -s "$beta/cobalt-host-manifest.txt.sshsig" \
+    < "$beta/cobalt-host-manifest.txt"
+bootstrap_line=$(awk \
+    '$1 == "bootstrap" && $2 == "install.sh" && NF == 4 {print $3 " " $4}' \
+    "$beta/cobalt-host-manifest.txt")
+IFS=' ' read -r bootstrap_bytes bootstrap_sha <<EOF
+$bootstrap_line
+EOF
+[ "$(size_file "$INSTALLER")" = "$bootstrap_bytes" ]
+[ "$(sha256_file "$INSTALLER")" = "$bootstrap_sha" ]
+
+mock_bin=$WORK/mock-bin
+mkdir "$mock_bin"
+cat > "$mock_bin/curl" <<'EOF'
+#!/bin/sh
+set -eu
+output=
+url=
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o)
+            output=$2
+            shift
+            ;;
+        https://*) url=$1 ;;
+    esac
+    shift
+done
+printf '%s\n' "$url" >> "$KOBO_TEST_URL_LOG"
+prefix=https://github.com/BandarLabs/Cobalt/releases/download/beta-v$KOBO_TEST_VERSION/
+case "$url" in
+    "$prefix"*) cp "$KOBO_TEST_RELEASE/${url#"$prefix"}" "$output" ;;
+    *) exit 22 ;;
+esac
+EOF
+chmod 755 "$mock_bin/curl"
+first_beta_home=$WORK/home-first-beta
+HOME=$first_beta_home XDG_DATA_HOME=$first_beta_home/data \
+XDG_CACHE_HOME=$first_beta_home/cache \
+PATH="$mock_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+KOBO_INSTALLER_TESTING=1 KOBO_TEST_RELEASE=$beta \
+KOBO_TEST_VERSION=$WORKSPACE_VERSION \
+KOBO_TEST_URL_LOG=$WORK/first-beta-urls \
+sh "$INSTALLER" --yes --no-setup --no-path --platform linux-x86_64 \
+    --beta --version "$WORKSPACE_VERSION" >/dev/null
+if grep -F '/releases/latest/download/' "$WORK/first-beta-urls" >/dev/null; then
+    printf 'first beta unexpectedly depended on a stable latest asset\n' >&2
+    exit 1
+fi
+grep -F "/releases/download/beta-v${WORKSPACE_VERSION}/cobalt-host-manifest.txt" \
+    "$WORK/first-beta-urls" >/dev/null
 
 # Clean install, update, and idempotent rerun.
 home=$WORK/home-clean
@@ -130,13 +192,30 @@ KOBO_INSTALLER_BASE_URL="file://$stable" \
 sh "$INSTALLER" --yes --no-setup --platform linux-x86_64 >/dev/null
 [ "$(grep -Fc '# >>> Cobalt kobo installer >>>' "$path_home/.profile")" -eq 1 ]
 
-# A live lock refuses; a stale lock is cleaned up.
+# A live or stale-looking lock fails closed. Concurrent attempts cannot delete
+# and replace one another's lock; reclamation is an explicit manual action.
 lock_home=$WORK/home-lock
 mkdir -p "$lock_home/data/kobo/install.lock"
 printf '%s\n' "$$" > "$lock_home/data/kobo/install.lock/pid"
 expect_failure "active install lock" \
     run_install "$lock_home" "$stable" --platform linux-x86_64
 printf '%s\n' 999999 > "$lock_home/data/kobo/install.lock/pid"
+set +e
+run_install "$lock_home" "$stable" --platform linux-x86_64 \
+    >"$WORK/lock-one.out" 2>&1 &
+lock_one=$!
+run_install "$lock_home" "$stable" --platform linux-x86_64 \
+    >"$WORK/lock-two.out" 2>&1 &
+lock_two=$!
+wait "$lock_one"
+lock_one_status=$?
+wait "$lock_two"
+lock_two_status=$?
+set -e
+[ "$lock_one_status" -ne 0 ]
+[ "$lock_two_status" -ne 0 ]
+[ "$(cat "$lock_home/data/kobo/install.lock/pid")" = 999999 ]
+rm -rf "$lock_home/data/kobo/install.lock"
 run_install "$lock_home" "$stable" --platform linux-x86_64 >/dev/null
 
 # Stable/beta and explicit version enforcement.

--- a/tools/installer-test.sh
+++ b/tools/installer-test.sh
@@ -97,13 +97,14 @@ run_host_update() {
     release=$2
     channel=$3
     shift 3
+    selected=$(cat "$home/data/kobo/current")
     HOME=$home \
     XDG_DATA_HOME=$home/data \
     XDG_CACHE_HOME=$home/cache \
     PATH=/usr/bin:/bin:/usr/sbin:/sbin \
     KOBO_INSTALLER_TESTING=1 \
     KOBO_INSTALLER_BASE_URL="file://$release" \
-    "$@" sh "$home/data/kobo/updater/install.sh" \
+    "$@" sh "$home/data/kobo/hosts/$selected/updater.sh" \
         --host-update --channel "$channel" --platform linux-x86_64
 }
 
@@ -199,6 +200,24 @@ grep -F "/releases/download/v0.3.3/cobalt-host-manifest.txt" \
 # path, Beta is explicit, and neither path invokes setup or touches a volume.
 host_update_home=$WORK/home-host-update
 run_install "$host_update_home" "$stable" --platform linux-x86_64 >/dev/null
+setup_release=$host_update_home/data/kobo/releases/0.3.3-stable
+setup_state_sha=$(sha256_file "$host_update_home/data/kobo/install-state")
+setup_manifest_sha=$(sha256_file "$setup_release/cobalt-host-manifest.txt")
+setup_signature_sha=$(sha256_file "$setup_release/cobalt-host-manifest.txt.sig")
+setup_device_sha=$(sha256_file "$setup_release/cobalt-0.3.3-KoboRoot.tgz")
+command_destination=$(readlink "$host_update_home/.local/bin/kobo")
+ln -s "$host_update_home/.local/bin/kobo" "$host_update_home/.local/bin/kobo-compat"
+assert_setup_cache_unchanged() {
+    [ "$(sha256_file "$host_update_home/data/kobo/install-state")" = "$setup_state_sha" ]
+    [ "$(sha256_file "$setup_release/cobalt-host-manifest.txt")" = "$setup_manifest_sha" ]
+    [ "$(sha256_file "$setup_release/cobalt-host-manifest.txt.sig")" = "$setup_signature_sha" ]
+    [ "$(sha256_file "$setup_release/cobalt-0.3.3-KoboRoot.tgz")" = "$setup_device_sha" ]
+    grep -Fx "release $setup_release" "$host_update_home/data/kobo/install-state" >/dev/null
+    grep -Fx "channel stable" "$host_update_home/data/kobo/install-state" >/dev/null
+    grep -Fx "version 0.3.3" "$host_update_home/data/kobo/install-state" >/dev/null
+    grep -Fx "version 0.3.3" "$setup_release/cobalt-host-manifest.txt" >/dev/null
+    [ "$(readlink "$host_update_home/.local/bin/kobo")" = "$command_destination" ]
+}
 attached=$host_update_home/mounted-reader
 mkdir -p "$attached/.kobo"
 printf 'N365000000000,4.9.77,4.45.23697\n' > "$attached/.kobo/version"
@@ -207,33 +226,83 @@ run_host_update "$host_update_home" "$stable" stable > "$WORK/already-current.ou
 grep -F "already current on the stable channel" "$WORK/already-current.out" >/dev/null
 run_host_update "$host_update_home" "$beta" beta >/dev/null
 [ "$("$host_update_home/.local/bin/kobo")" = beta-one ]
-grep -Fx "host-channel beta" "$host_update_home/data/kobo/install-state" >/dev/null
-grep -Fx \
-    "release $host_update_home/data/kobo/releases/0.3.3-stable" \
-    "$host_update_home/data/kobo/install-state" >/dev/null
+[ "$("$host_update_home/.local/bin/kobo-compat")" = beta-one ]
+selected=$(cat "$host_update_home/data/kobo/current")
+grep -Fx beta "$host_update_home/data/kobo/hosts/$selected/CHANNEL" >/dev/null
+assert_setup_cache_unchanged
 run_host_update "$host_update_home" "$stable" stable >/dev/null
 [ "$("$host_update_home/.local/bin/kobo")" = stable-one ]
-grep -Fx "host-channel stable" "$host_update_home/data/kobo/install-state" >/dev/null
+[ "$("$host_update_home/.local/bin/kobo-compat")" = stable-one ]
+selected=$(cat "$host_update_home/data/kobo/current")
+grep -Fx stable "$host_update_home/data/kobo/hosts/$selected/CHANNEL" >/dev/null
+assert_setup_cache_unchanged
 [ "$(cat "$attached/untouched")" = "owner bytes" ]
 
 host_updated=$WORK/host-updated
 make_release "$host_updated" 0.3.5 stable stable-two
+rm "$host_updated/cobalt-0.3.5-KoboRoot.tgz" \
+    "$host_updated/cobalt-host-manifest.txt.sig" \
+    "$host_updated/install.sh"
 run_host_update "$host_update_home" "$host_updated" stable >/dev/null
 [ "$("$host_update_home/.local/bin/kobo")" = stable-two ]
+assert_setup_cache_unchanged
+
+activation_failure() {
+    point=$1
+    version=$2
+    marker=$3
+    release=$WORK/activation-$version
+    make_release "$release" "$version" stable "$marker"
+    previous=$(cat "$host_update_home/data/kobo/current")
+    previous_output=$("$host_update_home/.local/bin/kobo")
+    updater=$host_update_home/data/kobo/hosts/$previous/updater.sh
+    set +e
+    HOME=$host_update_home XDG_DATA_HOME=$host_update_home/data \
+    XDG_CACHE_HOME=$host_update_home/cache \
+    PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+    KOBO_INSTALLER_TESTING=1 KOBO_TEST_FAIL_AT=$point \
+    KOBO_INSTALLER_BASE_URL="file://$release" \
+    sh "$updater" \
+        --host-update --channel stable --platform linux-x86_64 \
+        >"$WORK/activation-$point.out" 2>&1
+    status=$?
+    set -e
+    [ "$status" -ne 0 ]
+    [ ! -d "$host_update_home/data/kobo/install.lock" ]
+    test -z "$(find "$host_update_home/data/kobo" -maxdepth 1 -name '.current.new.*' -print)"
+    test -z "$(find "$host_update_home/data/kobo/hosts" -maxdepth 1 -name '.new-*' -print)"
+    [ "$(readlink "$host_update_home/.local/bin/kobo")" = "$command_destination" ]
+    assert_setup_cache_unchanged
+    if [ "$point" = after-selector ]; then
+        [ "$("$host_update_home/.local/bin/kobo")" = "$marker" ]
+        [ "$("$host_update_home/.local/bin/kobo-compat")" = "$marker" ]
+    else
+        [ "$(cat "$host_update_home/data/kobo/current")" = "$previous" ]
+        [ "$("$host_update_home/.local/bin/kobo")" = "$previous_output" ]
+        [ "$("$host_update_home/.local/bin/kobo-compat")" = "$previous_output" ]
+    fi
+    run_host_update "$host_update_home" "$release" stable >/dev/null
+    [ "$("$host_update_home/.local/bin/kobo")" = "$marker" ]
+    [ "$("$host_update_home/.local/bin/kobo-compat")" = "$marker" ]
+    assert_setup_cache_unchanged
+}
+activation_failure host-directory 0.3.6 stable-three
+activation_failure before-selector 0.3.7 stable-four
+activation_failure after-selector 0.3.8 stable-five
 
 host_truncated=$WORK/host-truncated
-make_release "$host_truncated" 0.3.6 stable stable-three
-printf x >> "$host_truncated/kobo-0.3.6-linux-x86_64.tar.gz"
+make_release "$host_truncated" 0.3.9 stable stable-six
+printf x >> "$host_truncated/kobo-0.3.9-linux-x86_64.tar.gz"
 expect_failure "host update truncated download" \
     run_host_update "$host_update_home" "$host_truncated" stable
 host_checksum=$WORK/host-checksum
-make_release "$host_checksum" 0.3.6 stable stable-three
-printf X | dd of="$host_checksum/kobo-0.3.6-linux-x86_64.tar.gz" \
+make_release "$host_checksum" 0.3.9 stable stable-six
+printf X | dd of="$host_checksum/kobo-0.3.9-linux-x86_64.tar.gz" \
     bs=1 seek=8 conv=notrunc 2>/dev/null
 expect_failure "host update checksum failure" \
     run_host_update "$host_update_home" "$host_checksum" stable
 host_signature=$WORK/host-signature
-make_release "$host_signature" 0.3.6 stable stable-three
+make_release "$host_signature" 0.3.9 stable stable-six
 printf x >> "$host_signature/cobalt-host-manifest.txt"
 expect_failure "host update signature failure" \
     run_host_update "$host_update_home" "$host_signature" stable
@@ -253,12 +322,13 @@ conflicting_path=$WORK/host-update-conflict
 mkdir "$conflicting_path"
 printf '#!/bin/sh\nexit 0\n' > "$conflicting_path/kobo"
 chmod 755 "$conflicting_path/kobo"
+selected=$(cat "$host_update_home/data/kobo/current")
 expect_failure "host update command conflict" env \
     PATH="$conflicting_path:/usr/bin:/bin:/usr/sbin:/sbin" \
     HOME="$host_update_home" XDG_DATA_HOME="$host_update_home/data" \
     XDG_CACHE_HOME="$host_update_home/cache" KOBO_INSTALLER_TESTING=1 \
     KOBO_INSTALLER_BASE_URL="file://$beta" \
-    sh "$host_update_home/data/kobo/updater/install.sh" \
+    sh "$host_update_home/data/kobo/hosts/$selected/updater.sh" \
     --host-update --channel beta
 
 # Clean install, update, and idempotent rerun.

--- a/tools/installer-test.sh
+++ b/tools/installer-test.sh
@@ -41,6 +41,8 @@ make_release() {
 printf '%s\n' '$marker'
 EOF
     chmod 755 "$directory/package/kobo"
+    cp "$INSTALLER" "$directory/package/updater.sh"
+    chmod 700 "$directory/package/updater.sh"
     printf 'license\n' > "$directory/package/LICENSE"
     printf 'notices\n' > "$directory/package/THIRD-PARTY.md"
     printf 'dependency terms\n' > "$directory/package/licenses/LICENSE-Rust-dependencies.txt"
@@ -90,6 +92,21 @@ run_install() {
     sh "$INSTALLER" --yes --no-setup --no-path "$@"
 }
 
+run_host_update() {
+    home=$1
+    release=$2
+    channel=$3
+    shift 3
+    HOME=$home \
+    XDG_DATA_HOME=$home/data \
+    XDG_CACHE_HOME=$home/cache \
+    PATH=/usr/bin:/bin:/usr/sbin:/sbin \
+    KOBO_INSTALLER_TESTING=1 \
+    KOBO_INSTALLER_BASE_URL="file://$release" \
+    "$@" sh "$home/data/kobo/updater/install.sh" \
+        --host-update --channel "$channel" --platform linux-x86_64
+}
+
 expect_failure() {
     label=$1
     shift
@@ -100,7 +117,9 @@ expect_failure() {
 }
 
 stable=$WORK/stable
+beta=$WORK/beta
 make_release "$stable" 0.3.3 stable stable-one
+make_release "$beta" 0.3.4 beta beta-one
 grep -F "https://bandarlabs.github.io/Cobalt/install.sh" "$ROOT/README.md" >/dev/null
 if grep -Eq 'beta-v[0-9.]+/install\.sh|sh -s -- --beta' "$ROOT/README.md"; then
     printf 'README exposes a beta bootstrap route\n' >&2
@@ -175,6 +194,72 @@ grep -F "/releases/latest/download/cobalt-host-manifest.txt" \
 grep -F "/releases/latest/download/install.sh" "$WORK/pages-urls" >/dev/null
 grep -F "/releases/download/v0.3.3/cobalt-host-manifest.txt" \
     "$WORK/pages-urls" >/dev/null
+
+# Host-only update uses the installed verified updater. Stable is the normal
+# path, Beta is explicit, and neither path invokes setup or touches a volume.
+host_update_home=$WORK/home-host-update
+run_install "$host_update_home" "$stable" --platform linux-x86_64 >/dev/null
+attached=$host_update_home/mounted-reader
+mkdir -p "$attached/.kobo"
+printf 'N365000000000,4.9.77,4.45.23697\n' > "$attached/.kobo/version"
+printf 'owner bytes\n' > "$attached/untouched"
+run_host_update "$host_update_home" "$stable" stable > "$WORK/already-current.out"
+grep -F "already current on the stable channel" "$WORK/already-current.out" >/dev/null
+run_host_update "$host_update_home" "$beta" beta >/dev/null
+[ "$("$host_update_home/.local/bin/kobo")" = beta-one ]
+grep -Fx "host-channel beta" "$host_update_home/data/kobo/install-state" >/dev/null
+grep -Fx \
+    "release $host_update_home/data/kobo/releases/0.3.3-stable" \
+    "$host_update_home/data/kobo/install-state" >/dev/null
+run_host_update "$host_update_home" "$stable" stable >/dev/null
+[ "$("$host_update_home/.local/bin/kobo")" = stable-one ]
+grep -Fx "host-channel stable" "$host_update_home/data/kobo/install-state" >/dev/null
+[ "$(cat "$attached/untouched")" = "owner bytes" ]
+
+host_updated=$WORK/host-updated
+make_release "$host_updated" 0.3.5 stable stable-two
+run_host_update "$host_update_home" "$host_updated" stable >/dev/null
+[ "$("$host_update_home/.local/bin/kobo")" = stable-two ]
+
+host_truncated=$WORK/host-truncated
+make_release "$host_truncated" 0.3.6 stable stable-three
+printf x >> "$host_truncated/kobo-0.3.6-linux-x86_64.tar.gz"
+expect_failure "host update truncated download" \
+    run_host_update "$host_update_home" "$host_truncated" stable
+host_checksum=$WORK/host-checksum
+make_release "$host_checksum" 0.3.6 stable stable-three
+printf X | dd of="$host_checksum/kobo-0.3.6-linux-x86_64.tar.gz" \
+    bs=1 seek=8 conv=notrunc 2>/dev/null
+expect_failure "host update checksum failure" \
+    run_host_update "$host_update_home" "$host_checksum" stable
+host_signature=$WORK/host-signature
+make_release "$host_signature" 0.3.6 stable stable-three
+printf x >> "$host_signature/cobalt-host-manifest.txt"
+expect_failure "host update signature failure" \
+    run_host_update "$host_update_home" "$host_signature" stable
+
+mkdir "$host_update_home/data/kobo/install.lock"
+printf '%s\n' "$$" > "$host_update_home/data/kobo/install.lock/pid"
+expect_failure "host update lock contention" \
+    run_host_update "$host_update_home" "$host_updated" stable
+printf '%s\n' 999999 > "$host_update_home/data/kobo/install.lock/pid"
+expect_failure "host update stale-looking lock" \
+    run_host_update "$host_update_home" "$host_updated" stable
+rm -rf "$host_update_home/data/kobo/install.lock"
+expect_failure "host update unsupported platform" \
+    run_host_update "$host_update_home" "$host_updated" stable \
+    env KOBO_TEST_UNAME_S=FreeBSD
+conflicting_path=$WORK/host-update-conflict
+mkdir "$conflicting_path"
+printf '#!/bin/sh\nexit 0\n' > "$conflicting_path/kobo"
+chmod 755 "$conflicting_path/kobo"
+expect_failure "host update command conflict" env \
+    PATH="$conflicting_path:/usr/bin:/bin:/usr/sbin:/sbin" \
+    HOME="$host_update_home" XDG_DATA_HOME="$host_update_home/data" \
+    XDG_CACHE_HOME="$host_update_home/cache" KOBO_INSTALLER_TESTING=1 \
+    KOBO_INSTALLER_BASE_URL="file://$beta" \
+    sh "$host_update_home/data/kobo/updater/install.sh" \
+    --host-update --channel beta
 
 # Clean install, update, and idempotent rerun.
 home=$WORK/home-clean

--- a/tools/installer-test.sh
+++ b/tools/installer-test.sh
@@ -3,7 +3,6 @@ set -eu
 
 ROOT=$(CDPATH='' cd -- "$(dirname "$0")/.." && pwd)
 WORK=$ROOT/target/installer-tests
-WORKSPACE_VERSION=$(sed -n 's/^version = "\([0-9][0-9.]*\)"$/\1/p' "$ROOT/Cargo.toml")
 rm -rf "$WORK"
 mkdir -p "$WORK"
 trap 'rm -rf "$WORK"' EXIT HUP INT TERM
@@ -101,25 +100,28 @@ expect_failure() {
 }
 
 stable=$WORK/stable
-beta=$WORK/beta
 make_release "$stable" 0.3.3 stable stable-one
-make_release "$beta" "$WORKSPACE_VERSION" beta beta-one
-grep -F \
-    "https://github.com/BandarLabs/Cobalt/releases/download/beta-v${WORKSPACE_VERSION}/install.sh" \
-    "$ROOT/README.md" >/dev/null
-grep -F "sh -s -- --beta --version ${WORKSPACE_VERSION}" "$ROOT/README.md" >/dev/null
 grep -F "https://bandarlabs.github.io/Cobalt/install.sh" "$ROOT/README.md" >/dev/null
+if grep -Eq 'beta-v[0-9.]+/install\.sh|sh -s -- --beta' "$ROOT/README.md"; then
+    printf 'README exposes a beta bootstrap route\n' >&2
+    exit 1
+fi
+expect_failure "release installer beta route" \
+    env HOME="$WORK/home-reject-beta" KOBO_INSTALLER_TESTING=1 \
+    sh "$INSTALLER" --beta
+expect_failure "Pages installer beta route" \
+    env HOME="$WORK/home-pages-reject-beta" sh "$PAGES_INSTALLER" --beta
 
-# The first beta does not depend on a stable installer asset. An explicit beta
-# version resolves every download against its immutable beta-vX.Y.Z release.
+# The separately verified route checks the stable release installer before
+# execution with the out-of-band signer.
 printf '%s\n' "$SIGNER" > "$WORK/high-assurance-signers"
 ssh-keygen -Y verify -q -f "$WORK/high-assurance-signers" \
     -I cobalt-release -n cobalt-host-release \
-    -s "$beta/cobalt-host-manifest.txt.sshsig" \
-    < "$beta/cobalt-host-manifest.txt"
+    -s "$stable/cobalt-host-manifest.txt.sshsig" \
+    < "$stable/cobalt-host-manifest.txt"
 bootstrap_line=$(awk \
     '$1 == "bootstrap" && $2 == "install.sh" && NF == 4 {print $3 " " $4}' \
-    "$beta/cobalt-host-manifest.txt")
+    "$stable/cobalt-host-manifest.txt")
 IFS=' ' read -r bootstrap_bytes bootstrap_sha <<EOF
 $bootstrap_line
 EOF
@@ -144,43 +146,35 @@ while [ "$#" -gt 0 ]; do
     shift
 done
 printf '%s\n' "$url" >> "$KOBO_TEST_URL_LOG"
-prefix=https://github.com/BandarLabs/Cobalt/releases/download/beta-v$KOBO_TEST_VERSION/
 case "$url" in
-    "$prefix"*) cp "$KOBO_TEST_RELEASE/${url#"$prefix"}" "$output" ;;
+    https://github.com/BandarLabs/Cobalt/releases/latest/download/*)
+        cp "$KOBO_TEST_RELEASE/${url#https://github.com/BandarLabs/Cobalt/releases/latest/download/}" \
+            "$output"
+        ;;
+    https://github.com/BandarLabs/Cobalt/releases/download/v0.3.3/*)
+        cp "$KOBO_TEST_RELEASE/${url#https://github.com/BandarLabs/Cobalt/releases/download/v0.3.3/}" \
+            "$output"
+        ;;
     *) exit 22 ;;
 esac
 EOF
 chmod 755 "$mock_bin/curl"
-first_beta_home=$WORK/home-first-beta
-HOME=$first_beta_home XDG_DATA_HOME=$first_beta_home/data \
-XDG_CACHE_HOME=$first_beta_home/cache \
+# Once main:/docs is promoted, Pages discovers stable and verifies the signed
+# release installer before running it.
+pages_home=$WORK/home-pages
+: > "$WORK/pages-urls"
+HOME=$pages_home XDG_DATA_HOME=$pages_home/data \
+XDG_CACHE_HOME=$pages_home/cache \
 PATH="$mock_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
-KOBO_INSTALLER_TESTING=1 KOBO_TEST_RELEASE=$beta \
-KOBO_TEST_VERSION=$WORKSPACE_VERSION \
-KOBO_TEST_URL_LOG=$WORK/first-beta-urls \
-sh "$INSTALLER" --yes --no-setup --no-path --platform linux-x86_64 \
-    --beta --version "$WORKSPACE_VERSION" >/dev/null
-if grep -F '/releases/latest/download/' "$WORK/first-beta-urls" >/dev/null; then
-    printf 'first beta unexpectedly depended on a stable latest asset\n' >&2
-    exit 1
-fi
-grep -F "/releases/download/beta-v${WORKSPACE_VERSION}/cobalt-host-manifest.txt" \
-    "$WORK/first-beta-urls" >/dev/null
-
-# Once main:/docs is promoted, the Pages discovery bootstrap is
-# channel-agnostic. It verifies the signed release installer before running it.
-pages_beta_home=$WORK/home-pages-beta
-: > "$WORK/pages-beta-urls"
-HOME=$pages_beta_home XDG_DATA_HOME=$pages_beta_home/data \
-XDG_CACHE_HOME=$pages_beta_home/cache \
-PATH="$mock_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
-KOBO_INSTALLER_TESTING=1 KOBO_TEST_RELEASE=$beta \
-KOBO_TEST_VERSION=$WORKSPACE_VERSION \
-KOBO_TEST_URL_LOG=$WORK/pages-beta-urls \
+KOBO_INSTALLER_TESTING=1 KOBO_TEST_RELEASE=$stable \
+KOBO_TEST_URL_LOG=$WORK/pages-urls \
 sh "$PAGES_INSTALLER" --yes --no-setup --no-path --platform linux-x86_64 \
-    --beta --version "$WORKSPACE_VERSION" >/dev/null
-grep -F "/releases/download/beta-v${WORKSPACE_VERSION}/install.sh" \
-    "$WORK/pages-beta-urls" >/dev/null
+    >/dev/null
+grep -F "/releases/latest/download/cobalt-host-manifest.txt" \
+    "$WORK/pages-urls" >/dev/null
+grep -F "/releases/latest/download/install.sh" "$WORK/pages-urls" >/dev/null
+grep -F "/releases/download/v0.3.3/cobalt-host-manifest.txt" \
+    "$WORK/pages-urls" >/dev/null
 
 # Clean install, update, and idempotent rerun.
 home=$WORK/home-clean
@@ -237,9 +231,7 @@ set -e
 rm -rf "$lock_home/data/kobo/install.lock"
 run_install "$lock_home" "$stable" --platform linux-x86_64 >/dev/null
 
-# Stable/beta and explicit version enforcement.
-run_install "$WORK/home-beta" "$beta" --beta --platform linux-arm64
-grep -Fx "channel beta" "$WORK/home-beta/data/kobo/install-state" >/dev/null
+# Stable and explicit version enforcement.
 run_install "$WORK/home-version" "$stable" --version 0.3.3 --platform macos-arm64
 expect_failure "wrong explicit version" \
     run_install "$WORK/home-wrong-version" "$stable" --version 9.9.9 --platform linux-x86_64

--- a/tools/installer-test.sh
+++ b/tools/installer-test.sh
@@ -26,6 +26,9 @@ SIGNER=$(printf '%s\n' "$SIGNER" | awk '{print $1 " " $2 " " $3}')
 INSTALLER=$WORK/install.sh
 sed "s|cobalt-release ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL7XUR3p+tvPgftO/kRbigc8gagzP2RBDG3tWIu/1KXe|$SIGNER|" \
     "$ROOT/install.sh" > "$INSTALLER"
+PAGES_INSTALLER=$WORK/pages-install.sh
+sed "s|cobalt-release ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL7XUR3p+tvPgftO/kRbigc8gagzP2RBDG3tWIu/1KXe|$SIGNER|" \
+    "$ROOT/docs/install.sh" > "$PAGES_INSTALLER"
 
 make_release() {
     directory=$1
@@ -105,6 +108,7 @@ grep -F \
     "https://github.com/BandarLabs/Cobalt/releases/download/beta-v${WORKSPACE_VERSION}/install.sh" \
     "$ROOT/README.md" >/dev/null
 grep -F "sh -s -- --beta --version ${WORKSPACE_VERSION}" "$ROOT/README.md" >/dev/null
+grep -F "https://bandarlabs.github.io/Cobalt/install.sh" "$ROOT/README.md" >/dev/null
 
 # The first beta does not depend on a stable installer asset. An explicit beta
 # version resolves every download against its immutable beta-vX.Y.Z release.
@@ -162,6 +166,21 @@ if grep -F '/releases/latest/download/' "$WORK/first-beta-urls" >/dev/null; then
 fi
 grep -F "/releases/download/beta-v${WORKSPACE_VERSION}/cobalt-host-manifest.txt" \
     "$WORK/first-beta-urls" >/dev/null
+
+# Once main:/docs is promoted, the Pages discovery bootstrap is
+# channel-agnostic. It verifies the signed release installer before running it.
+pages_beta_home=$WORK/home-pages-beta
+: > "$WORK/pages-beta-urls"
+HOME=$pages_beta_home XDG_DATA_HOME=$pages_beta_home/data \
+XDG_CACHE_HOME=$pages_beta_home/cache \
+PATH="$mock_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+KOBO_INSTALLER_TESTING=1 KOBO_TEST_RELEASE=$beta \
+KOBO_TEST_VERSION=$WORKSPACE_VERSION \
+KOBO_TEST_URL_LOG=$WORK/pages-beta-urls \
+sh "$PAGES_INSTALLER" --yes --no-setup --no-path --platform linux-x86_64 \
+    --beta --version "$WORKSPACE_VERSION" >/dev/null
+grep -F "/releases/download/beta-v${WORKSPACE_VERSION}/install.sh" \
+    "$WORK/pages-beta-urls" >/dev/null
 
 # Clean install, update, and idempotent rerun.
 home=$WORK/home-clean


### PR DESCRIPTION
## Product contract

- Public bootstrap and prebuilt `kobo setup` install the stable/main Kobo platform only through the eventual Pages URL.
- The Kobo platform Beta channel is selected only in Cobalt Settings after stable installation. Settings confirms and persists changes and verifies signed Stable/Beta OTA manifests.
- `kobo update` is host-only. Stable is default; `kobo update --channel beta` explicitly selects only the host CLI channel. It never discovers or writes an attached reader and never changes the cached Stable USB setup release.

## Host update transaction

Every signed host archive contains `kobo`, its verified next updater, licenses, and provenance. The updater extracts that archive into an immutable directory identified by version, channel, platform, and archive SHA-256. A fixed launcher and public `kobo` symlink remain unchanged. One atomically replaced regular `current` selector file switches the complete CLI/updater pair.

Host update never rewrites `install-state`, the Stable release path, device package, raw setup signature, or setup manifest. An interruption before selector replacement leaves the complete old host live; after replacement it leaves the complete new host live. Reruns clean transaction staging, reuse verified immutable directories, and report already-current releases without replacement. Compatibility symlinks resolving through `kobo` continue to work.

## Verification and trust boundaries

The updater reuses platform/Rosetta/WSL detection, the fail-closed installation lock, stale staging cleanup, conflict detection, SSHSIG manifest verification, exact archive length/SHA-256 checks, and bounded downloads. Beta prereleases do not publish a standalone bootstrap, but their signed host archive carries the next updater for an existing managed installation.

The one-line Pages route trusts GitHub Pages HTTPS for its running discovery bytes. The documented high-assurance Stable route verifies the SSHSIG manifest and script checksum before execution. Stable/Beta platform OTA remains separately controlled and signed inside Cobalt Settings.

## USB safety

USB setup stages and byte-verifies a complete managed tree, swaps whole directories, isolates owner folders, rolls back failures, and recovers interrupted transactions without mixing managed versions. NickelMenu configuration remains outside this transaction.

## Validation

- `cargo test -p kobo-cli` — 222 passed
- strict `kobo-cli` Clippy with all targets/features — passed
- ShellCheck and `sh -n` for both bootstrap stages and release scripts — passed
- `tools/installer-test.sh` — passed
- `node --test tools/*.test.mjs` — 29 passed
- `actionlint .github/workflows/*.yml` — passed

Focused updater coverage verifies Stable/Beta updates leave setup state, release path, manifest signature, device package bytes, and selected Stable setup version unchanged. It injects failures before immutable-directory activation, before selector replacement, and immediately after selector replacement; verifies coherent old/new CLI-updater pairs, unchanged aliases/state, lock cleanup, rerun recovery, signature/checksum/truncation failures, unsupported hosts, and command conflicts.

## Physical acceptance

No physical USB installation or eject was performed. Beta platform artifacts still require acceptance on supported readers before Stable promotion. This PR targets `beta` and remains unmerged.
