### PR TITLE
Release 0.3.5 to beta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "icon-import"
-version = "0.3.4"
+version = "0.3.5"
 
 [[package]]
 name = "image"
@@ -548,14 +548,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-abi"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "kobo-app-store"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-arxiv"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-audiobook"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-doc",
  "kobo-json",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-backgammon"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-bookview"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-brief"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-chat"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-cli"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-app-store",
  "kobo-image",
@@ -635,14 +635,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-dict"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "unicode-normalization",
 ]
 
 [[package]]
 name = "kobo-doc"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-html",
  "miniz_oxide 0.9.1",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doctor"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -659,14 +659,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-gallery"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-guard"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gutenbird"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-hal"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-abi",
  "kobo-doc",
@@ -698,21 +698,21 @@ dependencies = [
 
 [[package]]
 name = "kobo-handoff"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-hello"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-hn"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-html"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "ratex-layout",
  "ratex-parser",
@@ -732,18 +732,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-image"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "image",
 ]
 
 [[package]]
 name = "kobo-json"
-version = "0.3.4"
+version = "0.3.5"
 
 [[package]]
 name = "kobo-launcher"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -751,7 +751,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-magnet"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-morse"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-net"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "http",
  "httparse",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-opds"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-json",
  "kobo-xml",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-policy"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-abi",
  "kobo-dict",
@@ -797,18 +797,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-profile"
-version = "0.3.4"
+version = "0.3.5"
 
 [[package]]
 name = "kobo-protocol"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-ui",
 ]
 
 [[package]]
 name = "kobo-read"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-rss"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sdk"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-policy",
  "kobo-protocol",
@@ -842,7 +842,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-settings"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-app-store",
  "kobo-json",
@@ -851,7 +851,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-shell"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-abi",
  "kobo-policy",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekick"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -869,7 +869,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekickd"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -877,7 +877,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sim"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-net",
  "kobo-policy",
@@ -890,14 +890,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-smoke"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-store"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sudoku"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tap"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-term"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-ui",
  "vt100",
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-terminal"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-policy",
  "kobo-sdk",
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-text"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "fontdue",
  "kobo-ui",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tictactoe"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-todo"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -968,18 +968,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-ui"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "kobo-xml"
-version = "0.3.4"
+version = "0.3.5"
 
 [[package]]
 name = "kobo-zotero-reader"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "kobod"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "base64",
  "kobo-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 rust-version = "1.85.1"
 license = "AGPL-3.0-only"

--- a/apps/backgammon/Cargo.toml
+++ b/apps/backgammon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kobo-backgammon"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/apps/catalog.json
+++ b/apps/catalog.json
@@ -29,7 +29,7 @@
       "display_name": "Backgammon",
       "short_label": "Backgammon",
       "summary": "Play complete solo or pass-and-play backgammon on one Kobo.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "minimum_cobalt_version": "0.3.1",
       "glyph": "circle",
       "capabilities": []

--- a/docs/apps/backgammon/index.html
+++ b/docs/apps/backgammon/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Play complete solo or pass-and-play backgammon on one Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/backgammon.png">
 <meta name="twitter:image:alt" content="A grayscale Backgammon board with legal move markers on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-FiKQJ2orITaTIaSNV24w1GmHz/UHDwtvZl7El6vhS/A='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-ONKdU7QH9iuW1YUDC2LnMKusB4lKq7ij80RMHTtozxU='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "0.1.0",
+      "softwareVersion": "0.1.1",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Backgammon</h1>
       <p class="summary">Play complete solo or pass-and-play backgammon on one Kobo.</p>
-      <div class="meta"><span>Version 0.1.0</span><span>No additional permissions</span></div>
+      <div class="meta"><span>Version 0.1.1</span><span>No additional permissions</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/backgammon.png" width="1072" height="1448" alt="A grayscale Backgammon board with legal move markers on a Kobo">


### PR DESCRIPTION
Gets the beta channel publishing again. Nothing else changes.

## Why

`beta-v0.3.4` was published on 2 September, before the `main` sync, #79 and
#101 landed. `beta-release.yml` enforces immutable beta versions, so with
`Cargo.toml` still at 0.3.4 the guard sets `publish=false` and the `device`,
`host` and `publish` jobs skip. The run then reports **success having built
nothing** — on the most recent beta commit, `prepare` passed and the other
three jobs were skipped.

The result is that the newest artifact anyone can flash predates every change
merged since. That is the state right now.

Separately, `apps.yml` has failed on every beta push since the sync:

```
backgammon: package inputs changed (release inputs) but version 0.1.0 is not newer than 0.1.0
```

Backgammon is the only package flagged. So `app-catalog-beta` is frozen at
2 September too.

## What this does

- workspace `0.3.4` → `0.3.5`
- backgammon `0.1.0` → `0.1.1` in its `Cargo.toml` and `apps/catalog.json`
- regenerated `Cargo.lock` and the backgammon Store page

## What it produces

Merging this publishes `beta-v0.3.5`, the first beta artifact containing the
`main` sync, #79 rendering throughput, and #101 Clara BW supplicant reap. One
flash covers all three.

Verified locally on this branch: `cargo fmt --check`, `clippy -D warnings`,
71 test binaries with zero failures, and all 29 `tools/*.test.mjs` host tests.
Generated app pages are in sync.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791063125&installation_model_id=20525&pr_number=102&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F102&signature=33dd79c819b8a2566af90c83c090c22cb216a7561705a06cf3e786dff18fa61c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->