### PR TITLE
Stop passing the audit on a snapshot nobody agreed to trust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,23 @@ jobs:
           elif printf '%s\n' "$output" | grep -Eq \
             'error loading advisory database|expected RUSTSEC-[0-9-]+ to be in'; then
             printf '%s\n' "$output" >&2
-            echo "Current advisory database is malformed; using the last verified snapshot." >&2
+            # Auditing the pinned snapshot is blind to every advisory published
+            # after the pin, and it reported that as a clean audit in a line of
+            # stderr nobody reads. Say so where a run is read from, and refuse
+            # unless somebody has accepted the blind spot with an expiry date.
+            snapshot="$(git -C advisory-db-fallback rev-parse HEAD)"
+            echo "::warning title=Advisory database fallback::The current RustSec database failed to load. This run can only audit the snapshot pinned at ${snapshot}, which cannot see any advisory published after it."
+            {
+              echo "### Advisory database fallback"
+              echo
+              echo "The current RustSec advisory database failed to load."
+              echo "This run can only audit the snapshot pinned at \`${snapshot}\`,"
+              echo "which cannot see any advisory published after it."
+            } >> "$GITHUB_STEP_SUMMARY"
+            node tools/advisory-db-fallback.mjs \
+              --record tools/advisory-db-fallback.json \
+              --snapshot "$snapshot" \
+              --today "$(date -u +%F)"
             cargo audit --db advisory-db-fallback --no-fetch
           else
             printf '%s\n' "$output" >&2

--- a/tools/advisory-db-fallback.mjs
+++ b/tools/advisory-db-fallback.mjs
@@ -3,6 +3,20 @@ import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const RECORD_PATH = "tools/advisory-db-fallback.json";
+const SNAPSHOT_PATTERN = /^[0-9a-f]{40}$/;
+
+// Expiry is decided by comparing two date strings, which orders them by date
+// only while both are real dates written the one way. `2026-13-45` sorts after
+// every genuine date and would never expire, so a date that does not exist is
+// not a date here.
+export function isCalendarDate(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value ?? "")) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return (
+    Number.isFinite(parsed.getTime()) &&
+    parsed.toISOString().slice(0, 10) === value
+  );
+}
 
 // Auditing against a pinned snapshot answers a question nobody asked: it is
 // blind to every advisory published after the pin, and it reports that as a
@@ -20,13 +34,13 @@ export function fallbackFailure(record, snapshot, today) {
   ) {
     return `${RECORD_PATH} is not a format_version 1 record with a reason`;
   }
