### PR TITLE
Fail the beta run when packaged changes have no release

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -14,12 +14,19 @@ concurrency:
 
 jobs:
   prepare:
-    if: github.ref == 'refs/heads/beta'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
       publish: ${{ steps.release.outputs.publish }}
     steps:
+      # Every job used to be gated on the branch, so dispatching this workflow
+      # anywhere else skipped all of them and reported success.
+      - name: Refuse to publish the beta channel from another branch
+        if: github.ref != 'refs/heads/beta'
+        run: |
+          echo "This workflow publishes the beta channel and only runs on refs/heads/beta." >&2
+          echo "It was started on ${GITHUB_REF}; re-run it with the beta branch selected." >&2
+          exit 1
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
@@ -46,7 +53,10 @@ jobs:
           fi
           if [ "$tag_count" -eq 1 ]; then
             release="$RUNNER_TEMP/release.json"
-            gh release view "$tag" --json tagName,isDraft,isPrerelease,assets,targetCommitish \
+            # The release is created against an existing tag, so GitHub fills
+            # targetCommitish with the default branch and it says nothing about
+            # what was published. The tag ref below is the authority.
+            gh release view "$tag" --json tagName,isDraft,isPrerelease,assets \
               > "$release"
             node - "$release" "$tag" "$VERSION" <<'NODE'
           const fs = require("fs");
@@ -142,6 +152,14 @@ jobs:
               test "$(sha256sum "$name" | cut -d' ' -f1)" = "$checksum"
             done < cobalt-host-manifest.txt
             cd "$GITHUB_WORKSPACE"
+            # The tag being an ancestor of this commit only proves beta has not
+            # rewritten history. Beta can still have moved on with packaged
+            # changes the published tag does not carry, and skipping the build
+            # then reports success while no reader receives them.
+            changed="$RUNNER_TEMP/changed-since-$tag"
+            git diff --name-only --diff-filter=ACDMRT "$tag_sha" "$GITHUB_SHA" > "$changed"
+            node tools/device-package-changes.mjs --tag "$tag" --version "$VERSION" \
+              < "$changed"
             echo "publish=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/tools/device-package-changes.mjs
