### PR TITLE
Keep the simulator up when a browser connection comes to nothing

### DIFF
--- a/crates/kobo-sim/src/lib.rs
+++ b/crates/kobo-sim/src/lib.rs
@@ -350,12 +350,22 @@ impl Server {
 
     /// Serves requests indefinitely. The listener is bound only to IPv4 localhost.
     ///
+    /// One connection that goes wrong is reported and stepped over rather than
+    /// ending the session. A browser opening a speculative connection and
+    /// closing it unused, a port knock, or a reload abandoned halfway all
+    /// arrive here as a read error on one stream, and none of them is a reason
+    /// to take the panel away from somebody who is working.
+    ///
     /// # Errors
     ///
-    /// Returns an error if accepting, reading, or writing a request fails.
+    /// Returns an error if the listener itself stops accepting, which is not
+    /// something the next connection would recover from.
     pub fn serve(&mut self) -> io::Result<()> {
         loop {
-            self.serve_one()?;
+            let (stream, _) = self.listener.accept()?;
+            if let Err(error) = self.handle(stream) {
+                report_dropped_request(&error);
+            }
         }
     }
 
@@ -605,7 +615,10 @@ impl AppServer {
     pub fn serve(&self) -> io::Result<()> {
         let session = self.accept_app()?;
         loop {
-            self.serve_one(&session)?;
+            let (stream, _) = self.http.accept()?;
+            if let Err(error) = session.handle_http(stream) {
+                report_dropped_request(&error);
+            }
         }
     }
 
@@ -624,14 +637,20 @@ impl AppServer {
     /// Call [`Self::set_nonblocking`] with `true` first. Returns `false` when
     /// no browser request is currently pending.
     ///
+    /// A connection that fails to produce a request is reported and counted as
+    /// served, for the reason given on [`Server::serve`]: the developer whose
+    /// application is running behind this is not the one who opened it.
+    ///
     /// # Errors
     ///
-    /// Returns an error when accepting, reading, or writing the request fails.
+    /// Returns an error when the listener itself stops accepting.
     pub fn try_serve_one(&self, session: &AppSession) -> io::Result<bool> {
         match self.http.accept() {
             Ok((stream, _)) => {
                 stream.set_nonblocking(false)?;
-                session.handle_http(stream)?;
+                if let Err(error) = session.handle_http(stream) {
+                    report_dropped_request(&error);
+                }
                 Ok(true)
             }
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => Ok(false),
@@ -2166,6 +2185,14 @@ fn parse_local_address(address: &str) -> io::Result<SocketAddr> {
     Ok(SocketAddr::from(([127, 0, 0, 1], port)))
 }
 
+/// Says that one browser connection came to nothing, and carries on.
+///
+/// On stderr rather than stdout, so it cannot be mistaken for the address line
+/// the simulator prints for somebody to paste into a browser.
+fn report_dropped_request(error: &io::Error) {
+    eprintln!("kobo: dropped one browser connection: {error}");
+}
+
 #[derive(Debug, Eq, PartialEq)]
 struct HttpRequest {
     method: String,
@@ -2949,6 +2976,32 @@ mod tests {
         drop(server);
         assert!(!socket_path.exists());
         fs::remove_dir(root).expect("remove private directory");
+    }
+
+    /// A dropped connection is the commonest thing a listener on a developer's
+    /// own machine sees, and it used to end the session: the browser preconnect
+    /// that is never used, whatever is watching for open ports, a reload
+    /// abandoned before the request went out. Each one arrived as an
+    /// `UnexpectedEof` from the first read and took the simulator, and the
+    /// application running behind it, down with it.
+    #[test]
+    fn a_connection_that_sends_no_request_does_not_end_the_session() {
+        let mut server = Server::bind_address("127.0.0.1:0").expect("bind simulator");
+        let address = server.local_addr().expect("simulator address");
+        thread::spawn(move || server.serve());
+
+        TcpStream::connect(address)
+            .expect("open a connection")
+            .shutdown(std::net::Shutdown::Both)
+            .expect("close it again unused");
+
+        let mut stream = TcpStream::connect(address).expect("ask for the page afterwards");
+        stream
+            .write_all(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .expect("send the request");
+        let mut answer = [0_u8; 15];
+        stream.read_exact(&mut answer).expect("read the answer");
+        assert_eq!(&answer, b"HTTP/1.1 200 OK");
     }
 
     #[test]


### PR DESCRIPTION
A connection that opens and closes without sending a request ended the whole
dev session. The first read returns zero bytes, `read_request` turns that into
an `UnexpectedEof`, and all three serve loops passed it straight up: the
simulator exited, taking the application running behind it with it, and the
next `kobo drive` got a bare connection refused with no hint as to why.

Nothing unusual has to happen for that to occur. A browser opening a
speculative connection it never uses, anything watching for open ports, a
reload abandoned before the request went out, all arrive here identically.

Reproduced on `beta` while running the example applications on the
`clara-bw-391` profile:

```
$ kobo dev --builtin 127.0.0.1:8810      # serving, drive works
$ python3 -c "import socket; socket.create_connection(('127.0.0.1',8810)).close()"
kobo: request ended early                # the simulator is gone
$ kobo drive --address 127.0.0.1:8810 --step dump
kobo: line 1: dump: connect to the simulator at 127.0.0.1:8810: Connection refused
```

A failed connection is now reported on stderr and stepped over. Accept failures
stay fatal, because a listener that has stopped accepting is not something the
next connection recovers from.

After the change the same sequence leaves the session up, both for the built-in
simulator and for `kobo dev` serving an SDK application:

```
kobo: dropped one browser connection: request ended early
$ kobo drive --address 127.0.0.1:8811 --step 'tap Increment' --step dump
              Heading(1)  ["Counter"]
                    Text  ["Value: 2"]
```

Covered by a regression test that closes a connection unused and then asks for
the page. `cargo test --workspace` is 2097 passed, 0 failed, 4 ignored; clippy
is clean on the crate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791069356&installation_model_id=20525&pr_number=105&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F105&signature=ed3cf10721fdc24fe6e10b7c2228aa657833e0b0e14e75fe22c288eff16c5248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->