-  if (!/^[0-9a-f]{40}$/.test(record.snapshot || "")) {
+  if (!SNAPSHOT_PATTERN.test(record.snapshot || "")) {
     return `${RECORD_PATH} names no advisory database snapshot`;
   }
   if (record.snapshot !== snapshot) {
     return `${RECORD_PATH} accepts snapshot ${record.snapshot}, but this run pins ${snapshot}`;
   }
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(record.expires || "")) {
+  if (!isCalendarDate(record.expires)) {
     return `${RECORD_PATH} has no expiry date`;
   }
   if (record.expires < today) {
@@ -56,7 +70,7 @@ export function fallbackRefusal(failure, snapshot) {
   ].join("\n");
 }
 
-function argumentsFrom(argv) {
+export function argumentsFrom(argv) {
   const allowed = ["--record", "--snapshot", "--today"];
   const usage =
     "usage: node tools/advisory-db-fallback.mjs --record PATH --snapshot SHA --today YYYY-MM-DD";
@@ -68,6 +82,20 @@ function argumentsFrom(argv) {
     values.set(flag, value);
   }
   if (values.size !== allowed.length) throw new Error(usage);
+  // The shapes the usage line describes are the shapes the comparisons below
+  // assume, and nothing else checks them. A malformed date silently decides the
+  // expiry the wrong way round, which is the one answer this tool exists to get
+  // right, so say so here rather than audit blind on a typo.
+  const snapshot = values.get("--snapshot");
+  if (!SNAPSHOT_PATTERN.test(snapshot)) {
+    throw new Error(
+      `--snapshot ${snapshot} is not a 40-character advisory database commit`
+    );
+  }
+  const today = values.get("--today");
+  if (!isCalendarDate(today)) {
+    throw new Error(`--today ${today} is not a date written YYYY-MM-DD`);
+  }
   return values;
 }
 

--- a/tools/advisory-db-fallback.mjs
+++ b/tools/advisory-db-fallback.mjs
@@ -1,0 +1,97 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const RECORD_PATH = "tools/advisory-db-fallback.json";
+
+// Auditing against a pinned snapshot answers a question nobody asked: it is
+// blind to every advisory published after the pin, and it reports that as a
+// clean audit. It is still the right thing to do while the upstream database
+// genuinely will not load, so the blind spot is allowed, named and dated, and
+// it stops being allowed on the date it says.
+export function fallbackFailure(record, snapshot, today) {
+  if (record === null) {
+    return `no ${RECORD_PATH} accepts auditing against a pinned snapshot`;
+  }
+  if (
+    record?.format_version !== 1 ||
+    typeof record.reason !== "string" ||
+    record.reason.trim().length === 0
+  ) {
+    return `${RECORD_PATH} is not a format_version 1 record with a reason`;
+  }
+  if (!/^[0-9a-f]{40}$/.test(record.snapshot || "")) {
+    return `${RECORD_PATH} names no advisory database snapshot`;
+  }
+  if (record.snapshot !== snapshot) {
+    return `${RECORD_PATH} accepts snapshot ${record.snapshot}, but this run pins ${snapshot}`;
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(record.expires || "")) {
+    return `${RECORD_PATH} has no expiry date`;
+  }
+  if (record.expires < today) {
+    return `${RECORD_PATH} stopped accepting this snapshot on ${record.expires}, and today is ${today}`;
+  }
+  return null;
+}
+
+export function fallbackRefusal(failure, snapshot) {
+  return [
+    "The current RustSec advisory database failed to load, so this run can only",
+    `audit against the snapshot pinned at ${snapshot}. That snapshot cannot see any`,
+    "advisory published after it, and passing on it reports an audit nobody performed.",
+    "",
+    `Refusing because ${failure}.`,
+    "",
+    `To accept that blind spot for a bounded time, commit ${RECORD_PATH}:`,
+    "",
+    "  {",
+    '    "format_version": 1,',
+    `    "snapshot": "${snapshot}",`,
+    '    "expires": "YYYY-MM-DD",',
+    '    "reason": "why the upstream database will not load"',
+    "  }",
+    "",
+    "Remove it as soon as upstream loads again; it expires on its own either way."
+  ].join("\n");
+}
+
+function argumentsFrom(argv) {
+  const allowed = ["--record", "--snapshot", "--today"];
+  const usage =
+    "usage: node tools/advisory-db-fallback.mjs --record PATH --snapshot SHA --today YYYY-MM-DD";
+  const values = new Map();
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!allowed.includes(flag) || !value) throw new Error(usage);
+    values.set(flag, value);
+  }
+  if (values.size !== allowed.length) throw new Error(usage);
+  return values;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const values = argumentsFrom(process.argv.slice(2));
+    const snapshot = values.get("--snapshot");
+    let record = null;
+    try {
+      record = JSON.parse(readFileSync(values.get("--record"), "utf8"));
+    } catch {
+      record = null;
+    }
+    const failure = fallbackFailure(record, snapshot, values.get("--today"));
+    if (failure) {
+      console.error(fallbackRefusal(failure, snapshot));
+      process.exitCode = 1;
+    } else {
+      console.log(
+        `Auditing against pinned snapshot ${snapshot}, accepted until ${record.expires}: ${record.reason}`
+      );
+    }
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/tools/advisory-db-fallback.test.mjs
+++ b/tools/advisory-db-fallback.test.mjs
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { fallbackFailure, fallbackRefusal } from "./advisory-db-fallback.mjs";
+
+const SNAPSHOT = "309ad29d8fe448bf986019e05d47b9e0e29a2218";
+
+function record(overrides = {}) {
+  return {
+    format_version: 1,
+    snapshot: SNAPSHOT,
+    expires: "2026-09-18",
+    reason: "upstream shipped an unparseable advisory",
+    ...overrides
+  };
+}
+
+test("an unacknowledged fallback is refused", () => {
+  assert.match(
+    fallbackFailure(null, SNAPSHOT, "2026-09-04"),
+    /no tools\/advisory-db-fallback\.json accepts auditing against a pinned snapshot/
+  );
+});
+
+test("a dated acknowledgement of this snapshot is accepted until it expires", () => {
+  assert.equal(fallbackFailure(record(), SNAPSHOT, "2026-09-04"), null);
+  assert.equal(fallbackFailure(record(), SNAPSHOT, "2026-09-18"), null);
+  assert.match(
+    fallbackFailure(record(), SNAPSHOT, "2026-09-19"),
+    /stopped accepting this snapshot on 2026-09-18, and today is 2026-09-19/
+  );
+});
+
+test("moving the pin voids the acknowledgement of the old one", () => {
+  const moved = "0".repeat(40);
+  assert.match(
+    fallbackFailure(record(), moved, "2026-09-04"),
+    new RegExp(`accepts snapshot ${SNAPSHOT}, but this run pins ${moved}`)
+  );
+});
+
+test("an acknowledgement without a reason, a date or a snapshot is refused", () => {
+  assert.match(
+    fallbackFailure(record({ reason: "  " }), SNAPSHOT, "2026-09-04"),
+    /format_version 1 record with a reason/
+  );
+  assert.match(
+    fallbackFailure(record({ format_version: 2 }), SNAPSHOT, "2026-09-04"),
+    /format_version 1 record with a reason/
+  );
+  assert.match(
+    fallbackFailure(record({ snapshot: "309ad29d" }), SNAPSHOT, "2026-09-04"),
+    /names no advisory database snapshot/
+  );
+  assert.match(
+    fallbackFailure(record({ expires: "soon" }), SNAPSHOT, "2026-09-04"),
+    /has no expiry date/
+  );
+});
+
+test("the refusal says what the blind spot is and how to accept it", () => {
+  const message = fallbackRefusal("no record", SNAPSHOT);
+  assert.match(message, /cannot see any\nadvisory published after it/);
+  assert.match(message, /reports an audit nobody performed/);
+  assert.match(message, new RegExp(`"snapshot": "${SNAPSHOT}"`));
+  assert.match(message, /"expires": "YYYY-MM-DD"/);
+});

--- a/tools/advisory-db-fallback.test.mjs
+++ b/tools/advisory-db-fallback.test.mjs
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { fallbackFailure, fallbackRefusal } from "./advisory-db-fallback.mjs";
+import {
+  argumentsFrom,
+  fallbackFailure,
+  fallbackRefusal
+} from "./advisory-db-fallback.mjs";
 
 const SNAPSHOT = "309ad29d8fe448bf986019e05d47b9e0e29a2218";
 
@@ -54,6 +58,48 @@ test("an acknowledgement without a reason, a date or a snapshot is refused", () 
   assert.match(
     fallbackFailure(record({ expires: "soon" }), SNAPSHOT, "2026-09-04"),
     /has no expiry date/
+  );
+  // Well shaped and not a date: it sorts after every real one, so left alone it
+  // would accept the blind spot for ever.
+  assert.match(
+    fallbackFailure(record({ expires: "2026-13-45" }), SNAPSHOT, "2026-09-04"),
+    /has no expiry date/
+  );
+});
+
+test("a run that says which snapshot and which day is taken at its word", () => {
+  const values = argumentsFrom([
+    "--record",
+    "tools/advisory-db-fallback.json",
+    "--snapshot",
+    SNAPSHOT,
+    "--today",
+    "2026-09-04"
+  ]);
+  assert.equal(values.get("--snapshot"), SNAPSHOT);
+  assert.equal(values.get("--today"), "2026-09-04");
+});
+
+test("a run that cannot say which snapshot or which day is refused", () => {
+  const args = (snapshot, today) => [
+    "--record",
+    "tools/advisory-db-fallback.json",
+    "--snapshot",
+    snapshot,
+    "--today",
+    today
+  ];
+  assert.throws(
+    () => argumentsFrom(args("309ad29d", "2026-09-04")),
+    /--snapshot 309ad29d is not a 40-character advisory database commit/
+  );
+  assert.throws(
+    () => argumentsFrom(args(SNAPSHOT, "4 September 2026")),
+    /--today 4 September 2026 is not a date written YYYY-MM-DD/
+  );
+  assert.throws(
+    () => argumentsFrom(args(SNAPSHOT, "2026-13-45")),
+    /--today 2026-13-45 is not a date written YYYY-MM-DD/
   );
 });
 