+++ b/tools/device-package-changes.mjs
@@ -1,0 +1,150 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Everything whose content reaches a reader inside the device package, or that
+// decides how that package is built.
+//
+// `crates/` and `examples/` are taken whole: the packaged binaries listed in
+// kobo-cli's INSTALLED_PACKAGES are kobod and fifteen of the sixteen example
+// members, and the crates around them are the closure those are built from.
+// Being broader than the closure here costs a version bump nobody needed;
+// being narrower ships a device package no reader can get.
+//
+// `apps/` is deliberately absent. Store-only applications reach a reader
+// through the signed app catalog, which is published by its own workflow on
+// every merge, so demanding a platform release for them would turn every app
+// landing red. `installedPackagesOutsideTheGate` below is what stops that
+// exclusion from quietly becoming wrong.
+const DEVICE_PACKAGE_DIRECTORIES = ["crates", "examples", ".cargo"];
+const DEVICE_PACKAGE_FILES = ["Cargo.toml", "Cargo.lock"];
+const TOOLCHAIN_PREFIX = "rust-toolchain";
+
+export function affectsDevicePackage(path) {
+  if (typeof path !== "string") return false;
+  const normalized = path.trim().split("\\").join("/");
+  if (normalized.length === 0) return false;
+  if (DEVICE_PACKAGE_FILES.includes(normalized)) return true;
+  // rust-toolchain and rust-toolchain.toml pin the compiler the package is
+  // built with; anything else at the root sharing that name is a pin too.
+  if (!normalized.includes("/") && normalized.startsWith(TOOLCHAIN_PREFIX)) return true;
+  return DEVICE_PACKAGE_DIRECTORIES.some(
+    directory => normalized.startsWith(`${directory}/`)
+  );
+}
+
+export function devicePackageChanges(paths) {
+  return [...new Set(paths.filter(path => affectsDevicePackage(path)))].sort();
+}
+
+// kobo-cli decides what goes into the package. Read its list back rather than
+// keeping a second copy of it here.
+export function installedPackageNames(cliSource) {
+  const match = /const INSTALLED_PACKAGES[^=]*=\s*&\[([\s\S]*?)\n\];/.exec(cliSource);
+  if (!match) throw new Error("read INSTALLED_PACKAGES from crates/kobo-cli/src/main.rs");
+  // The first string of each tuple is the package; the second is a feature.
+  const names = [...match[1].matchAll(/^\s*\(\s*"([^"]+)"/gm)].map(entry => entry[1]);
+  if (names.length === 0) throw new Error("INSTALLED_PACKAGES names no packages");
+  return names;
+}
+
+export function workspaceMembers(rootManifest) {
+  const match = /^members\s*=\s*\[([\s\S]*?)^\]/m.exec(rootManifest);
+  if (!match) throw new Error("read the workspace members from Cargo.toml");
+  return [...match[1].matchAll(/"([^"]+)"/g)].map(entry => entry[1]);
+}
+
+// A packaged application added somewhere this gate does not watch would be a
+// silent hole in it, which is the whole class of bug being fixed here.
+export function installedPackagesOutsideTheGate(names, directoryOf) {
+  return names.filter(name => {
+    const directory = directoryOf(name);
+    if (!directory) {
+      throw new Error(`${name} is packaged for the device but names no workspace member`);
+    }
+    return !affectsDevicePackage(`${directory}/Cargo.toml`);
+  });
+}
+
+export function nextPatchVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) throw new Error(`invalid workspace version ${version}`);
+  return `${match[1]}.${match[2]}.${Number(match[3]) + 1}`;
+}
+
+// The run that finds these changes is the one that decided there was nothing to
+// publish, so the report has to name the single edit that makes it publish.
+export function unpublishedChangeReport(tag, version, changes) {
+  const next = nextPatchVersion(version);
+  return [
+    `${tag} is already published, but the device package is not what beta now builds.`,
+    "These paths differ between the published tag and this commit:",
+    ...changes.map(path => `  ${path}`),
+    "",
+    `No reader receives them while the workspace version stays at ${version}.`,
+    `Raise version in [workspace.package] in Cargo.toml from ${version} to ${next},`,
+    `push again, and this workflow will build and publish beta-v${next}.`
+  ].join("\n");
+}
+
+function packageDirectories(root) {
+  const directories = new Map();
+  for (const member of workspaceMembers(readFileSync(join(root, "Cargo.toml"), "utf8"))) {
+    const manifest = readFileSync(join(root, member, "Cargo.toml"), "utf8");
+    const name = /^name\s*=\s*"([^"]+)"$/m.exec(manifest)?.[1];
+    if (name) directories.set(name, member);
+  }
+  return directories;
+}
+
+function argumentsFrom(argv) {
+  const allowed = ["--tag", "--version", "--root"];
+  const usage =
+    "usage: node tools/device-package-changes.mjs --tag TAG --version VERSION [--root PATH] < changed-paths";
+  const values = new Map([["--root", "."]]);
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!allowed.includes(flag) || !value) throw new Error(usage);
+    values.set(flag, value);
+  }
+  if (!values.has("--tag") || !values.has("--version")) throw new Error(usage);
+  return values;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const values = argumentsFrom(process.argv.slice(2));
+    const tag = values.get("--tag");
+    const version = values.get("--version");
+    const root = values.get("--root");
+
+    const directories = packageDirectories(root);
+    const unwatched = installedPackagesOutsideTheGate(
+      installedPackageNames(
+        readFileSync(join(root, "crates/kobo-cli/src/main.rs"), "utf8")
+      ),
+      name => directories.get(name)
+    );
+    if (unwatched.length > 0) {
+      throw new Error(
+        `these packages go into the device package from a directory this check does not watch: ${unwatched.join(", ")}\n` +
+          "Add their directory to DEVICE_PACKAGE_DIRECTORIES in tools/device-package-changes.mjs."
+      );
+    }
+
+    const paths = readFileSync(0, "utf8").split("\n").filter(Boolean);
+    const changes = devicePackageChanges(paths);
+    if (changes.length > 0) {
+      console.error(unpublishedChangeReport(tag, version, changes));
+      process.exitCode = 1;
+    } else {
+      console.log(
+        `No device package input changed since ${tag}; ${paths.length} changed path(s) reach readers without a release.`
+      );
+    }
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/tools/device-package-changes.test.mjs
+++ b/tools/device-package-changes.test.mjs
@@ -1,0 +1,142 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  affectsDevicePackage,
+  devicePackageChanges,
+  installedPackageNames,
+  installedPackagesOutsideTheGate,
+  nextPatchVersion,
+  unpublishedChangeReport,
+  workspaceMembers
+} from "./device-package-changes.mjs";
+
+test("packaged source, manifests and toolchain pins reach readers only in a release", () => {
+  for (const path of [
+    "crates/kobod/src/main.rs",
+    "crates/kobo-protocol/src/lib.rs",
+    "examples/todo/src/main.rs",
+    "examples/launcher/Cargo.toml",
+    "Cargo.toml",
+    "Cargo.lock",
+    "rust-toolchain",
+    "rust-toolchain.toml",
+    ".cargo/config.toml"
+  ]) {
+    assert.equal(affectsDevicePackage(path), true, path);
+  }
+});
+
+// A Store-only application is published by its own workflow on the merge that
+// lands it. Demanding a platform release for it would turn every app landing
+// red, which is the failure the rest of this file exists to avoid.
+test("Store-only applications and documentation reach readers without a release", () => {
+  for (const path of [
+    "apps/backgammon/src/main.rs",
+    "apps/backgammon/Cargo.toml",
+    "apps/catalog.json",
+    "README.md",
+    "docs/index.html",
+    "docs/apps/backgammon/index.html",
+    "docs/media/site/apps/backgammon.png",
+    "docs/sitemap.xml",
+    "kobo-shot.png",
+    ".github/workflows/ci.yml",
+    "tools/check-app-versions.mjs"
+  ]) {
+    assert.equal(affectsDevicePackage(path), false, path);
+  }
+});
+
+test("directory names are matched whole", () => {
+  assert.equal(affectsDevicePackage("crates-notes.md"), false);
+  assert.equal(affectsDevicePackage("examples-old/todo/src/main.rs"), false);
+  assert.equal(affectsDevicePackage("docs/Cargo.toml"), false);
+  assert.equal(affectsDevicePackage("docs/rust-toolchain.toml"), false);
+});
+
+test("a mixed push reports only the paths that need a release", () => {
+  assert.deepEqual(
+    devicePackageChanges([
+      "docs/index.html",
+      "crates/kobo-ui/src/list.rs",
+      "apps/backgammon/src/main.rs",
+      "README.md",
+      "Cargo.lock",
+      "crates/kobo-ui/src/list.rs"
+    ]),
+    ["Cargo.lock", "crates/kobo-ui/src/list.rs"]
+  );
+  assert.deepEqual(
+    devicePackageChanges(["docs/index.html", "apps/backgammon/src/main.rs"]),
+    []
+  );
+});
+
+test("the packaged binary list is read from the packaging code, not copied", () => {
+  const names = installedPackageNames(
+    'const INSTALLED_PACKAGES: &[(&str, Option<&str>)] = &[\n    ("kobod", Some("device-write")),\n    ("kobo-launcher", None),\n];\n'
+  );
+  assert.deepEqual(names, ["kobod", "kobo-launcher"]);
+  assert.throws(
+    () => installedPackageNames("nothing here"),
+    /read INSTALLED_PACKAGES/
+  );
+});
+
+test("a packaged application outside the watched directories is named", () => {
+  const directories = new Map([
+    ["kobod", "crates/kobod"],
+    ["kobo-todo", "examples/todo"],
+    ["kobo-backgammon", "apps/backgammon"]
+  ]);
+  const directoryOf = name => directories.get(name);
+  assert.deepEqual(
+    installedPackagesOutsideTheGate(["kobod", "kobo-todo"], directoryOf),
+    []
+  );
+  assert.deepEqual(
+    installedPackagesOutsideTheGate(["kobod", "kobo-backgammon"], directoryOf),
+    ["kobo-backgammon"]
+  );
+  assert.throws(
+    () => installedPackagesOutsideTheGate(["kobo-unknown"], directoryOf),
+    /kobo-unknown is packaged for the device but names no workspace member/
+  );
+});
+
+// The exclusion of apps/ is only safe while nothing packaged lives there, and
+// this is what notices the day that changes.
+test("every package this tree ships to a device is inside the gate", () => {
+  const members = workspaceMembers(readFileSync("Cargo.toml", "utf8"));
+  const directories = new Map();
+  for (const member of members) {
+    const name = /^name\s*=\s*"([^"]+)"$/m.exec(
+      readFileSync(`${member}/Cargo.toml`, "utf8")
+    )?.[1];
+    if (name) directories.set(name, member);
+  }
+  const names = installedPackageNames(
+    readFileSync("crates/kobo-cli/src/main.rs", "utf8")
+  );
+  assert.ok(names.length > 1, "INSTALLED_PACKAGES should name several packages");
+  assert.deepEqual(
+    installedPackagesOutsideTheGate(names, name => directories.get(name)),
+    []
+  );
+});
+
+test("the report names the exact version bump that publishes the change", () => {
+  const report = unpublishedChangeReport("beta-v0.3.5", "0.3.5", ["Cargo.lock"]);
+  assert.match(report, /beta-v0\.3\.5 is already published/);
+  assert.match(report, /^ {2}Cargo\.lock$/m);
+  assert.match(report, /from 0\.3\.5 to 0\.3\.6/);
+  assert.match(report, /publish beta-v0\.3\.6/);
+});
+
+test("version arithmetic refuses anything that is not a release number", () => {
+  assert.equal(nextPatchVersion("0.3.9"), "0.3.10");
+  assert.equal(nextPatchVersion("1.0.0"), "1.0.1");
+  assert.throws(() => nextPatchVersion("0.3"), /invalid workspace version 0\.3/);
+  assert.throws(() => nextPatchVersion("0.3.5-beta"), /invalid workspace version/);
+});


