### PR TITLE
Fail the beta run when packaged changes have no release

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -14,12 +14,19 @@ concurrency:
 
 jobs:
   prepare:
-    if: github.ref == 'refs/heads/beta'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
       publish: ${{ steps.release.outputs.publish }}
     steps:
+      # Every job used to be gated on the branch, so dispatching this workflow
+      # anywhere else skipped all of them and reported success.
+      - name: Refuse to publish the beta channel from another branch
+        if: github.ref != 'refs/heads/beta'
+        run: |
+          echo "This workflow publishes the beta channel and only runs on refs/heads/beta." >&2
+          echo "It was started on ${GITHUB_REF}; re-run it with the beta branch selected." >&2
+          exit 1
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
@@ -45,7 +52,10 @@ jobs:
           fi
           if [ "$tag_count" -eq 1 ]; then
             release="$RUNNER_TEMP/release.json"
-            gh release view "$tag" --json tagName,isDraft,isPrerelease,assets,targetCommitish \
+            # The release is created against an existing tag, so GitHub fills
+            # targetCommitish with the default branch and it says nothing about
+            # what was published. The tag ref below is the authority.
+            gh release view "$tag" --json tagName,isDraft,isPrerelease,assets \
               > "$release"
             node - "$release" "$tag" "$VERSION" <<'NODE'
           const fs = require("fs");
@@ -141,6 +151,14 @@ jobs:
               test "$(sha256sum "$name" | cut -d' ' -f1)" = "$checksum"
             done < cobalt-host-manifest.txt
             cd "$GITHUB_WORKSPACE"
+            # The tag being an ancestor of this commit only proves beta has not
+            # rewritten history. Beta can still have moved on with packaged
+            # changes the published tag does not carry, and skipping the build
+            # then reports success while no reader receives them.
+            changed="$RUNNER_TEMP/changed-since-$tag"
+            git diff --name-only --diff-filter=ACDMRT "$tag_sha" "$GITHUB_SHA" > "$changed"
+            node tools/device-package-changes.mjs --tag "$tag" --version "$VERSION" \
+              < "$changed"
             echo "publish=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/tools/device-package-changes.mjs
