### PR TITLE
Render pictures in colour on Kaleido panels (Clara Colour, Libra Colour)

### DIFF
--- a/apps/morse/src/main.rs
+++ b/apps/morse/src/main.rs
@@ -1024,11 +1024,11 @@ mod tests {
                 if let Command::PutPicture {
                     width,
                     height,
-                    grey,
+                    pixels,
                     ..
                 } = command
                 {
-                    panel = letter_in(grey, *width, *height);
+                    panel = letter_in(pixels, *width, *height);
                 }
             }
             seen.push((beat.lit, panel));

--- a/crates/kobo-abi/src/lib.rs
+++ b/crates/kobo-abi/src/lib.rs
@@ -533,7 +533,29 @@ pub mod hwtcon {
     pub const WAVEFORM_GL16: u32 = 3;
     pub const WAVEFORM_GLR16: u32 = 4;
     pub const WAVEFORM_A2: u32 = 6;
+    /// The four waveforms the controller gained with the colour panels: dark
+    /// mode GC16 and GL16, and the colour variants of GC16 and GLR16. Whether
+    /// a given firmware's waveform file carries them is not knowable from
+    /// userland, so the display layer stays on the shared greyscale set and
+    /// records these for the day an owner-attended run says otherwise.
+    pub const WAVEFORM_GCK16: u32 = 8;
+    pub const WAVEFORM_GLKW16: u32 = 9;
+    pub const WAVEFORM_GCC16: u32 = 10;
+    pub const WAVEFORM_GLRC16: u32 = 11;
     pub const WAVEFORM_AUTO: u32 = 257;
+
+    /// Bits for [`HwtconUpdateData::flags`].
+    ///
+    /// The controller quantises the framebuffer to the panel's grey levels
+    /// when asked, and on a colour panel decides per update whether to drive
+    /// the colour filter. Bits `0x7f00` select a colour processing mode; zero
+    /// there leaves the choice to the driver's global setting. The
+    /// monochrome bit forces a greyscale update whatever the global setting
+    /// says, which is what every update from a greyscale surface wants.
+    pub const FLAG_DITHER: u32 = 0x1;
+    pub const FLAG_MONOCHROME_ONLY: u32 = 0x8000;
+    pub const FLAG_COLOUR_FILTER_MASK: u32 = 0x7f00;
+    pub const FLAG_COLOUR_FILTER_STANDARD: u32 = 0x100;
 
     #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
     #[repr(C)]

--- a/crates/kobo-hal/src/display.rs
+++ b/crates/kobo-hal/src/display.rs
@@ -325,6 +325,36 @@ impl DisplaySession {
         self.geometry
     }
 
+    /// How to lay colour pixels out for this panel, when it can show them.
+    ///
+    /// `None` on a greyscale panel, and on a colour panel whose framebuffer
+    /// bitfields do not resolve to one byte per channel. Callers that get
+    /// `None` render in grey exactly as before; callers that get `Some` may
+    /// build regions with [`surface::RegionSnapshot::from_rgb`] and submit
+    /// them with [`crate::refresh::RefreshIntent::ColourContent`].
+    #[must_use]
+    pub fn colour(&self) -> Option<surface::ChannelOrder> {
+        self.profile
+            .colour_panel
+            .then(|| surface::ChannelOrder::from_profile(self.profile))
+            .flatten()
+    }
+
+    /// The plan as this panel can run it: a colour intent on a panel without
+    /// a colour filter becomes the quality update it would have been anyway,
+    /// so the flags asking for colour processing never reach a driver that
+    /// was not written to expect them.
+    fn for_this_panel(&self, plan: RefreshPlan) -> RefreshPlan {
+        if self.colour().is_some() {
+            plan
+        } else {
+            RefreshPlan {
+                intent: plan.intent.without_colour(),
+                ..plan
+            }
+        }
+    }
+
     /// Captures the exact current bytes of `region` so they can be restored.
     ///
     /// # Errors
@@ -472,6 +502,7 @@ impl DisplaySession {
     }
 
     fn issue(&self, plan: RefreshPlan) -> Result<IssuedRefresh, DisplayError> {
+        let plan = self.for_this_panel(plan);
         let marker = unique_marker()?;
         let submitted_waveform = plan.waveform(self.backend);
         let (translated_waveform, submit) = match self.backend {
@@ -690,7 +721,8 @@ fn smoke_wait_timing(session: &DisplaySession) -> Result<String, DisplayError> {
                         lines,
                         "{update:>6}  {:<8} {:>8}  {:>10}  {:>9}  {:>7}",
                         match intent {
-                            crate::refresh::RefreshIntent::QualityContent => "GC16",
+                            crate::refresh::RefreshIntent::QualityContent
+                            | crate::refresh::RefreshIntent::ColourContent => "GC16",
                             crate::refresh::RefreshIntent::TextContent => "GL16",
                             crate::refresh::RefreshIntent::FastFeedback => "DU",
                         },
@@ -1035,6 +1067,63 @@ mod tests {
                 Err(DisplayError::WriteRejected(_))
             ));
         }
+    }
+
+    #[test]
+    fn colour_is_offered_only_by_a_colour_panel_and_downgraded_elsewhere() {
+        use crate::refresh::RefreshIntent;
+        use kobo_profile::CLARA_COLOUR_393;
+
+        let grey = DisplaySession::open_verified(
+            &CLARA_BW_391,
+            matched_snapshot(),
+            Path::new("/dev/null"),
+            WritePolicy::ReadyOnly,
+        )
+        .expect("matched device opens");
+        assert!(grey.colour().is_none());
+
+        let colour = DisplaySession::open_verified(
+            &CLARA_COLOUR_393,
+            snapshot_for(
+                &CLARA_COLOUR_393,
+                IdentitySnapshot {
+                    serial_prefix: Some(CLARA_COLOUR_393.serial_prefix.into()),
+                    firmware_version: Some(CLARA_COLOUR_393.firmware_versions[0].into()),
+                    kernel_release: Some(CLARA_COLOUR_393.kernel_release.into()),
+                    device_code: Some(393),
+                },
+            ),
+            Path::new("/dev/null"),
+            WritePolicy::ReadyOnly,
+        )
+        .expect("matched device opens");
+        assert!(colour.colour().is_some());
+
+        let plan = RefreshPlan::new(
+            SMOKE_FIXED_REGION,
+            RefreshIntent::ColourContent,
+            false,
+            CLARA_BW_391.width,
+            CLARA_BW_391.height,
+        )
+        .expect("on screen");
+        assert_eq!(
+            grey.for_this_panel(plan).intent,
+            RefreshIntent::QualityContent
+        );
+        assert_eq!(grey.for_this_panel(plan).hwtcon_update_data(1).flags, 0);
+        assert_eq!(
+            colour.for_this_panel(plan).intent,
+            RefreshIntent::ColourContent
+        );
+        // Greyscale intents pass through both untouched.
+        let text = RefreshPlan {
+            intent: RefreshIntent::TextContent,
+            ..plan
+        };
+        assert_eq!(grey.for_this_panel(text), text);
+        assert_eq!(colour.for_this_panel(text), text);
     }
 
     #[test]

--- a/crates/kobo-hal/src/refresh.rs
+++ b/crates/kobo-hal/src/refresh.rs
@@ -71,12 +71,16 @@ impl Backend {
             Self::Hwtcon => match intent {
                 RefreshIntent::FastFeedback => hwtcon::WAVEFORM_DU,
                 RefreshIntent::TextContent => hwtcon::WAVEFORM_GL16,
-                RefreshIntent::QualityContent => hwtcon::WAVEFORM_GC16,
+                RefreshIntent::QualityContent | RefreshIntent::ColourContent => {
+                    hwtcon::WAVEFORM_GC16
+                }
             },
             Self::Mxcfb => match intent {
                 RefreshIntent::FastFeedback => mxcfb::WAVEFORM_DU,
                 RefreshIntent::TextContent => mxcfb::WAVEFORM_GL16,
-                RefreshIntent::QualityContent => mxcfb::WAVEFORM_GC16,
+                RefreshIntent::QualityContent | RefreshIntent::ColourContent => {
+                    mxcfb::WAVEFORM_GC16
+                }
             },
         }
     }
@@ -136,6 +140,51 @@ pub enum RefreshIntent {
     TextContent,
     /// A complete replacement that also clears accumulated ghosting.
     QualityContent,
+    /// A change whose pixels carry colour, on a panel that can show it.
+    ///
+    /// The framebuffer holds red, green and blue separately for this region
+    /// and the controller is asked to drive the colour filter from them. It
+    /// runs the same sixteen-level waveform as [`Self::QualityContent`]: the
+    /// controller's colour-specific waveforms are not present in every
+    /// firmware's waveform table, and a missing one fails after the ioctl has
+    /// returned success. On a greyscale panel or an i.MX6 backend this is a
+    /// quality update and nothing more; the session downgrades it before it
+    /// gets here.
+    ColourContent,
+}
+
+impl RefreshIntent {
+    /// Whether the update writes anything other than equal red, green and
+    /// blue, and so needs a panel that can tell them apart.
+    #[must_use]
+    pub const fn needs_colour_panel(self) -> bool {
+        matches!(self, Self::ColourContent)
+    }
+
+    /// The intent to submit when the panel cannot show colour.
+    #[must_use]
+    pub const fn without_colour(self) -> Self {
+        match self {
+            Self::ColourContent => Self::QualityContent,
+            other => other,
+        }
+    }
+
+    /// The update flags an hwtcon controller needs for this intent.
+    ///
+    /// Greyscale updates keep sending zero, exactly what every validated
+    /// device has been receiving: the driver's global colour setting decides
+    /// and equal channels look the same either way. A colour update names
+    /// the standard colour processing mode explicitly so that it does not
+    /// depend on what the previous owner of the panel left configured.
+    /// Dithering stays off on both; the surface already quantised.
+    #[must_use]
+    pub const fn hwtcon_flags(self) -> u32 {
+        match self {
+            Self::ColourContent => hwtcon::FLAG_COLOUR_FILTER_STANDARD,
+            Self::FastFeedback | Self::TextContent | Self::QualityContent => 0,
+        }
+    }
 }
 
 /// A clipped region and what is to be done to it.
@@ -189,7 +238,7 @@ impl RefreshPlan {
                 hwtcon::UPDATE_MODE_PARTIAL
             },
             update_marker: marker,
-            flags: 0,
+            flags: self.intent.hwtcon_flags(),
             dither_mode: 0,
         }
     }
@@ -347,6 +396,44 @@ mod tests {
         assert_eq!(update.dither_mode, 0);
         assert_eq!(update.quant_bit, 0);
         assert_eq!(update.alt_buffer_data, mxcfb::MxcfbAltBufferData::default());
+    }
+
+    #[test]
+    fn only_a_colour_update_sets_hwtcon_flags() {
+        let region = Rect {
+            x: 0,
+            y: 0,
+            width: 64,
+            height: 64,
+        };
+        for intent in [
+            RefreshIntent::FastFeedback,
+            RefreshIntent::TextContent,
+            RefreshIntent::QualityContent,
+        ] {
+            let plan = RefreshPlan::new(region, intent, false, 1072, 1448).expect("on screen");
+            assert_eq!(plan.hwtcon_update_data(1).flags, 0, "{intent:?}");
+            assert!(!intent.needs_colour_panel());
+            assert_eq!(intent.without_colour(), intent);
+        }
+
+        let colour = RefreshPlan::new(region, RefreshIntent::ColourContent, false, 1072, 1448)
+            .expect("on screen");
+        let update = colour.hwtcon_update_data(1);
+        assert_eq!(update.flags, hwtcon::FLAG_COLOUR_FILTER_STANDARD);
+        assert_eq!(update.flags & hwtcon::FLAG_COLOUR_FILTER_MASK, update.flags);
+        assert_eq!(update.flags & hwtcon::FLAG_MONOCHROME_ONLY, 0);
+        assert_eq!(update.dither_mode, 0);
+        // The same sixteen-level waveform as a quality update on both
+        // backends: colour is carried by the flags and the pixels, not by a
+        // waveform the firmware may not have.
+        assert_eq!(update.waveform_mode, hwtcon::WAVEFORM_GC16);
+        assert_eq!(colour.waveform(Backend::Mxcfb), mxcfb::WAVEFORM_GC16);
+        assert!(RefreshIntent::ColourContent.needs_colour_panel());
+        assert_eq!(
+            RefreshIntent::ColourContent.without_colour(),
+            RefreshIntent::QualityContent
+        );
     }
 
     #[test]

