### PR TITLE
Release 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "icon-import"
-version = "0.3.2"
+version = "0.3.3"
 
 [[package]]
 name = "image"
@@ -548,14 +548,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-abi"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "kobo-app-store"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-arxiv"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-audiobook"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-doc",
  "kobo-json",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-bookview"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-brief"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-chat"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-app-store",
  "kobo-image",
@@ -625,14 +625,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-dict"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "unicode-normalization",
 ]
 
 [[package]]
 name = "kobo-doc"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-html",
  "miniz_oxide 0.9.1",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doctor"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -649,14 +649,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-gallery"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-guard"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gutenbird"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -677,7 +677,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-hal"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-abi",
  "kobo-doc",
@@ -688,21 +688,21 @@ dependencies = [
 
 [[package]]
 name = "kobo-handoff"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-hello"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-hn"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-html"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "ratex-layout",
  "ratex-parser",
@@ -722,18 +722,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-image"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "image",
 ]
 
 [[package]]
 name = "kobo-json"
-version = "0.3.2"
+version = "0.3.3"
 
 [[package]]
 name = "kobo-launcher"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-magnet"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-morse"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -757,7 +757,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-net"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "http",
  "httparse",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-opds"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-json",
  "kobo-xml",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-policy"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-abi",
  "kobo-dict",
@@ -787,18 +787,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-profile"
-version = "0.3.2"
+version = "0.3.3"
 
 [[package]]
 name = "kobo-protocol"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-ui",
 ]
 
 [[package]]
 name = "kobo-read"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-rss"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sdk"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-policy",
  "kobo-protocol",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-settings"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -840,7 +840,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-shell"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-abi",
  "kobo-policy",
@@ -849,7 +849,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekick"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekickd"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -866,7 +866,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sim"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-net",
  "kobo-policy",
@@ -879,14 +879,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-smoke"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-store"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sudoku"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tap"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-term"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-ui",
  "vt100",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-terminal"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-policy",
  "kobo-sdk",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-text"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "fontdue",
  "kobo-ui",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tictactoe"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-todo"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -957,18 +957,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-ui"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "kobo-xml"
-version = "0.3.2"
+version = "0.3.3"
 
 [[package]]
 name = "kobo-zotero-reader"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -979,7 +979,7 @@ dependencies = [
 
 [[package]]
 name = "kobod"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "base64",
  "kobo-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.85.1"
 license = "AGPL-3.0-only"

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -10,7 +10,7 @@ code 389), firmware 4.38.23697**, the **Kobo Clara HD N249 (device code
 376), firmware 4.38.23684 or 4.38.23697**, the **Kobo Libra 2 N418 (device
 code 388), firmware 4.38.23697**, the **Kobo Clara Colour N367 (device code
 393), firmware 4.45.23697**, and the **Kobo Libra Colour N428 (device code
-390), firmware 4.45.23697**. Support remains tied to the exact
+390), firmware 4.45.23697 or 4.46.23836**. Support remains tied to the exact
 firmware, kernel, framebuffer, touch, and identity combination in the
 [device support matrix](DEVICES.md#device-support-matrix).
 


### PR DESCRIPTION
Bump the platform version to 0.3.3 and document Kobo Libra Colour firmware 4.46.23836 in the installation guide.

Release notes: Kobo Libra Colour support for firmware 4.46.23836.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790985347&installation_model_id=20525&pr_number=97&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F97&signature=003f8f0d5278b5acefa332d1f6835bfe3820dad233ff17b4f49339ea43c2e9e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->