### PR TITLE
Check app versions against the catalog the merge will publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,49 +56,50 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -o pipefail
+          release_tag="$(node tools/app-catalog-channel.mjs)"
+          echo "Checking app versions against the $release_tag channel."
           mkdir -p published-state
-          gh release download app-catalog \
+          gh release download "$release_tag" \
             --dir published-state \
             --pattern cobalt-app-catalog.json
           catalog_sha256="$(
             sha256sum published-state/cobalt-app-catalog.json | cut -d' ' -f1
           )"
           provenance_count="$(
-            gh release view app-catalog --json assets \
+            gh release view "$release_tag" --json assets \
               --jq '[.assets[] | select(.name == "cobalt-app-catalog-provenance.json")] | length'
           )"
-          if [ "$provenance_count" -eq 1 ]; then
-            gh release download app-catalog \
-              --dir published-state \
-              --pattern cobalt-app-catalog-provenance.json
-            published_sha="$(
-              # shellcheck disable=SC2016
-              node -e '
-                const fs = require("fs");
-                const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-                if (
-                  value.format_version !== 1 ||
-                  value.channel !== "app-catalog" ||
-                  !/^[0-9a-f]{40}$/.test(value.source_sha) ||
-                  value.catalog_sha256 !== process.argv[2]
-                ) process.exit(1);
-                process.stdout.write(value.source_sha);
-              ' \
-                published-state/cobalt-app-catalog-provenance.json \
-                "$catalog_sha256"
-            )"
-          elif [ "$provenance_count" -eq 0 ]; then
-            # The first promotion migrates the legacy catalog, which predates
-            # provenance assets. Do not use this fallback after provenance is
-            # present.
-            published_sha="$(gh api \
-              "repos/${GITHUB_REPOSITORY}/actions/workflows/apps.yml/runs?branch=main&status=success&per_page=1" \
-              --jq '.workflow_runs[0].head_sha')"
-            test -n "$published_sha"
-          else
-            echo "stable app catalog has duplicate provenance assets" >&2
+          # Every publication since the legacy catalog migration writes
+          # provenance, so the migration fallback that read a workflow run's head
+          # SHA is no longer a legitimate answer. A missing asset now means the
+          # channel was published by hand or a run was interrupted, and guessing
+          # a base revision would check this branch against the wrong tree.
+          if [ "$provenance_count" -ne 1 ]; then
+            echo "$release_tag carries $provenance_count catalog provenance assets; exactly one is required" >&2
+            echo "Re-run the app publication workflow on the channel branch to restore it." >&2
             exit 1
           fi
+          gh release download "$release_tag" \
+            --dir published-state \
+            --pattern cobalt-app-catalog-provenance.json
+          published_sha="$(
+            # shellcheck disable=SC2016
+            node -e '
+              const fs = require("fs");
+              const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+              if (
+                value.format_version !== 1 ||
+                value.channel !== process.argv[3] ||
+                !/^[0-9a-f]{40}$/.test(value.source_sha) ||
+                value.catalog_sha256 !== process.argv[2]
+              ) process.exit(1);
+              process.stdout.write(value.source_sha);
+            ' \
+              published-state/cobalt-app-catalog-provenance.json \
+              "$catalog_sha256" \
+              "$release_tag"
+          )"
           git cat-file -e "${published_sha}^{commit}"
           node tools/check-app-versions.mjs \
             --registry apps/catalog.json \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,10 @@ jobs:
           CC_armv7_unknown_linux_musleabihf: arm-linux-gnueabihf-gcc
           CFLAGS_armv7_unknown_linux_musleabihf: -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0
       - name: Require versions for changed app packages