--- a/crates/kobo-hal/src/surface.rs
+++ b/crates/kobo-hal/src/surface.rs
@@ -315,19 +315,55 @@ impl RegionSnapshot {
         rgb: &[u8],
         order: ChannelOrder,
     ) -> Result<Self, SurfaceError> {
-        let placement = RegionPlacement::new(geometry, region)?;
-        let expected = (region.width as usize)
-            .saturating_mul(region.height as usize)
-            .saturating_mul(3);
-        if rgb.len() != expected {
+        let row_bytes = (region.width as usize).saturating_mul(3);
+        let expected = row_bytes.saturating_mul(region.height as usize);
+        if row_bytes == 0 || rgb.len() != expected {
             return Err(SurfaceError::RegionMismatch);
         }
+        Self::from_rgb_rows(geometry, region, rgb.chunks_exact(row_bytes), order)
+    }
+
+    /// Builds a writable region from RGB rows read straight out of a larger
+    /// image.
+    ///
+    /// The same as [`Self::from_rgb`] for an image that already lives row by
+    /// row inside something wider, such as a rendered frame, so the region
+    /// need not be copied out into its own buffer first. Every row must hold
+    /// exactly three bytes per pixel of `region.width`, and there must be
+    /// exactly `region.height` of them.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the region is invalid for `geometry`, a row is
+    /// the wrong length, or the row count differs from the region's height.
+    pub fn from_rgb_rows<'a>(
+        geometry: SurfaceGeometry,
+        region: Rect,
+        rows: impl IntoIterator<Item = &'a [u8]>,
+        order: ChannelOrder,
+    ) -> Result<Self, SurfaceError> {
+        let placement = RegionPlacement::new(geometry, region)?;
+        let row_bytes = (region.width as usize).saturating_mul(3);
         let mut pixels = vec![0_u8; placement.total_bytes()];
-        for (pixel, colour) in pixels
-            .chunks_exact_mut(SUPPORTED_BYTES_PER_PIXEL)
-            .zip(rgb.chunks_exact(3))
-        {
-            order.store(pixel, [colour[0], colour[1], colour[2]]);
+        let mut targets = pixels.chunks_exact_mut(placement.row_bytes);
+        let mut written = 0_usize;
+        for source in rows {
+            // A source with more rows than the region is as wrong as one
+            // with fewer; neither may be quietly cropped to fit.
+            let target = targets.next().ok_or(SurfaceError::RegionMismatch)?;
+            if source.len() != row_bytes {
+                return Err(SurfaceError::RegionMismatch);
+            }
+            for (pixel, colour) in target
+                .chunks_exact_mut(SUPPORTED_BYTES_PER_PIXEL)
+                .zip(source.chunks_exact(3))
+            {
+                order.store(pixel, [colour[0], colour[1], colour[2]]);
+            }
+            written += 1;
+        }
+        if written != region.height as usize {
+            return Err(SurfaceError::RegionMismatch);
         }
         Ok(Self { placement, pixels })
     }
@@ -480,6 +516,48 @@ mod tests {
 
         assert!(matches!(
             RegionSnapshot::from_rgb(CLARA, region, &rgb[..5], mediatek),
+            Err(SurfaceError::RegionMismatch)
+        ));
+    }
+
+    #[test]
+    fn colour_rows_from_a_wider_image_match_the_copied_region() {
+        let region = Rect {
+            x: 4,
+            y: 4,
+            width: 2,
+            height: 2,
+        };
+        let order = ChannelOrder::from_profile(&LIBRA_2_388).expect("resolves");
+        // A three-pixel-wide image of which the middle two columns are wanted.
+        let image = [
+            [0, 0, 0, 10, 20, 30, 40, 50, 60, 0, 0, 0],
+            [0, 0, 0, 70, 80, 90, 11, 12, 13, 0, 0, 0],
+        ];
+        let rows = image.iter().map(|row| &row[3..9]);
+        let from_rows = RegionSnapshot::from_rgb_rows(CLARA, region, rows, order).expect("built");
+        let copied = RegionSnapshot::from_rgb(
+            CLARA,
+            region,
+            &[10, 20, 30, 40, 50, 60, 70, 80, 90, 11, 12, 13],
+            order,
+        )
+        .expect("built");
+        assert!(from_rows.matches(&copied));
+
+        let short = image.iter().take(1).map(|row| &row[3..9]);
+        assert!(matches!(
+            RegionSnapshot::from_rgb_rows(CLARA, region, short, order),
+            Err(SurfaceError::RegionMismatch)
+        ));
+        let narrow = image.iter().map(|row| &row[3..8]);
+        assert!(matches!(
+            RegionSnapshot::from_rgb_rows(CLARA, region, narrow, order),
+            Err(SurfaceError::RegionMismatch)
+        ));
+        let long = image.iter().chain(image.iter()).map(|row| &row[3..9]);
+        assert!(matches!(
+            RegionSnapshot::from_rgb_rows(CLARA, region, long, order),
             Err(SurfaceError::RegionMismatch)
         ));
     }

--- a/crates/kobo-hal/src/surface.rs
+++ b/crates/kobo-hal/src/surface.rs
@@ -8,6 +8,7 @@
 //! `device-write` feature, so a default build has no callable pixel-write path.
 
 use crate::refresh::Rect;
+use kobo_profile::{Bitfield, DeviceProfile};
 use std::fs::File;
 use std::io;
 use std::os::unix::fs::FileExt;
@@ -20,6 +21,53 @@ pub const SUPPORTED_BYTES_PER_PIXEL: usize = 4;
 /// The verified Clara BW surface reports red/green/blue/alpha at bit offsets
 /// 0/8/16/24, which on this little-endian device places alpha in the last byte.
 pub const ALPHA_BYTE_INDEX: usize = 3;
+
+/// Which byte of a supported pixel holds each colour channel.
+///
+/// A greyscale write never needs this: it puts the same value in every
+/// non-alpha byte and the order cannot matter. A colour write does, and the
+/// answer comes from the framebuffer's reported bitfields rather than an
+/// assumption. The two controller families disagree: the `MediaTek` panels
+/// report red at bit 0 and the i.MX6 panels report blue there.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ChannelOrder {
+    red: usize,
+    green: usize,
+    blue: usize,
+}
+
+impl ChannelOrder {
+    /// Resolves the byte of each channel from the framebuffer's bitfields.
+    ///
+    /// `None` when any channel is not a whole byte inside the four, or two
+    /// channels share one, or one of them sits where alpha does. Every
+    /// supported profile resolves; the check is there for the snapshot a
+    /// future device reports.
+    #[must_use]
+    pub fn from_bitfields(red: Bitfield, green: Bitfield, blue: Bitfield) -> Option<Self> {
+        let byte = |field: Bitfield| {
+            (field.length == 8 && field.offset % 8 == 0 && field.msb_right == 0)
+                .then_some(field.offset as usize / 8)
+                .filter(|index| *index < SUPPORTED_BYTES_PER_PIXEL && *index != ALPHA_BYTE_INDEX)
+        };
+        let (red, green, blue) = (byte(red)?, byte(green)?, byte(blue)?);
+        (red != green && green != blue && red != blue).then_some(Self { red, green, blue })
+    }
+
+    /// The order a profile's framebuffer facts describe.
+    #[must_use]
+    pub fn from_profile(profile: &DeviceProfile) -> Option<Self> {
+        Self::from_bitfields(profile.red, profile.green, profile.blue)
+    }
+
+    /// Writes one colour into the four bytes of a pixel, opaque.
+    fn store(self, pixel: &mut [u8], [red, green, blue]: [u8; 3]) {
+        pixel[self.red] = red;
+        pixel[self.green] = green;
+        pixel[self.blue] = blue;
+        pixel[ALPHA_BYTE_INDEX] = u8::MAX;
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SurfaceGeometry {
@@ -248,6 +296,41 @@ impl RegionSnapshot {
         }
         Ok(Self { placement, pixels })
     }
+
+    /// Builds a writable region from one rendered 8-bit RGB image.
+    ///
+    /// The colour counterpart of [`Self::from_grayscale`], with the same
+    /// guarantees: a validated placement, and a rejection when `rgb` does not
+    /// hold exactly three bytes per pixel of `region`. Each channel goes to
+    /// the byte `order` names, so the same rendered image lands correctly on
+    /// either channel layout.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the region is invalid for `geometry` or `rgb`
+    /// does not hold exactly three bytes per pixel of `region`.
+    pub fn from_rgb(
+        geometry: SurfaceGeometry,
+        region: Rect,
+        rgb: &[u8],
+        order: ChannelOrder,
+    ) -> Result<Self, SurfaceError> {
+        let placement = RegionPlacement::new(geometry, region)?;
+        let expected = (region.width as usize)
+            .saturating_mul(region.height as usize)
+            .saturating_mul(3);
+        if rgb.len() != expected {
+            return Err(SurfaceError::RegionMismatch);
+        }
+        let mut pixels = vec![0_u8; placement.total_bytes()];
+        for (pixel, colour) in pixels
+            .chunks_exact_mut(SUPPORTED_BYTES_PER_PIXEL)
+            .zip(rgb.chunks_exact(3))
+        {
+            order.store(pixel, [colour[0], colour[1], colour[2]]);
+        }
+        Ok(Self { placement, pixels })
+    }
 }
 
 /// Reads the exact bytes of `region`.
@@ -313,10 +396,93 @@ pub fn write_region(
 #[cfg(test)]
 mod tests {
     use super::{
-        read_region, RegionPlacement, RegionSnapshot, SurfaceError, SurfaceGeometry,
+        read_region, ChannelOrder, RegionPlacement, RegionSnapshot, SurfaceError, SurfaceGeometry,
         ALPHA_BYTE_INDEX, SUPPORTED_BYTES_PER_PIXEL,
     };
     use crate::refresh::Rect;
+    use kobo_profile::{
+        Bitfield, CLARA_COLOUR_393, ELIPSA_2E_389, LIBRA_2_388, SUPPORTED_PROFILES,
+    };
+
+    #[test]
+    fn every_colour_profile_names_a_byte_for_each_channel() {
+        for profile in SUPPORTED_PROFILES {
+            if profile.colour_panel {
+                assert!(
+                    ChannelOrder::from_profile(profile).is_some(),
+                    "{} channel layout",
+                    profile.id
+                );
+            }
+        }
+        // The Elipsa 2E reports no bitfields at all. It is greyscale, so
+        // nothing asks; the point is that the answer is `None`, not a guess.
+        assert!(ChannelOrder::from_profile(&ELIPSA_2E_389).is_none());
+        let mediatek = ChannelOrder::from_profile(&CLARA_COLOUR_393).expect("resolves");
+        assert_eq!((mediatek.red, mediatek.green, mediatek.blue), (0, 1, 2));
+        let imx = ChannelOrder::from_profile(&LIBRA_2_388).expect("resolves");
+        assert_eq!((imx.red, imx.green, imx.blue), (2, 1, 0));
+    }
+
+    #[test]
+    fn a_channel_layout_that_is_not_whole_bytes_is_refused() {
+        let byte = |offset| Bitfield {
+            offset,
+            length: 8,
+            msb_right: 0,
+        };
+        assert!(ChannelOrder::from_bitfields(byte(0), byte(8), byte(16)).is_some());
+        // 5-6-5 packing, two channels in one byte, and a channel over alpha.
+        assert!(ChannelOrder::from_bitfields(
+            Bitfield {
+                offset: 11,
+                length: 5,
+                msb_right: 0
+            },
+            Bitfield {
+                offset: 5,
+                length: 6,
+                msb_right: 0
+            },
+            Bitfield {
+                offset: 0,
+                length: 5,
+                msb_right: 0
+            },
+        )
+        .is_none());
+        assert!(ChannelOrder::from_bitfields(byte(0), byte(0), byte(16)).is_none());
+        assert!(ChannelOrder::from_bitfields(byte(0), byte(8), byte(24)).is_none());
+    }
+
+    #[test]
+    fn colour_pixels_land_in_the_bytes_the_layout_names() {
+        let region = Rect {
+            x: 4,
+            y: 4,
+            width: 2,
+            height: 1,
+        };
+        let rgb = [10, 20, 30, 40, 50, 60];
+        let mediatek = ChannelOrder::from_profile(&CLARA_COLOUR_393).expect("resolves");
+        let snapshot = RegionSnapshot::from_rgb(CLARA, region, &rgb, mediatek).expect("built");
+        assert_eq!(snapshot.pixels(), &[10, 20, 30, 255, 40, 50, 60, 255]);
+
+        let imx = ChannelOrder::from_profile(&LIBRA_2_388).expect("resolves");
+        let snapshot = RegionSnapshot::from_rgb(CLARA, region, &rgb, imx).expect("built");
+        assert_eq!(snapshot.pixels(), &[30, 20, 10, 255, 60, 50, 40, 255]);
+
+        // A grey image written through either path is byte-identical.
+        let grey = RegionSnapshot::from_grayscale(CLARA, region, &[7, 9]).expect("built");
+        let as_colour =
+            RegionSnapshot::from_rgb(CLARA, region, &[7, 7, 7, 9, 9, 9], imx).expect("built");
+        assert!(grey.matches(&as_colour));
+
+        assert!(matches!(
+            RegionSnapshot::from_rgb(CLARA, region, &rgb[..5], mediatek),
+            Err(SurfaceError::RegionMismatch)
+        ));
+    }
 
     const CLARA: SurfaceGeometry = SurfaceGeometry {
         width: 1072,

--- a/crates/kobo-image/src/lib.rs
+++ b/crates/kobo-image/src/lib.rs
@@ -13,7 +13,7 @@
 
 use image::imageops::FilterType;
 use image::metadata::Orientation;
-use image::{DynamicImage, ImageDecoder, ImageEncoder, ImageReader};
+use image::{DynamicImage, ImageDecoder, ImageEncoder, ImageReader, RgbImage};
 use std::fmt;
 use std::io::Cursor;
 
@@ -77,6 +77,33 @@ pub fn encode_png_grey(width: u32, height: u32, grey: &[u8]) -> Result<Vec<u8>, 
     Ok(png)
 }
 
+/// Wraps colour panel bytes up as a PNG: three bytes per pixel, red, green,
+/// blue, the layout a colour frame off the simulator or the panel holds.
+///
+/// # Errors
+///
+/// Returns [`ImageError::Undecodable`] when `rgb` is not exactly
+/// `width * height * 3` bytes, and [`ImageError::TooManyPixels`] past
+/// [`MAX_PIXELS`].
+pub fn encode_png_rgb(width: u32, height: u32, rgb: &[u8]) -> Result<Vec<u8>, ImageError> {
+    let pixels = u64::from(width) * u64::from(height);
+    if pixels > MAX_PIXELS {
+        return Err(ImageError::TooManyPixels { pixels });
+    }
+    if rgb.len() as u64 != pixels * 3 {
+        return Err(ImageError::Undecodable(format!(
+            "{} bytes for a {width} by {height} colour frame, which needs {}",
+            rgb.len(),
+            pixels * 3
+        )));
+    }
+    let mut png = Vec::new();
+    image::codecs::png::PngEncoder::new(&mut png)
+        .write_image(rgb, width, height, image::ExtendedColorType::Rgb8)
+        .map_err(|error| ImageError::Undecodable(error.to_string()))?;
+    Ok(png)
+}
+
 /// How a picture should occupy the rectangle a component assigned to it.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub enum FitMode {
@@ -127,16 +154,21 @@ impl fmt::Display for ImageError {
 
 impl std::error::Error for ImageError {}
 
-/// One picture, in the only form the panel has any use for: eight bit grey,
-/// one byte per pixel, top row first, no padding.
+/// One picture, in the form the panel has use for: eight bit grey, one byte
+/// per pixel, top row first, no padding, and beside it, when the picture was
+/// read for a panel that can show it, the same pixels in colour.
 ///
-/// The same layout the drawing surface uses, so painting one is a copy rather
-/// than a conversion.
+/// The grey is always there and is the same layout the drawing surface uses,
+/// so painting one is a copy rather than a conversion. The colour is three
+/// bytes per pixel, red, green, blue, and is present only for pictures made
+/// by [`decode_colour`] or [`Picture::from_rgb`]; every other path produces a
+/// picture that is grey and nothing else, exactly as before colour existed.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Picture {
     width: u32,
     height: u32,
     grey: Vec<u8>,
+    colour: Option<Vec<u8>>,
 }
 
 impl Picture {
@@ -162,7 +194,56 @@ impl Picture {
             width,
             height,
             grey,
+            colour: None,
         })
+    }
+
+    /// Builds a colour picture from red, green, blue bytes, deriving the grey
+    /// the same way [`decode`] would have.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ImageError::TooManyPixels`] when the dimensions exceed
+    /// [`MAX_PIXELS`], and [`ImageError::Undecodable`] when `rgb` is not
+    /// exactly `width * height * 3` bytes.
+    pub fn from_rgb(width: u32, height: u32, rgb: Vec<u8>) -> Result<Self, ImageError> {
+        let pixels = checked_pixels(width, height)?;
+        if rgb.len() as u64 != pixels * 3 {
+            return Err(ImageError::Undecodable(format!(
+                "{} bytes for a {width} by {height} colour picture, which needs {}",
+                rgb.len(),
+                pixels * 3
+            )));
+        }
+        let source = RgbImage::from_raw(width, height, rgb)
+            .ok_or_else(|| ImageError::Undecodable("the picture is not its own size".to_owned()))?;
+        let grey = image::imageops::grayscale(&source);
+        Ok(Self {
+            width,
+            height,
+            grey: grey.into_raw(),
+            colour: Some(source.into_raw()),
+        })
+    }
+
+    /// The pixels in colour, three bytes each, row by row from the top, when
+    /// the picture was read for a colour panel.
+    #[must_use]
+    pub fn colour(&self) -> Option<&[u8]> {
+        self.colour.as_deref()
+    }
+
+    /// The colour bytes, giving up the picture; `None` for a grey one.
+    #[must_use]
+    pub fn into_colour(self) -> Option<Vec<u8>> {
+        self.colour
+    }
+
+    /// The same picture with its colour discarded.
+    #[must_use]
+    pub fn into_grey_picture(mut self) -> Self {
+        self.colour = None;
+        self
     }
 
     #[must_use]
@@ -308,7 +389,18 @@ impl Picture {
         let left = (scaled_width - width) / 2;
         let top = (scaled_height - height) / 2;
         let cropped = image::imageops::crop_imm(&scaled, left, top, width, height).to_image();
-        Self::from_grey(width, height, cropped.into_raw())
+        let mut picture = Self::from_grey(width, height, cropped.into_raw())?;
+        if let Some(colour) = &self.colour {
+            let source =
+                RgbImage::from_raw(self.width, self.height, colour.clone()).ok_or_else(|| {
+                    ImageError::Undecodable("the colour is not its own size".to_owned())
+                })?;
+            let scaled =
+                image::imageops::resize(&source, scaled_width, scaled_height, FilterType::Lanczos3);
+            let cropped = image::imageops::crop_imm(&scaled, left, top, width, height).to_image();
+            picture.colour = Some(cropped.into_raw());
+        }
+        Ok(picture)
     }
 
     /// Resamples to the largest size inside the box, in either direction.
@@ -325,10 +417,32 @@ impl Picture {
             .ok_or_else(|| ImageError::Undecodable("the picture is not its own size".to_owned()))?;
         let scaled =
             image::imageops::resize(&source, target_width, target_height, FilterType::Lanczos3);
+        // The colour plane is resampled on its own with the same filter, so a
+        // grey picture pays nothing and a colour one keeps its two planes the
+        // same size.
+        let colour = match &self.colour {
+            Some(colour) => {
+                let source = RgbImage::from_raw(self.width, self.height, colour.clone())
+                    .ok_or_else(|| {
+                        ImageError::Undecodable("the colour is not its own size".to_owned())
+                    })?;
+                Some(
+                    image::imageops::resize(
+                        &source,
+                        target_width,
+                        target_height,
+                        FilterType::Lanczos3,
+                    )
+                    .into_raw(),
+                )
+            }
+            None => None,
+        };
         Ok(Self {
             width: target_width,
             height: target_height,
             grey: scaled.into_raw(),
+            colour,
         })
     }
 
@@ -339,6 +453,11 @@ impl Picture {
     /// is banding, and a band across a photograph is far more obvious than the
     /// grain this leaves. Fewer than two levels is treated as two: one grey is
     /// not a picture.
+    ///
+    /// Only the grey plane is dithered. The colour plane, when there is one,
+    /// is quantised by the panel controller against its own colour filter,
+    /// and a picture dithered for sixteen greys and then drawn through that
+    /// filter would carry the grain twice.
     pub fn dither(&mut self, levels: u8) {
         let levels = u32::from(levels.max(2));
         let width = self.width as usize;
@@ -543,11 +662,77 @@ pub fn decode(bytes: &[u8]) -> Result<Picture, ImageError> {
     Picture::from_grey(luma.width(), luma.height(), grey)
 }
 
+/// Reads a picture that arrived over the network, keeping its colour.
+///
+/// The same refusals and the same grey as [`decode`]: the grey plane of the
+/// result is byte for byte what [`decode`] would have produced, so a caller
+/// that switches between the two on the panel's say-so draws the same picture
+/// on a greyscale reader either way. Transparency is composited onto white
+/// per channel before anything else, for the reason given in [`decode`].
+///
+/// Costs more memory than [`decode`] at its peak, four bytes a pixel rather
+/// than two, which is why it is a separate function and not a flag: a reader
+/// without a colour panel has no reason to pay it.
+///
+/// # Errors
+///
+/// As for [`decode`].
+pub fn decode_colour(bytes: &[u8]) -> Result<Picture, ImageError> {
+    if bytes.len() > MAX_SOURCE_BYTES {
+        return Err(ImageError::TooManyBytes { bytes: bytes.len() });
+    }
+    let reader = ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .map_err(|error| ImageError::Undecodable(error.to_string()))?;
+    if reader.format().is_none() {
+        return Err(ImageError::UnknownFormat);
+    }
+    let (width, height) = reader
+        .into_dimensions()
+        .map_err(|error| ImageError::Undecodable(error.to_string()))?;
+    let pixels = u64::from(width) * u64::from(height);
+    if pixels > MAX_PIXELS {
+        return Err(ImageError::TooManyPixels { pixels });
+    }
+    let mut decoder = ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .map_err(|error| ImageError::Undecodable(error.to_string()))?
+        .into_decoder()
+        .map_err(|error| ImageError::Undecodable(error.to_string()))?;
+    let orientation = decoder
+        .orientation()
+        .map_err(|error| ImageError::Undecodable(error.to_string()))?;
+    let mut image = DynamicImage::from_decoder(decoder)
+        .map_err(|error| ImageError::Undecodable(error.to_string()))?;
+    image.apply_orientation(orientation);
+
+    let rgba = image.to_rgba8();
+    let (width, height) = rgba.dimensions();
+    let mut rgb = Vec::with_capacity(width as usize * height as usize * 3);
+    let mut grey = Vec::with_capacity(width as usize * height as usize);
+    // Luminance first, exactly as `decode` computes it, then each channel
+    // composited onto white, so the grey plane matches `decode` and the
+    // colour plane matches what the grey was taken from.
+    let luma = image.to_luma_alpha8();
+    for (pixel, luma) in rgba.pixels().zip(luma.pixels()) {
+        let alpha = u32::from(pixel[3]);
+        let on_paper = |value: u8| {
+            u8::try_from((u32::from(value) * alpha + 255 * (255 - alpha) + 127) / 255)
+                .unwrap_or(255)
+        };
+        rgb.extend_from_slice(&[on_paper(pixel[0]), on_paper(pixel[1]), on_paper(pixel[2])]);
+        grey.push(on_paper(luma[0]));
+    }
+    let mut picture = Picture::from_grey(width, height, grey)?;
+    picture.colour = Some(rgb);
+    Ok(picture)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        decode, fitted_size, size, FitMode, ImageError, Picture, MAX_ENLARGEMENT, MAX_PIXELS,
-        PANEL_GREYS,
+        decode, decode_colour, encode_png_rgb, fitted_size, size, FitMode, ImageError, Picture,
+        MAX_ENLARGEMENT, MAX_PIXELS, PANEL_GREYS,
     };
     use image::{DynamicImage, ImageFormat, RgbImage, RgbaImage};
     use std::io::Cursor;
@@ -651,6 +836,54 @@ mod tests {
         let half = decode(&png(1, 1, vec![0, 0, 0, 128])).expect("png");
         assert_eq!(opaque.grey(), &[0]);
         assert_eq!(half.grey(), &[127]);
+    }
+
+    #[test]
+    fn decoding_in_colour_keeps_the_colour_and_the_very_same_grey() {
+        let bytes = png(3, 1, vec![255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 128]);
+        let grey = decode(&bytes).expect("grey");
+        let colour = decode_colour(&bytes).expect("colour");
+        assert_eq!(colour.grey(), grey.grey(), "the two decoders must agree");
+        assert!(grey.colour().is_none());
+        // Opaque red and green survive; the half-transparent blue is laid on
+        // white per channel, so it comes out a pale blue and not a dark one.
+        assert_eq!(
+            colour.colour(),
+            Some(&[255, 0, 0, 0, 255, 0, 127, 127, 255][..])
+        );
+        assert_eq!(colour.width(), 3);
+
+        let jpeg = decode_colour(&tiny_jpeg()).expect("jpeg");
+        assert_eq!(jpeg.colour().map(<[u8]>::len), Some(4 * 4 * 3));
+        assert_eq!(jpeg.grey(), decode(&tiny_jpeg()).expect("grey").grey());
+    }
+
+    #[test]
+    fn a_colour_picture_scales_both_planes_together_and_can_drop_one() {
+        let mut rgb = Vec::new();
+        for _ in 0..8 * 8 {
+            rgb.extend_from_slice(&[200, 40, 40]);
+        }
+        let picture = Picture::from_rgb(8, 8, rgb).expect("sized");
+        assert!(Picture::from_rgb(8, 8, vec![0; 64]).is_err());
+        let fitted = picture.fit(4, 4).expect("fit");
+        assert_eq!((fitted.width(), fitted.height()), (4, 4));
+        assert_eq!(fitted.grey().len(), 16);
+        let colour = fitted.colour().expect("kept");
+        assert_eq!(colour.len(), 48);
+        // A flat colour resamples to itself.
+        assert!(colour.chunks_exact(3).all(|c| c == [200, 40, 40]));
+        let covered = picture.cover(2, 4).expect("cover");
+        assert_eq!(covered.colour().map(<[u8]>::len), Some(2 * 4 * 3));
+        let grey_only = fitted.clone().into_grey_picture();
+        assert!(grey_only.colour().is_none());
+        assert_eq!(grey_only.grey(), fitted.grey());
+        assert_eq!(fitted.into_colour().map(|c| c.len()), Some(48));
+
+        let png = encode_png_rgb(1, 1, &[1, 2, 3]).expect("png");
+        let back = decode_colour(&png).expect("round trip");
+        assert_eq!(back.colour(), Some(&[1, 2, 3][..]));
+        assert!(encode_png_rgb(1, 1, &[1, 2]).is_err());
     }
 
     #[test]

--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -289,6 +289,7 @@ pub const CLARA_BW_391: DeviceProfile = DeviceProfile {
     kernel_release: "4.9.77",
     write_ready: true,
     reap_nickel_supplicant: false,
+    colour_panel: false,
 };
 
 /// The 2025 P365 hardware refresh of the Clara BW. Kobo lists N365 and P365
@@ -355,6 +356,7 @@ pub const CLARA_BW_395: DeviceProfile = DeviceProfile {
     kernel_release: "4.9.77",
     write_ready: true,
     reap_nickel_supplicant: false,
+    colour_panel: false,
 };
 
 /// The Kobo Clara HD, added upstream without i.MX6 hardware to test on.
@@ -422,6 +424,7 @@ pub const CLARA_HD_376: DeviceProfile = DeviceProfile {
     kernel_release: "4.1.15-00136-g12655eaaef89",
     write_ready: true,
     reap_nickel_supplicant: false,
+    colour_panel: false,
 };
 
 /// Kobo Clara Colour, whose measured framebuffer geometry, HWTCON interface,
@@ -440,6 +443,7 @@ pub const CLARA_COLOUR_393: DeviceProfile = DeviceProfile {
     serial_prefix: "N367",
     write_ready: true,
     reap_nickel_supplicant: false,
+    colour_panel: true,
     ..CLARA_BW_391
 };
 
@@ -499,6 +503,7 @@ pub const ELIPSA_2E_389: DeviceProfile = DeviceProfile {
     kernel_release: "4.9.77",
     write_ready: true,
     reap_nickel_supplicant: false,
+    colour_panel: false,
 };
 
 /// Kobo Libra 2, codename `io`, an i.MX6SLL Mark 7 device driven by
@@ -592,6 +597,7 @@ pub const LIBRA_2_388: DeviceProfile = DeviceProfile {
     // a normal hand-back, and the clean recovery after the leftover one was
     // killed during a live session.
     reap_nickel_supplicant: true,
+    colour_panel: false,
 };
 
 /// Kobo Libra Colour, a `MediaTek` HWTCON device like the Clara BW, and the
@@ -686,6 +692,7 @@ pub const LIBRA_COLOUR_390: DeviceProfile = DeviceProfile {
     // radio on i.MX6SLL; this is a MediaTek device whose Wi-Fi stack is shared
     // with Bluetooth and known to behave differently.
     reap_nickel_supplicant: false,
+    colour_panel: true,
 };
 
 /// Kobo Libra Colour on firmware 4.46.23836. The doctor report and attended
@@ -945,6 +952,22 @@ pub struct DeviceProfile {
     /// can test; enable this per device once the symptom and the fix are
     /// observed on it.
     pub reap_nickel_supplicant: bool,
+    /// Whether the panel has a colour filter array over its greyscale layer.
+    ///
+    /// A Kaleido panel reports exactly the same framebuffer as its greyscale
+    /// sibling: 32 bits per pixel, the same bitfields, the same geometry. The
+    /// difference is downstream of the framebuffer, in the controller, which
+    /// on these panels reads the red, green and blue bytes separately and
+    /// drives each sub-pixel behind its own filter. Nothing readable from
+    /// `/sys` or the framebuffer says so, which is why it is a profile fact.
+    ///
+    /// When false, the runtime writes every pixel with equal red, green and
+    /// blue and never asks for colour processing; a colour picture is drawn
+    /// as its luminance. When true, a picture that arrived in colour is
+    /// written in colour and the update asks the controller to use the
+    /// filter. The greyscale path is identical either way, so a wrong `true`
+    /// costs colour content and nothing else.
+    pub colour_panel: bool,
 }
 
 /// Pose geometry derived by a profile's [`GeometryRule`].
@@ -2713,5 +2736,34 @@ mod tests {
     fn missing_identity_blocks_every_write() {
         let blockers = CLARA_BW_391.write_identity_blockers(&DeviceSnapshot::default());
         assert_eq!(blockers.len(), 4);
+    }
+
+    #[test]
+    fn only_the_kaleido_panels_claim_colour() {
+        // The colour readers share every framebuffer field with a greyscale
+        // sibling, so this is the one place the difference is recorded, and
+        // a spread literal must not lose it.
+        for profile in SUPPORTED_PROFILES {
+            let expected = matches!(
+                profile.id,
+                "clara-colour-393" | "libra-colour-390" | "libra-colour-390-4.46.23836"
+            );
+            assert_eq!(
+                profile.colour_panel, expected,
+                "{} colour_panel should be {expected}",
+                profile.id
+            );
+        }
+        // Applications learn this from the profile name in the identity
+        // reply, which is a fixed frame that cannot grow a field. The name
+        // therefore has to say what the flag says.
+        for profile in SUPPORTED_PROFILES {
+            assert_eq!(
+                profile.colour_panel,
+                profile.id.contains("colour"),
+                "{} name and colour flag disagree",
+                profile.id
+            );
+        }
     }
 }

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -1293,7 +1293,11 @@ impl DeviceIdentity {
     /// would cost three times the bytes to be drawn as grey.
     #[must_use]
     pub fn colour_panel(&self) -> bool {
-        self.profile_id.to_ascii_lowercase().contains("colour")
+        const NAME: &[u8] = b"colour";
+        self.profile_id
+            .as_bytes()
+            .windows(NAME.len())
+            .any(|window| window.eq_ignore_ascii_case(NAME))
     }
 }
 

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -7,9 +7,9 @@ use std::io::{self, Read, Write};
 
 use kobo_ui::{
     ActionId, BannerLevel, BarAction, BarStyle, BottomAction, Caret, Cell, ControlState,
-    FontHandle, Freeform, Glyph, NavBar, Node, NodeId, PageTurns, Percent, PictureHandle, Row,
-    RowLead, RowState, Screen, Space, TextScale, Tile, TilePicture, TileShape, TileState, TopBar,
-    TransferFailure, MAX_BAR_ACTIONS, MAX_TERMINAL_COLUMNS, MAX_TERMINAL_ROWS,
+    FontHandle, Freeform, Glyph, NavBar, Node, NodeId, PageTurns, Percent, PictureFormat,
+    PictureHandle, Row, RowLead, RowState, Screen, Space, TextScale, Tile, TilePicture, TileShape,
+    TileState, TopBar, TransferFailure, MAX_BAR_ACTIONS, MAX_TERMINAL_COLUMNS, MAX_TERMINAL_ROWS,
     MIN_NAV_DESTINATIONS,
 };
 use std::cmp::min;
@@ -46,7 +46,10 @@ pub const MAGIC: [u8; 4] = *b"KOBO";
 /// Version 10 adds exact text-hold coordinates and typed offline dictionary
 /// requests/results. Version 11 adds the identity request and its result,
 /// both tags an older side has no reading for. Update-channel requests were
-/// later added on new tags without changing the shapes of existing frames.
+/// later added on new tags without changing the shapes of existing frames, and
+/// so were colour pictures: a grey picture still travels on the tags it always
+/// did, byte for byte, and a colour one travels on tags of its own that an
+/// older runtime refuses rather than misreads.
 pub const VERSION: u8 = 11;
 pub const HEADER_LEN: usize = 14;
 /// The largest single frame either side will read.
@@ -57,10 +60,12 @@ pub const HEADER_LEN: usize = 14;
 /// Eight megabytes bounds a runaway peer just as well and costs nothing when
 /// frames stay small, which every frame except an audio reply does.
 pub const MAX_FRAME_LEN: usize = 8 * 1_048_576;
-/// The largest decoded picture accepted from one application.
+/// The largest decoded picture accepted from one application, in bytes.
 ///
 /// Four Clara panels is the same bound used by `kobo-image`: enough headroom
-/// for a high-resolution source while remaining below the per-app cache.
+/// for a high-resolution source while remaining below the per-app cache. A
+/// bound on bytes rather than pixels, so a colour picture, at three bytes a
+/// pixel, fits a third as many of them; one Clara panel of colour fits.
 pub const MAX_PICTURE_BYTES: usize = 4 * 1072 * 1448;
 /// Largest picture sent as one legacy `PutPicture` frame.
 pub const MAX_INLINE_PICTURE_BYTES: usize = 768 * 1024;
@@ -660,20 +665,28 @@ pub enum Message {
         handle: PictureHandle,
         width: u32,
         height: u32,
-        /// Eight-bit grey, row major, exactly `width * height` bytes.
-        grey: Vec<u8>,
+        /// How `pixels` is laid out. Grey travels on the tag it always has;
+        /// colour on one of its own, so the field costs nothing on the wire.
+        format: PictureFormat,
+        /// Row major, exactly `width * height * format.bytes_per_pixel()`
+        /// bytes: one grey byte, or red, green and blue.
+        pixels: Vec<u8>,
     },
     /// Starts an atomic picture upload larger than one protocol frame.
     BeginPicture {
         handle: PictureHandle,
         width: u32,
         height: u32,
+        format: PictureFormat,
     },
     /// One in-order span of a picture started by [`Message::BeginPicture`].
+    ///
+    /// Bytes in the format the upload was begun with; a chunk does not carry
+    /// the format itself, so its boundaries need not fall on a pixel.
     PictureChunk {
         handle: PictureHandle,
         offset: u32,
-        grey: Vec<u8>,
+        pixels: Vec<u8>,
     },
     /// Makes a completely received upload visible to screens.
     CommitPicture {
@@ -1266,6 +1279,24 @@ pub struct DeviceIdentity {
     pub panel_height: u32,
 }
 
+impl DeviceIdentity {
+    /// Whether the reader's panel can show colour.
+    ///
+    /// Read from the profile name rather than a field of its own, because the
+    /// identity frame is a fixed shape older runtimes already send and an
+    /// added field would be misread by them rather than refused. The profile
+    /// names follow the products, and every panel with a colour filter is
+    /// sold with "Colour" in its name; the profile crate holds a test that
+    /// keeps its colour flag and its names in step, so this stays true as
+    /// panels are added. An application that gets `true` may send a picture
+    /// with `PictureFormat::Rgb`; one that gets `false` should not, since it
+    /// would cost three times the bytes to be drawn as grey.
+    #[must_use]
+    pub fn colour_panel(&self) -> bool {
+        self.profile_id.to_ascii_lowercase().contains("colour")
+    }
+}
+
 fn validate_identity(identity: &DeviceIdentity) -> Result<(), ProtocolError> {
     for text in [
         &identity.profile_id,
@@ -1752,17 +1783,19 @@ pub fn encode(frame: &Frame) -> Result<Vec<u8>, ProtocolError> {
             handle,
             width,
             height,
-            grey,
+            pixels,
+            ..
         } => {
             push_u32(&mut payload, handle.0);
             push_u32(&mut payload, *width);
             push_u32(&mut payload, *height);
-            payload.extend_from_slice(grey);
+            payload.extend_from_slice(pixels);
         }
         Message::BeginPicture {
             handle,
             width,
             height,
+            ..
         } => {
             push_u32(&mut payload, handle.0);
             push_u32(&mut payload, *width);
@@ -1771,11 +1804,11 @@ pub fn encode(frame: &Frame) -> Result<Vec<u8>, ProtocolError> {
         Message::PictureChunk {
             handle,
             offset,
-            grey,
+            pixels,
         } => {
             push_u32(&mut payload, handle.0);
             push_u32(&mut payload, *offset);
-            payload.extend_from_slice(grey);
+            payload.extend_from_slice(pixels);
         }
         Message::CommitPicture { handle } | Message::DropPicture { handle } => {
             push_u32(&mut payload, handle.0);
@@ -2259,6 +2292,37 @@ fn encoded_task_len(work: &Task) -> Result<usize, ProtocolError> {
     Ok(length)
 }
 
+fn put_picture_layout(
+    width: u32,
+    height: u32,
+    format: PictureFormat,
+    pixels: &[u8],
+) -> Result<(u8, usize), ProtocolError> {
+    // The declared size and the bytes must agree before anything is
+    // allocated on the strength of either, or a decoder reading by
+    // dimension would run off the end of a short payload.
+    let expected = picture_len(width, height, format)?;
+    if expected != pixels.len() {
+        return Err(ProtocolError::InvalidValue("picture size"));
+    }
+    if pixels.len() > MAX_INLINE_PICTURE_BYTES {
+        return Err(ProtocolError::FrameTooLarge);
+    }
+    Ok((put_picture_tag(format), 12 + pixels.len()))
+}
+
+fn begin_picture_layout(
+    width: u32,
+    height: u32,
+    format: PictureFormat,
+) -> Result<(u8, usize), ProtocolError> {
+    let expected = picture_len(width, height, format)?;
+    if expected == 0 || expected > MAX_PICTURE_BYTES {
+        return Err(ProtocolError::FrameTooLarge);
+    }
+    Ok((begin_picture_tag(format), 12))
+}
+
 fn encoded_message_layout(message: &Message) -> Result<(u8, usize), ProtocolError> {
     match message {
         Message::Hello { name } => Ok((1, encoded_string_len(name)?)),
@@ -2312,40 +2376,28 @@ fn encoded_message_layout(message: &Message) -> Result<(u8, usize), ProtocolErro
         Message::PutPicture {
             width,
             height,
-            grey,
+            format,
+            pixels,
             ..
-        } => {
-            // The declared size and the bytes must agree before anything is
-            // allocated on the strength of either, or a decoder reading by
-            // dimension would run off the end of a short payload.
-            let expected = picture_len(*width, *height)?;
-            if expected != grey.len() {
-                return Err(ProtocolError::InvalidValue("picture size"));
-            }
-            if grey.len() > MAX_INLINE_PICTURE_BYTES {
-                return Err(ProtocolError::FrameTooLarge);
-            }
-            Ok((18, 12 + grey.len()))
-        }
+        } => put_picture_layout(*width, *height, *format, pixels),
         Message::DropPicture { .. } => Ok((19, 4)),
-        Message::BeginPicture { width, height, .. } => {
-            let expected = picture_len(*width, *height)?;
-            if expected == 0 || expected > MAX_PICTURE_BYTES {
-                return Err(ProtocolError::FrameTooLarge);
-            }
-            Ok((20, 12))
-        }
-        Message::PictureChunk { offset, grey, .. } => {
-            if grey.is_empty()
-                || grey.len() > MAX_PICTURE_CHUNK_BYTES
+        Message::BeginPicture {
+            width,
+            height,
+            format,
+            ..
+        } => begin_picture_layout(*width, *height, *format),
+        Message::PictureChunk { offset, pixels, .. } => {
+            if pixels.is_empty()
+                || pixels.len() > MAX_PICTURE_CHUNK_BYTES
                 || usize::try_from(*offset)
                     .ok()
-                    .and_then(|offset| offset.checked_add(grey.len()))
+                    .and_then(|offset| offset.checked_add(pixels.len()))
                     .is_none_or(|end| end > MAX_PICTURE_BYTES)
             {
                 return Err(ProtocolError::FrameTooLarge);
             }
-            Ok((21, 8 + grey.len()))
+            Ok((21, 8 + pixels.len()))
         }
         Message::CommitPicture { .. } => Ok((22, 4)),
         Message::CoverChanged { .. } => Ok((23, 1)),
@@ -2363,11 +2415,27 @@ fn encoded_message_layout(message: &Message) -> Result<(u8, usize), ProtocolErro
     }
 }
 
-fn picture_len(width: u32, height: u32) -> Result<usize, ProtocolError> {
-    usize::try_from(width)
-        .ok()
-        .and_then(|width| width.checked_mul(usize::try_from(height).ok()?))
+fn picture_len(width: u32, height: u32, format: PictureFormat) -> Result<usize, ProtocolError> {
+    format
+        .byte_len(width, height)
         .ok_or(ProtocolError::FrameTooLarge)
+}
+
+/// Grey pictures keep the tag they have always had; colour ones take a tag of
+/// their own, so an older runtime refuses the frame instead of reading three
+/// bytes a pixel as one.
+const fn put_picture_tag(format: PictureFormat) -> u8 {
+    match format {
+        PictureFormat::Grey => 18,
+        PictureFormat::Rgb => 28,
+    }
+}
+
+const fn begin_picture_tag(format: PictureFormat) -> u8 {
+    match format {
+        PictureFormat::Grey => 20,
+        PictureFormat::Rgb => 29,
+    }
 }
 
 #[allow(
@@ -4192,30 +4260,41 @@ pub fn decode(bytes: &[u8]) -> Result<Frame, ProtocolError> {
             3 => ShellEvent::Refused(ShellError::try_from(reader.u8()?)?),
             _ => return Err(ProtocolError::InvalidValue("shell event")),
         }),
-        18 => {
+        tag @ (18 | 28) => {
+            let format = if tag == 18 {
+                PictureFormat::Grey
+            } else {
+                PictureFormat::Rgb
+            };
             let handle = PictureHandle(reader.u32()?);
             let width = reader.u32()?;
             let height = reader.u32()?;
-            let expected = picture_len(width, height)?;
+            let expected = picture_len(width, height, format)?;
             if expected > MAX_INLINE_PICTURE_BYTES {
                 return Err(ProtocolError::FrameTooLarge);
             }
-            let grey = reader.take(expected)?.to_vec();
+            let pixels = reader.take(expected)?.to_vec();
             Message::PutPicture {
                 handle,
                 width,
                 height,
-                grey,
+                format,
+                pixels,
             }
         }
         19 => Message::DropPicture {
             handle: PictureHandle(reader.u32()?),
         },
-        20 => {
+        tag @ (20 | 29) => {
+            let format = if tag == 20 {
+                PictureFormat::Grey
+            } else {
+                PictureFormat::Rgb
+            };
             let handle = PictureHandle(reader.u32()?);
             let width = reader.u32()?;
             let height = reader.u32()?;
-            let expected = picture_len(width, height)?;
+            let expected = picture_len(width, height, format)?;
             if expected == 0 || expected > MAX_PICTURE_BYTES {
                 return Err(ProtocolError::FrameTooLarge);
             }
@@ -4223,6 +4302,7 @@ pub fn decode(bytes: &[u8]) -> Result<Frame, ProtocolError> {
                 handle,
                 width,
                 height,
+                format,
             }
         }
         21 => {
@@ -4242,7 +4322,7 @@ pub fn decode(bytes: &[u8]) -> Result<Frame, ProtocolError> {
             Message::PictureChunk {
                 handle,
                 offset,
-                grey: reader.take(length)?.to_vec(),
+                pixels: reader.take(length)?.to_vec(),
             }
         }
         22 => Message::CommitPicture {
@@ -8831,11 +8911,123 @@ mod picture_tests {
                 handle: PictureHandle(4),
                 width: 3,
                 height: 2,
-                grey: vec![0, 32, 64, 96, 128, 160],
+                format: PictureFormat::Grey,
+                pixels: vec![0, 32, 64, 96, 128, 160],
             },
         };
         let bytes = encode(&frame).expect("encode");
         assert_eq!(decode(&bytes).expect("decode"), frame);
+    }
+
+    /// Where the message tag sits in a frame: after the magic and the version.
+    const TAG_INDEX: usize = MAGIC.len() + 1;
+
+    #[test]
+    fn a_grey_picture_is_the_same_bytes_it_was_before_colour_existed() {
+        // The frame an application built last year, byte for byte: magic,
+        // version, request id, tag 18, length, then the handle, the size and
+        // the pixels. A runtime from before colour reads it unchanged.
+        let frame = Frame {
+            request_id: 1,
+            message: Message::PutPicture {
+                handle: PictureHandle(4),
+                width: 2,
+                height: 1,
+                format: PictureFormat::Grey,
+                pixels: vec![7, 9],
+            },
+        };
+        let bytes = encode(&frame).expect("encode");
+        assert_eq!(bytes[MAGIC.len()], VERSION);
+        assert_eq!(bytes[TAG_INDEX], 18, "the grey tag did not move");
+        assert_eq!(
+            &bytes[HEADER_LEN..],
+            &[0, 0, 0, 4, 0, 0, 0, 2, 0, 0, 0, 1, 7, 9]
+        );
+
+        let begin = encode(&Frame {
+            request_id: 1,
+            message: Message::BeginPicture {
+                handle: PictureHandle(4),
+                width: 2,
+                height: 1,
+                format: PictureFormat::Grey,
+            },
+        })
+        .expect("encode");
+        assert_eq!(begin[TAG_INDEX], 20);
+    }
+
+    #[test]
+    fn a_colour_picture_travels_on_its_own_tag_at_three_bytes_a_pixel() {
+        let frame = Frame {
+            request_id: 1,
+            message: Message::PutPicture {
+                handle: PictureHandle(4),
+                width: 2,
+                height: 1,
+                format: PictureFormat::Rgb,
+                pixels: vec![255, 0, 0, 0, 0, 255],
+            },
+        };
+        let bytes = encode(&frame).expect("encode");
+        assert_eq!(bytes[TAG_INDEX], 28);
+        assert_eq!(decode(&bytes).expect("decode"), frame);
+
+        // The same pixels declared grey are the wrong length and refused; a
+        // colour picture short of three bytes a pixel likewise.
+        assert!(matches!(
+            encode(&Frame {
+                request_id: 1,
+                message: Message::PutPicture {
+                    handle: PictureHandle(4),
+                    width: 2,
+                    height: 1,
+                    format: PictureFormat::Grey,
+                    pixels: vec![255, 0, 0, 0, 0, 255],
+                },
+            }),
+            Err(ProtocolError::InvalidValue(_))
+        ));
+        assert!(matches!(
+            encode(&Frame {
+                request_id: 1,
+                message: Message::PutPicture {
+                    handle: PictureHandle(4),
+                    width: 2,
+                    height: 1,
+                    format: PictureFormat::Rgb,
+                    pixels: vec![255, 0, 0, 0],
+                },
+            }),
+            Err(ProtocolError::InvalidValue(_))
+        ));
+
+        let begin = Frame {
+            request_id: 1,
+            message: Message::BeginPicture {
+                handle: PictureHandle(4),
+                width: 1072,
+                height: 1448,
+                format: PictureFormat::Rgb,
+            },
+        };
+        let bytes = encode(&begin).expect("a full colour panel fits the byte bound");
+        assert_eq!(bytes[TAG_INDEX], 29);
+        assert_eq!(decode(&bytes).expect("decode"), begin);
+        // Two colour panels do not: the bound is on bytes, not pixels.
+        assert!(matches!(
+            encode(&Frame {
+                request_id: 1,
+                message: Message::BeginPicture {
+                    handle: PictureHandle(4),
+                    width: 1072,
+                    height: 1448 * 2,
+                    format: PictureFormat::Rgb,
+                },
+            }),
+            Err(ProtocolError::FrameTooLarge)
+        ));
     }
 
     #[test]
@@ -8848,7 +9040,8 @@ mod picture_tests {
                 handle: PictureHandle(4),
                 width: 100,
                 height: 100,
-                grey: vec![0; 99],
+                format: PictureFormat::Grey,
+                pixels: vec![0; 99],
             },
         });
         assert!(matches!(refused, Err(ProtocolError::InvalidValue(_))));
@@ -8862,7 +9055,8 @@ mod picture_tests {
                 handle: PictureHandle(4),
                 width: u32::try_from(MAX_INLINE_PICTURE_BYTES + 1).expect("fits"),
                 height: 1,
-                grey: vec![0; MAX_INLINE_PICTURE_BYTES + 1],
+                format: PictureFormat::Grey,
+                pixels: vec![0; MAX_INLINE_PICTURE_BYTES + 1],
             },
         });
         assert!(matches!(refused, Err(ProtocolError::FrameTooLarge)));
@@ -8875,11 +9069,12 @@ mod picture_tests {
                 handle: PictureHandle(4),
                 width: 1072,
                 height: 1448,
+                format: PictureFormat::Grey,
             },
             Message::PictureChunk {
                 handle: PictureHandle(4),
                 offset: 0,
-                grey: vec![17; 4096],
+                pixels: vec![17; 4096],
             },
             Message::CommitPicture {
                 handle: PictureHandle(4),
@@ -8902,7 +9097,7 @@ mod picture_tests {
             message: Message::PictureChunk {
                 handle: PictureHandle(4),
                 offset: 0,
-                grey: vec![0; MAX_PICTURE_CHUNK_BYTES + 1],
+                pixels: vec![0; MAX_PICTURE_CHUNK_BYTES + 1],
             },
         });
         assert!(matches!(refused, Err(ProtocolError::FrameTooLarge)));

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -22,11 +22,11 @@ pub use kobo_ui::{
     BannerLevel, BarAction, BarStyle, BottomAction, Caret, Cell, Chip, Chrome, ControlState,
     DiagnosticSeverity, DisplayMetrics, Emphasis, Fold, FontHandle, Freeform, Glyph, InlineFormula,
     LayoutIssue, LayoutIssueKind, NavBar, Node, NodeId, Overlay, OverlayKind, ParagraphAlignment,
-    ParagraphPresentation, Percent, PictureHandle, ProseArea, RichTextSpan, Row, RowLead, RowState,
-    Screen, SlotWidth, Space, TextHit, TextPresentation, TextSelection, Tile, TilePicture,
-    TileShape, TileState, TopBar, TransferFailure, CLARA_BW_METRICS, MAX_BAND_SLOTS, MAX_CELLS,
-    MAX_CHIPS, MAX_CHOICE_OPTIONS, MAX_COLUMNS, MAX_INLINE_FORMULAE, MAX_QUOTE_DEPTH, MAX_ROWS,
-    MAX_TABS, MAX_TERMINAL_COLUMNS, MAX_TERMINAL_ROWS, TILE_BADGE_LIMIT,
+    ParagraphPresentation, Percent, PictureFormat, PictureHandle, ProseArea, RichTextSpan, Row,
+    RowLead, RowState, Screen, SlotWidth, Space, TextHit, TextPresentation, TextSelection, Tile,
+    TilePicture, TileShape, TileState, TopBar, TransferFailure, CLARA_BW_METRICS, MAX_BAND_SLOTS,
+    MAX_CELLS, MAX_CHIPS, MAX_CHOICE_OPTIONS, MAX_COLUMNS, MAX_INLINE_FORMULAE, MAX_QUOTE_DEPTH,
+    MAX_ROWS, MAX_TABS, MAX_TERMINAL_COLUMNS, MAX_TERMINAL_ROWS, TILE_BADGE_LIMIT,
 };
 use std::collections::BTreeMap;
 use std::collections::VecDeque;
@@ -2705,7 +2705,8 @@ pub enum Command {
         handle: PictureHandle,
         width: u32,
         height: u32,
-        grey: Vec<u8>,
+        format: PictureFormat,
+        pixels: Vec<u8>,
     },
     /// Release a picture the runtime is holding.
     DropPicture(PictureHandle),
@@ -3214,17 +3215,51 @@ impl Context {
         height: u32,
         grey: Vec<u8>,
     ) -> Option<TilePicture> {
-        let expected = usize::try_from(width)
-            .ok()
-            .and_then(|width| width.checked_mul(usize::try_from(height).ok()?))?;
-        if expected == 0 || expected != grey.len() || expected > MAX_PICTURE_BYTES {
+        self.put_picture_with(handle, width, height, PictureFormat::Grey, grey)
+    }
+
+    /// [`Self::put_picture`] for a picture in colour: three bytes per pixel,
+    /// red, green, blue, row major.
+    ///
+    /// Only worth sending when the reader can show it. A colour picture costs
+    /// three times the wire and the runtime's cache of a grey one, and on a
+    /// greyscale panel the runtime draws its luminance, which is exactly what
+    /// [`Self::put_picture`] would have sent for a third of the bytes. Ask
+    /// with [`Self::read_identity`] and [`DeviceIdentity::colour_panel`]
+    /// first; a runtime from before colour pictures existed refuses the frame
+    /// and drops the connection, so an application that has not been told the
+    /// panel is colour should not send one.
+    ///
+    /// The byte bound is the same as for grey, so a colour picture may be at
+    /// most a third as many pixels: one full Clara panel fits.
+    pub fn put_colour_picture(
+        &mut self,
+        handle: PictureHandle,
+        width: u32,
+        height: u32,
+        rgb: Vec<u8>,
+    ) -> Option<TilePicture> {
+        self.put_picture_with(handle, width, height, PictureFormat::Rgb, rgb)
+    }
+
+    fn put_picture_with(
+        &mut self,
+        handle: PictureHandle,
+        width: u32,
+        height: u32,
+        format: PictureFormat,
+        pixels: Vec<u8>,
+    ) -> Option<TilePicture> {
+        let expected = format.byte_len(width, height)?;
+        if expected == 0 || expected != pixels.len() || expected > MAX_PICTURE_BYTES {
             return None;
         }
         self.commands.push(Command::PutPicture {
             handle,
             width,
             height,
-            grey,
+            format,
+            pixels,
         });
         Some(TilePicture::new(handle, width, height))
     }
@@ -4988,22 +5023,25 @@ impl Client {
                     handle,
                     width,
                     height,
-                    grey,
+                    format,
+                    pixels,
                 } => {
-                    if grey.len() <= MAX_INLINE_PICTURE_BYTES {
+                    if pixels.len() <= MAX_INLINE_PICTURE_BYTES {
                         self.send(Message::PutPicture {
                             handle,
                             width,
                             height,
-                            grey,
+                            format,
+                            pixels,
                         })?;
                     } else {
                         self.send(Message::BeginPicture {
                             handle,
                             width,
                             height,
+                            format,
                         })?;
-                        for (index, chunk) in grey.chunks(MAX_PICTURE_CHUNK_BYTES).enumerate() {
+                        for (index, chunk) in pixels.chunks(MAX_PICTURE_CHUNK_BYTES).enumerate() {
                             let offset = index
                                 .checked_mul(MAX_PICTURE_CHUNK_BYTES)
                                 .and_then(|offset| u32::try_from(offset).ok())
@@ -5013,7 +5051,7 @@ impl Client {
                             self.send(Message::PictureChunk {
                                 handle,
                                 offset,
-                                grey: chunk.to_vec(),
+                                pixels: chunk.to_vec(),
                             })?;
                         }
                         self.send(Message::CommitPicture { handle })?;
@@ -6040,7 +6078,8 @@ mod tests {
                 Message::BeginPicture {
                     handle: PictureHandle(9),
                     width: 1072,
-                    height: 1448
+                    height: 1448,
+                    format: PictureFormat::Grey,
                 }
             ));
             let expected = 1072_usize * 1448;
@@ -6049,7 +6088,7 @@ mod tests {
                 let Message::PictureChunk {
                     handle,
                     offset,
-                    grey,
+                    pixels,
                 } = kobo_protocol::read_from(&mut daemon_stream)
                     .expect("chunk")
                     .message
@@ -6058,8 +6097,8 @@ mod tests {
                 };
                 assert_eq!(handle, PictureHandle(9));
                 assert_eq!(usize::try_from(offset).expect("offset"), received);
-                assert!(grey.len() <= MAX_PICTURE_CHUNK_BYTES);
-                received += grey.len();
+                assert!(pixels.len() <= MAX_PICTURE_CHUNK_BYTES);
+                received += pixels.len();
             }
             assert!(matches!(
                 kobo_protocol::read_from(&mut daemon_stream)
@@ -6076,10 +6115,46 @@ mod tests {
                 handle: PictureHandle(9),
                 width: 1072,
                 height: 1448,
-                grey: vec![127; 1072 * 1448],
+                format: PictureFormat::Grey,
+                pixels: vec![127; 1072 * 1448],
             }])
             .expect("upload");
         daemon.join().expect("daemon");
+    }
+
+    #[test]
+    fn a_colour_picture_is_checked_at_three_bytes_a_pixel() {
+        let mut context = Context {
+            commands: Vec::new(),
+            next_task: 1,
+            in_flight: 0,
+            metrics: CLARA_BW_METRICS,
+            retrying: Vec::new(),
+        };
+        assert!(context
+            .put_colour_picture(PictureHandle(1), 2, 2, vec![0; 4])
+            .is_none());
+        assert!(context
+            .put_picture(PictureHandle(1), 2, 2, vec![0; 12])
+            .is_none());
+        let placed = context
+            .put_colour_picture(PictureHandle(1), 2, 2, vec![0; 12])
+            .expect("sized correctly");
+        assert_eq!(placed, TilePicture::new(PictureHandle(1), 2, 2));
+        assert!(matches!(
+            context.commands.last(),
+            Some(Command::PutPicture {
+                format: PictureFormat::Rgb,
+                ..
+            })
+        ));
+        // Two Clara panels of grey fit the byte bound; two of colour do not.
+        assert!(context
+            .put_picture(PictureHandle(2), 1072, 1448 * 2, vec![0; 1072 * 1448 * 2])
+            .is_some());
+        assert!(context
+            .put_colour_picture(PictureHandle(2), 1072, 1448 * 2, vec![0; 1072 * 1448 * 6])
+            .is_none());
     }
 }
 

--- a/crates/kobo-sim/src/lib.rs
+++ b/crates/kobo-sim/src/lib.rs
@@ -170,7 +170,10 @@ impl PanelPreview {
                             kobo_ui::tone::PAPER
                         }
                     }
-                    PanelWaveform::Gl16 | PanelWaveform::Gc16 => target,
+                    // The simulated panel is a Clara BW, which has no colour
+                    // filter: a colour update lands as its luminance, exactly
+                    // as the runtime writes it on that device.
+                    PanelWaveform::Gl16 | PanelWaveform::Gc16 | PanelWaveform::Colour => target,
                 };
                 // An LCD cannot reproduce electrophoretic residue. Retaining
                 // one sixteenth of the previous displayed value makes stale
@@ -727,22 +730,27 @@ fn hold_picture(state: &Arc<Mutex<AppState>>, message: Message) -> io::Result<()
                 handle,
                 width,
                 height,
-                grey,
-            } => picture_result(handle, pictures.put_report(handle, width, height, grey)),
+                format,
+                pixels,
+            } => picture_result(
+                handle,
+                pictures.put_report_with(handle, width, height, format, pixels),
+            ),
             Message::BeginPicture {
                 handle,
                 width,
                 height,
-            } => (!pictures.begin_upload(handle, width, height))
+                format,
+            } => (!pictures.begin_upload_with(handle, width, height, format))
                 .then(|| format!("picture {} upload refused", handle.0)),
             Message::PictureChunk {
                 handle,
                 offset,
-                grey,
+                pixels,
             } => (!pictures.upload_chunk(
                 handle,
                 usize::try_from(offset).unwrap_or(usize::MAX),
-                &grey,
+                &pixels,
             ))
             .then(|| format!("picture {} chunk refused", handle.0)),
             Message::CommitPicture { handle } => {

--- a/crates/kobo-ui/src/lib.rs
+++ b/crates/kobo-ui/src/lib.rs
@@ -8808,22 +8808,24 @@ impl Surface {
         })
     }
 
-    /// The colour bytes of `region`, three per pixel row by row, when the
-    /// frame holds colour. `None` for a frame that has none, or a region that
-    /// is not inside it: the caller then has exactly the grey path it had.
+    /// The colour bytes of `region`, one row at a time with three bytes per
+    /// pixel, when the frame holds colour. The rows are borrowed from the
+    /// frame rather than copied, so a caller writing them elsewhere pays for
+    /// one buffer, not two. `None` for a frame that has no colour, or a
+    /// region that is not inside it: the caller then has exactly the grey
+    /// path it had.
     #[must_use]
-    pub fn colour_region(&self, region: Rect) -> Option<Vec<u8>> {
+    pub fn colour_rows(&self, region: Rect) -> Option<impl Iterator<Item = &[u8]> + '_> {
         let chroma = self.chroma.as_ref()?;
         let (left, top, width, height) = region_extent(region)?;
         if left.checked_add(width)? > self.width || top.checked_add(height)? > self.height {
             return None;
         }
-        let mut out = Vec::with_capacity(width * height * 3);
-        for y in top..top + height {
-            let start = (y * self.width + left) * 3;
-            out.extend_from_slice(chroma.get(start..start + width * 3)?);
-        }
-        Some(out)
+        let stride = self.width * 3;
+        Some((top..top + height).map(move |y| {
+            let start = y * stride + left * 3;
+            &chroma[start..start + width * 3]
+        }))
     }
 
     /// The colour plane, brought into being from the grey one on first use.
@@ -10590,9 +10592,10 @@ fn draw_picture(surface: &mut Surface, rect: Rect, pixels: PicturePixels<'_>, cl
                     let index = base + sample_x;
                     match colour {
                         Some(colour) => {
-                            for (sum, channel) in total.iter_mut().zip(&colour[index * 3..]) {
-                                *sum += u32::from(*channel);
-                            }
+                            let pixel = &colour[index * 3..index * 3 + 3];
+                            total[0] += u32::from(pixel[0]);
+                            total[1] += u32::from(pixel[1]);
+                            total[2] += u32::from(pixel[2]);
                         }
                         None => total[0] += u32::from(pixels.grey[index]),
                     }
@@ -13794,23 +13797,24 @@ mod tests {
             width: 2,
             height: 1
         }));
-        assert_eq!(
-            frame.colour_region(Rect {
+        let rows: Option<Vec<&[u8]>> = frame
+            .colour_rows(Rect {
                 x: 1,
                 y: 0,
                 width: 2,
-                height: 1
-            }),
-            Some(vec![255, 0, 255, 215, 215, 215])
-        );
-        assert_eq!(
-            frame.colour_region(Rect {
-                x: 3,
-                y: 0,
-                width: 2,
-                height: 1
-            }),
-            None,
+                height: 1,
+            })
+            .map(Iterator::collect);
+        assert_eq!(rows, Some(vec![&[255, 0, 255, 215, 215, 215][..]]));
+        assert!(
+            frame
+                .colour_rows(Rect {
+                    x: 3,
+                    y: 0,
+                    width: 2,
+                    height: 1,
+                })
+                .is_none(),
             "a region past the edge is refused"
         );
         for v in [0_u8, 1, 17, 137, 254, 255] {

--- a/crates/kobo-ui/src/lib.rs
+++ b/crates/kobo-ui/src/lib.rs
@@ -8712,11 +8712,41 @@ fn corner_inset(radius: i32, from_edge: i32) -> i32 {
     radius - (run + 1) / 2
 }
 
+/// The luminance of one colour, by the weights broadcast television settled
+/// on for the same purpose: turning a colour picture into the grey one a
+/// monochrome set would show.
+///
+/// Used wherever a colour pixel needs the single grey value the rest of the
+/// pipeline reasons about: the planner's grey test, the greyscale panels, the
+/// simulator's monochrome preview. Integer throughout; the weights sum to one
+/// thousand so a grey colour comes back as exactly itself.
+#[must_use]
+pub const fn luma([red, green, blue]: [u8; 3]) -> u8 {
+    let weighted = 299 * red as u32 + 587 * green as u32 + 114 * blue as u32;
+    // Rounded, not truncated, so that (v, v, v) gives v for every v.
+    ((weighted + 500) / 1000) as u8
+}
+
+/// A rendered frame: one grey byte per pixel, and, once anything has been
+/// drawn in colour, three colour bytes per pixel beside it.
+///
+/// `pixels` is the frame as every greyscale panel and every existing caller
+/// sees it, and it is always complete: a colour draw writes the luminance
+/// here and the colour into `chroma`. `chroma` is absent until the first
+/// colour draw and dropped again by [`Surface::clear`], so a frame with no
+/// colour in it costs exactly what it did before colour existed, and a
+/// runtime on a greyscale panel can ignore the plane altogether.
+///
+/// When `chroma` is present every grey write also lands in it as three
+/// equal bytes, so the two planes describe one picture. Code that writes
+/// `pixels` directly, as tests do, keeps that promise only while `chroma` is
+/// `None`.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Surface {
     pub width: usize,
     pub height: usize,
     pub pixels: Vec<u8>,
+    pub chroma: Option<Vec<u8>>,
 }
 
 impl Surface {
@@ -8726,11 +8756,112 @@ impl Surface {
             width,
             height,
             pixels: vec![tone::PAPER; width.saturating_mul(height)],
+            chroma: None,
         }
     }
 
     pub fn clear(&mut self, value: u8) {
         self.pixels.fill(value);
+        self.chroma = None;
+    }
+
+    /// The colour of one pixel, whether or not the frame holds any colour.
+    #[must_use]
+    pub fn rgb_at(&self, index: usize) -> Option<[u8; 3]> {
+        match &self.chroma {
+            Some(chroma) => chroma
+                .get(index * 3..index * 3 + 3)
+                .map(|c| [c[0], c[1], c[2]]),
+            None => self.pixels.get(index).map(|grey| [*grey; 3]),
+        }
+    }
+
+    /// Whether any pixel of the frame is a colour rather than a grey.
+    ///
+    /// Cheap when no colour has been drawn; a scan of the colour plane when
+    /// one exists, because a plane that was needed for one picture may since
+    /// have been painted over in grey.
+    #[must_use]
+    pub fn has_colour(&self) -> bool {
+        self.chroma
+            .as_ref()
+            .is_some_and(|chroma| chroma.chunks_exact(3).any(|c| c[0] != c[1] || c[1] != c[2]))
+    }
+
+    /// Whether any pixel inside `region` is a colour rather than a grey.
+    #[must_use]
+    pub fn region_has_colour(&self, region: Rect) -> bool {
+        let Some(chroma) = &self.chroma else {
+            return false;
+        };
+        let Some((left, top, width, height)) = region_extent(region) else {
+            return false;
+        };
+        (top..top.saturating_add(height)).any(|y| {
+            let start = y.saturating_mul(self.width).saturating_add(left) * 3;
+            let end = start.saturating_add(width * 3);
+            chroma
+                .get(start..end)
+                .unwrap_or(&[])
+                .chunks_exact(3)
+                .any(|c| c[0] != c[1] || c[1] != c[2])
+        })
+    }
+
+    /// The colour bytes of `region`, three per pixel row by row, when the
+    /// frame holds colour. `None` for a frame that has none, or a region that
+    /// is not inside it: the caller then has exactly the grey path it had.
+    #[must_use]
+    pub fn colour_region(&self, region: Rect) -> Option<Vec<u8>> {
+        let chroma = self.chroma.as_ref()?;
+        let (left, top, width, height) = region_extent(region)?;
+        if left.checked_add(width)? > self.width || top.checked_add(height)? > self.height {
+            return None;
+        }
+        let mut out = Vec::with_capacity(width * height * 3);
+        for y in top..top + height {
+            let start = (y * self.width + left) * 3;
+            out.extend_from_slice(chroma.get(start..start + width * 3)?);
+        }
+        Some(out)
+    }
+
+    /// The colour plane, brought into being from the grey one on first use.
+    fn chroma_mut(&mut self) -> &mut Vec<u8> {
+        if self.chroma.is_none() {
+            let mut plane = Vec::with_capacity(self.pixels.len() * 3);
+            for grey in &self.pixels {
+                plane.extend_from_slice(&[*grey; 3]);
+            }
+            self.chroma = Some(plane);
+        }
+        self.chroma.as_mut().expect("just created")
+    }
+
+    /// Writes one grey value to a pixel of both planes.
+    fn set_grey(&mut self, index: usize, value: u8) {
+        if let Some(pixel) = self.pixels.get_mut(index) {
+            *pixel = value;
+        }
+        if let Some(chroma) = &mut self.chroma {
+            if let Some(colour) = chroma.get_mut(index * 3..index * 3 + 3) {
+                colour.fill(value);
+            }
+        }
+    }
+
+    /// Turns one pixel of both planes to its opposite.
+    fn invert_at(&mut self, index: usize) {
+        if let Some(pixel) = self.pixels.get_mut(index) {
+            *pixel = u8::MAX - *pixel;
+        }
+        if let Some(chroma) = &mut self.chroma {
+            if let Some(colour) = chroma.get_mut(index * 3..index * 3 + 3) {
+                for channel in colour {
+                    *channel = u8::MAX - *channel;
+                }
+            }
+        }
     }
 
     pub fn fill_rect(&mut self, rect: Rect, value: u8) {
@@ -8745,9 +8876,7 @@ impl Surface {
                 let row = usize::try_from(y).unwrap_or(0).saturating_mul(self.width);
                 for x in clipped.x..clipped.x + clipped.width {
                     let index = row.saturating_add(usize::try_from(x).unwrap_or(0));
-                    if let Some(pixel) = self.pixels.get_mut(index) {
-                        *pixel = value;
-                    }
+                    self.set_grey(index, value);
                 }
             }
         }
@@ -8772,9 +8901,7 @@ impl Surface {
                 let row = usize::try_from(y).unwrap_or(0).saturating_mul(self.width);
                 for x in clipped.x..clipped.x + clipped.width {
                     let index = row.saturating_add(usize::try_from(x).unwrap_or(0));
-                    if let Some(pixel) = self.pixels.get_mut(index) {
-                        *pixel = u8::MAX - *pixel;
-                    }
+                    self.invert_at(index);
                 }
             }
         }
@@ -8810,9 +8937,7 @@ impl Surface {
                 .saturating_mul(self.width);
             for x in clipped.x..clipped.x + clipped.width {
                 let index = start.saturating_add(usize::try_from(x).unwrap_or(0));
-                if let Some(pixel) = self.pixels.get_mut(index) {
-                    *pixel = u8::MAX - *pixel;
-                }
+                self.invert_at(index);
             }
         }
     }
@@ -8864,24 +8989,58 @@ impl Surface {
     /// panel resolves sixteen grey levels, so stair-stepped text is visibly
     /// worse than blended text at no extra refresh cost.
     pub fn blend(&mut self, x: i32, y: i32, value: u8, coverage: u8) {
-        if x < 0 || y < 0 {
-            return;
-        }
-        let (Ok(x), Ok(y)) = (usize::try_from(x), usize::try_from(y)) else {
-            return;
-        };
-        if x >= self.width {
-            return;
-        }
-        let Some(index) = y.checked_mul(self.width).and_then(|row| row.checked_add(x)) else {
+        let Some(index) = self.index_of(x, y) else {
             return;
         };
         if let Some(pixel) = self.pixels.get_mut(index) {
-            let destination = i32::from(*pixel);
-            let ink = i32::from(value);
-            let mixed = destination + (ink - destination) * i32::from(coverage) / 255;
-            *pixel = u8::try_from(mixed.clamp(0, 255)).unwrap_or(*pixel);
+            *pixel = mix(*pixel, value, coverage);
         }
+        if let Some(chroma) = &mut self.chroma {
+            if let Some(colour) = chroma.get_mut(index * 3..index * 3 + 3) {
+                for channel in colour {
+                    *channel = mix(*channel, value, coverage);
+                }
+            }
+        }
+    }
+
+    /// [`Self::blend`] for a colour: mixes each channel by `coverage` and
+    /// keeps the grey plane at the result's luminance.
+    ///
+    /// This is the only way colour gets into a frame, which is what lets the
+    /// grey plane stay authoritative for everything that is not a picture.
+    /// The colour plane comes into being on the first call.
+    pub fn blend_colour(&mut self, x: i32, y: i32, colour: [u8; 3], coverage: u8) {
+        let Some(index) = self.index_of(x, y) else {
+            return;
+        };
+        if index >= self.pixels.len() {
+            return;
+        }
+        let chroma = self.chroma_mut();
+        let Some(target) = chroma.get_mut(index * 3..index * 3 + 3) else {
+            return;
+        };
+        for (channel, ink) in target.iter_mut().zip(colour) {
+            *channel = mix(*channel, ink, coverage);
+        }
+        let mixed = [target[0], target[1], target[2]];
+        if let Some(pixel) = self.pixels.get_mut(index) {
+            *pixel = luma(mixed);
+        }
+    }
+
+    fn index_of(&self, x: i32, y: i32) -> Option<usize> {
+        if x < 0 || y < 0 {
+            return None;
+        }
+        let (Ok(x), Ok(y)) = (usize::try_from(x), usize::try_from(y)) else {
+            return None;
+        };
+        if x >= self.width {
+            return None;
+        }
+        y.checked_mul(self.width).and_then(|row| row.checked_add(x))
     }
 
     pub fn stroke_rect(&mut self, rect: Rect, value: u8) {
@@ -8924,6 +9083,25 @@ impl Surface {
     }
 }
 
+/// Mixes `ink` into `destination` by `coverage`, where 0 leaves it untouched
+/// and 255 replaces it.
+fn mix(destination: u8, ink: u8, coverage: u8) -> u8 {
+    let destination = i32::from(destination);
+    let mixed = destination + (i32::from(ink) - destination) * i32::from(coverage) / 255;
+    u8::try_from(mixed.clamp(0, 255)).unwrap_or(u8::MAX)
+}
+
+/// A rectangle as unsigned left, top, width and height, or `None` when any
+/// side is negative and so cannot index a frame.
+fn region_extent(region: Rect) -> Option<(usize, usize, usize, usize)> {
+    Some((
+        usize::try_from(region.x).ok()?,
+        usize::try_from(region.y).ok()?,
+        usize::try_from(region.width).ok()?,
+        usize::try_from(region.height).ok()?,
+    ))
+}
+
 /// How much repainting is permitted before the panel gets a cleaning refresh,
 /// counted in whole panels' worth of changed pixels.
 ///
@@ -8946,6 +9124,14 @@ pub enum PanelWaveform {
     Gl16,
     /// Full sixteen-level refresh that clears accumulated residue.
     Gc16,
+    /// Sixteen-level refresh of a region holding colour, written in colour.
+    ///
+    /// Chosen whenever the changed region has a pixel whose channels differ.
+    /// The runtime writes that region's colour plane to the framebuffer and
+    /// asks the controller to drive the colour filter; on a panel without one
+    /// the runtime writes grey and this is a quality update. Partial unless
+    /// it is also the cleaning refresh, when it covers the whole panel.
+    Colour,
 }
 
 impl PanelWaveform {
@@ -8955,7 +9141,15 @@ impl PanelWaveform {
             Self::Du => "DU",
             Self::Gl16 => "GL16",
             Self::Gc16 => "GC16",
+            Self::Colour => "COLOUR",
         }
+    }
+
+    /// Whether the runtime should write the region's colour plane rather
+    /// than its grey one.
+    #[must_use]
+    pub const fn writes_colour(self) -> bool {
+        matches!(self, Self::Colour)
     }
 }
 
@@ -8982,6 +9176,10 @@ pub struct FramePlanner {
     width: usize,
     height: usize,
     previous: Vec<u8>,
+    /// The colour plane of the last committed frame, kept only while a frame
+    /// with colour has been shown; `None` means every previous pixel was
+    /// the grey in `previous`.
+    previous_chroma: Option<Vec<u8>>,
     dirty: u64,
     refreshes: u64,
     started: bool,
@@ -8994,6 +9192,7 @@ impl FramePlanner {
             width,
             height,
             previous: vec![tone::INK; width.saturating_mul(height)],
+            previous_chroma: None,
             dirty: 0,
             refreshes: 0,
             started: false,
@@ -9018,34 +9217,53 @@ impl FramePlanner {
             width: i32::try_from(self.width).ok()?,
             height: i32::try_from(self.height).ok()?,
         };
-        let (region, waveform, dirty) = if self.started {
+        // A cleaning refresh repaints the whole panel, and a whole panel with
+        // a colour picture on it has to be repainted in colour or the picture
+        // comes back grey.
+        let clean = || {
+            if surface.has_colour() {
+                (whole, PanelWaveform::Colour, 0, true)
+            } else {
+                (whole, PanelWaveform::Gc16, 0, true)
+            }
+        };
+        let (region, waveform, dirty, full) = if self.started {
             let (changed, flipped) = self.changed(surface)?;
             // The budget is checked before this update is added to it, so that
             // a full panel's worth of repainting still buys exactly
             // PANEL_CLEAN_INTERVAL updates before anything flashes, as it did
             // when updates rather than pixels were being counted.
             if self.dirty >= self.clean_after() {
-                (whole, PanelWaveform::Gc16, 0)
+                clean()
+            } else if surface.region_has_colour(changed) {
+                (
+                    changed,
+                    PanelWaveform::Colour,
+                    self.dirty.saturating_add(flipped),
+                    false,
+                )
             } else if Self::has_grey(surface, changed) {
                 (
                     changed,
                     PanelWaveform::Gl16,
                     self.dirty.saturating_add(flipped),
+                    false,
                 )
             } else {
                 (
                     changed,
                     PanelWaveform::Du,
                     self.dirty.saturating_add(flipped),
+                    false,
                 )
             }
         } else {
-            (whole, PanelWaveform::Gc16, 0)
+            clean()
         };
         Some(FrameTransition {
             region,
             waveform,
-            full: waveform == PanelWaveform::Gc16,
+            full,
             refresh: self.refreshes.saturating_add(1),
             dirty,
         })
@@ -9061,6 +9279,13 @@ impl FramePlanner {
             return false;
         }
         self.previous.copy_from_slice(&surface.pixels);
+        // Kept only while there is colour to remember: a frame that has gone
+        // back to grey is fully described by `previous`, and holding a plane
+        // for it would make every later comparison three times the work.
+        self.previous_chroma = surface
+            .has_colour()
+            .then(|| surface.chroma.clone())
+            .flatten();
         self.dirty = transition.dirty;
         self.refreshes = transition.refresh;
         self.started = true;
@@ -9090,12 +9315,29 @@ impl FramePlanner {
         let (mut left, mut right) = (usize::MAX, 0usize);
         let (mut top, mut bottom) = (usize::MAX, 0usize);
         let mut flipped = 0_u64;
+        // A pixel has changed when its grey has, or when either frame holds
+        // colour for it and the colour has. Two greys that match cannot hide
+        // a colour change when neither side has a plane, which is the common
+        // case and stays the single comparison it always was.
+        let colour_differs = |index: usize| -> bool {
+            if surface.chroma.is_none() && self.previous_chroma.is_none() {
+                return false;
+            }
+            let current = surface.rgb_at(index);
+            let previous = match &self.previous_chroma {
+                Some(chroma) => chroma
+                    .get(index * 3..index * 3 + 3)
+                    .map(|c| [c[0], c[1], c[2]]),
+                None => self.previous.get(index).map(|grey| [*grey; 3]),
+            };
+            current != previous
+        };
         for (index, _) in surface
             .pixels
             .iter()
             .zip(self.previous.iter())
             .enumerate()
-            .filter(|(_, (current, previous))| current != previous)
+            .filter(|(index, (current, previous))| current != previous || colour_differs(*index))
         {
             let (x, y) = (index % self.width, index / self.width);
             left = left.min(x);
@@ -9150,12 +9392,53 @@ impl FramePlanner {
     }
 }
 
-/// Eight-bit grey pixels, row major, `width * height` of them.
+/// How the bytes of a picture are laid out.
+///
+/// Grey is what every application has always sent and what every panel can
+/// show. Colour is three bytes per pixel, red then green then blue, and is
+/// only worth sending when the runtime has said the panel can show it; on any
+/// other panel it is drawn as its luminance, which costs three times the
+/// transfer for the same picture.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum PictureFormat {
+    /// One byte per pixel.
+    Grey,
+    /// Three bytes per pixel, red, green, blue.
+    Rgb,
+}
+
+impl PictureFormat {
+    #[must_use]
+    pub const fn bytes_per_pixel(self) -> usize {
+        match self {
+            Self::Grey => 1,
+            Self::Rgb => 3,
+        }
+    }
+
+    /// The byte count of a `width` by `height` picture in this format, or
+    /// `None` when it does not fit in memory arithmetic.
+    #[must_use]
+    pub fn byte_len(self, width: u32, height: u32) -> Option<usize> {
+        usize::try_from(width)
+            .ok()?
+            .checked_mul(usize::try_from(height).ok()?)?
+            .checked_mul(self.bytes_per_pixel())
+    }
+}
+
+/// Eight-bit grey pixels, row major, `width * height` of them, and the same
+/// pixels in colour when the picture arrived that way.
+///
+/// `grey` is always present so that nothing drawing a picture has to know
+/// about colour; `colour` holds three bytes per pixel in the same order and is
+/// what a colour panel draws instead.
 #[derive(Clone, Copy, Debug)]
 pub struct PicturePixels<'a> {
     pub width: u32,
     pub height: u32,
     pub grey: &'a [u8],
+    pub colour: Option<&'a [u8]>,
 }
 
 /// Where the renderer finds the pictures an application handed over.
@@ -9977,16 +10260,28 @@ struct HeldPicture {
     handle: PictureHandle,
     width: u32,
     height: u32,
+    /// The luminance of every pixel, derived on arrival for a colour picture
+    /// so that drawing never has to convert.
     grey: Vec<u8>,
+    /// Three bytes per pixel when the picture arrived in colour.
+    colour: Option<Vec<u8>>,
     used: std::cell::Cell<u64>,
+}
+
+impl HeldPicture {
+    /// What the budget is charged for this picture: both planes.
+    fn bytes(&self) -> usize {
+        self.grey.len() + self.colour.as_ref().map_or(0, Vec::len)
+    }
 }
 
 struct PendingPicture {
     handle: PictureHandle,
     width: u32,
     height: u32,
+    format: PictureFormat,
     expected: usize,
-    grey: Vec<u8>,
+    bytes: Vec<u8>,
 }
 
 /// The pictures one application has handed over, bounded by total size.
@@ -10053,18 +10348,52 @@ impl PictureCache {
         height: u32,
         grey: Vec<u8>,
     ) -> Option<Vec<PictureHandle>> {
-        let expected = usize::try_from(width).ok().and_then(|width| {
-            usize::try_from(height)
-                .ok()
-                .and_then(|h| width.checked_mul(h))
-        });
-        let expected = expected?;
-        if expected == 0 || expected != grey.len() || grey.len() > self.budget {
+        self.put_report_with(handle, width, height, PictureFormat::Grey, grey)
+    }
+
+    /// [`Self::put_report`] for a picture in any format.
+    ///
+    /// A colour picture is charged for both the colour bytes and the grey
+    /// plane derived from them, because both are held: the grey so that a
+    /// greyscale panel draws without converting, the colour so that a colour
+    /// panel draws what was sent.
+    pub fn put_report_with(
+        &mut self,
+        handle: PictureHandle,
+        width: u32,
+        height: u32,
+        format: PictureFormat,
+        bytes: Vec<u8>,
+    ) -> Option<Vec<PictureHandle>> {
+        let expected = format.byte_len(width, height)?;
+        if expected == 0 || expected != bytes.len() {
+            return None;
+        }
+        let (grey, colour) = match format {
+            PictureFormat::Grey => (bytes, None),
+            PictureFormat::Rgb => (
+                bytes
+                    .chunks_exact(3)
+                    .map(|c| luma([c[0], c[1], c[2]]))
+                    .collect(),
+                Some(bytes),
+            ),
+        };
+        let entry = HeldPicture {
+            handle,
+            width,
+            height,
+            grey,
+            colour,
+            used: std::cell::Cell::new(0),
+        };
+        let size = entry.bytes();
+        if size > self.budget {
             return None;
         }
         self.remove(handle);
         let mut evicted = Vec::new();
-        while self.held + grey.len() > self.budget {
+        while self.held + size > self.budget {
             let Some(oldest) = self
                 .entries
                 .iter()
@@ -10075,18 +10404,13 @@ impl PictureCache {
                 break;
             };
             evicted.push(self.entries[oldest].handle);
-            self.held -= self.entries[oldest].grey.len();
+            self.held -= self.entries[oldest].bytes();
             self.entries.remove(oldest);
         }
-        self.held += grey.len();
+        self.held += size;
         self.clock.set(self.clock.get() + 1);
-        self.entries.push(HeldPicture {
-            handle,
-            width,
-            height,
-            grey,
-            used: std::cell::Cell::new(self.clock.get()),
-        });
+        entry.used.set(self.clock.get());
+        self.entries.push(entry);
         Some(evicted)
     }
 
@@ -10095,12 +10419,23 @@ impl PictureCache {
     /// Starting another upload cancels the incomplete one. The previous live
     /// value under `handle` remains drawable until [`Self::commit_upload`].
     pub fn begin_upload(&mut self, handle: PictureHandle, width: u32, height: u32) -> bool {
-        let expected = usize::try_from(width).ok().and_then(|width| {
-            usize::try_from(height)
-                .ok()
-                .and_then(|height| width.checked_mul(height))
-        });
-        let Some(expected) = expected else {
+        self.begin_upload_with(handle, width, height, PictureFormat::Grey)
+    }
+
+    /// [`Self::begin_upload`] for a picture in any format.
+    ///
+    /// The budget check here is on the bytes in flight. A colour picture is
+    /// charged for its grey plane as well once it lands, so an upload that
+    /// starts may still be refused at commit; the sender learns that from the
+    /// commit result exactly as it would for eviction.
+    pub fn begin_upload_with(
+        &mut self,
+        handle: PictureHandle,
+        width: u32,
+        height: u32,
+        format: PictureFormat,
+    ) -> bool {
+        let Some(expected) = format.byte_len(width, height) else {
             self.pending = None;
             return false;
         };
@@ -10112,8 +10447,9 @@ impl PictureCache {
             handle,
             width,
             height,
+            format,
             expected,
-            grey: Vec::with_capacity(expected),
+            bytes: Vec::with_capacity(expected),
         });
         true
     }
@@ -10124,13 +10460,13 @@ impl PictureCache {
             return false;
         };
         if pending.handle != handle
-            || offset != pending.grey.len()
-            || pending.grey.len().saturating_add(bytes.len()) > pending.expected
+            || offset != pending.bytes.len()
+            || pending.bytes.len().saturating_add(bytes.len()) > pending.expected
         {
             self.pending = None;
             return false;
         }
-        pending.grey.extend_from_slice(bytes);
+        pending.bytes.extend_from_slice(bytes);
         true
     }
 
@@ -10140,15 +10476,21 @@ impl PictureCache {
     /// mismatched upload.
     pub fn commit_upload(&mut self, handle: PictureHandle) -> Option<Vec<PictureHandle>> {
         let pending = self.pending.take()?;
-        if pending.handle != handle || pending.grey.len() != pending.expected {
+        if pending.handle != handle || pending.bytes.len() != pending.expected {
             return None;
         }
-        self.put_report(pending.handle, pending.width, pending.height, pending.grey)
+        self.put_report_with(
+            pending.handle,
+            pending.width,
+            pending.height,
+            pending.format,
+            pending.bytes,
+        )
     }
 
     pub fn remove(&mut self, handle: PictureHandle) {
         if let Some(index) = self.entries.iter().position(|entry| entry.handle == handle) {
-            self.held -= self.entries[index].grey.len();
+            self.held -= self.entries[index].bytes();
             self.entries.remove(index);
         }
     }
@@ -10186,6 +10528,7 @@ impl Pictures for PictureCache {
             width: entry.width,
             height: entry.height,
             grey: &entry.grey,
+            colour: entry.colour.as_deref(),
         })
     }
 
@@ -10224,6 +10567,11 @@ fn draw_picture(surface: &mut Surface, rect: Rect, pixels: PicturePixels<'_>, cl
     if pixels.grey.len() < source_width * source_height {
         return;
     }
+    // Colour is drawn only when the whole plane is there; a short one is
+    // treated as absent rather than read past.
+    let colour = pixels
+        .colour
+        .filter(|colour| colour.len() >= source_width * source_height * 3);
     let target_width = rect.width as usize;
     let target_height = rect.height as usize;
     for y in visible.y..visible.y + visible.height {
@@ -10234,17 +10582,31 @@ fn draw_picture(surface: &mut Surface, rect: Rect, pixels: PicturePixels<'_>, cl
             let column = (x - rect.x) as usize;
             let from_x = column * source_width / target_width;
             let to_x = max(from_x + 1, (column + 1) * source_width / target_width);
-            let mut total = 0u32;
+            let mut total = [0u32; 3];
             let mut counted = 0u32;
             for sample_y in from_y..to_y.min(source_height) {
                 let base = sample_y * source_width;
                 for sample_x in from_x..to_x.min(source_width) {
-                    total += u32::from(pixels.grey[base + sample_x]);
+                    let index = base + sample_x;
+                    match colour {
+                        Some(colour) => {
+                            for (sum, channel) in total.iter_mut().zip(&colour[index * 3..]) {
+                                *sum += u32::from(*channel);
+                            }
+                        }
+                        None => total[0] += u32::from(pixels.grey[index]),
+                    }
                     counted += 1;
                 }
             }
-            if let Some(mean) = total.checked_div(counted) {
-                surface.blend(x, y, u8::try_from(mean).unwrap_or(u8::MAX), 255);
+            if counted == 0 {
+                continue;
+            }
+            let mean = |sum: u32| u8::try_from(sum / counted).unwrap_or(u8::MAX);
+            if colour.is_some() {
+                surface.blend_colour(x, y, [mean(total[0]), mean(total[1]), mean(total[2])], 255);
+            } else {
+                surface.blend(x, y, mean(total[0]), 255);
             }
         }
     }
@@ -13273,6 +13635,190 @@ mod tests {
     }
 
     #[test]
+    fn a_colour_picture_plans_a_colour_update_and_grey_over_it_does_not() {
+        let mut planner = FramePlanner::new(8, 4);
+        let mut frame = Surface::new(8, 4);
+        let first = planner.plan(&frame).expect("first frame refreshes");
+        assert!(planner.commit(&frame, first));
+        assert!(frame.chroma.is_none(), "a grey frame has no colour plane");
+
+        // One red pixel: the changed region is that pixel and it is colour.
+        frame.blend_colour(3, 2, [200, 20, 20], 255);
+        assert_eq!(frame.pixels[2 * 8 + 3], luma([200, 20, 20]));
+        let colour = planner.plan(&frame).expect("colour changed");
+        assert_eq!(colour.waveform, PanelWaveform::Colour);
+        assert!(!colour.full);
+        assert_eq!(
+            colour.region,
+            Rect {
+                x: 3,
+                y: 2,
+                width: 1,
+                height: 1
+            }
+        );
+        assert!(planner.commit(&frame, colour));
+        assert!(planner.plan(&frame).is_none(), "unchanged frame refreshes");
+
+        // A different colour with the same luminance is still a change: the
+        // grey plane alone would have missed it.
+        let same_luma = [20, 200, 20];
+        let candidate = [0u8, 255, 0];
+        let green = if luma(candidate) == luma([200, 20, 20]) {
+            candidate
+        } else {
+            same_luma
+        };
+        frame.blend_colour(3, 2, green, 255);
+        let recoloured = planner.plan(&frame).expect("hue changed");
+        assert_eq!(recoloured.waveform, PanelWaveform::Colour);
+        assert!(planner.commit(&frame, recoloured));
+
+        // Grey elsewhere is planned as grey: colour on the panel does not
+        // make every later update a colour one.
+        frame.fill_rect(
+            Rect {
+                x: 0,
+                y: 0,
+                width: 1,
+                height: 1,
+            },
+            tone::INK,
+        );
+        let ink = planner.plan(&frame).expect("ink changed");
+        assert_eq!(ink.waveform, PanelWaveform::Du);
+        assert!(planner.commit(&frame, ink));
+
+        // Painting grey over the colour pixel is a grey update of that pixel,
+        // and the frame no longer holds colour.
+        frame.fill_rect(
+            Rect {
+                x: 3,
+                y: 2,
+                width: 1,
+                height: 1,
+            },
+            tone::MUTED,
+        );
+        assert!(!frame.has_colour());
+        let covered = planner.plan(&frame).expect("colour covered");
+        assert_eq!(covered.waveform, PanelWaveform::Gl16);
+        assert!(planner.commit(&frame, covered));
+
+        // And a cleared frame drops the plane altogether.
+        frame.clear(tone::PAPER);
+        assert!(frame.chroma.is_none());
+    }
+
+    #[test]
+    fn a_cleaning_refresh_over_colour_is_planned_in_colour() {
+        let mut planner = FramePlanner::new(2, 1);
+        let mut frame = Surface::new(2, 1);
+        let first = planner.plan(&frame).expect("first");
+        assert!(planner.commit(&frame, first));
+        frame.blend_colour(1, 0, [10, 90, 200], 255);
+        let colour = planner.plan(&frame).expect("colour");
+        assert!(planner.commit(&frame, colour));
+        // Each flip repaints one of the two pixels, so the budget of eight
+        // panels' worth is sixteen flips.
+        for index in 0..=2 * PANEL_CLEAN_INTERVAL {
+            frame.fill_rect(
+                Rect {
+                    x: 0,
+                    y: 0,
+                    width: 1,
+                    height: 1,
+                },
+                if index % 2 == 0 {
+                    tone::INK
+                } else {
+                    tone::PAPER
+                },
+            );
+            let update = planner.plan(&frame).expect("update");
+            assert!(planner.commit(&frame, update));
+            if update.full {
+                assert_eq!(update.waveform, PanelWaveform::Colour);
+                assert_eq!(update.region.width, 2);
+                return;
+            }
+            assert_eq!(update.waveform, PanelWaveform::Du);
+        }
+        panic!("the panel was never cleaned");
+    }
+
+    #[test]
+    fn colour_and_grey_planes_describe_one_picture() {
+        let mut frame = Surface::new(4, 1);
+        frame.blend_colour(0, 0, [255, 0, 0], 255);
+        frame.blend_colour(1, 0, [0, 255, 0], 255);
+        frame.fill_rect(
+            Rect {
+                x: 2,
+                y: 0,
+                width: 1,
+                height: 1,
+            },
+            40,
+        );
+        frame.blend(3, 0, 0, 128);
+        let chroma = frame.chroma.as_ref().expect("colour drawn");
+        assert_eq!(&chroma[6..9], &[40, 40, 40]);
+        assert_eq!(chroma[9], chroma[10]);
+        assert_eq!(chroma[10], chroma[11]);
+        for index in 0..4 {
+            assert_eq!(
+                frame.pixels[index],
+                luma(frame.rgb_at(index).expect("inside")),
+                "pixel {index}"
+            );
+        }
+        frame.invert_rect(Rect {
+            x: 0,
+            y: 0,
+            width: 4,
+            height: 1,
+        });
+        assert_eq!(frame.rgb_at(0), Some([0, 255, 255]));
+        assert_eq!(frame.rgb_at(2), Some([215, 215, 215]));
+        assert_eq!(frame.pixels[2], 215);
+        assert!(frame.region_has_colour(Rect {
+            x: 0,
+            y: 0,
+            width: 2,
+            height: 1
+        }));
+        assert!(!frame.region_has_colour(Rect {
+            x: 2,
+            y: 0,
+            width: 2,
+            height: 1
+        }));
+        assert_eq!(
+            frame.colour_region(Rect {
+                x: 1,
+                y: 0,
+                width: 2,
+                height: 1
+            }),
+            Some(vec![255, 0, 255, 215, 215, 215])
+        );
+        assert_eq!(
+            frame.colour_region(Rect {
+                x: 3,
+                y: 0,
+                width: 2,
+                height: 1
+            }),
+            None,
+            "a region past the edge is refused"
+        );
+        for v in [0_u8, 1, 17, 137, 254, 255] {
+            assert_eq!(luma([v, v, v]), v, "grey survives the round trip");
+        }
+    }
+
+    #[test]
     fn frame_planner_cleans_after_eight_panels_worth_of_repainting() {
         // Eight full-panel repaints still clean on the eighth, which is what a
         // run of page turns does. That behaviour is the one being preserved.
@@ -15900,6 +16446,97 @@ mod prose_tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn a_colour_picture_is_held_with_its_grey_and_drawn_in_colour() {
+        let mut cache = PictureCache::new(64);
+        let rgb = vec![255, 0, 0, 0, 255, 0, 0, 0, 255, 90, 90, 90];
+        assert_eq!(
+            cache.put_report_with(PictureHandle(1), 2, 2, PictureFormat::Rgb, rgb.clone()),
+            Some(Vec::new())
+        );
+        // Charged for both planes: twelve colour bytes and four grey ones.
+        assert_eq!(cache.bytes_held(), 16);
+        let held = cache.get(PictureHandle(1)).expect("held");
+        assert_eq!(held.colour, Some(rgb.as_slice()));
+        assert_eq!(
+            held.grey,
+            &[luma([255, 0, 0]), luma([0, 255, 0]), luma([0, 0, 255]), 90]
+        );
+        // The declared size is checked against the format's byte count.
+        assert!(cache
+            .put_report_with(PictureHandle(2), 2, 2, PictureFormat::Rgb, vec![0; 4])
+            .is_none());
+        assert!(cache
+            .put_report_with(PictureHandle(2), 2, 2, PictureFormat::Grey, vec![0; 12])
+            .is_none());
+
+        let mut surface = Surface::new(4, 4);
+        draw_picture(
+            &mut surface,
+            Rect {
+                x: 1,
+                y: 1,
+                width: 2,
+                height: 2,
+            },
+            cache.get(PictureHandle(1)).expect("held"),
+            Rect {
+                x: 0,
+                y: 0,
+                width: 4,
+                height: 4,
+            },
+        );
+        assert_eq!(surface.rgb_at(5), Some([255, 0, 0]));
+        assert_eq!(surface.rgb_at(6), Some([0, 255, 0]));
+        assert_eq!(surface.rgb_at(9), Some([0, 0, 255]));
+        assert_eq!(surface.rgb_at(10), Some([90, 90, 90]));
+        assert_eq!(surface.pixels[5], luma([255, 0, 0]));
+        assert_eq!(surface.rgb_at(0), Some([tone::PAPER; 3]));
+
+        // Shrunk, the colours average per channel.
+        let mut small = Surface::new(1, 1);
+        draw_picture(
+            &mut small,
+            Rect {
+                x: 0,
+                y: 0,
+                width: 1,
+                height: 1,
+            },
+            cache.get(PictureHandle(1)).expect("held"),
+            Rect {
+                x: 0,
+                y: 0,
+                width: 1,
+                height: 1,
+            },
+        );
+        assert_eq!(
+            small.rgb_at(0),
+            Some([86, 86, 86]),
+            "each channel is the mean of 255, 0, 0 and 90"
+        );
+    }
+
+    #[test]
+    fn a_colour_upload_is_committed_in_its_format() {
+        let mut cache = PictureCache::new(64);
+        assert!(cache.begin_upload_with(PictureHandle(3), 2, 1, PictureFormat::Rgb));
+        assert!(cache.upload_chunk(PictureHandle(3), 0, &[255, 0, 0]));
+        assert!(cache.upload_chunk(PictureHandle(3), 3, &[0, 0, 255]));
+        assert_eq!(cache.commit_upload(PictureHandle(3)), Some(Vec::new()));
+        let held = cache.get(PictureHandle(3)).expect("held");
+        assert_eq!(held.colour, Some(&[255, 0, 0, 0, 0, 255][..]));
+        assert_eq!(held.grey.len(), 2);
+        // A colour picture whose two planes overflow the budget is refused at
+        // commit even though its bytes alone fitted in flight.
+        let mut tight = PictureCache::new(12);
+        assert!(tight.begin_upload_with(PictureHandle(4), 2, 2, PictureFormat::Rgb));
+        assert!(tight.upload_chunk(PictureHandle(4), 0, &[0; 12]));
+        assert_eq!(tight.commit_upload(PictureHandle(4)), None);
     }
 
     #[test]

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -1714,8 +1714,12 @@ fn host_applications(
                             handle,
                             width,
                             height,
-                            grey,
-                        } => match apps[index].pictures.put_report(handle, width, height, grey) {
+                            format,
+                            pixels,
+                        } => match apps[index]
+                            .pictures
+                            .put_report_with(handle, width, height, format, pixels)
+                        {
                             None => trace(&format!("picture {} refused", handle.0)),
                             Some(evicted) => trace_picture_evictions(handle, &evicted),
                         },
@@ -1723,20 +1727,24 @@ fn host_applications(
                             handle,
                             width,
                             height,
+                            format,
                         } => {
-                            if !apps[index].pictures.begin_upload(handle, width, height) {
+                            if !apps[index]
+                                .pictures
+                                .begin_upload_with(handle, width, height, format)
+                            {
                                 trace(&format!("picture {} upload refused", handle.0));
                             }
                         }
                         Message::PictureChunk {
                             handle,
                             offset,
-                            grey,
+                            pixels,
                         } => {
                             if !apps[index].pictures.upload_chunk(
                                 handle,
                                 usize::try_from(offset).unwrap_or(usize::MAX),
-                                &grey,
+                                &pixels,
                             ) {
                                 trace(&format!("picture {} chunk refused", handle.0));
                             }
@@ -3432,10 +3440,20 @@ impl Painter {
             width: u32::try_from(transition.region.width).unwrap_or(0),
             height: u32::try_from(transition.region.height).unwrap_or(0),
         };
+        // A colour transition is written in colour only where the panel can
+        // show it. Everywhere else it is the quality update it would have been
+        // before colour existed, drawn from the grey plane, which is what the
+        // session would downgrade it to anyway.
+        let colour = transition
+            .waveform
+            .writes_colour()
+            .then(|| display.colour())
+            .flatten();
         let intent = match transition.waveform {
             PanelWaveform::Du => RefreshIntent::FastFeedback,
             PanelWaveform::Gl16 => RefreshIntent::TextContent,
-            PanelWaveform::Gc16 => RefreshIntent::QualityContent,
+            PanelWaveform::Colour if colour.is_some() => RefreshIntent::ColourContent,
+            PanelWaveform::Gc16 | PanelWaveform::Colour => RefreshIntent::QualityContent,
         };
 
         let started = Instant::now();
@@ -3443,8 +3461,13 @@ impl Painter {
         // path runs at a few megabytes per second on the i.MX6's uncached
         // framebuffer, so writing the whole screen for every frame cost about
         // 1.6 seconds per tap regardless of how small the change was.
-        let region_gray = {
-            let out_of_surface = || "the transition region is not inside the surface".to_owned();
+        let out_of_surface = || "the transition region is not inside the surface".to_owned();
+        let frame = if let Some(order) = colour {
+            let rgb = surface
+                .colour_region(transition.region)
+                .ok_or_else(out_of_surface)?;
+            RegionSnapshot::from_rgb(display.geometry(), region, &rgb, order)
+        } else {
             let x = usize::try_from(transition.region.x).map_err(|_| out_of_surface())?;
             let y = usize::try_from(transition.region.y).map_err(|_| out_of_surface())?;
             let width = usize::try_from(transition.region.width).map_err(|_| out_of_surface())?;
@@ -3455,10 +3478,9 @@ impl Painter {
                 let end = start + width;
                 gray.extend_from_slice(surface.pixels.get(start..end).ok_or_else(out_of_surface)?);
             }
-            gray
-        };
-        let frame = RegionSnapshot::from_grayscale(display.geometry(), region, &region_gray)
-            .map_err(|error| format!("prepare the frame: {error}"))?;
+            RegionSnapshot::from_grayscale(display.geometry(), region, &gray)
+        }
+        .map_err(|error| format!("prepare the frame: {error}"))?;
         let converted = started.elapsed();
         let fence = display
             .restore_timed(&frame)

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -3463,10 +3463,10 @@ impl Painter {
         // 1.6 seconds per tap regardless of how small the change was.
         let out_of_surface = || "the transition region is not inside the surface".to_owned();
         let frame = if let Some(order) = colour {
-            let rgb = surface
-                .colour_region(transition.region)
+            let rows = surface
+                .colour_rows(transition.region)
                 .ok_or_else(out_of_surface)?;
-            RegionSnapshot::from_rgb(display.geometry(), region, &rgb, order)
+            RegionSnapshot::from_rgb_rows(display.geometry(), region, rows, order)
         } else {
             let x = usize::try_from(transition.region.x).map_err(|_| out_of_surface())?;
             let y = usize::try_from(transition.region.y).map_err(|_| out_of_surface())?;

--- a/crates/kobod/src/main.rs
+++ b/crates/kobod/src/main.rs
@@ -557,8 +557,9 @@ fn serve_application(
                 handle,
                 width,
                 height,
-                grey,
-            } => match pictures.put_report(handle, width, height, grey) {
+                format,
+                pixels,
+            } => match pictures.put_report_with(handle, width, height, format, pixels) {
                 None => println!("picture {} refused", handle.0),
                 Some(evicted) if !evicted.is_empty() => {
                     println!("picture {} evicted {evicted:?}", handle.0);
@@ -569,20 +570,21 @@ fn serve_application(
                 handle,
                 width,
                 height,
+                format,
             } => {
-                if !pictures.begin_upload(handle, width, height) {
+                if !pictures.begin_upload_with(handle, width, height, format) {
                     println!("picture {} upload refused", handle.0);
                 }
             }
             Message::PictureChunk {
                 handle,
                 offset,
-                grey,
+                pixels,
             } => {
                 if !pictures.upload_chunk(
                     handle,
                     usize::try_from(offset).unwrap_or(usize::MAX),
-                    &grey,
+                    &pixels,
                 ) {
                     println!("picture {} chunk refused", handle.0);
                 }

--- a/tools/abi/hwtcon_conformance.c
+++ b/tools/abi/hwtcon_conformance.c
@@ -22,6 +22,15 @@ _Static_assert(WAVEFORM_MODE_GC16 == 2, "GC16 waveform");
 _Static_assert(WAVEFORM_MODE_GL16 == 3, "GL16 waveform");
 _Static_assert(WAVEFORM_MODE_GLR16 == 4, "GLR16 waveform");
 _Static_assert(WAVEFORM_MODE_A2 == 6, "A2 waveform");
+_Static_assert(WAVEFORM_MODE_GCK16 == 8, "GCK16 waveform");
+_Static_assert(WAVEFORM_MODE_GLKW16 == 9, "GLKW16 waveform");
+_Static_assert(WAVEFORM_MODE_GCC16 == 10, "GCC16 waveform");
+_Static_assert(WAVEFORM_MODE_GLRC16 == 11, "GLRC16 waveform");
+/* Update flags the colour path relies on; kobo-abi names them for what they do. */
+_Static_assert(HWTCON_FLAG_USE_DITHERING == 0x1, "dither flag");
+_Static_assert(HWTCON_FLAG_CFA_SKIP == 0x8000, "monochrome-only flag");
+_Static_assert(HWTCON_FLAG_CFA_FLDS_MASK == 0x7f00, "colour filter mask");
+_Static_assert(HWTCON_FLAG_CFA_EINK_NORMAL == 0x100, "standard colour filter mode");
 
 int main(void)
 {


### PR DESCRIPTION
## Why

Clara Colour and Libra Colour have a Kaleido 3 colour filter over the same greyscale panel every other Kobo uses. Cobalt has only ever written luminance to them, so pictures on those devices came out grey. This PR adds a colour path for pictures end to end while keeping every greyscale device byte-for-byte on its current behaviour.

**Not tested on hardware yet** — I don't have a Kaleido device. It needs a run on a Clara Colour or Libra Colour before this can be released (see checklist below). Nothing changes in what gets written on the BW/Libra 2/Clara HD/Elipsa devices, so those are unaffected.

## What changes, by crate

| Crate | Change |
|---|---|
| `kobo-profile` | `colour_panel: bool` on `DeviceProfile`, true only for `CLARA_COLOUR_393` and `LIBRA_COLOUR_390`. A test pins `colour_panel == id.contains("colour")` for every supported profile, because applications only ever see the name (see protocol note). |
| `kobo-abi` | hwtcon waveform ids `GCK16 8 / GLKW16 9 / GCC16 10 / GLRC16 11` and update flags (dithering `0x1`, monochrome-only `0x8000`, colour-filter mode mask `0x7f00`, standard mode `0x100`). Added as `_Static_assert`s in `tools/abi/hwtcon_conformance.c`; `check-hwtcon.sh` passes against Kobo's published kernel header (`linux/v4.9/include/linux/hwtcon_ioctl_cmd.h` from Kobo's GPL source drop). |
| `kobo-hal` | `RefreshIntent::ColourContent` — GC16 with the standard colour-filter flag on hwtcon, plain GC16 on mxcfb. `DisplaySession::issue()` downgrades it to `QualityContent` on any panel without `colour_panel`, so nothing new is ever sent to a greyscale driver. `ChannelOrder` is read from the framebuffer bitfields (i.MX is BGRA, MTK is RGBA) and `RegionSnapshot::from_rgb` writes accordingly. |
| `kobo-ui` | `Surface` gets an optional chroma plane, allocated lazily on the first colour blend, kept in step by every write method, dropped on `clear`. Screens with no colour cost nothing extra. `PanelWaveform::Colour`; `FramePlanner` emits it when the region it is writing carries colour and tracks previous chroma for change detection. `PictureFormat { Grey, Rgb }`, `PictureCache::put_report_with` / `begin_upload_with`; existing grey methods are unchanged wrappers. `draw_picture` scales RGB per channel. `luma()` is Rec.601. |
| `kobo-protocol` | RGB pictures travel on **new tags 28 (inline) and 29 (begin upload)**. Grey stays on 18/20 with an identical wire layout, so **no `VERSION` bump**. `PictureChunk.grey` renamed to `pixels` (wire unchanged). `DeviceIdentity::colour_panel()` is derived from the profile name because `Welcome` is a fixed 7-byte frame and `kobo-profile` is `publish = false` so the published crates cannot depend on it. |
| `kobo-sdk` | `put_colour_picture(handle, w, h, rgb)`; `Command::PutPicture` gains `format` and `grey` → `pixels`. Re-exports `PictureFormat`. |
| `kobo-image` | `Picture` keeps an optional RGB plane. `decode_colour` (grey output byte-identical to `decode`), `from_rgb`, `encode_png_rgb`; `scaled_to` / `cover` scale both planes. `dither` is grey-only and documented as such. |
| `kobod` | `Painter::paint` writes the RGB region when the transition carries colour **and** the display reports a channel order; grey plane otherwise. |
| `kobo-sim` | Accepts the new messages. The preview panel is a Clara BW, so colour lands as luminance — which is exactly what that device would show. No RGB preview yet. |
| `apps/morse` | Test pattern updated for the field rename. |

## Design decisions worth a look

- **GC16 + standard colour-filter flag rather than `GCC16`.** GCC16 is not guaranteed to be present in every device's waveform table; GC16 is, and the colour-filter mode field is what actually tells the driver to render through the CFA. If a Kaleido test shows GCC16 is better, it's a one-line change in `refresh.rs`.
- **Dithering off.** Kobo's own UI dithers for colour, but I'd rather see the raw result first and add dithering as a separate, measured change.
- **Grey intents keep flags = 0.** `hwtcon_flags()` returns the colour-filter flag only for `ColourContent`. Validated devices see exactly what they saw before.
- **Only pictures.** Text and chrome stay in the grey plane. There is no colour API for widgets in this PR.
- **No protocol version bump.** Follows the existing convention of adding tags rather than bumping; an old `kobod` will reject tag 28/29 with the existing unknown-tag error.

## Hardware validation needed (Clara Colour / Libra Colour)

- [ ] Gallery example shows a colour picture in colour, not grey
- [ ] Channel order is correct (red is red — MTK is RGBA; a swapped R/B would show as cyan/orange)
- [ ] Colour region refresh doesn't flash or leave residue worse than a normal GC16
- [ ] Grey screens (home, text) look and refresh exactly as before
- [ ] `kobod` trace shows `ColourContent` only on colour transitions
- [ ] Try `GCC16` in place of `GC16` in `RefreshIntent::ColourContent` and compare

## Conflicts

Touches `Painter::paint` in `kobod/src/device.rs`, which #79 also edits. The overlap is small (the intent match and the frame-building block); whichever lands second needs a short rebase.

## Checks

- `cargo fmt --all -- --check` ✓
- `cargo test --workspace --all-targets --all-features` ✓ (0 failures)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` ✓
- `sh tools/abi/check-hwtcon.sh <kobo kernel header>` ✓

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791049534&installation_model_id=20525&pr_number=99&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F99&signature=8b4ddba9275e9962e99189d8d0f408296e9f922ef34238768635b171412e42c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->