### PR DESCRIPTION
`beta-release.yml` skips `device`, `host` and `publish` whenever the workspace
version already has a published tag, and the run reports success. The only
assertion it makes about that tag is `git merge-base --is-ancestor`, which
proves beta has not rewritten history and nothing else. Beta can advance with
packaged changes and the run still calls it a success.

This diffs the published tag against `GITHUB_SHA` and fails when anything the
device package is built from differs: `crates/`, `examples/`, `Cargo.toml`,
`Cargo.lock`, `rust-toolchain*`, `.cargo/`.

### What stays quiet, and why it matters

`apps/` is deliberately **not** in that set, alongside documentation, marketing
assets, the README and site content. Store-only applications reach a reader
through the signed catalog that `apps.yml` publishes on the merge that lands
them, with no platform release involved, exactly as `docs/RELEASE-TRAIN.md`
describes. Requiring a workspace version bump for them would turn every one of
the ~30 incoming app landings red.

`examples/` **is** in the set, which is the other half of the same fact.
`kobo-cli`'s `INSTALLED_PACKAGES` names sixteen packaged binaries, and fifteen
of them (`kobo-todo`, `kobo-terminal`, `kobo-launcher`, `kobo-store`, ...) live
under `examples/`, not `apps/`. A change to any of those does change
`KoboRoot.tgz`.

