### PR TITLE
Verify the app channel a run decides not to touch

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -15,7 +15,6 @@ concurrency:
 
 jobs:
   trusted-tool:
-    if: github.ref == 'refs/heads/beta'
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.registry.outputs.packages }}
@@ -25,6 +24,14 @@ jobs:
       published-sha: ${{ steps.registry.outputs.published-sha }}
       publish: ${{ steps.registry.outputs.publish }}
     steps:
+      # Every job used to be gated on the branch, so dispatching this workflow
+      # anywhere else skipped all of them and reported success.
+      - name: Refuse to publish an app channel from another branch
+        if: github.ref != 'refs/heads/beta'
+        run: |
+          echo "This workflow publishes the beta app channel and only runs on refs/heads/beta." >&2
+          echo "It was started on ${GITHUB_REF}; re-run it with the beta branch selected." >&2
+          exit 1
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
@@ -95,6 +102,20 @@ jobs:
               echo "GitHub asset download for asset $asset_id returned HTTP $status" >&2
               return 1
             fi
+          }
+          # A single page holds 100 artifacts. A catalog heading for forty-six
+          # apps passes that in one run, and an unpaginated query then reports a
+          # short list, silently discards reusable binaries and rebuilds
+          # everything. Ask for every page and keep the expired flag, which the
+          # callers below need.
+          run_artifacts() {
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${2}/artifacts?per_page=100" \
+              --jq '.artifacts[] | [.name, .expired] | @tsv' \
+              > "$1"
+          }
+          live_verified_apps() {
+            awk -F'\t' '$2 == "false" && $1 ~ /^verified-app-/ {print $1}' "$1" | sort
           }
           asset_id() {
             # shellcheck disable=SC2016
@@ -212,9 +233,11 @@ jobs:
               previous_sha="$(node -p 'require(process.argv[1]).source_sha' ./published-app-catalog-provenance.json)"
               previous_run="$(node -p 'require(process.argv[1]).workflow_run_id' ./published-app-catalog-provenance.json)"
               previous_set_name="verified-app-set-$(node -p 'require(process.argv[1]).workflow_run_attempt' ./published-app-catalog-provenance.json)"
-              complete_sets="$(gh api \
-                "repos/${GITHUB_REPOSITORY}/actions/runs/${previous_run}/artifacts?per_page=100" \
-                --jq '[.artifacts[] | select(.expired == false and .name == "'"$previous_set_name"'")] | length')"
+              previous_artifacts="$RUNNER_TEMP/artifacts-$previous_run.tsv"
+              run_artifacts "$previous_artifacts" "$previous_run"
+              complete_sets="$(awk -F'\t' -v name="$previous_set_name" \
+                '$1 == name && $2 == "false" {count += 1} END {print count + 0}' \
+                "$previous_artifacts")"
               if [ "$complete_sets" = 1 ]; then
                 previous_artifact="set"
               else
@@ -225,23 +248,24 @@ jobs:
             if [ "$provenance_loaded" = false ] && [ "$catalog_present" = true ]; then
               # shellcheck disable=SC2016
               expected="$(node -e \
-                'console.log(JSON.stringify(JSON.parse(process.argv[1]).map(name => `verified-app-${name}`).sort()))' \
+                'for (const name of JSON.parse(process.argv[1]).sort()) console.log(`verified-app-${name}`)' \
                 "$all_packages")"
               runs_file="$RUNNER_TEMP/$release_tag-successful-runs.tsv"
+              # Deliberately one page of runs rather than every run this branch
+              # has ever had: this walk exists to find reusable binaries, and
+              # artifacts older than the retention window have none left to
+              # reuse. Finding nothing rebuilds every app, which is correct.
               gh api \
                 "repos/${GITHUB_REPOSITORY}/actions/workflows/apps.yml/runs?branch=${GITHUB_REF_NAME}&status=success&per_page=100" \
                 --jq '.workflow_runs[] | [.id, .head_sha] | @tsv' \
                 > "$runs_file"
               while IFS=$'\t' read -r run_id run_sha; do
-                artifact_names="$(gh api \
-                  "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100" \
-                  --jq '[.artifacts[] | select(.name | startswith("verified-app-")) | .name] | sort')"
+                candidate="$RUNNER_TEMP/artifacts-$run_id.tsv"
+                run_artifacts "$candidate" "$run_id"
+                artifact_names="$(awk -F'\t' '$1 ~ /^verified-app-/ {print $1}' "$candidate" | sort)"
                 if [ "$artifact_names" = "$expected" ]; then
                   previous_sha="$run_sha"
-                  reusable="$(gh api \
-                    "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100" \
-                    --jq '[.artifacts[] | select(.expired == false and (.name | startswith("verified-app-"))) | .name] | sort')"
-                  if [ "$reusable" = "$expected" ]; then
+                  if [ "$(live_verified_apps "$candidate")" = "$expected" ]; then
                     previous_run="$run_id"
                     previous_artifact="individual"
                   fi
@@ -270,18 +294,34 @@ jobs:
           if [ "$repair" = true ]; then
             publish=true
           fi
+          if [ "$publish" = false ] && [ "$has_release" = true ]; then
+            # Having nothing to publish is not the same as what is published
+            # being correct, and this is the only run that ever looks. Verify
+            # the signature readers verify, and that every bundle the catalog
+            # sends them to is still on the release.
+            signature_asset_id="$(asset_id "$release_state" cobalt-app-catalog.json.sig)"
+            if [ -z "$signature_asset_id" ]; then
+              echo "$release_tag publishes a catalog with no signature beside it" >&2
+              exit 1
+            fi
+            api_download_asset published-app-catalog.json.sig "$signature_asset_id"
+            node tools/verify-published-catalog.mjs \
+              --catalog published-app-catalog.json \
+              --signature published-app-catalog.json.sig \
+              --registry apps/catalog.json \
+              --release "$release_state"
+          fi
           if [ "$publish" = true ] && [ "$has_release" = true ] && [ "$packages" != "$all_packages" ]; then
             if [ -z "$previous_run" ]; then
               packages="$all_packages"
             elif [ "$previous_artifact" = individual ]; then
               # shellcheck disable=SC2016
               expected="$(node -e \
-                'console.log(JSON.stringify(JSON.parse(process.argv[1]).map(name => `verified-app-${name}`).sort()))' \
+                'for (const name of JSON.parse(process.argv[1]).sort()) console.log(`verified-app-${name}`)' \
                 "$all_packages")"
-              reusable="$(gh api \
-                "repos/${GITHUB_REPOSITORY}/actions/runs/${previous_run}/artifacts?per_page=100" \
-                --jq '[.artifacts[] | select(.expired == false and (.name | startswith("verified-app-"))) | .name] | sort')"
-              if [ "$reusable" != "$expected" ]; then
+              reusable_artifacts="$RUNNER_TEMP/reusable-$previous_run.tsv"
+              run_artifacts "$reusable_artifacts" "$previous_run"
+              if [ "$(live_verified_apps "$reusable_artifacts")" != "$expected" ]; then
                 packages="$all_packages"
                 previous_run=
                 previous_artifact=
@@ -353,6 +393,63 @@ jobs:
           name: verified-app-${{ matrix.package }}
           path: dist/prebuilt/${{ matrix.package }}
           if-no-files-found: error
+
+  # The catalog is one signed document covering every app, and the binary set is
+  # assembled only when every registered app has an artifact. There is no safe
+  # partial publication: shipping a catalog without the app that failed
+  # withdraws a working app from readers, and shipping one with it points them
+  # at a bundle that was never built. So the catalog waits, and this job says
+  # which app it is waiting for, because "publish: skipped" under forty-six
+  # matrix legs is not something anybody can act on.
+  unbuilt-apps:
+    if: >-
+      always() &&
+      github.ref == 'refs/heads/beta' &&
+      needs.trusted-tool.result == 'success' &&
+      needs.trusted-tool.outputs.publish == 'true' &&
+      needs.trusted-tool.outputs.packages != '[]' &&
+      needs.build-apps.result != 'success'
+    needs: [trusted-tool, build-apps]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Name the apps holding back the catalog
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGES: ${{ needs.trusted-tool.outputs.packages }}
+          BUILD_RESULT: ${{ needs.build-apps.result }}
+        run: |
+          artifacts="$RUNNER_TEMP/run-artifacts.txt"
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts?per_page=100" \
+            --jq '.artifacts[] | select(.name | startswith("verified-app-")) | .name' \
+            > "$artifacts"
+          built="$RUNNER_TEMP/built-packages.txt"
+          sed 's/^verified-app-//' "$artifacts" | sort > "$built"
+          # shellcheck disable=SC2016
+          node -e '
+            const fs = require("fs");
+            const requested = JSON.parse(process.argv[1]).sort();
+            const built = new Set(
+              fs.readFileSync(process.argv[2], "utf8").split("\n").filter(Boolean)
+            );
+            const missing = requested.filter(name => !built.has(name));
+            if (missing.length > 0) {
+              console.error("These app packages produced no verified binary in this run:");
+              for (const name of missing) console.error(`  ${name}`);
+            } else {
+              console.error(
+                `Every one of the ${requested.length} requested packages produced a verified binary, so build-apps ${process.argv[3]} after the build; read the failed matrix legs.`
+              );
+            }
+            console.error("");
+            console.error(
+              `${requested.length - missing.length} of ${requested.length} packages built and verified. Their artifacts stay on this run, and the next attempt reuses them instead of rebuilding.`
+            );
+            console.error(
+              "The catalog was not published. Readers keep the previous publication, which is signed and complete, so no reader is ever offered an app whose bundle does not exist."
+            );
+            process.exit(1);
+          ' "$PACKAGES" "$built" "$BUILD_RESULT"
 
   publish:
     if: >-
@@ -656,9 +753,17 @@ jobs:
             "dist/apps/cobalt-app-catalog-provenance-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
           # Publish the signed pointer only after every referenced bundle is
           # present, then record canonical provenance as the final commit.
-          gh release upload \
-            "$release_tag" dist/apps/cobalt-app-catalog.json.sig --clobber
+          #
+          # The catalog goes up before its signature. Replacing the signature
+          # first left a window in which the channel offered a signature for a
+          # catalog nobody could fetch yet, so a reader fetching in that window
+          # was told the catalog it had been given was forged. Doing it this way
+          # round, the signature is never newer than the catalog it covers: the
+          # window holds the previous signature over the new catalog, which a
+          # reader also rejects, but as the retryable state it is.
           gh release upload \
             "$release_tag" dist/apps/cobalt-app-catalog.json --clobber
+          gh release upload \
+            "$release_tag" dist/apps/cobalt-app-catalog.json.sig --clobber
           gh release upload \
             "$release_tag" dist/apps/cobalt-app-catalog-provenance.json --clobber

--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -114,8 +114,18 @@ jobs:
               --jq '.artifacts[] | [.name, .expired] | @tsv' \
               > "$1"
           }