+++ b/tools/device-package-changes.mjs
@@ -1,0 +1,91 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Everything whose content reaches a reader inside the device package, or that
+// decides how that package is built. A change under any of these cannot arrive
+// on a device without a new release, so publishing nothing is the wrong answer.
+// Documentation, marketing assets and site content are deliberately absent:
+// they land on beta constantly and reach readers without a release at all.
+const DEVICE_PACKAGE_DIRECTORIES = ["crates", "apps", ".cargo"];
+const DEVICE_PACKAGE_FILES = ["Cargo.toml", "Cargo.lock"];
+const TOOLCHAIN_PREFIX = "rust-toolchain";
+
+export function affectsDevicePackage(path) {
+  if (typeof path !== "string") return false;
+  const normalized = path.trim().split("\\").join("/");
+  if (normalized.length === 0) return false;
+  if (DEVICE_PACKAGE_FILES.includes(normalized)) return true;
+  // rust-toolchain and rust-toolchain.toml pin the compiler the package is
+  // built with; anything else at the root sharing that name is a pin too.
+  if (!normalized.includes("/") && normalized.startsWith(TOOLCHAIN_PREFIX)) return true;
+  return DEVICE_PACKAGE_DIRECTORIES.some(
+    directory => normalized.startsWith(`${directory}/`)
+  );
+}
+
+export function devicePackageChanges(paths) {
+  return [...new Set(paths.filter(path => affectsDevicePackage(path)))].sort();
+}
+
+export function nextPatchVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) throw new Error(`invalid workspace version ${version}`);
+  return `${match[1]}.${match[2]}.${Number(match[3]) + 1}`;
+}
+
+// The run that finds these changes is the one that decided there was nothing to
+// publish, so the report has to name the single edit that makes it publish.
+export function unpublishedChangeReport(tag, version, changes) {
+  const next = nextPatchVersion(version);
+  return [
+    `${tag} is already published, but the device package is not what beta now builds.`,
+    "These paths differ between the published tag and this commit:",
+    ...changes.map(path => `  ${path}`),
+    "",
+    `No reader receives them while the workspace version stays at ${version}.`,
+    `Raise version in [workspace.package] in Cargo.toml from ${version} to ${next},`,
+    `push again, and this workflow will build and publish beta-v${next}.`
+  ].join("\n");
+}
+
+function argumentsFrom(argv) {
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if ((flag !== "--tag" && flag !== "--version") || !value) {
+      throw new Error(
+        "usage: node tools/device-package-changes.mjs --tag TAG --version VERSION < changed-paths"
+      );
+    }
+    values.set(flag, value);
+  }
+  if (values.size !== 2) {
+    throw new Error(
+      "usage: node tools/device-package-changes.mjs --tag TAG --version VERSION < changed-paths"
+    );
+  }
+  return values;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const values = argumentsFrom(process.argv.slice(2));
+    const tag = values.get("--tag");
+    const version = values.get("--version");
+    const paths = readFileSync(0, "utf8").split("\n").filter(Boolean);
+    const changes = devicePackageChanges(paths);
+    if (changes.length > 0) {
+      console.error(unpublishedChangeReport(tag, version, changes));
+      process.exitCode = 1;
+    } else {
+      console.log(
+        `No device package input changed since ${tag}; ${paths.length} changed path(s) reach readers without a release.`
+      );
+    }
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/tools/device-package-changes.test.mjs
+++ b/tools/device-package-changes.test.mjs
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  affectsDevicePackage,
+  devicePackageChanges,
+  nextPatchVersion,
+  unpublishedChangeReport
+} from "./device-package-changes.mjs";
+
+test("packaged source, manifests and toolchain pins reach readers only in a release", () => {
+  for (const path of [
+    "crates/kobo-protocol/src/lib.rs",
+    "apps/backgammon/src/main.rs",
+    "apps/backgammon/Cargo.toml",
+    "Cargo.toml",
+    "Cargo.lock",
+    "rust-toolchain",
+    "rust-toolchain.toml",
+    ".cargo/config.toml"
+  ]) {
+    assert.equal(affectsDevicePackage(path), true, path);
+  }
+});
+
+test("documentation, marketing assets and site content reach readers without one", () => {
+  for (const path of [
+    "README.md",
+    "docs/index.html",
+    "docs/apps/backgammon/index.html",
+    "docs/assets/kobo-shot.png",
+    "docs/sitemap.xml",
+    "kobo-shot.png",
+    "CONTRIBUTING.md",
+    ".github/workflows/ci.yml",
+    "tools/check-app-versions.mjs"
+  ]) {
+    assert.equal(affectsDevicePackage(path), false, path);
+  }
+});
+
+test("directory names are matched whole", () => {
+  assert.equal(affectsDevicePackage("appstore/notes.md"), false);
+  assert.equal(affectsDevicePackage("crates-notes.md"), false);
+  assert.equal(affectsDevicePackage("docs/Cargo.toml"), false);
+  assert.equal(affectsDevicePackage("docs/rust-toolchain.toml"), false);
+});
+
+test("a mixed push reports only the paths that need a release", () => {
+  assert.deepEqual(
+    devicePackageChanges([
+      "docs/index.html",
+      "crates/kobo-ui/src/list.rs",
+      "README.md",
+      "Cargo.lock",
+      "crates/kobo-ui/src/list.rs"
+    ]),
+    ["Cargo.lock", "crates/kobo-ui/src/list.rs"]
+  );
+  assert.deepEqual(devicePackageChanges(["docs/index.html", "README.md"]), []);
+});
+
+test("the report names the exact version bump that publishes the change", () => {
+  const report = unpublishedChangeReport("beta-v0.3.5", "0.3.5", ["Cargo.lock"]);
+  assert.match(report, /beta-v0\.3\.5 is already published/);
+  assert.match(report, /^ {2}Cargo\.lock$/m);
+  assert.match(report, /from 0\.3\.5 to 0\.3\.6/);
+  assert.match(report, /publish beta-v0\.3\.6/);
+});
+
+test("version arithmetic refuses anything that is not a release number", () => {
+  assert.equal(nextPatchVersion("0.3.9"), "0.3.10");
+  assert.equal(nextPatchVersion("1.0.0"), "1.0.1");
+  assert.throws(() => nextPatchVersion("0.3"), /invalid workspace version 0\.3/);
+  assert.throws(() => nextPatchVersion("0.3.5-beta"), /invalid workspace version/);
+});