+        # This workflow runs on every push, tags included, and a tag belongs to
+        # no app catalog channel. The gate is about what a merge will publish,
+        # and nothing merges into a tag.
+        if: github.ref_type == 'branch'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,19 +92,37 @@ jobs:
             node -e '
               const fs = require("fs");
               const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-              if (
-                value.format_version !== 1 ||
-                value.channel !== process.argv[3] ||
-                !/^[0-9a-f]{40}$/.test(value.source_sha) ||
-                value.catalog_sha256 !== process.argv[2]
-              ) process.exit(1);
+              const channel = process.argv[3];
+              const faults = [];
+              if (value.format_version !== 1) {
+                faults.push(`format_version is ${JSON.stringify(value.format_version)}, and this run only reads 1`);
+              }
+              if (value.channel !== channel) {
+                faults.push(`channel is ${JSON.stringify(value.channel)}, but this asset was downloaded from ${channel}`);
+              }
+              if (!/^[0-9a-f]{40}$/.test(value.source_sha)) {
+                faults.push(`source_sha is ${JSON.stringify(value.source_sha)}, which is not a full commit sha`);
+              }
+              if (value.catalog_sha256 !== process.argv[2]) {
+                faults.push(`catalog_sha256 is ${JSON.stringify(value.catalog_sha256)}, but the catalog published beside it hashes to ${process.argv[2]}`);
+              }
+              if (faults.length > 0) {
+                console.error(`${channel} carries provenance this run cannot read a base revision from:`);
+                for (const fault of faults) console.error(`  ${fault}`);
+                console.error("Re-run the app publication workflow on the channel branch to restore it.");
+                process.exit(1);
+              }
               process.stdout.write(value.source_sha);
             ' \
               published-state/cobalt-app-catalog-provenance.json \
               "$catalog_sha256" \
               "$release_tag"
           )"
-          git cat-file -e "${published_sha}^{commit}"
+          if ! git cat-file -e "${published_sha}^{commit}" 2>/dev/null; then
+            echo "$release_tag was published from $published_sha, which is not a commit in this checkout" >&2
+            echo "A force-push over the channel branch can strand its published catalog this way." >&2
+            exit 1
+          fi
           node tools/check-app-versions.mjs \
             --registry apps/catalog.json \
             --published-catalog published-state/cobalt-app-catalog.json \