That split is only safe while nothing packaged lives under `apps/`, so the
check reads `INSTALLED_PACKAGES` back from `crates/kobo-cli/src/main.rs`,
resolves each name to its workspace member directory, and refuses to run at all
if one of them sits somewhere it does not watch. A unit test asserts the same
thing against this tree, so the day a packaged application moves under `apps/`
the gate says so instead of going quiet.

Two smaller false-greens in the same file:

- Dispatching this workflow on any branch other than `beta` skipped every job
  and reported success. `prepare` now fails and says which branch it needs.
- The release lookup fetched `targetCommitish` and never asserted on it.
  GitHub fills it with the default branch because the release is created
  against a tag that already exists (`beta-v0.3.3`, `0.3.4` and `0.3.5` all
  record `"main"`), so it carries no information. The tag ref beside it is the
  authority, and the dead field is gone.

## Demonstration

Replaying real beta history through the `publish=false` branch exactly as
GitHub runs a `run:` block (`bash -e`, no `pipefail`). These are the three runs
that reported `OVERALL: success` with everything skipped:

    --- [old gate] run 33805734059 (PR #100) at 079a5fa0
        step exit=0  GITHUB_OUTPUT=[publish=false ]
        => run is GREEN, device/host/publish skipped

    --- [new gate] run 33805734059 (PR #100) at 079a5fa0
        beta-v0.3.4 is already published, but the device package is not what beta now builds.
        These paths differ between the published tag and this commit:
          Cargo.lock
          Cargo.toml
          crates/kobo-cli/src/main.rs
          crates/kobo-policy/src/credentials.rs
          crates/kobo-profile/src/lib.rs
          crates/kobo-ui/src/lib.rs
          examples/chat/src/conversation.rs
        No reader receives them while the workspace version stays at 0.3.4.
        Raise version in [workspace.package] in Cargo.toml from 0.3.4 to 0.3.5,
        push again, and this workflow will build and publish beta-v0.3.5.
        step exit=1  GITHUB_OUTPUT=[]
        => run is RED at the version gate

Runs `33805786973` (#79) and `33807793988` (#101) behave identically: green
before, red after. `0.3.5` is exactly the bump the message asks for, and
exactly what shipped them in the end.

A documentation, README and marketing asset push stays quiet:

    changed: README.md
    changed: docs/index.html
    changed: docs/media/site/scratch-asset.html
    No device package input changed since beta-v0.3.5; 3 changed path(s) reach readers without a release.
    step exit=0  GITHUB_OUTPUT=[publish=false ]
    => run is GREEN

A Store-only application landing stays quiet, which is the case that would
otherwise have broken every incoming app:

    changed: apps/backgammon/src/main.rs
    changed: docs/apps/backgammon/index.html
    No device package input changed since beta-v0.3.5; 2 changed path(s) reach readers without a release.
    step exit=0  GITHUB_OUTPUT=[publish=false ]
    => run is GREEN

A packaged application goes red:

    These paths differ between the published tag and this commit:
      examples/todo/src/main.rs
    step exit=1  => RED

So does one packaged source file added to a documentation push, naming only the
file that needs the release:

    These paths differ between the published tag and this commit:
      crates/kobo-ui/src/lib.rs
    step exit=1  => RED

A commit identical to the published tag stays green with `publish=false`.

## Tests

`node --test tools/*.test.mjs`: 38 tests, 38 pass, 0 fail (29 before this
change). `bash -n` passes on every `run:` block in the file and the YAML parses
with all four jobs. Branched from current `beta`, so #103's `set -o pipefail`
in this same step is preserved.