### PR DESCRIPTION
When the current RustSec advisory database fails to load, `ci.yml` audits
against a snapshot pinned at `309ad29d` and exits green. That snapshot cannot
see a single advisory published after the pin, so a clean result there means
nothing except that the pin is old, and the only trace of the substitution was
a line of stderr in the middle of a passing job.

The fallback now announces itself where a run is actually read, as a workflow
warning annotation and in the job summary, both naming the exact snapshot the
audit could see. And it stops being free: unless `tools/advisory-db-fallback.json`
exists, names this snapshot, gives a reason and carries an expiry date that has
not passed, the run fails. The snapshot is read back from the checkout with
`git rev-parse`, so moving the pin voids an acceptance of the old one and the
two cannot drift apart.

The record is deliberately not in this change. A green audit should require
either a database that loads or a dated, reasoned decision to accept one that
does not.

## Demonstration

Replaying the step with a stubbed `cargo audit`, old gate against new:

    ## the database loads and finds nothing
      [old gate] step exit=0  => GREEN
      [new gate] step exit=0  => GREEN

    ## the database loads and finds a vulnerability
      [old gate] step exit=1  => RED
      [new gate] step exit=1  => RED

    ## the database is malformed, nobody has accepted the blind spot
      [old gate] Current advisory database is malformed; using the last verified snapshot.
                 Scanning Cargo.lock for vulnerabilities (pinned snapshot); 0 found
                 step exit=0  => GREEN
      [new gate] ::warning title=Advisory database fallback::The current RustSec database
                 failed to load. This run can only audit the snapshot pinned at 6cdce16e,
                 which cannot see any advisory published after it.
                 Refusing because no tools/advisory-db-fallback.json accepts auditing
                 against a pinned snapshot.
                 step exit=1  => RED

    ## the database is malformed, the blind spot is accepted and current
      [new gate] Auditing against pinned snapshot 6cdce16e, accepted until 2099-01-01:
                 upstream shipped an unparseable advisory
                 step exit=0  => GREEN

    ## the same acceptance, after its expiry date
      [new gate] Refusing because tools/advisory-db-fallback.json stopped accepting this
                 snapshot on 2020-01-01, and today is 2026-09-03.
                 step exit=1  => RED

    ## the acceptance is current but the pin has moved
      [new gate] Refusing because tools/advisory-db-fallback.json accepts snapshot
                 309ad29d..., but this run pins 6cdce16e...
                 step exit=1  => RED

The warning and job summary are written in every fallback case, whether it is
then accepted or refused.

## Tests

`node --test tools/*.test.mjs`: 34 tests, 34 pass, 0 fail (29 before this
change). `bash -n` passes on every `run:` block in the file and the YAML parses
with all four jobs.