--- a/tools/app-catalog-channel.mjs
+++ b/tools/app-catalog-channel.mjs
@@ -1,0 +1,47 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The pre-merge check and the post-merge publication have to read the same
+// published catalog. When they disagree, an app the smaller catalog does not
+// list yet is skipped entirely before the merge and rejected immediately after
+// it, so the pull request goes green and the merge goes red.
+const CHANNELS = new Map([
+  ["main", "app-catalog"],
+  ["beta", "app-catalog-beta"]
+]);
+
+function branchName(ref) {
+  if (typeof ref !== "string") return "";
+  return ref.trim().replace(/^refs\/heads\//, "");
+}
+
+// A pull request is checked against the catalog its base branch publishes, not
+// the branch it happens to be built from. Branches that are neither release
+// channel are integration work headed for beta, and beta lists every app stable
+// lists, so reading beta can only ever check more than stable would.
+export function catalogReleaseTag({ eventName, baseRef, refName }) {
+  const pullRequest =
+    eventName === "pull_request" || eventName === "pull_request_target";
+  const target = branchName(pullRequest ? baseRef : refName);
+  if (!target) {
+    throw new Error(
+      `${eventName || "this event"} names no branch to resolve an app catalog channel from`
+    );
+  }
+  return CHANNELS.get(target) || "app-catalog-beta";
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    console.log(
+      catalogReleaseTag({
+        eventName: process.env.GITHUB_EVENT_NAME,
+        baseRef: process.env.GITHUB_BASE_REF,
+        refName: process.env.GITHUB_REF_NAME
+      })
+    );
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/tools/app-catalog-channel.mjs
+++ b/tools/app-catalog-channel.mjs
@@ -19,9 +19,18 @@ function branchName(ref) {
 // the branch it happens to be built from. Branches that are neither release
 // channel are integration work headed for beta, and beta lists every app stable
 // lists, so reading beta can only ever check more than stable would.
-export function catalogReleaseTag({ eventName, baseRef, refName }) {
+export function catalogReleaseTag({ eventName, baseRef, refName, refType }) {
   const pullRequest =
     eventName === "pull_request" || eventName === "pull_request_target";
+  // A tag is not a branch, and the ref name of one carries no hint of the
+  // channel it was cut from. Falling through to the default would answer beta
+  // for a stable release tag and check the tagged tree against a base revision
+  // from another line of history.
+  if (!pullRequest && refType !== undefined && refType !== "branch") {
+    throw new Error(
+      `${eventName || "this event"} is on a ${refType}, and only a branch names an app catalog channel`
+    );
+  }
   const target = branchName(pullRequest ? baseRef : refName);
   if (!target) {
     throw new Error(
@@ -37,7 +46,8 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
       catalogReleaseTag({
         eventName: process.env.GITHUB_EVENT_NAME,
         baseRef: process.env.GITHUB_BASE_REF,
-        refName: process.env.GITHUB_REF_NAME
+        refName: process.env.GITHUB_REF_NAME,
+        refType: process.env.GITHUB_REF_TYPE
       })
     );
   } catch (error) {

--- a/tools/app-catalog-channel.test.mjs
+++ b/tools/app-catalog-channel.test.mjs
@@ -47,6 +47,40 @@ test("branches outside the release channels are checked against beta", () => {
   );
 });
 
+test("a tag refuses to guess a channel from its name", () => {
+  assert.throws(
+    () =>
+      catalogReleaseTag({ eventName: "push", refName: "v0.3.5", refType: "tag" }),
+    /push is on a tag/
+  );
+  // The name of a channel release tag looks resolvable and is not: it says
+  // which catalog was published, not which branch this tree came from.
+  assert.throws(
+    () =>
+      catalogReleaseTag({
+        eventName: "push",
+        refName: "app-catalog-beta",
+        refType: "tag"
+      }),
+    /push is on a tag/
+  );
+  assert.equal(
+    catalogReleaseTag({ eventName: "push", refName: "beta", refType: "branch" }),
+    "app-catalog-beta"
+  );
+  // A pull request reads its base branch, which is a branch whatever ref the
+  // merge commit was built from.
+  assert.equal(
+    catalogReleaseTag({
+      eventName: "pull_request",
+      baseRef: "main",
+      refName: "1234/merge",
+      refType: "tag"
+    }),
+    "app-catalog"
+  );
+});
+
 test("an event that names no branch refuses to guess a channel", () => {
   assert.throws(
     () => catalogReleaseTag({ eventName: "pull_request", baseRef: "", refName: "1/merge" }),

--- a/tools/app-catalog-channel.test.mjs
+++ b/tools/app-catalog-channel.test.mjs
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { catalogReleaseTag } from "./app-catalog-channel.mjs";
+
+test("a pull request is checked against the catalog its base branch publishes", () => {
+  assert.equal(
+    catalogReleaseTag({
+      eventName: "pull_request",
+      baseRef: "beta",
+      refName: "1234/merge"
+    }),
+    "app-catalog-beta"
+  );
+  assert.equal(
+    catalogReleaseTag({
+      eventName: "pull_request",
+      baseRef: "main",
+      refName: "1234/merge"
+    }),
+    "app-catalog"
+  );
+});
+
+test("a push is checked against the catalog its own branch publishes", () => {
+  assert.equal(
+    catalogReleaseTag({ eventName: "push", refName: "beta" }),
+    "app-catalog-beta"
+  );
+  assert.equal(
+    catalogReleaseTag({ eventName: "push", refName: "main" }),
+    "app-catalog"
+  );
+  assert.equal(
+    catalogReleaseTag({ eventName: "push", refName: "refs/heads/main" }),
+    "app-catalog"
+  );
+});
+
+test("branches outside the release channels are checked against beta", () => {
+  assert.equal(
+    catalogReleaseTag({ eventName: "push", refName: "app/backgammon" }),
+    "app-catalog-beta"
+  );
+  assert.equal(
+    catalogReleaseTag({ eventName: "workflow_dispatch", refName: "fix/wifi" }),
+    "app-catalog-beta"
+  );
+});
+
+test("an event that names no branch refuses to guess a channel", () => {
+  assert.throws(
+    () => catalogReleaseTag({ eventName: "pull_request", baseRef: "", refName: "1/merge" }),
+    /pull_request names no branch/
+  );
+  assert.throws(
+    () => catalogReleaseTag({ eventName: "push", refName: undefined }),
+    /push names no branch/
+  );
+});

--- a/tools/check-app-versions.test.mjs
+++ b/tools/check-app-versions.test.mjs
@@ -139,6 +139,54 @@ test("catalog removal still requires publication without a build", () => {
   assert.equal(releaseNeeded(values.registry, values.published, new Set()), true);
 });
 
+// A new app reaches the stable catalog one promotion after it reaches beta.
+// While the two disagree, checking a beta-bound change against stable waves the
+// app through, and the very next publication to beta rejects it.
+test("a new app is version-checked only against a catalog that already lists it", () => {
+  const values = fixture();
+  const app = {
+    package: "kobo-backgammon",
+    id: "backgammon",
+    display_name: "Backgammon",
+    short_label: "Backgammon",
+    summary: "Play backgammon",
+    version: "0.1.0",
+    minimum_cobalt_version: "0.3.1",
+    glyph: "dice",
+    capabilities: []
+  };
+  values.registry.apps.push(app);
+  const stable = values.published;
+  const beta = {
+    format_version: 1,
+    entries: [
+      ...stable.entries,
+      {
+        manifest: {
+          format_version: 1,
+          id: app.id,
+          display_name: app.display_name,
+          short_label: app.short_label,
+          summary: app.summary,
+          version: app.version,
+          minimum_cobalt_version: app.minimum_cobalt_version,
+          glyph: app.glyph,
+          capabilities: app.capabilities,
+          binary_sha256: "1".repeat(64),
+          binary_bytes: 5
+        }
+      }
+    ]
+  };
+  const affected = new Set([app.package]);
+
+  assert.doesNotThrow(() => checkEntries(values.registry, stable, affected));
+  assert.throws(
+    () => checkEntries(values.registry, beta, affected),
+    /backgammon: package inputs changed \(release inputs\).*version 0\.1\.0 is not newer than 0\.1\.0/s
+  );
+});
+
 test("changing an app ID to a different Cargo package is a release input", () => {
   const previous = {
     format_version: 1,


### PR DESCRIPTION
The pre-merge gate in `ci.yml` downloads the stable `app-catalog` release,
while the publication that follows a merge to `beta` reads `app-catalog-beta`.
`check-app-versions.mjs` skips any app the reference catalog does not list, so
an app that exists on beta but not yet on stable is never checked before the
merge and is checked immediately after it. The pull request goes green and the
merge goes red. Stable lists fifteen apps, beta lists sixteen; backgammon is
the sixteenth, and it is the one that broke.

This resolves the reference channel from the branch the work is headed for
rather than hardcoding stable: a pull request uses its base branch, a push uses
the branch it landed on, `main` maps to `app-catalog` and everything else maps
to `app-catalog-beta`. Branches that are neither channel are integration work
bound for beta, and beta lists every app stable lists, so reading beta can only
ever check more than reading stable would.

The same step also now requires the catalog provenance asset instead of falling
back to the head SHA of the last successful publication run. The comment beside
that fallback said not to use it once provenance was present; nothing enforced
it. Both channels have carried provenance since the legacy catalog migration,
so a missing asset means a hand-made or interrupted release, and guessing a
base revision would compare the branch against the wrong tree.

## Demonstration

A scratch commit changes `apps/backgammon/src/main.rs` and leaves the catalog
version at `0.1.1`, exactly the shape that merged red.

Before, the check as `ci.yml` runs it today:

    $ node tools/check-app-versions.mjs --registry apps/catalog.json \
        --published-catalog stable-catalog.json --base 4dd749ab
    Every changed app package has a new version.
    exit=0

After, against the catalog the merge will publish:

    $ node tools/check-app-versions.mjs --registry apps/catalog.json \
        --published-catalog beta-catalog.json --base 626cc8bb
    backgammon: package inputs changed (release inputs) but version 0.1.1 is not newer than 0.1.1
    Set each affected app to a strictly newer numeric version.
    exit=1

With the version bumped to `0.1.2`, the same check is quiet again:

    Every changed app package has a new version.
    exit=0

## Tests

`node --test tools/*.test.mjs`: 34 tests, 34 pass, 0 fail (29 before this
change). New coverage: the four channel resolution cases in
`tools/app-catalog-channel.test.mjs`, and a `check-app-versions.test.mjs` case
that asserts a regression in a new app passes against a catalog that does not
list it and fails against one that does.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791069127&installation_model_id=20525&pr_number=104&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F104&signature=6911d55b73ac5cfeb642318fbcdd1e51cc6e3fe596eb918048445a703a977cee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
