### PR TITLE
Fail the beta version guard when a tag lookup fails

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -35,6 +35,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
+          set -o pipefail
           tag="beta-v${VERSION}"
           tag_count="$(git ls-remote --tags origin "refs/tags/$tag" | wc -l)"
           release_count="$(gh release list --limit 100 --json tagName \


### PR DESCRIPTION
The immutable-version guard in `beta-release.yml` reads the remote tag list
through two pipelines, and the step runs without `pipefail`:

```
tag_count="$(git ls-remote --tags origin "refs/tags/$tag" | wc -l)"
...
latest="$(git ls-remote --tags origin 'refs/tags/beta-v*' |
  sed -n 's#...#\1#p' | sort -V | tail -n 1)"
```

When `git ls-remote` fails, `wc -l` still exits zero and reports no tags, and
the second pipeline yields an empty string. The guard then evaluates
`[ -n "$latest" ]` as false and skips the monotonic-version check entirely
before writing `publish=true`, so a run can publish a version that is not
newer than the one already on the channel and nothing goes red.

Locally, with the step's own `set -e` and a remote that cannot be reached:

```
$ bash -c 'set -e; c="$(git ls-remote --tags bad refs/tags/x | wc -l)"; echo "count=$c"'
count=0            # still running, gate skipped

$ bash -c 'set -e; set -o pipefail; c="$(git ls-remote --tags bad refs/tags/x | wc -l)"'
$ echo $?
128                # step fails
```

This step set `pipefail` before the workflow was split into `prepare`,
`device`, `host` and `publish`; the rewrite dropped it. Restoring it makes a
failed tag lookup fail the step instead of being read as "no tags exist".

One line, scoped to the guard step. No other pipeline in the workflow depends
on a failing left-hand side being ignored, and the remaining `test`/`grep`
assertions in the step are already fail-closed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791068450&installation_model_id=20525&pr_number=103&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F103&signature=1d53a0c4bcb4e11b50a980672231e6c4d957b9c272e1f810dd3c0bd938df7aaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->