### PR DESCRIPTION
`beta-release.yml` skips `device`, `host` and `publish` whenever the workspace
version already has a published tag, and the run reports success. The only
assertion it makes about that tag is `git merge-base --is-ancestor`, which
proves beta has not rewritten history and nothing else. Beta can advance with
packaged changes and the run still calls it a success.

This diffs the published tag against `GITHUB_SHA` and fails when anything that
lands inside the device package differs: `crates/`, `apps/`, `Cargo.toml`,
`Cargo.lock`, `rust-toolchain*`, `.cargo/`. Documentation, marketing assets,
the README and site content stay quiet, because they reach readers without a
release and they arrive constantly.

The path classification and the failure message live in
`tools/device-package-changes.mjs` with unit tests, since the gate that hid
this had no test harness at all.

Two smaller false-greens in the same file:

- Dispatching this workflow on any branch other than `beta` skipped every job
  and reported success. `prepare` now fails and says which branch it needs.
- The release lookup fetched `targetCommitish` and never asserted on it.
  GitHub fills it with the default branch because the release is created
  against a tag that already exists (`beta-v0.3.3`, `0.3.4` and `0.3.5` all
  record `"main"`), so it carries no information. The tag ref beside it is the
  authority, and the dead field is gone.

## Demonstration

Replaying real beta history through the `publish=false` branch exactly as
GitHub runs a `run:` block (`bash -e`, no `pipefail`). These are the three runs
that reported `OVERALL: success` with everything skipped:

    --- [old gate] run 33805734059 (PR #100) at 079a5fa0
        step exit=0  GITHUB_OUTPUT=[publish=false ]
        => run is GREEN, device/host/publish skipped

    --- [new gate] run 33805734059 (PR #100) at 079a5fa0
        beta-v0.3.4 is already published, but the device package is not what beta now builds.
        These paths differ between the published tag and this commit:
          Cargo.lock
          Cargo.toml
          apps/backgammon/src/main.rs
          apps/catalog.json
          crates/kobo-cli/src/main.rs
          crates/kobo-policy/src/credentials.rs
          crates/kobo-profile/src/lib.rs
          crates/kobo-ui/src/lib.rs
          ...
        No reader receives them while the workspace version stays at 0.3.4.
        Raise version in [workspace.package] in Cargo.toml from 0.3.4 to 0.3.5,
        push again, and this workflow will build and publish beta-v0.3.5.
        step exit=1  GITHUB_OUTPUT=[]
        => run is RED at the version gate

Runs `33805786973` (#79) and `33807793988` (#101) behave identically: green
before, red after. `0.3.5` is exactly the bump the message asks for, and
exactly what shipped them in the end.

A docs, README and marketing asset push on top of the published tag stays
quiet:

    changed: README.md
    changed: docs/index.html
    changed: docs/media/site/scratch-asset.html

    No device package input changed since beta-v0.3.5; 3 changed path(s) reach readers without a release.
    step exit=0  GITHUB_OUTPUT=[publish=false ]
    => run is GREEN, device/host/publish skipped

Adding one packaged file to that same push turns it red, naming only the file
that needs the release:

    These paths differ between the published tag and this commit:
      crates/kobo-ui/src/lib.rs
    step exit=1
    => run is RED at the version gate

A commit identical to the published tag stays green with `publish=false`.

## Tests

`node --test tools/*.test.mjs`: 35 tests, 35 pass, 0 fail (29 before this
change). `bash -n` passes on every `run:` block in the file and the YAML parses
with all four jobs intact.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791069390&installation_model_id=20525&pr_number=106&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F106&signature=bf772c716b82b713e148c5c0a08382cf970ae4b4396c199de65c134e3ecc44b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->