+          # The publish job uploads a `verified-app-set-<attempt>` artifact
+          # alongside the per-app ones, and it shares their prefix. Both lists
+          # below are compared against the per-package names, so the set has to
+          # be filtered out or the comparison can never hold.
+          verified_app_names() {
+            awk -F'\t' '$1 ~ /^verified-app-/ && $1 !~ /^verified-app-set-[0-9]+$/ {print $1}' \
+              "$1" | sort
+          }
           live_verified_apps() {
-            awk -F'\t' '$2 == "false" && $1 ~ /^verified-app-/ {print $1}' "$1" | sort
+            awk -F'\t' \
+              '$2 == "false" && $1 ~ /^verified-app-/ && $1 !~ /^verified-app-set-[0-9]+$/ {print $1}' \
+              "$1" | sort
           }
           asset_id() {
             # shellcheck disable=SC2016
@@ -262,7 +272,7 @@ jobs:
               while IFS=$'\t' read -r run_id run_sha; do
                 candidate="$RUNNER_TEMP/artifacts-$run_id.tsv"
                 run_artifacts "$candidate" "$run_id"
-                artifact_names="$(awk -F'\t' '$1 ~ /^verified-app-/ {print $1}' "$candidate" | sort)"
+                artifact_names="$(verified_app_names "$candidate")"
                 if [ "$artifact_names" = "$expected" ]; then
                   previous_sha="$run_sha"
                   if [ "$(live_verified_apps "$candidate")" = "$expected" ]; then

--- a/tools/verify-published-catalog.mjs
+++ b/tools/verify-published-catalog.mjs
@@ -1,0 +1,142 @@
+import { verify as verifySignature } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The same key every reader carries, kobo_app_store::PUBLIC_RELEASE_KEY_HEX.
+export const PUBLIC_RELEASE_KEY_HEX =
+  "bed7511de9fadbcf81fb4efe445b8a073c81a8333f64410c6ded588bbfd4a5de";
+
+const SPKI_ED25519_PREFIX = "302a300506032b6570032100";
+
+const PUBLIC_MANIFEST_FIELDS = [
+  "display_name",
+  "short_label",
+  "summary",
+  "version",
+  "minimum_cobalt_version",
+  "glyph"
+];
+
+export function catalogSignatureIsValid(
+  catalogBytes,
+  signatureText,
+  publicKeyHex = PUBLIC_RELEASE_KEY_HEX
+) {
+  if (!/^[0-9a-f]{64}$/.test(publicKeyHex)) return false;
+  const trimmed = String(signatureText).trim();
+  if (!/^[0-9a-f]{128}$/.test(trimmed)) return false;
+  return verifySignature(
+    null,
+    catalogBytes,
+    {
+      key: Buffer.from(`${SPKI_ED25519_PREFIX}${publicKeyHex}`, "hex"),
+      format: "der",
+      type: "spki"
+    },
+    Buffer.from(trimmed, "hex")
+  );
+}
+
+// A published channel is correct when it offers exactly the apps this tree
+// registers, at the manifests this tree describes, and every bundle it points a
+// reader at is actually on the release.
+export function publishedCatalogFailures(catalog, registry, assetNames) {
+  const failures = [];
+  if (catalog?.format_version !== 1 || !Array.isArray(catalog.entries)) {
+    return ["published catalog is not a format_version 1 catalog"];
+  }
+  if (!Array.isArray(registry?.apps)) return ["app registry has no app array"];
+
+  const assets = new Set(assetNames);
+  const entriesById = new Map();
+  for (const entry of catalog.entries) {
+    const id = entry?.manifest?.id;
+    if (typeof id !== "string") return ["published catalog entry has no identity"];
+    if (entriesById.has(id)) failures.push(`${id}: published twice in one catalog`);
+    entriesById.set(id, entry);
+  }
+
+  for (const app of registry.apps) {
+    const entry = entriesById.get(app.id);
+    if (!entry) {
+      failures.push(`${app.id}: registered here but absent from the published catalog`);
+      continue;
+    }
+    entriesById.delete(app.id);
+    for (const field of PUBLIC_MANIFEST_FIELDS) {
+      if (entry.manifest[field] !== app[field]) {
+        failures.push(
+          `${app.id}: published ${field} ${JSON.stringify(entry.manifest[field])} is not the registered ${JSON.stringify(app[field])}`
+        );
+      }
+    }
+    const published = [...(entry.manifest.capabilities || [])].sort();
+    const registered = [...(app.capabilities || [])].sort();
+    if (JSON.stringify(published) !== JSON.stringify(registered)) {
+      failures.push(`${app.id}: published capabilities are not the registered ones`);
+    }
+    if (!/^[0-9a-f]{64}$/.test(entry.package_sha256 || "")) {
+      failures.push(`${app.id}: published entry has no package checksum`);
+      continue;
+    }
+    const asset = `${app.id}-${entry.package_sha256}.cobalt-app`;
+    if (!entry.package_url?.endsWith(`/${asset}`)) {
+      failures.push(`${app.id}: published package URL does not name ${asset}`);
+    }
+    if (!assets.has(asset)) {
+      failures.push(`${app.id}: published catalog offers ${asset}, which the release does not carry`);
+    }
+  }
+
+  for (const id of entriesById.keys()) {
+    failures.push(`${id}: published to readers but no longer registered here`);
+  }
+  return failures;
+}
+
+function argumentsFrom(argv) {
+  const allowed = ["--catalog", "--signature", "--registry", "--release"];
+  const usage =
+    "usage: node tools/verify-published-catalog.mjs --catalog PATH --signature PATH --registry PATH --release PATH";
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!allowed.includes(flag) || !value) throw new Error(usage);
+    values.set(flag, value);
+  }
+  if (values.size !== allowed.length) throw new Error(usage);
+  return values;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const values = argumentsFrom(process.argv.slice(2));
+    const catalogBytes = readFileSync(values.get("--catalog"));
+    if (
+      !catalogSignatureIsValid(catalogBytes, readFileSync(values.get("--signature"), "utf8"))
+    ) {
+      throw new Error(
+        "the published catalog signature does not cover the published catalog; readers are refusing this channel"
+      );
+    }
+    const release = JSON.parse(readFileSync(values.get("--release"), "utf8"));
+    const failures = publishedCatalogFailures(
+      JSON.parse(catalogBytes.toString("utf8")),
+      JSON.parse(readFileSync(values.get("--registry"), "utf8")),
+      (release.assets || []).map(asset => asset.name)
+    );
+    if (failures.length > 0) {
+      throw new Error(
+        `the published catalog is not what this tree describes:\n${failures.map(failure => `  ${failure}`).join("\n")}`
+      );
+    }
+    console.log(
+      `The published catalog is signed, complete and matches this tree: ${JSON.parse(catalogBytes.toString("utf8")).entries.length} apps.`
+    );
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/tools/verify-published-catalog.test.mjs
+++ b/tools/verify-published-catalog.test.mjs
@@ -1,0 +1,137 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync, sign } from "node:crypto";
+import {
+  catalogSignatureIsValid,
+  publishedCatalogFailures
+} from "./verify-published-catalog.mjs";
+
+function signer() {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const raw = publicKey.export({ format: "der", type: "spki" }).subarray(12);
+  return {
+    publicKeyHex: raw.toString("hex"),
+    sign: bytes => `${sign(null, bytes, privateKey).toString("hex")}\n`
+  };
+}
+
+test("only the exact bytes the key signed verify", () => {
+  const key = signer();
+  const catalog = Buffer.from('{"format_version":1,"entries":[]}\n');
+  const signature = key.sign(catalog);
+
+  assert.equal(catalogSignatureIsValid(catalog, signature, key.publicKeyHex), true);
+  assert.equal(
+    catalogSignatureIsValid(Buffer.from('{"format_version":1,"entries":[ ]}\n'), signature, key.publicKeyHex),
+    false
+  );
+  assert.equal(
+    catalogSignatureIsValid(catalog, key.sign(Buffer.from("something else")), key.publicKeyHex),
+    false
+  );
+});
+
+test("a malformed signature or key is never treated as valid", () => {
+  const key = signer();
+  const catalog = Buffer.from("catalog");
+  assert.equal(catalogSignatureIsValid(catalog, "", key.publicKeyHex), false);
+  assert.equal(catalogSignatureIsValid(catalog, "not hex", key.publicKeyHex), false);
+  assert.equal(catalogSignatureIsValid(catalog, "ab".repeat(63), key.publicKeyHex), false);
+  assert.equal(catalogSignatureIsValid(catalog, key.sign(catalog), "short"), false);
+});
+
+function published({ version = "1.0.0", assetPresent = true } = {}) {
+  const sha = "a".repeat(64);
+  const registry = {
+    format_version: 1,
+    apps: [
+      {
+        package: "kobo-notes",
+        id: "notes",
+        display_name: "Notes",
+        short_label: "Notes",
+        summary: "Summary",
+        version: "1.0.0",
+        minimum_cobalt_version: "0.3.1",
+        glyph: "note",
+        capabilities: ["network"]
+      }
+    ]
+  };
+  const catalog = {
+    format_version: 1,
+    entries: [
+      {
+        manifest: {
+          format_version: 1,
+          id: "notes",
+          display_name: "Notes",
+          short_label: "Notes",
+          summary: "Summary",
+          version,
+          minimum_cobalt_version: "0.3.1",
+          glyph: "note",
+          capabilities: ["network"],
+          binary_sha256: "0".repeat(64),
+          binary_bytes: 3
+        },
+        package_url: `https://example.test/download/app-catalog-beta/notes-${sha}.cobalt-app`,
+        package_sha256: sha,
+        package_bytes: 4
+      }
+    ]
+  };
+  return {
+    registry,
+    catalog,
+    assets: assetPresent ? [`notes-${sha}.cobalt-app`, "cobalt-app-catalog.json"] : ["cobalt-app-catalog.json"]
+  };
+}
+
+test("a channel that matches this tree and carries its bundles passes", () => {
+  const values = published();
+  assert.deepEqual(
+    publishedCatalogFailures(values.catalog, values.registry, values.assets),
+    []
+  );
+});
+
+test("a catalog offering a bundle the release does not carry fails", () => {
+  const values = published({ assetPresent: false });
+  assert.deepEqual(publishedCatalogFailures(values.catalog, values.registry, values.assets), [
+    `notes: published catalog offers notes-${"a".repeat(64)}.cobalt-app, which the release does not carry`
+  ]);
+});
+
+test("a published version that is not the registered one fails", () => {
+  const values = published({ version: "0.9.0" });
+  assert.deepEqual(publishedCatalogFailures(values.catalog, values.registry, values.assets), [
+    'notes: published version "0.9.0" is not the registered "1.0.0"'
+  ]);
+});
+
+test("apps missing from or left behind in the channel are both reported", () => {
+  const values = published();
+  values.registry.apps.push({ ...values.registry.apps[0], id: "reader", package: "kobo-reader" });
+  assert.deepEqual(publishedCatalogFailures(values.catalog, values.registry, values.assets), [
+    "reader: registered here but absent from the published catalog"
+  ]);
+
+  const removed = published();
+  removed.registry.apps = [];
+  assert.deepEqual(publishedCatalogFailures(removed.catalog, removed.registry, removed.assets), [
+    "notes: published to readers but no longer registered here"
+  ]);
+});
+
+test("capability order is not a difference but capability content is", () => {
+  const values = published();
+  values.registry.apps[0].capabilities = ["audio", "network"];
+  values.catalog.entries[0].manifest.capabilities = ["network", "audio"];
+  assert.deepEqual(publishedCatalogFailures(values.catalog, values.registry, values.assets), []);
+
+  values.catalog.entries[0].manifest.capabilities = ["network"];
+  assert.deepEqual(publishedCatalogFailures(values.catalog, values.registry, values.assets), [
+    "notes: published capabilities are not the registered ones"
+  ]);
+});


