### PR TITLE
Reap the Nickel supplicant on the Clara BW refresh

### DIFF
--- a/crates/kobo-profile/src/lib.rs
+++ b/crates/kobo-profile/src/lib.rs
@@ -360,7 +360,13 @@ pub const CLARA_BW_395: DeviceProfile = DeviceProfile {
     firmware_versions: &["4.45.23697"],
     kernel_release: "4.9.77",
     write_ready: true,
-    reap_nickel_supplicant: false,
+    // The refresh carries the same MediaTek radio, firmware, and kernel as the
+    // N365, so the two-supplicant collision measured there applies unchanged:
+    // hand back without reaping and Nickel's restarted reader races the
+    // leftover process for `wlan0`, leaving Wi-Fi down until a reboot. This
+    // profile was left at `false` when the reap landed for the N365, so the
+    // fix never ran on the refreshed hardware that needed it just as much.
+    reap_nickel_supplicant: true,
 };
 
 /// The Kobo Clara HD, added upstream without i.MX6 hardware to test on.
@@ -1734,9 +1740,13 @@ mod tests {
     /// The supplicant reap is declared, not guessed. The Libra 2 is the one
     /// device where both halves were measured: the two-supplicant collision
     /// after a normal hand-back, and the clean recovery once the leftover one
-    /// was killed. Every other profile keeps its current behaviour until the
-    /// same evidence exists for it, so a change to one of these values is a
-    /// claim about a device and needs the measurement to go with it.
+    /// was killed. The two Clara BW profiles are the same board, radio,
+    /// firmware, and kernel under two device codes, so evidence gathered on
+    /// either one covers both; splitting them is what let the N365 carry the
+    /// reap while the P365 refresh silently went without it. Every other
+    /// profile keeps its current behaviour until the same evidence exists for
+    /// it, so a change to one of these values is a claim about a device and
+    /// needs the measurement to go with it.
     #[test]
     fn the_supplicant_reap_is_declared_only_where_it_was_measured() {
         let declared = super::SUPPORTED_PROFILES
@@ -1747,7 +1757,7 @@ mod tests {
             declared,
             [
                 ("clara-bw-391", true),
-                ("clara-bw-395", false),
+                ("clara-bw-395", true),
                 ("clara-hd-376", false),
                 ("clara-colour-393", false),
                 ("elipsa-2e-389", false),


### PR DESCRIPTION
The supplicant reap added for the Clara BW N365 was never enabled for the
P365 refresh, so `reap_nickel_supplicant` stayed `false` on `clara-bw-395`.
The two profiles describe the same board, radio, firmware, and kernel under
different device codes, so the handoff fix was disabled on hardware that
needed it identically.

This matches the symptom reported against beta v0.3.4 on a P365: handing back
to Nickel brings Wi-Fi down and it stays down until a reboot. That is the
failure half of the collision measured on the N365 and the Libra 2, observed
on a device where the fix could not run.

**Status:** the failure is observed on the P365; the cure is inherited from the
N365 measurement rather than measured on the refresh directly. Flashing this to
a P365 and confirming Wi-Fi survives handoff is what closes that gap.

Scope is the profile flag, the comment recording why the two Clara BW profiles
share evidence, and the declaration test. No runtime behaviour changes on any
other device.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791062054&installation_model_id=20525&pr_number=101&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F101&signature=d35e497178d322ff7ede8662e723cc33903701919280a3c838ee4f8e896c63e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->