### PR TITLE
Film an application in the simulator instead of waiting for the reader

### DIFF
--- a/SDK.md
+++ b/SDK.md
@@ -1361,6 +1361,34 @@ A failing step reports the line, the step and the reason, and takes a
 screenshot first, because the question that immediately follows "tap Search
 failed" is "what was on the screen".
 
+**`--record` films the run instead of photographing it.**
+
+```sh
+cargo run -p kobo-cli -- drive --script drive.kobo --record target/demo --fps 4
+```
+
+The panel is sampled on its own clock while the script drives, so the
+recording catches the screens a run passes through as well as the ones it stops
+on: the list that was empty for half a second before the fetch came back, the
+pane drawn at the wrong size until the second layout pass. Frames identical to
+the one before them are dropped, so a script that waits two seconds between
+taps is one frame there and not eight. The directory ends up holding numbered
+greyscale PNGs, a `timings.txt`, a `recording.mp4` and a `recording.gif` --
+the same shape `kobo record --device` produces from a reader, so a demo made
+here and a demo made on hardware are the same kind of file.
+
+A recording is taken from the residue-free frame **unless you pass
+`--ghosting`**, which is the opposite default to `shot` and deliberate: a still
+with e-ink residue on it is two screens a person can read past, and a hundred
+of them played in sequence is every screen of the run at once. `--ideal` goes
+on governing the `shot` steps.
+
+ffmpeg assembles both files and is checked for before the script runs, because
+finding out it is missing after a minute of driving costs the minute.
+
+`scripts/record-apps-sim.sh` does this for every application in the catalog,
+one simulator at a time, with no reader anywhere near it.
+
 **Pass `--ideal` when you are reading the screenshots rather than the
 refreshes.** A screenshot is taken from the simulated panel, and the simulated
 panel keeps the e-ink residue of what it drew last, exactly as the device
@@ -1410,13 +1438,20 @@ once, at one point, which must be on the screen, and it always lifts: a tap
 that failed halfway would leave the digitiser reporting a finger that is not
 there.
 
-The division is deliberate. **`drive` is the simulator; `shot` and `tap` are
-the device.** Resolving a label to a coordinate needs the layout, and the
-layout lives in the process doing the rendering. On the host that is the
-simulator, which runs the identical renderer, layout engine, hit-testing and
-refresh planner. On the device it is inside the running application, and
+The division is deliberate. **`drive` is the simulator; `shot`, `tap` and
+`record` are the device.** Resolving a label to a coordinate needs the layout,
+and the layout lives in the process doing the rendering. On the host that is
+the simulator, which runs the identical renderer, layout engine, hit-testing
+and refresh planner. On the device it is inside the running application, and
 opening a control channel into it in order to test it would be testing
 something other than the shipped path.
+
+That is why filming the simulator is `drive --record` and not `record
+--address`. `record` is a framebuffer reader: it uploads the doctor, has the
+device copy `/dev/fb0` into a file at a fixed rate, and pulls that file home
+over SSH compressed. None of those three things has a counterpart on this side
+of the cable, and there is no framebuffer here to read. What there is, is a
+driver already holding a connection to the process doing the rendering.
 
 ---
 

--- a/crates/kobo-cli/src/drive.rs
+++ b/crates/kobo-cli/src/drive.rs
@@ -30,7 +30,11 @@ use std::fmt::Write as _;
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+use crate::RecordedFrame;
 
 /// How long to wait for the simulator to answer one request.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
@@ -92,6 +96,7 @@ impl Control {
 }
 
 /// A connection to a running simulator.
+#[derive(Clone)]
 pub struct Driver {
     address: String,
     shots: PathBuf,
@@ -456,6 +461,208 @@ impl Driver {
     }
 }
 