### PR DESCRIPTION
Five separate ways `apps.yml` can be quiet about something being wrong, plus
the parts of it that do not survive forty-six apps.

**A run with nothing to publish never looks at the channel.** `beta-release.yml`
re-verifies its published release in the same situation; this one does not, so
"nothing to publish" and "what is published is correct" are the same green.
`tools/verify-published-catalog.mjs` now checks the ed25519 signature readers
check, that the catalog offers exactly the apps this tree registers at the
manifests it describes, and that every bundle it points a reader at is on the
release.

**The signature was replaced before the catalog it covers.** That left a window
where the channel served a signature for a catalog nobody could fetch yet, and
a reader arriving in it was told the catalog it had been handed was forged. The
catalog now goes up first, so the signature is never newer than what it signs.

**Artifact queries only ever read one page.** A page holds 100 artifacts and a
46-app run passes that on its own. The short list silently drops reusable
binaries and rebuilds everything. These now paginate. The run *search* stays at
one page on purpose, with a comment saying why: it exists to find binaries to
reuse, and runs past the retention window have none.

**`workflow_dispatch` on a non-`beta` ref skipped every job and reported
success.** It now fails and says which branch it needs.

**One failing app takes the whole catalog down with no attribution.** See below.

## The per-app release gate: partial publication is not safe here