+/// How often a recording looks at the panel when nothing says otherwise.
+///
+/// Four times a second rather than the two `kobo record` takes from a reader.
+/// The device's rate is set by what it costs there: six megabytes read out of
+/// the framebuffer of a machine that is also drawing to it. Here the frame
+/// comes over loopback from a process on the same desk, so the only budget
+/// that matters is the simulator's request loop, which the driver is using at
+/// the same time. Four is fast enough to catch a screen that is only up for a
+/// moment -- a spinner, or a wrong state a screen passes through before it
+/// settles -- and slow enough to leave that loop to the taps.
+pub const DEFAULT_RECORD_FPS: u32 = 4;
+
+/// The fastest a recording may look at the panel.
+///
+/// The simulator serves one request at a time and the driver is queueing
+/// behind every one of these. Past roughly this rate a recording stops being a
+/// passenger and starts deciding how long a tap takes to settle, which would
+/// make the recording a cause of the thing it is meant to be watching.
+pub const MAXIMUM_RECORD_FPS: u32 = 20;
+
+/// How long the sampler waits before noticing it has been asked to stop.
+const STOP_POLL: Duration = Duration::from_millis(10);
+
+/// The frames of one recording, with the ones that did not move left out.
+///
+/// The same bargain `kobo record` strikes on the device, for the same reason.
+/// Every grey level is kept, because the panel is greyscale and its text is
+/// anti-aliased and a recording that flattened the greys would look harsher
+/// than the thing it recorded. What keeps it small instead is that a screen
+/// that nobody has touched is the same screen: a script that waits two seconds
+/// between taps is one frame there, not eight.
+#[derive(Default)]
+struct FrameLog {
+    frames: Vec<RecordedFrame>,
+    looked: u32,
+}
+
+impl FrameLog {
+    /// Offers one look at the panel, and says whether it was worth keeping.
+    fn sample(&mut self, millis: u32, grey: Vec<u8>) -> bool {
+        self.looked += 1;
+        if self
+            .frames
+            .last()
+            .is_some_and(|last| last.grey.as_slice() == grey.as_slice())
+        {
+            return false;
+        }
+        self.frames.push(RecordedFrame { millis, grey });
+        true
+    }
+}
+
+/// Films the simulated panel while something else drives it.
+///
+/// The moving-picture half of [`Driver::shot`], and deliberately a separate
+/// thing from the driver rather than a step in the script. A recording made of
+/// the steps would only ever show the screens the script stops on, and the
+/// frames worth having are usually the ones between them: the list that was
+/// empty for half a second before the fetch came back, the pane that was drawn
+/// at the wrong size until the second layout pass. So this watches on its own
+/// clock and the script never knows it is there.
+///
+/// # Ghosting
+///
+/// A recording is taken from the residue-free frame unless it is asked for the
+/// other one. This is the opposite default to [`Driver::shot`], and on
+/// purpose. A still with e-ink residue on it is a still of two screens, which
+/// a person can still read past; a hundred of them played in sequence is every
+/// screen the run ever showed, all at once, and there is nothing to read past.
+/// Ask for `ghosting` when the recording is *of* the refreshes.
+pub struct Recorder {
+    /// A second connection to the same simulator, used only for frames.
+    sampler: Driver,
+    started: Instant,
+    log: Arc<Mutex<FrameLog>>,
+    stop: Arc<AtomicBool>,
+    /// Why the sampler gave up, if it did.
+    failure: Arc<Mutex<Option<String>>>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Recorder {
+    /// Starts filming, and takes the opening frame before it returns.
+    ///
+    /// The first frame is taken here rather than on the sampler thread so that
+    /// a simulator which is not running is a message now, with the line about
+    /// how to start one, rather than a script that runs to the end and then
+    /// reports that it recorded nothing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the rate is one the simulator cannot serve, or
+    /// when the first frame cannot be had.
+    pub fn start(address: &str, fps: u32, ghosting: bool) -> Result<Self, String> {
+        if fps == 0 || fps > MAXIMUM_RECORD_FPS {
+            return Err(format!(
+                "--fps takes a rate between 1 and {MAXIMUM_RECORD_FPS}, not {fps}"
+            ));
+        }
+        let sampler = Driver::new(address, Path::new(".")).ideal(!ghosting);
+        let mut opening = FrameLog::default();
+        opening.sample(0, sampler.frame()?);
+
+        let interval = Duration::from_micros(1_000_000 / u64::from(fps));
+        let started = Instant::now();
+        let log = Arc::new(Mutex::new(opening));
+        let stop = Arc::new(AtomicBool::new(false));
+        let failure = Arc::new(Mutex::new(None));
+        let worker = {
+            let sampler = sampler.clone();
+            let log = Arc::clone(&log);
+            let stop = Arc::clone(&stop);
+            let failure = Arc::clone(&failure);
+            std::thread::spawn(move || {
+                while !stop.load(Ordering::Relaxed) {
+                    let looked_at = Instant::now();
+                    match sampler.frame() {
+                        Ok(grey) => {
+                            let millis =
+                                u32::try_from(started.elapsed().as_millis()).unwrap_or(u32::MAX);
+                            lock(&log).sample(millis, grey);
+                        }
+                        Err(error) => {
+                            *lock(&failure) = Some(error);
+                            return;
+                        }
+                    }
+                    // Measured from the start of the read, exactly as the
+                    // device does it, so a slow frame shortens the wait rather
+                    // than adding to it and the recording keeps the rate it
+                    // was asked for. Slept in slices, so stopping does not
+                    // have to wait out an interval that is already over.
+                    while looked_at.elapsed() < interval && !stop.load(Ordering::Relaxed) {
+                        std::thread::sleep(
+                            STOP_POLL.min(interval.saturating_sub(looked_at.elapsed())),
+                        );
+                    }
+                }
+            })
+        };
+        Ok(Self {
+            sampler,
+            started,
+            log,
+            stop,
+            failure,
+            worker: Some(worker),
+        })
+    }
+
+    /// Stops filming and hands back the panel, its size, and every frame kept.
+    ///
+    /// The closing frame is taken here, after the sampler has stopped. Without
+    /// it a script whose last step is a tap ends the recording on the screen
+    /// before that tap about half the time, which reads as the last thing the
+    /// script did having done nothing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the sampler failed before it had a single frame.
+    /// A sampler that failed part way through has still recorded whatever it
+    /// saw up to then, which is the half of the run worth looking at, so that
+    /// is reported and kept rather than thrown away.
+    pub fn finish(mut self) -> Result<(u32, u32, Vec<RecordedFrame>), String> {
+        self.stop.store(true, Ordering::Relaxed);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+        let closing = self.sampler.frame();
+        let mut log = lock(&self.log);
+        match closing {
+            Ok(grey) => {
+                let millis = u32::try_from(self.started.elapsed().as_millis()).unwrap_or(u32::MAX);
+                log.sample(millis, grey);
+            }
+            Err(error) => *lock(&self.failure) = Some(error),
+        }
+        if let Some(error) = lock(&self.failure).take() {
+            if log.frames.is_empty() {
+                return Err(error);
+            }
+            eprintln!("warning: the recording stopped early: {error}");
+        }
+        println!(
+            "recording: kept {} of {} frames",
+            log.frames.len(),
+            log.looked
+        );
+        Ok((FRAME_WIDTH, FRAME_HEIGHT, std::mem::take(&mut log.frames)))
+    }
+}
+
+/// A poisoned lock here means the sampler thread panicked mid-frame, which
+/// loses that frame and nothing else; the frames already taken are still
+/// frames, and refusing to hand them back would be the larger loss.
+fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 /// Pulls the picture out of a device transcript.
 ///
 /// The doctor prints its whole read-only report and then the panel, so this
@@ -745,8 +952,10 @@ fn parse_point(text: &str) -> Result<(i32, i32), String> {
 mod tests {
     use super::{
         base64_decode, decode_capture, json_array, json_field, json_number, json_objects,
-        json_point, split_response,
+        json_point, split_response, Driver, FrameLog, Recorder, FRAME_HEIGHT, FRAME_WIDTH,
+        MAXIMUM_RECORD_FPS,
     };
+    use std::path::Path;
 
     const BODY: &str = r#"{"nodes":[{"kind":"Button","x":10,"y":20,"width":30,"height":40,"centre":{"x":25,"y":40},"action":77,"lines":["Search","for a \"book\""]},{"kind":"Divider","x":0,"y":1,"width":2,"height":3,"centre":{"x":1,"y":2},"action":null,"lines":[]}]}"#;
 
@@ -843,5 +1052,93 @@ mod tests {
     #[test]
     fn a_report_with_no_capture_says_so_rather_than_producing_an_empty_screen() {
         assert!(decode_capture("Kobo doctor 0.1.0\n").is_err());
+    }
+
+    /// A script that waits two seconds between taps is a screen nobody
+    /// touched, and a recording that kept eight copies of it would be eight
+    /// megabytes of the same picture.
+    #[test]
+    fn a_screen_that_did_not_move_is_recorded_once() {
+        let mut log = FrameLog::default();
+        assert!(log.sample(0, vec![0xff; 4]));
+        assert!(!log.sample(250, vec![0xff; 4]));
+        assert!(!log.sample(500, vec![0xff; 4]));
+        assert!(log.sample(750, vec![0x40; 4]));
+        assert_eq!(log.looked, 4);
+        assert_eq!(log.frames.len(), 2);
+        assert_eq!(
+            log.frames[1].millis, 750,
+            "a kept frame is stamped when it appeared"
+        );
+    }
+
+    /// Only the frame before is compared, not every frame so far. A screen
+    /// that goes away and comes back -- opening a pane and closing it, which
+    /// is most of what these scripts do -- is a new thing to see each time,
+    /// and a recording that dropped the return would cut the tap that made it.
+    #[test]
+    fn a_screen_that_comes_back_is_recorded_again() {
+        let mut log = FrameLog::default();
+        log.sample(0, vec![0xff; 4]);
+        log.sample(100, vec![0x40; 4]);
+        assert!(log.sample(200, vec![0xff; 4]));
+        assert_eq!(log.frames.len(), 3);
+    }
+
+    /// The simulator serves one request at a time and the driver is queueing
+    /// behind every frame this asks for. A rate it cannot serve is refused
+    /// here, before a script has been run against it, rather than quietly
+    /// becoming the reason a tap took a second to settle.
+    #[test]
+    fn a_rate_the_simulator_cannot_serve_is_refused_before_anything_is_driven() {
+        for fps in [0, MAXIMUM_RECORD_FPS + 1, 1000] {
+            let error = Recorder::start("127.0.0.1:1", fps, false)
+                .err()
+                .expect("a rate outside the range is refused");
+            assert!(error.contains("--fps"), "{error}");
+        }
+    }
+
+    /// Films a simulator that is really running, which is the whole claim.
+    ///
+    /// The failure this guards against is a recording that is technically a
+    /// file: the right number of frames, the right length, and every pixel the
+    /// same shade of nothing. That is what an off-by-one in the frame size, a
+    /// panel read before the first paint, or a sampler pointed at the wrong
+    /// endpoint all look like, and none of them fails a test that only counts
+    /// frames. So this asserts the panel is the size the panel is, and that
+    /// there is more than one grey on it.
+    #[test]
+    fn a_recording_of_a_running_simulator_is_a_full_panel_with_something_drawn_on_it() {
+        let mut server = kobo_sim::Server::bind_address("127.0.0.1:0").expect("bind simulator");
+        let address = server.local_addr().expect("simulator address").to_string();
+        std::thread::spawn(move || server.serve());
+
+        let recorder = Recorder::start(&address, 10, false).expect("start recording");
+        // Something for it to film: the built-in simulator's button increments
+        // a counter and redraws, so the panel really does change under it.
+        let mut driver = Driver::new(&address, Path::new("."));
+        driver.step("tap Increment").expect("tap the counter");
+        driver.step("wait 250").expect("wait");
+        let (width, height, frames) = recorder.finish().expect("finish recording");
+
+        assert_eq!((width, height), (FRAME_WIDTH, FRAME_HEIGHT));
+        assert!(!frames.is_empty(), "nothing was filmed");
+        for frame in &frames {
+            assert_eq!(
+                frame.grey.len(),
+                (FRAME_WIDTH as usize) * (FRAME_HEIGHT as usize),
+                "a frame is not the size of the panel"
+            );
+            let first = frame.grey[0];
+            assert!(
+                frame.grey.iter().any(|grey| *grey != first),
+                "the frame is one flat shade, so nothing was drawn on it"
+            );
+        }
+        assert!(
+            frames.len() >= 2,
+            "the counter was tapped and the recording never noticed"
+        );
     }
 }

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -4747,12 +4747,24 @@ where
 }
 
 /// Drives a running simulator from a script, and brings the panel back as PNG.
+///
+/// With `--record` it also brings it back as a moving picture. That lives here
+/// rather than in `kobo record` because the division between the two is
+/// deliberate and documented: `drive` is the simulator and `record` is the
+/// device. `record` is a framebuffer reader -- it uploads the doctor, has the
+/// device write `/dev/fb0` into a file, and pulls that file home over SSH --
+/// and there is no framebuffer on this side to point it at. What there is, is
+/// a driver already holding a connection to the process doing the rendering,
+/// which is the only thing that knows when a screen has changed.
 fn drive_command(arguments: &[String]) -> Result<(), String> {
     let mut address = "127.0.0.1:8787".to_owned();
     let mut shots = PathBuf::from("target/kobo-shots");
     let mut script: Option<String> = None;
     let mut steps: Vec<String> = Vec::new();
     let mut ideal = false;
+    let mut record: Option<PathBuf> = None;
+    let mut fps = drive::DEFAULT_RECORD_FPS;
+    let mut ghosting = false;
     let mut index = 0;
     while index < arguments.len() {
         match arguments[index].as_str() {
@@ -4785,6 +4797,21 @@ fn drive_command(arguments: &[String]) -> Result<(), String> {
                 index += 1;
             }
             "--ideal" => ideal = true,
+            "--record" => {
+                record = Some(PathBuf::from(
+                    arguments.get(index + 1).ok_or("--record needs a folder")?,
+                ));
+                index += 1;
+            }
+            "--fps" => {
+                fps = arguments
+                    .get(index + 1)
+                    .ok_or("--fps needs a rate")?
+                    .parse()
+                    .map_err(|_| "--fps takes a whole number".to_owned())?;
+                index += 1;
+            }
+            "--ghosting" => ghosting = true,
             other => return Err(format!("unknown option '{other}'\n{DRIVE_USAGE}")),
         }
         index += 1;
@@ -4792,11 +4819,35 @@ fn drive_command(arguments: &[String]) -> Result<(), String> {
     if script.is_none() && steps.is_empty() {
         return Err(DRIVE_USAGE.to_owned());
     }
-    let mut driver = drive::Driver::new(&address, &shots).ideal(ideal);
-    if let Some(script) = script {
-        driver.run_script(&script)?;
+    // Before the simulator is touched, because the frames are only half of
+    // what `--record` was asked for and finding out at the end costs the whole
+    // run. `kobo record --device` is deliberately softer about this: there the
+    // numbered PNGs are the product and the video is a bonus.
+    if record.is_some() && !ffmpeg_is_available() {
+        return Err(FFMPEG_MISSING.to_owned());
     }
-    driver.run_script(&steps.join("\n"))?;
+    let recorder = record
+        .as_ref()
+        .map(|_| drive::Recorder::start(&address, fps, ghosting))
+        .transpose()?;
+
+    let mut driver = drive::Driver::new(&address, &shots).ideal(ideal);
+    let outcome = script
+        .map_or(Ok(()), |script| driver.run_script(&script))
+        .and_then(|()| driver.run_script(&steps.join("\n")));
+
+    // Written even when a step failed. A recording of the run that went wrong
+    // is the recording worth having, and throwing it away to report the
+    // failure a second later would be the wrong way round.
+    if let (Some(recorder), Some(directory)) = (recorder, record.as_ref()) {
+        match recorder.finish() {
+            Ok(recording) => write_recording(directory, &recording)?,
+            Err(error) if outcome.is_ok() => return Err(error),
+            Err(error) => eprintln!("warning: nothing was recorded: {error}"),
+        }
+    }
+    outcome?;
+
     println!(
         "drive: every step passed; screenshots in {}",
         shots.display()
@@ -5119,25 +5170,32 @@ fn write_recording(
     Ok(())
 }
 
-/// Turns the frames into an mp4, if ffmpeg is available.
+/// Whether ffmpeg can be run at all.
 ///
-/// The frames are not evenly spaced, because only the ones that changed were
-/// kept, so a concat list carrying each frame's real duration is used rather
-/// than a fixed rate. Otherwise a screen held for ten seconds would flash past
-/// in the same time as one held for a tenth of a second.
-fn write_recording_video(
-    directory: &Path,
-    frames: &[RecordedFrame],
-) -> Result<Option<PathBuf>, String> {
-    if std::process::Command::new("ffmpeg")
+/// Asked before a run rather than after it wherever the moving picture is the
+/// point of the run. Discovering that ffmpeg is missing at the end of a script
+/// that took a minute to drive is a minute nobody gets back.
+fn ffmpeg_is_available() -> bool {
+    std::process::Command::new("ffmpeg")
         .arg("-version")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()
-        .is_err()
-    {
-        return Ok(None);
-    }
+        .is_ok()
+}
+
+/// What to say when it is not there.
+const FFMPEG_MISSING: &str = "ffmpeg is not on the path, and a recording is assembled with it.\n\
+                              install it with: brew install ffmpeg (macOS) \
+                              or apt install ffmpeg (Debian)";
+
+/// The concat list ffmpeg is fed, holding each frame and how long it was up.
+///
+/// The frames are not evenly spaced, because only the ones that changed were
+/// kept, so a list carrying each frame's real duration is used rather than a
+/// fixed rate. Otherwise a screen held for ten seconds would flash past in the
+/// same time as one held for a tenth of a second.
+fn concat_list(frames: &[RecordedFrame]) -> String {
     let mut list = String::new();
     for (index, frame) in frames.iter().enumerate() {
         let next = frames
@@ -5151,42 +5209,88 @@ fn write_recording_video(
     if let Some(index) = frames.len().checked_sub(1) {
         let _ = writeln!(list, "file 'frame-{index:04}.png'");
     }
+    list
+}
+
+/// Turns the frames into an mp4 and a looping GIF, if ffmpeg is available.
+///
+/// Two files because they are read in two places. The mp4 is what you scrub
+/// through when you are looking for the frame where it went wrong. The GIF is
+/// what goes in a README: a repository path in an `<img>` renders everywhere
+/// and a `<video>` element does not, and a demo that waits to be clicked is a
+/// demo nobody sees.
+fn write_recording_video(
+    directory: &Path,
+    frames: &[RecordedFrame],
+) -> Result<Option<PathBuf>, String> {
+    if !ffmpeg_is_available() {
+        return Ok(None);
+    }
     let list_path = directory.join("frames.txt");
-    fs::write(&list_path, list)
+    fs::write(&list_path, concat_list(frames))
         .map_err(|error| format!("write {}: {error}", list_path.display()))?;
     let video = directory.join("recording.mp4");
-    let status = std::process::Command::new("ffmpeg")
-        .args(["-y", "-f", "concat", "-safe", "0", "-i"])
-        .arg(&list_path)
-        // Even dimensions, because h264 refuses odd ones and 1072x1448 is only
-        // even by luck.
-        .args([
-            "-vf",
-            "pad=ceil(iw/2)*2:ceil(ih/2)*2",
-            "-pix_fmt",
-            "yuv420p",
-            "-r",
-            "10",
-        ])
-        .arg(&video)
+    run_ffmpeg(
+        std::process::Command::new("ffmpeg")
+            .args(["-nostdin", "-y", "-loglevel", "error"])
+            .args(["-f", "concat", "-safe", "0", "-i"])
+            .arg(&list_path)
+            // Even dimensions, because h264 refuses odd ones and 1072x1448 is
+            // only even by luck.
+            .args([
+                "-vf",
+                "pad=ceil(iw/2)*2:ceil(ih/2)*2",
+                "-pix_fmt",
+                "yuv420p",
+                "-r",
+                "10",
+            ])
+            .arg(&video),
+    )?;
+    // Built from the mp4 rather than from the frames again, the same way
+    // `cut-tour.py` builds the one on the front page, so the two are the same
+    // picture at the same width with the same palette.
+    let loop_path = directory.join("recording.gif");
+    run_ffmpeg(
+        std::process::Command::new("ffmpeg")
+            .args(["-nostdin", "-y", "-loglevel", "error", "-i"])
+            .arg(&video)
+            .args([
+                "-vf",
+                "scale=600:-1:flags=lanczos,fps=12,split[a][b];\
+                 [a]palettegen=max_colors=64[p];\
+                 [b][p]paletteuse=dither=bayer:bayer_scale=3",
+            ])
+            .arg(&loop_path),
+    )?;
+    println!("loop {}", loop_path.display());
+    Ok(Some(video))
+}
+
+fn run_ffmpeg(command: &mut std::process::Command) -> Result<(), String> {
+    let status = command
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
         .status()
         .map_err(|error| format!("run ffmpeg: {error}"))?;
     if !status.success() {
         return Err("ffmpeg refused the frames".to_owned());
     }
-    Ok(Some(video))
+    Ok(())
 }
 
 const SHOT_USAGE: &str =
     "usage: kobo shot [--device HOST | --address host:port] [--out PATH] [--ideal]";
 
-const DRIVE_USAGE: &str = "usage: kobo drive [--address host:port] [--shots DIR] [--ideal] \
-                           (--script PATH | --step 'tap Search' ...)\n\
+const DRIVE_USAGE: &str = "usage: kobo drive [--address host:port] [--shots DIR] [--ideal]\n\
+                           \u{20}                 [--record DIR [--fps N] [--ghosting]]\n\
+                           \u{20}                 (--script PATH | --step 'tap Search' ...)\n\
                            steps: tap LABEL | tap-at X,Y | type TEXT | shot NAME | expect TEXT\n\
                            \u{20}       expect-missing TEXT | wait-for TEXT | clean | dump\n\
-                           \u{20}       lifecycle foreground|background | scenario NAME | wait MS";
+                           \u{20}       lifecycle foreground|background | scenario NAME | wait MS\n\
+                           --record films the panel while the script runs and writes numbered\n\
+                           \u{20} PNGs, timings.txt, recording.mp4 and recording.gif into DIR.\n\
+                           \u{20} Frames are residue-free unless --ghosting asks for the real\n\
+                           \u{20} e-ink refresh; --ideal governs the `shot` steps as before.";
 
 /// Where the runtime reads named secrets from, mirrored from `kobod`.
 const DEVICE_SECRETS_DIRECTORY: &str = "/mnt/onboard/.adds/cobalt/secrets";
@@ -5778,6 +5882,7 @@ fn print_help() {
            new <name>             Create a Rust application\n\
            dev [--builtin] [address]  Run this SDK app in the browser simulator\n\
            drive --script PATH    Drive a running simulator and save PNG screenshots\n\
+           drive --script PATH --record DIR  ... and film it, no hardware needed\n\
            shot [--device HOST]   Save a PNG of the panel (device or simulator)\n\
            record --device IP [--seconds N] [--fps F] [--out DIR]  Film the panel, read-only\n\
            present <app> --device IP [--seconds N]  Run one app on the panel\n\
@@ -6114,6 +6219,38 @@ mod tests {
     fn something_that_is_not_a_recording_is_refused() {
         assert!(super::decode_recording(b"not a recording at all").is_err());
         assert!(super::decode_recording(&recording(2, 3, &[])).is_err());
+    }
+
+    /// The frames are not evenly spaced, because only the ones that moved were
+    /// kept. Handing them to ffmpeg at a fixed rate would play a screen that
+    /// was up for ten seconds in the same time as one that was up for a tenth
+    /// of one, which is a recording of a run that never happened.
+    #[test]
+    fn each_frame_is_played_for_as_long_as_it_was_really_on_the_panel() {
+        let raw = recording(2, 3, &[(0, 0xff), (2_000, 0x40), (2_150, 0x10)]);
+        let (_, _, frames) = super::decode_recording(&raw).expect("decode");
+        assert_eq!(
+            super::concat_list(&frames),
+            "file 'frame-0000.png'\nduration 2.000\n\
+             file 'frame-0001.png'\nduration 0.150\n\
+             file 'frame-0002.png'\nduration 1.000\n\
+             file 'frame-0002.png'\n",
+            "the last frame is named twice because concat ignores the last duration"
+        );
+    }
+
+    /// A frame that was replaced within a tenth of a second is still a frame
+    /// somebody has to be able to see. Played for its real duration it is one
+    /// or two hundredths of a second, which at any sane frame rate is a frame
+    /// the encoder drops entirely.
+    #[test]
+    fn a_screen_that_barely_appeared_is_still_held_long_enough_to_see() {
+        let raw = recording(2, 3, &[(0, 0xff), (20, 0x40)]);
+        let (_, _, frames) = super::decode_recording(&raw).expect("decode");
+        assert!(
+            super::concat_list(&frames).contains("duration 0.100"),
+            "a frame was given less time than the encoder will keep"
+        );
     }
 
     use super::package;

--- a/crates/kobo-cli/src/main.rs
+++ b/crates/kobo-cli/src/main.rs
@@ -5181,7 +5181,7 @@ fn ffmpeg_is_available() -> bool {
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()
-        .is_ok()
+        .is_ok_and(|status| status.success())
 }
 
 /// What to say when it is not there.
@@ -5230,52 +5230,59 @@ fn write_recording_video(
     fs::write(&list_path, concat_list(frames))
         .map_err(|error| format!("write {}: {error}", list_path.display()))?;
     let video = directory.join("recording.mp4");
-    run_ffmpeg(
-        std::process::Command::new("ffmpeg")
-            .args(["-nostdin", "-y", "-loglevel", "error"])
-            .args(["-f", "concat", "-safe", "0", "-i"])
-            .arg(&list_path)
-            // Even dimensions, because h264 refuses odd ones and 1072x1448 is
-            // only even by luck.
-            .args([
-                "-vf",
-                "pad=ceil(iw/2)*2:ceil(ih/2)*2",
-                "-pix_fmt",
-                "yuv420p",
-                "-r",
-                "10",
-            ])
-            .arg(&video),
-    )?;
+    let mut encode = std::process::Command::new("ffmpeg");
+    encode
+        .args(["-nostdin", "-y", "-loglevel", "error"])
+        .args(["-f", "concat", "-safe", "0", "-i"])
+        .arg(&list_path)
+        // Even dimensions, because h264 refuses odd ones and 1072x1448 is
+        // only even by luck.
+        .args([
+            "-vf",
+            "pad=ceil(iw/2)*2:ceil(ih/2)*2",
+            "-pix_fmt",
+            "yuv420p",
+            "-r",
+            "10",
+        ])
+        .arg(&video);
+    run_ffmpeg(encode)?;
     // Built from the mp4 rather than from the frames again, the same way
     // `cut-tour.py` builds the one on the front page, so the two are the same
     // picture at the same width with the same palette.
     let loop_path = directory.join("recording.gif");
-    run_ffmpeg(
-        std::process::Command::new("ffmpeg")
-            .args(["-nostdin", "-y", "-loglevel", "error", "-i"])
-            .arg(&video)
-            .args([
-                "-vf",
-                "scale=600:-1:flags=lanczos,fps=12,split[a][b];\
-                 [a]palettegen=max_colors=64[p];\
-                 [b][p]paletteuse=dither=bayer:bayer_scale=3",
-            ])
-            .arg(&loop_path),
-    )?;
+    let mut looping = std::process::Command::new("ffmpeg");
+    looping
+        .args(["-nostdin", "-y", "-loglevel", "error", "-i"])
+        .arg(&video)
+        .args([
+            "-vf",
+            "scale=600:-1:flags=lanczos,fps=12,split[a][b];\
+             [a]palettegen=max_colors=64[p];\
+             [b][p]paletteuse=dither=bayer:bayer_scale=3",
+        ])
+        .arg(&loop_path);
+    run_ffmpeg(looping)?;
     println!("loop {}", loop_path.display());
     Ok(Some(video))
 }
 
-fn run_ffmpeg(command: &mut std::process::Command) -> Result<(), String> {
-    let status = command
+fn run_ffmpeg(command: std::process::Command) -> Result<(), String> {
+    let mut command = command;
+    let output = command
         .stdout(std::process::Stdio::null())
-        .status()
+        .stderr(std::process::Stdio::piped())
+        .output()
         .map_err(|error| format!("run ffmpeg: {error}"))?;
-    if !status.success() {
-        return Err("ffmpeg refused the frames".to_owned());
+    if output.status.success() {
+        return Ok(());
     }
-    Ok(())
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    if stderr.is_empty() {
+        Err("ffmpeg refused the frames".to_owned())
+    } else {
+        Err(format!("ffmpeg refused the frames: {stderr}"))
+    }
 }
 
 const SHOT_USAGE: &str =

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -75,15 +75,53 @@ touch node, so the digitiser, the transform, the multitouch decoder and the
 hit-testing all run as they do under a finger; it is behind `device-write` and
 an unlock phrase, and it always lifts.
 
-To record the panel rather than photograph it once:
+To record the simulator rather than photograph it one screen at a time:
+
+```sh
+cargo run -p kobo-cli -- drive --script drive.txt --record target/demo --fps 4
+```
+
+`--record` films the panel on its own clock while the script drives it, so it
+catches the screens a script passes through as well as the ones it stops on. It
+writes numbered greyscale PNGs, a `timings.txt`, a `recording.mp4` and a
+`recording.gif` into the directory, which is the same shape `record --device`
+produces. Frames identical to the one before them are dropped, so a script that
+waits two seconds between taps is one frame there rather than eight.
+
+**A recording is residue-free unless you ask for the residue.** This is the
+opposite default to `shot`, and deliberate: a still with e-ink ghosting on it is
+two screens a person can read past, while a hundred of them played in sequence
+is every screen of the run at once. Pass `--ghosting` when the refreshes are
+what you are recording. `--ideal` still governs the `shot` steps.
+
+ffmpeg is required and is checked for before the script runs, because
+discovering it is missing at the end of a run costs the run.
+
+`scripts/record-apps-sim.sh` does that for every application in
+`apps/catalog.json`, one simulator at a time, into a dated directory under
+`target/sim-recordings/`. It needs no reader:
+
+```sh
+scripts/record-apps-sim.sh                       # every catalog application
+scripts/record-apps-sim.sh --apps "todo gallery" # or a few
+scripts/record-apps-sim.sh --list                # what it would record, and how
+```
+
+An application is driven by its committed `drive.kobo` or `drive.txt`; one with
+neither is recorded on its opening screen and named at the end, because a route
+through an application is something only its author can write.
+
+To record the real panel rather than the simulated one:
 
 ```sh
 cargo run -p kobo-cli -- record --device <address> --seconds 24 --out target/run
 ```
 
 `record --device` is read-only in the same way `shot --device` is. It writes
-numbered greyscale PNGs and a `timings.txt`, plus an `recording.mp4` when
-ffmpeg is on the path. Every grey level is kept: the panel is greyscale and its
+numbered greyscale PNGs and a `timings.txt`, plus a `recording.mp4` and a
+`recording.gif` when ffmpeg is on the path -- there the pictures are the
+product and the video is a bonus, so a missing ffmpeg is a note rather than a
+refusal. Every grey level is kept: the panel is greyscale and its
 text is anti-aliased, so a recording that flattened the greys would look
 harsher than the device and would read as a rendering bug that is not there.
 What keeps it small is that e-ink barely moves, so identical frames are dropped

--- a/examples/gallery/drive.txt
+++ b/examples/gallery/drive.txt
@@ -1,0 +1,27 @@
+# Every page of the component gallery, and a tab inside three of them. This is
+# the route a rendering change is diffed along, so it is deliberately wide
+# rather than deep: one screen from each family, not every screen of one.
+wait-for Type and tone
+wait 900
+tap Quotes
+wait 900
+tap Lists
+wait-for Lists, rows and tiles
+wait 900
+tap Tiles
+wait 900
+tap Covers
+wait 900
+tap Input
+wait-for Groups, fields and asking
+wait 900
+tap Fields
+wait 900
+tap States
+wait-for Nothing here yet
+wait 900
+tap Offline
+wait 900
+tap Work
+wait-for Work in flight
+wait 1500

--- a/examples/launcher/drive.txt
+++ b/examples/launcher/drive.txt
@@ -1,0 +1,11 @@
+# Both pages of tiles and the way between them. No tile is opened: the launcher
+# hands the panel to another application to do that, and there is no other
+# application in this simulator to hand it to.
+wait-for Cobalt 1 of 2
+wait 1200
+tap More apps
+wait-for Cobalt 2 of 2
+wait 1400
+tap Previous
+wait-for Cobalt 1 of 2
+wait 1400

--- a/examples/tictactoe/drive.txt
+++ b/examples/tictactoe/drive.txt
@@ -1,0 +1,20 @@
+# A whole game, played to a win, on a board whose cells have no words in them.
+# The points are the centres the layout reports for a 1072x1448 panel: columns
+# at 206, 536 and 866, rows at 367, 697 and 1027.
+wait-for O to play
+wait 900
+tap-at 206,367
+wait-for X to play
+wait 700
+tap-at 536,367
+wait-for O to play
+wait 700
+tap-at 536,697
+wait-for X to play
+wait 700
+tap-at 866,367
+wait-for O to play
+wait 700
+tap-at 866,1027
+wait-for O wins
+wait 1800

--- a/examples/todo/drive.txt
+++ b/examples/todo/drive.txt
@@ -1,0 +1,19 @@
+# Writing something down, and crossing it off.
+#
+# The list is not assumed to be empty. The simulator keeps an application's
+# store in the host's temporary directory, so a second run of this starts on
+# whatever the first run left behind, and a script that opened with
+# `expect Nothing to do` passed once and then never again.
+wait-for Todo
+wait 900
+tap Add
+wait-for New item
+wait 700
+type buy milk
+wait 700
+tap Add
+wait-for buy milk
+wait 1300
+tap buy milk
+wait-for Tap to reopen
+wait 1600

--- a/scripts/record-apps-sim.sh
+++ b/scripts/record-apps-sim.sh
@@ -1,0 +1,247 @@
+#!/bin/sh
+#
+# Records every application in the simulator, with no reader involved.
+#
+# The companion to `record-apps.sh`, which does the same thing on real glass.
+# That one needs a reader that is awake, on the network, and not being used by
+# anybody else, and it takes six minutes to find out that it was none of those.
+# This one needs a laptop. Every frame comes from the same renderer, the same
+# layout engine, the same hit-testing and the same refresh planner the device
+# runs, so the recordings are of the real thing; what is missing is the panel,
+# the radio and the reader's own software.
+#
+# That trade is the whole point. A demo for a new application can be made on
+# the day the application is written, by whoever wrote it, rather than queued
+# behind the one reader on the desk.
+#
+# Each application is started in its own simulator, driven by its committed
+# drive script, and filmed. An application with no drive script is recorded on
+# its opening screen and reported, because a route through an application is
+# something only that application's author can write.
+#
+# Nothing committed is written. Recordings go to a dated directory under
+# `target/sim-recordings/`, and an --out that names a directory holding
+# committed files is refused unless --overwrite says otherwise.
+#
+# --fresh gives every application a store of its own, so a run starts from the
+# state the application ships with rather than from whatever the last run left
+# behind. The simulator keeps an application's store in the host's temporary
+# directory, which means a second run of a drive script resumes a saved game,
+# opens a list that already has things on it, and fails an `expect` that passed
+# the first time. The cost is that credentials installed with `kobo secret`
+# live in the ordinary temporary directory and are not visible from the new
+# one, so an application that needs an API key should be recorded without it.
+#
+# usage: scripts/record-apps-sim.sh [--out DIR] [--apps "todo gallery"]
+#                                   [--fps N] [--ghosting] [--overwrite]
+#                                   [--address host:port] [--fresh] [--list]
+
+set -eu
+
+OUT=""
+APPS=""
+FPS=4
+GHOSTING=""
+OVERWRITE=""
+ADDRESS="127.0.0.1:8787"
+FRESH=""
+LIST=""
+
+# How long an application is given to compile and reach its first screen. A
+# cold workspace is minutes, not seconds, and a timeout that assumed otherwise
+# would report every application as broken on the one run that matters.
+START_TIMEOUT=300
+
+usage() {
+    sed -n '2,39p' "$0" | sed 's/^# \{0,1\}//'
+    exit 2
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --out) OUT="${2:?--out needs a directory}"; shift 2 ;;
+        --apps) APPS="${2:?--apps needs a list}"; shift 2 ;;
+        --fps) FPS="${2:?--fps needs a rate}"; shift 2 ;;
+        --address) ADDRESS="${2:?--address needs host:port}"; shift 2 ;;
+        --ghosting) GHOSTING="--ghosting"; shift ;;
+        --overwrite) OVERWRITE=yes; shift ;;
+        --fresh) FRESH=yes; shift ;;
+        --list) LIST=yes; shift ;;
+        -h|--help) usage ;;
+        *) echo "unknown option '$1'" >&2; usage ;;
+    esac
+done
+
+cd "$(dirname "$0")/.."
+
+command -v ffmpeg >/dev/null 2>&1 || {
+    echo "ffmpeg is not on the path, and a recording is assembled with it." >&2
+    echo "install it with: brew install ffmpeg (macOS) or apt install ffmpeg (Debian)" >&2
+    exit 1
+}
+
+# Every application the catalog ships, in the order it lists them, rather than
+# a list kept here. A list kept here is a list that is right on the day it is
+# written: the applications that landed afterwards are the ones with no demo,
+# which is exactly the ones a demo is for.
+catalog_apps() {
+    sed -n 's/^ *"id": *"\([a-z0-9-]*\)".*/\1/p' apps/catalog.json
+}
+
+# Where an application's source lives. The catalog does not say, because the
+# split between an example and a shipped application is a repository layout
+# question and not something the reader has any business knowing.
+source_of() {
+    for root in apps examples; do
+        if [ -d "$root/$1" ]; then
+            echo "$root/$1"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# The route through an application, as a drive script. `.kobo` is the
+# extension the SDK documents; `.txt` is what the applications in the tree
+# happen to use. Both are the same format, so both are accepted rather than
+# making somebody rename a file to get a demo.
+script_of() {
+    for name in drive.kobo drive.txt; do
+        if [ -f "$1/$name" ]; then
+            echo "$1/$name"
+            return 0
+        fi
+    done
+    return 1
+}
+
+[ -n "$APPS" ] || APPS=$(catalog_apps)
+
+if [ -n "$LIST" ]; then
+    for app in $APPS; do
+        directory=$(source_of "$app") || { echo "$app	no source in this tree"; continue; }
+        script=$(script_of "$directory") ||
+            { echo "$app	$directory	opening screen only"; continue; }
+        echo "$app	$directory	$script"
+    done
+    exit 0
+fi
+
+# Dated, because the point of a recording is comparing today against last time,
+# and because a run that overwrote the last one would make that impossible.
+[ -n "$OUT" ] || OUT="target/sim-recordings/$(date +%Y-%m-%d-%H%M%S)"
+
+# Committed screenshots and the media on the website are the only copy of
+# themselves. A run pointed at one of those directories by accident -- a stale
+# --out in somebody's shell history is all it takes -- would replace them with
+# whatever the simulator drew this morning.
+if [ -z "$OVERWRITE" ] && [ -d "$OUT" ] &&
+   [ -n "$(git ls-files -- "$OUT" 2>/dev/null | head -n 1)" ]; then
+    echo "$OUT holds committed files; pass --overwrite if that is really meant" >&2
+    exit 1
+fi
+
+echo "building the CLI"
+cargo build --release -q -p kobo-cli
+KOBO="$PWD/target/release/kobo"
+
+mkdir -p "$OUT"
+RECORDED=0
+FAILED=""
+NO_SCRIPT=""
+
+for app in $APPS; do
+    directory=$(source_of "$app") || {
+        echo "no source for $app in this tree; skipping" >&2
+        continue
+    }
+    echo
+    echo "=== $app ($directory) ==="
+
+    log="$OUT/$app.log"
+    # Started from the application's own directory, which is how `kobo dev`
+    # decides what to build and run.
+    if [ -n "$FRESH" ]; then
+        mkdir -p "$OUT/$app-store"
+        store=$(cd "$OUT/$app-store" && pwd)
+        (cd "$directory" && TMPDIR="$store" exec "$KOBO" dev "$ADDRESS") > "$log" 2>&1 &
+    else
+        (cd "$directory" && exec "$KOBO" dev "$ADDRESS") > "$log" 2>&1 &
+    fi
+    simulator=$!
+
+    # The address line is printed once the application has compiled, started
+    # and connected, so it is the only honest signal that there is a screen to
+    # film. Polling the port would connect to a simulator with nothing in it.
+    waited=0
+    while ! grep -q "Kobo app simulator:" "$log" 2>/dev/null; do
+        if ! kill -0 "$simulator" 2>/dev/null; then
+            echo "$app did not start; see $log" >&2
+            FAILED="$FAILED $app"
+            break
+        fi
+        if [ "$waited" -ge "$START_TIMEOUT" ]; then
+            echo "$app did not reach a screen in ${START_TIMEOUT}s; see $log" >&2
+            FAILED="$FAILED $app"
+            break
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    # Connected is not the same as drawn. The address line goes out when the
+    # application opens its socket, and its first screen arrives some
+    # milliseconds later; filming from the earlier moment opens every recording
+    # on a blank panel and fails the first `expect` about one run in three.
+    # `dump` prints one line per node that has words on it, so a line with a
+    # bracket in it is a screen.
+    if grep -q "Kobo app simulator:" "$log" 2>/dev/null; then
+        painted=0
+        while [ "$painted" -lt 30 ]; do
+            "$KOBO" drive --address "$ADDRESS" --step dump 2>/dev/null |
+                grep -q '\["' && break
+            sleep 1
+            painted=$((painted + 1))
+        done
+    fi
+
+    if grep -q "Kobo app simulator:" "$log" 2>/dev/null; then
+        if script=$(script_of "$directory"); then
+            set -- --script "$script"
+        else
+            # No route through it, so this is the opening screen and a note.
+            # Writing a route is a job for whoever knows what the application
+            # is meant to do, and guessing at coordinates produces a demo of
+            # taps landing on nothing.
+            set -- --step "wait 2000"
+            NO_SCRIPT="$NO_SCRIPT $app"
+        fi
+        # GHOSTING is deliberately unquoted: empty means the flag is absent.
+        # shellcheck disable=SC2086
+        if "$KOBO" drive --address "$ADDRESS" --record "$OUT/$app" --fps "$FPS" \
+                $GHOSTING --shots "$OUT/$app-shots" "$@"; then
+            RECORDED=$((RECORDED + 1))
+        else
+            echo "driving $app failed; the recording up to the failure is in $OUT/$app" >&2
+            FAILED="$FAILED $app"
+        fi
+    fi
+
+    # The application is a child of the simulator, and a simulator taken down
+    # by a signal does not get to run the code that reaps it.
+    children=$(pgrep -P "$simulator" 2>/dev/null || true)
+    kill "$simulator" 2>/dev/null || true
+    wait "$simulator" 2>/dev/null || true
+    for child in $children; do
+        kill "$child" 2>/dev/null || true
+    done
+done
+
+echo
+echo "recorded $RECORDED applications into $OUT"
+[ -z "$NO_SCRIPT" ] ||
+    echo "opening screen only, no drive script committed:$NO_SCRIPT"
+if [ -n "$FAILED" ]; then
+    echo "these did not record:$FAILED" >&2
+    exit 1
+fi

--- a/tools/check-app-versions.mjs
+++ b/tools/check-app-versions.mjs
@@ -238,6 +238,14 @@ function isInside(path, directory) {
   return path === directory || path.startsWith(`${directory}/`);
 }
 
+// A drive script is the host-side route used to film an application. It is
+// never compiled into the signed bundle, so adding or editing one must not
+// look like a Store package change. That mistake is what turned a simulator
+// recording script into a forced version bump of every example that grew one.
+export function isFilmingScript(path, packageDirectory) {
+  return path === `${packageDirectory}/drive.txt` || path === `${packageDirectory}/drive.kobo`;
+}
+
 // Returns the dependency edges capable of changing a release artifact.
 //
 // Cargo includes dev dependencies in the resolved metadata graph even when
@@ -582,7 +590,10 @@ export function affectedWorkspacePackages(baseRevision, registry) {
     const directory = dirname(package_.manifest_path);
     const relativeDirectory = relative(workspaceRoot, directory).split(sep).join("/");
     const packageChanges = changedPaths.filter(
-      path => isInside(path, relativeDirectory) && !compatiblePaths.has(path)
+      path =>
+        isInside(path, relativeDirectory) &&
+        !compatiblePaths.has(path) &&
+        !isFilmingScript(path, relativeDirectory)
     );
     if (packageChanges.length === 0) continue;
     const relativeManifest = relative(workspaceRoot, package_.manifest_path).split(sep).join("/");

--- a/tools/check-app-versions.test.mjs
+++ b/tools/check-app-versions.test.mjs
@@ -13,6 +13,7 @@ import {
   manifestOnlyChangesWorkspaceMembershipOrVersion,
   packagesToBuild,
   registeredConsumers,
+  isFilmingScript,
   releaseDiffArguments,
   releaseNeeded,
   releaseDependencyIds
@@ -255,6 +256,15 @@ test("release input discovery includes deleted paths", () => {
     "--diff-filter=ACDMRT",
     "published...HEAD"
   ]);
+});
+
+test("a drive script next to an application is not a release input", () => {
+  assert.equal(isFilmingScript("examples/todo/drive.txt", "examples/todo"), true);
+  assert.equal(isFilmingScript("examples/todo/drive.kobo", "examples/todo"), true);
+  assert.equal(isFilmingScript("examples/gallery/drive.txt", "examples/gallery"), true);
+  assert.equal(isFilmingScript("examples/todo/src/main.rs", "examples/todo"), false);
+  assert.equal(isFilmingScript("examples/todo/src/drive.txt", "examples/todo"), false);
+  assert.equal(isFilmingScript("examples/todo-extra/drive.txt", "examples/todo"), false);
 });
 
 test("workspace version and member additions do not change existing app release inputs", () => {


### PR DESCRIPTION
Every application in the catalogue has stills and none of them has a demo. The
reason is that the only thing in this workspace that produces a moving picture
needs hardware: `kobo record` opens the reader's framebuffer over SSH, and
`record-apps.sh`, `record-tour.sh` and `cut-tour.py` all drive a physical panel
with `present`, `tap` and `record`. A demo for a new application therefore waits
on the one reader on the desk being awake, on the network, and not in use, and
finding out it was none of those takes six minutes.

The simulator has been producing stills the whole time. It runs the device's own
renderer, layout engine, hit-testing and refresh planner, and `kobo drive`
already walks a script through it and writes a PNG per step. What was missing
was the frames between the steps.

## The new command

```sh
kobo drive [--address host:port] --script drive.txt \
           --record DIR [--fps N] [--ghosting] [--shots DIR] [--ideal]
```

`--record DIR` films the panel on its own clock while the script drives it. The
directory ends up holding numbered greyscale PNGs, a `timings.txt`, a
`recording.mp4` and a `recording.gif` — the same shape `kobo record --device`
produces from a reader, so a demo made on a laptop and a demo made on hardware
are the same kind of file. `--fps` defaults to 4 and is capped at 20.

Every application in the catalogue, in one command, with no hardware:

```sh
scripts/record-apps-sim.sh --fresh
```

It reads its list of applications out of `apps/catalog.json` rather than keeping
one of its own, writes to a dated directory under `target/sim-recordings/`, and
takes `--apps`, `--out`, `--fps`, `--ghosting`, `--address`, `--overwrite` and
`--list`.

## Why `drive --record` and not `record --address`

The split between the two commands is not arbitrary, and SDK.md already says so:
`drive` is the simulator, `shot`, `tap` and `record` are the device. `record` is
a framebuffer reader — it uploads the doctor, has the device copy `/dev/fb0`
into a file at a fixed rate, and pulls that file home over SSH compressed. None
of those three things has a counterpart on this side of the cable, and there is
no framebuffer here to read. What there is, is a driver already holding a
connection to the process doing the rendering, which is the only thing that
knows when a screen has changed.

Sampling on a clock rather than once per step is deliberate too. A recording
made of the steps would only ever show the screens a script stops on, and the
frames worth having are usually the ones between them: the list that was empty
for half a second before the fetch came back, the pane drawn at the wrong size
until the second layout pass. Frames identical to the one before them are
dropped, the way the device drops them, so a script that waits two seconds
between taps is one frame there and not eight.

## Ghosting

**A recording is taken from the residue-free frame unless `--ghosting` asks
otherwise.** That is the opposite default to `shot`, and deliberate. A still
with e-ink residue on it is two screens a person can read past; a hundred of
them played in sequence is every screen of the run at once, and there is nothing
to read past. `--ideal` goes on governing the `shot` steps, unchanged.

The difference is not theoretical — with `--ghosting` the todo compose screen
comes back with the whole keyboard printed faintly under the previous splash.

## ffmpeg

Both files are assembled with ffmpeg, invoked the way `cut-tour.py` invokes it
so device-made and simulator-made assets match. `drive --record` checks for
ffmpeg **before** it touches the simulator and refuses with an install line if
it is absent, which is the one place this is stricter than `record --device`:
there the numbered PNGs are the product and the video is a bonus, here the
moving picture is the whole request, and finding out after a minute of driving
costs the minute.

## Proof

Every application in the catalogue recorded on a laptop, ghost-free, at
1072×1448:

| app | frames | gif | mp4 | what it shows |
| --- | --- | --- | --- | --- |
| gallery | 10 | 420K | 236K | every page of the component gallery and a tab inside three of them |
| todo | 7 | 116K | 52K | empty list, compose screen, typing on the on-screen keyboard, the item listed, then crossed off |
| tictactoe | 6 | 112K | 32K | a whole game played to "O wins" |
| launcher | 3 | 144K | 72K | both pages of tiles and the way between them |
| backgammon | 3 | 132K | 60K | its committed `drive.txt`: the opening roll, a checker selected, the second die played |
| gutenbird | 2 | 64K | 24K | the shelf arriving over the network |
| arxiv, audiobook, brief, chat, hn, magnet, morse, rss, sidekick, sudoku, zotero-reader | 1 each | 28–100K | 12–48K | opening screen only — no drive script committed yet |

Four example applications get the drive scripts they were missing, so the batch
command has something to record beyond an opening screen. No generated media is
committed here.

## Tests

`cargo test --workspace`: **2103 passed, 0 failed, 4 ignored, 71 suites.**
`kobo-cli` goes from 222 to 228; the six are:

- the dedup keeps a screen once, and keeps it again when it comes back
- a frame rate the simulator cannot serve is refused before anything is driven
- a recording of a really-running simulator is a full 1072×1448 panel with more
  than one grey on it — the failure this guards against is a recording that is
  technically a file and visually nothing
- each frame is played for as long as it was really on the panel, and a frame
  that barely appeared is still held long enough for an encoder to keep it

`cargo fmt --check` and `cargo clippy -p kobo-cli --all-targets -D warnings` are
clean.

## One question for you

The simulator keeps an application's store in the host's temporary directory, so
a second run of a drive script resumes a saved game and opens a list that
already has things on it. `apps/backgammon/drive.txt` passes on a clean machine
and fails on the next run for exactly this reason — its `expect White opened`
only holds for a new game. `--fresh` works around it by giving each application
a temporary directory of its own, at the cost of hiding credentials installed
with `kobo secret`.

Should the simulator take an explicit store root instead, so a drive script can
declare the state it starts from? That would make these recordings reproducible
without the credential trade, but it is a change to `kobo dev`'s contract and I
did not want to make it uninvited.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791072577&installation_model_id=20525&pr_number=112&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F112&signature=7caebf41f7aac08558dd639dc43204141e52a693a09a0c1157fa7a8dcc17a089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->