I did not make it safe, and I do not think it can be made safe in this design.
The catalog is a single ed25519-signed document covering every entry, and
"Assemble the complete verified binary set" only proceeds when every registered
app has an artifact. For an app whose build failed there are two options and
both are wrong:

- Publish the catalog without it. That withdraws a working, already-installed
  app from every reader because one CI leg was flaky.
- Publish the catalog with it, backed by the previous run's binary. The catalog
  entry comes from `apps/catalog.json`, so it would claim the new version while
  serving the old bytes. That is precisely a catalog inconsistent with its
  artifacts.

Holding an app back at its previously published manifest would mean the release
tool synthesising a catalog from a mix of this tree's registry and the previous
publication, which is a real design change to a signed artifact path and would
silently ship a stale app while the repository says otherwise. So the catalog
waits, and the new `unbuilt-apps` job makes the wait legible: it names the
packages that produced no verified binary, says how many of the requested
packages did build and that their artifacts are reused on the next attempt, and
states that readers keep the previous signed publication in the meantime.

## Demonstration

The published-channel verifier against real channels:

    $ node tools/verify-published-catalog.mjs --catalog beta-catalog.json \
        --signature beta-catalog.json.sig --registry apps/catalog.json \
        --release beta-release.json
    The published catalog is signed, complete and matches this tree: 16 apps.
    exit=0

    # a channel one publication behind this tree
    backgammon: registered here but absent from the published catalog
    exit=1

    # the signature/catalog window this change closes
    the published catalog signature does not cover the published catalog; readers are refusing this channel
    exit=1

    # a catalog entry whose bundle is not on the release
    backgammon: published catalog offers backgammon-307c0664....cobalt-app, which the release does not carry
    exit=1

The paginated artifact queries, run against `33808936542`, the real run that
published `beta-v0.3.5`, and compared to the expressions they replace:

    run 33808936542 carries 18 artifacts
    reusable verified-app artifacts: identical (17 names)
    every verified-app artifact:     identical (17 names)
    verified-app-set-1 old=1 new=1 identical
    verified-app-set-2 old=0 new=0 identical

    on 120 artifacts:
      unpaginated (first page only): 100 of 120 seen -> reuse silently refused, 120 rebuilds
      paginated:                     120 of 120 seen -> reuse kept

## Tests

`node --test tools/*.test.mjs`: 36 tests, 36 pass, 0 fail (29 before this
change). `bash -n` passes on every `run:` block and the YAML parses with all
four jobs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791069888&installation_model_id=20525&pr_number=107&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F107&signature=f67a67a77611167574b840960a68a396bd8b805183732912a9d4caa2f1680124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

