### PR TITLE
Let the beta catalog and platform publish independently

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -320,6 +320,15 @@ jobs:
               --signature published-app-catalog.json.sig \
               --registry apps/catalog.json \
               --release "$release_state"
+            # Having nothing to publish is not the same as Store inputs being
+            # unchanged. The platform used to skip a release while crates/
+            # moved; this is that gate for the catalog. apps/ and every
+            # registered Store package directory must not differ from the
+            # published source when this run decided not to touch the channel.
+            git diff --name-only --diff-filter=ACDMRT "$base" "$GITHUB_SHA" \
+              > "$RUNNER_TEMP/changed-since-catalog"
+            node tools/store-catalog-changes.mjs --channel "$release_tag" \
+              < "$RUNNER_TEMP/changed-since-catalog"
           fi
           if [ "$publish" = true ] && [ "$has_release" = true ] && [ "$packages" != "$all_packages" ]; then
             if [ -z "$previous_run" ]; then

--- a/docs/RELEASE-TRAIN.md
+++ b/docs/RELEASE-TRAIN.md
@@ -3,20 +3,66 @@
 Cobalt uses `beta` as its integration and physical-acceptance branch. Stable
 artifacts are promoted from beta rather than rebuilt.
 
+The beta **platform** (`beta-vX.Y.Z`) and the beta **Store catalog**
+(`app-catalog-beta`) are separate publications. A Store-only merge updates the
+catalog without a workspace version bump. A platform-only merge publishes a new
+`beta-vX.Y.Z` without bumping every Store app. Promoting one to stable does not
+promote the other.
+
+On every push to `beta`, two workflows start independently. Neither waits on
+the other:
+
+| Workflow | File | Concurrency | Publishes |
+|---|---|---|---|
+| **Publish apps** | `.github/workflows/apps.yml` | `cobalt-app-catalog-beta` | `app-catalog-beta` |
+| **Publish beta platform** | `.github/workflows/beta-release.yml` | `cobalt-beta-platform` | `beta-vX.Y.Z` |
+
+A Store-only change (`apps/`, or a registered Store package that still lives
+under `examples/`) leaves the platform run quiet and green. A platform-only
+change (`crates/`, device-only `examples/`, `Cargo.toml`, `Cargo.lock`, the
+toolchain pin) leaves the catalog run quiet and green after it re-verifies the
+already-published `app-catalog-beta`. Either run fails, rather than skipping,
+when the inputs it owns moved and it decided not to publish.
+
+Re-run a quiet channel from the Actions tab with the `beta` branch selected, or:
+
+```
+gh workflow run "Publish apps" --ref beta
+gh workflow run "Publish beta platform" --ref beta
+```
+
 ## Application changes
 
 1. Open each application pull request against `beta`.
 2. Merge only after CI succeeds. The merge publishes a signed beta Store
-   catalog; it does not modify the stable catalog.
+   catalog; it does not modify the stable catalog and does not require a
+   workspace version bump.
 3. Install or update the application from the beta Store on a physical Kobo.
    Record the beta catalog source commit, catalog SHA-256, package SHA-256, and
    acceptance evidence.
 4. Merge `beta` into `main` without squashing away the tested beta commit.
+   This merge does not publish a stable catalog and does not create `vX.Y.Z`.
 5. Run **Promote tested beta apps** from `main` with the recorded commit and
    catalog digest. The workflow verifies provenance and copies the exact tested
    `.cobalt-app` bytes before replacing the signed stable catalog. Readers
    reject a transient catalog/signature mismatch and retain their last verified
    catalog until the next check.
+
+   From the Actions tab, select **Promote tested beta apps**, branch `main`:
+
+   - `tested_commit`: the 40-character beta commit recorded in step 3
+   - `expected_catalog_sha256`: SHA-256 of that commit's `cobalt-app-catalog.json`
+   - `confirmation`: `promote-apps-` plus the first 12 characters of the commit
+
+   ```
+   gh workflow run "Promote tested beta apps" --ref main \
+     -f tested_commit=COMMIT \
+     -f expected_catalog_sha256=DIGEST \
+     -f confirmation=promote-apps-SHORTSHA
+   ```
+
+   Do not run **Promote tested beta**. That workflow publishes `vX.Y.Z` and
+   does not touch the Store catalog.
 
 ## Platform changes
 
@@ -24,16 +70,36 @@ artifacts are promoted from beta rather than rebuilt.
 2. Bump the workspace version once when cutting a beta candidate. The first
    push of that version publishes immutable `beta-vX.Y.Z` device and host
    assets, their signed manifest, and the bootstrap installer. Later app-only
-   pushes at the same version leave that platform release unchanged.
+   pushes at the same version leave that platform release unchanged, and a
+   platform bump does not republish `app-catalog-beta`.
 3. Install the beta release through Software Update and record the tested
    commit and archive SHA-256.
 4. Merge `beta` into `main` without squashing away the tested commit.
+   This merge does not create `vX.Y.Z` and does not replace the stable catalog.
 5. Run **Promote tested beta** from `main`. The workflow tags the tested commit
    and publishes the already-tested device package, four host packages,
    installer, manifest, and signatures as `vX.Y.Z` without rebuilding.
    The `docs/install.sh` merged to main is then available from the canonical
    GitHub Pages stable discovery URL. Beta itself never changes the live Pages
    source or publishes a public host bootstrap.
+
+   From the Actions tab, select **Promote tested beta**, branch `main`:
+
+   - `version`: the exact workspace version, for example `0.3.5`
+   - `tested_commit`: the 40-character commit recorded in step 3
+   - `expected_archive_sha256`: SHA-256 of `cobalt-VERSION-KoboRoot.tgz`
+   - `confirmation`: `promote-beta-v` plus the same version
+
+   ```
+   gh workflow run "Promote tested beta" --ref main \
+     -f version=X.Y.Z \
+     -f tested_commit=COMMIT \
+     -f expected_archive_sha256=DIGEST \
+     -f confirmation=promote-beta-vX.Y.Z
+   ```
+
+   Do not run **Promote tested beta apps**. That workflow replaces the stable
+   Store catalog and does not create `vX.Y.Z`.
 
 Direct stable publication from `main` is intentionally disabled for Store
 applications. A successful build is necessary but does not replace physical

--- a/tools/check-app-versions.mjs
+++ b/tools/check-app-versions.mjs
@@ -2,6 +2,11 @@ import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  storeCatalogChanges,
+  storeWatchDirectories,
+  unpublishedStoreChangeReport
+} from "./store-catalog-changes.mjs";
 
 const MANIFEST_FIELDS = [
   "id",
@@ -525,13 +530,35 @@ export function lockfileOnlyAddsPackages(previousSource, currentSource) {
   return true;
 }
 
-export function affectedWorkspacePackages(baseRevision, registry) {
+export function analyzeAppReleaseInputs(baseRevision, registry) {
   const metadata = JSON.parse(command("cargo", ["metadata", "--format-version", "1", "--locked"]));
   const workspaceRoot = resolve(metadata.workspace_root);
   const changedPaths = command("git", releaseDiffArguments(baseRevision))
     .split("\n")
     .filter(Boolean)
     .map(path => path.split(sep).join("/"));
+
+  const registeredPackages = registry.apps.map(app => app.package);
+  const registered = new Set(registeredPackages);
+  const workspaceMembers = new Set(metadata.workspace_members);
+  const workspacePackages = metadata.packages.filter(package_ => workspaceMembers.has(package_.id));
+  const packageDirectories = new Map(
+    workspacePackages.map(package_ => [
+      package_.name,
+      relative(workspaceRoot, dirname(package_.manifest_path)).split(sep).join("/")
+    ])
+  );
+  const storeDirectories = storeWatchDirectories(packageDirectories, registeredPackages);
+  const storeChanges = storeCatalogChanges(changedPaths, storeDirectories);
+  const empty = { affected: new Set(), storeChanges };
+  // A platform-only push must not force every Store app to bump. Device-package
+  // inputs (crates/, Cargo.toml, Cargo.lock, the toolchain pin) reach readers
+  // through beta-vX.Y.Z. The next catalog publication of an actually edited
+  // app compiles against whatever the platform then is.
+  if (storeChanges.length === 0) {
+    return empty;
+  }
+
   const compatibleManifest = readJson(
     resolve(
       dirname(fileURLToPath(import.meta.url)),
@@ -547,7 +574,6 @@ export function affectedWorkspacePackages(baseRevision, registry) {
     path => command("git", ["hash-object", path])
   );
 
-  const registeredPackages = registry.apps.map(app => app.package);
   const unconditionalGlobalInputs = new Set(["rust-toolchain", "rust-toolchain.toml"]);
   const changesGlobalInputs =
     changedPaths.some(path => unconditionalGlobalInputs.has(path) || path.startsWith(".cargo/")) ||
@@ -557,11 +583,9 @@ export function affectedWorkspacePackages(baseRevision, registry) {
         readFileSync(resolve(workspaceRoot, "Cargo.toml"), "utf8")
       ));
   if (changesGlobalInputs) {
-    return new Set(registeredPackages);
+    return { affected: new Set(registeredPackages), storeChanges };
   }
 
-  const workspaceMembers = new Set(metadata.workspace_members);
-  const workspacePackages = metadata.packages.filter(package_ => workspaceMembers.has(package_.id));
   const changedIdentities = new Set();
   const previousRegistry = JSON.parse(
     command("git", ["show", `${baseRevision}:apps/catalog.json`])
@@ -579,6 +603,7 @@ export function affectedWorkspacePackages(baseRevision, registry) {
     );
   }
   for (const package_ of workspacePackages) {
+    if (!registered.has(package_.name)) continue;
     const directory = dirname(package_.manifest_path);
     const relativeDirectory = relative(workspaceRoot, directory).split(sep).join("/");
     const packageChanges = changedPaths.filter(
@@ -617,7 +642,14 @@ export function affectedWorkspacePackages(baseRevision, registry) {
     for (const identity of lockChanges) changedIdentities.add(identity);
   }
 
-  return registeredConsumers(metadata, registeredPackages, changedIdentities);
+  return {
+    affected: registeredConsumers(metadata, registeredPackages, changedIdentities),
+    storeChanges
+  };
+}
+
+export function affectedWorkspacePackages(baseRevision, registry) {
+  return analyzeAppReleaseInputs(baseRevision, registry).affected;
 }
 
 function argumentsFrom(argv) {
@@ -648,7 +680,7 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
     const { values, mode } = argumentsFrom(process.argv.slice(2));
     const registry = readJson(resolve(values.get("--registry")), "app registry");
     const published = readJson(resolve(values.get("--published-catalog")), "published catalog");
-    const affected = affectedWorkspacePackages(values.get("--base"), registry);
+    const { affected, storeChanges } = analyzeAppReleaseInputs(values.get("--base"), registry);
     checkProtocolMinimums(registry, currentProtocolVersion());
     if (mode === "--list-packages") {
       console.log(JSON.stringify(packagesToBuild(registry, published, affected)));
@@ -656,6 +688,9 @@ if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.ur
       console.log(releaseNeeded(registry, published, affected) ? "true" : "false");
     } else {
       checkEntries(registry, published, affected);
+      if (storeChanges.length > 0 && !releaseNeeded(registry, published, affected)) {
+        throw new Error(unpublishedStoreChangeReport("the app catalog", storeChanges));
+      }
       console.log("Every changed app package has a new version.");
     }
   } catch (error) {

--- a/tools/check-app-versions.mjs
+++ b/tools/check-app-versions.mjs
@@ -530,6 +530,20 @@ export function lockfileOnlyAddsPackages(previousSource, currentSource) {
   return true;
 }
 
+// Given an explicit change list, decide whether the catalog must move.
+// Platform-only paths (crates/, Cargo.toml, Cargo.lock, CI, docs) produce an
+// empty affected set. The cargo walk that names individual Store packages is
+// reached only when a Store catalog input actually changed.
+export function storeImpactOfChangedPaths(changedPaths, packageDirectories, registeredPackages) {
+  const storeDirectories = storeWatchDirectories(packageDirectories, registeredPackages);
+  const storeChanges = storeCatalogChanges(changedPaths, storeDirectories);
+  return {
+    storeChanges,
+    catalogQuiet: storeChanges.length === 0,
+    affected: storeChanges.length === 0 ? new Set() : null
+  };
+}
+
 export function analyzeAppReleaseInputs(baseRevision, registry) {
   const metadata = JSON.parse(command("cargo", ["metadata", "--format-version", "1", "--locked"]));
   const workspaceRoot = resolve(metadata.workspace_root);
@@ -548,15 +562,14 @@ export function analyzeAppReleaseInputs(baseRevision, registry) {
       relative(workspaceRoot, dirname(package_.manifest_path)).split(sep).join("/")
     ])
   );
-  const storeDirectories = storeWatchDirectories(packageDirectories, registeredPackages);
-  const storeChanges = storeCatalogChanges(changedPaths, storeDirectories);
-  const empty = { affected: new Set(), storeChanges };
+  const impact = storeImpactOfChangedPaths(changedPaths, packageDirectories, registeredPackages);
+  const storeChanges = impact.storeChanges;
   // A platform-only push must not force every Store app to bump. Device-package
   // inputs (crates/, Cargo.toml, Cargo.lock, the toolchain pin) reach readers
   // through beta-vX.Y.Z. The next catalog publication of an actually edited
   // app compiles against whatever the platform then is.
-  if (storeChanges.length === 0) {
-    return empty;
+  if (impact.catalogQuiet) {
+    return { affected: impact.affected, storeChanges };
   }
 
   const compatibleManifest = readJson(

--- a/tools/check-app-versions.test.mjs
+++ b/tools/check-app-versions.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import {
+  analyzeAppReleaseInputs,
   changedLockPackageIdentities,
   changedRegistryPackages,
   checkEntries,
@@ -508,4 +509,24 @@ test("workspace package version-only lock changes affect no Store app", () => {
   const previous = `version = 4\n\n[[package]]\nname = "kobo-sdk"\nversion = "0.3.1"\ndependencies = [\n "shared",\n]\n`;
   const current = previous.replace('version = "0.3.1"', 'version = "0.3.2"');
   assert.deepEqual(changedLockPackageIdentities(previous, current), new Set());
+});
+
+// Since the last catalog publication, beta has moved crates/kobo-sim and
+// workflow files. Those are platform or CI inputs. The catalog must stay
+// quiet: requiring every Store app to bump here is the #101 failure mode.
+test("platform-only commits since the published catalog affect no Store package", () => {
+  const registry = JSON.parse(readFileSync("apps/catalog.json", "utf8"));
+  const { affected, storeChanges } = analyzeAppReleaseInputs(
+    "626cc8bbb3b801384c6c252d150b8508beef3e24",
+    registry
+  );
+  assert.deepEqual(storeChanges, []);
+  assert.deepEqual(affected, new Set());
+});
+
+test("the previous complete-set artifact is still excluded from per-app reuse", () => {
+  const source = readFileSync(".github/workflows/apps.yml", "utf8");
+  assert.match(source, /\$1 !~ \/\^verified-app-set-\[0-9\]\+\$\//);
+  assert.match(source, /previous_artifact="set"/);
+  assert.match(source, /the set has to/);
 });

--- a/tools/check-app-versions.test.mjs
+++ b/tools/check-app-versions.test.mjs
@@ -3,7 +3,6 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import {
-  analyzeAppReleaseInputs,
   changedLockPackageIdentities,
   changedRegistryPackages,
   checkEntries,
@@ -16,8 +15,15 @@ import {
   registeredConsumers,
   releaseDiffArguments,
   releaseNeeded,
-  releaseDependencyIds
+  releaseDependencyIds,
+  storeImpactOfChangedPaths
 } from "./check-app-versions.mjs";
+import {
+  registeredStorePackages,
+  storeCatalogChanges,
+  storeWatchDirectories,
+  workspacePackageDirectories
+} from "./store-catalog-changes.mjs";
 
 function fixture({ currentVersion = "1.0.0", summary = "Summary" } = {}) {
   const app = {
@@ -511,17 +517,50 @@ test("workspace package version-only lock changes affect no Store app", () => {
   assert.deepEqual(changedLockPackageIdentities(previous, current), new Set());
 });
 
-// Since the last catalog publication, beta has moved crates/kobo-sim and
-// workflow files. Those are platform or CI inputs. The catalog must stay
-// quiet: requiring every Store app to bump here is the #101 failure mode.
-test("platform-only commits since the published catalog affect no Store package", () => {
-  const registry = JSON.parse(readFileSync("apps/catalog.json", "utf8"));
-  const { affected, storeChanges } = analyzeAppReleaseInputs(
-    "626cc8bbb3b801384c6c252d150b8508beef3e24",
-    registry
+// The #101 failure mode: a crates/ or workflow edit looked like a Store
+// release input and demanded every app bump. The filter is tested against an
+// explicit path list so a shallow CI checkout does not have to contain the
+// last catalog publication.
+test("platform-only paths affect no Store package", () => {
+  const packageDirectories = new Map([
+    ["kobo-todo", "examples/todo"],
+    ["kobo-backgammon", "apps/backgammon"]
+  ]);
+  const registered = ["kobo-todo", "kobo-backgammon"];
+  const platformOnly = [
+    "crates/kobo-sim/src/lib.rs",
+    "crates/kobo-profile/src/lib.rs",
+    "Cargo.toml",
+    "Cargo.lock",
+    ".github/workflows/ci.yml",
+    "tools/check-app-versions.mjs",
+    "docs/RELEASE-TRAIN.md"
+  ];
+
+  const quiet = storeImpactOfChangedPaths(platformOnly, packageDirectories, registered);
+  assert.deepEqual(quiet.storeChanges, []);
+  assert.equal(quiet.catalogQuiet, true);
+  assert.deepEqual(quiet.affected, new Set());
+
+  const storeEdit = storeImpactOfChangedPaths(
+    ["apps/backgammon/src/main.rs", "crates/kobo-sim/src/lib.rs"],
+    packageDirectories,
+    registered
   );
-  assert.deepEqual(storeChanges, []);
-  assert.deepEqual(affected, new Set());
+  assert.deepEqual(storeEdit.storeChanges, ["apps/backgammon/src/main.rs"]);
+  assert.equal(storeEdit.catalogQuiet, false);
+  assert.equal(storeEdit.affected, null);
+
+  const directories = storeWatchDirectories(
+    workspacePackageDirectories(readFileSync("Cargo.toml", "utf8"), member =>
+      readFileSync(`${member}/Cargo.toml`, "utf8")
+    ),
+    registeredStorePackages(JSON.parse(readFileSync("apps/catalog.json", "utf8")))
+  );
+  assert.deepEqual(storeCatalogChanges(["crates/kobo-sim/src/lib.rs"], directories), []);
+  assert.deepEqual(storeCatalogChanges(["apps/backgammon/src/main.rs"], directories), [
+    "apps/backgammon/src/main.rs"
+  ]);
 });
 
 test("the previous complete-set artifact is still excluded from per-app reuse", () => {

--- a/tools/store-catalog-changes.mjs
+++ b/tools/store-catalog-changes.mjs
@@ -1,0 +1,123 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Everything whose content reaches a reader through the signed Store catalog.
+//
+// `apps/` is taken whole: it holds the registry and every Store-only package.
+// Registered packages that still live under `examples/` are watched by their
+// workspace directory, because those binaries are the same ones the catalog
+// signs. Device-only examples (launcher, settings, store, terminal, hello)
+// are not in the catalog and are not watched here.
+//
+// `crates/`, `Cargo.toml`, `Cargo.lock`, `rust-toolchain*` and `.cargo/` are
+// deliberately absent. Those are device-package inputs. A platform release
+// carries them; demanding a catalog republish for them is what turned a
+// Nickel-supplicant fix into sixteen Store version bumps and a red publish
+// job. The next Store publication of an actually edited app compiles against
+// whatever the platform then is.
+
+export function affectsStoreCatalog(path, directories) {
+  if (typeof path !== "string" || !Array.isArray(directories)) return false;
+  const normalized = path.trim().split("\\").join("/");
+  if (normalized.length === 0) return false;
+  return directories.some(
+    directory => normalized === directory || normalized.startsWith(`${directory}/`)
+  );
+}
+
+export function storeCatalogChanges(paths, directories) {
+  return [...new Set(paths.filter(path => affectsStoreCatalog(path, directories)))].sort();
+}
+
+export function storeWatchDirectories(packageDirectories, registeredPackages) {
+  const directories = new Set(["apps"]);
+  for (const name of registeredPackages) {
+    const directory = packageDirectories.get(name);
+    if (!directory) {
+      throw new Error(`${name} is in the Store catalog but names no workspace member`);
+    }
+    directories.add(directory);
+  }
+  return [...directories].sort();
+}
+
+export function workspacePackageDirectories(rootManifest, readMemberManifest) {
+  const match = /^members\s*=\s*\[([\s\S]*?)^\]/m.exec(rootManifest);
+  if (!match) throw new Error("read the workspace members from Cargo.toml");
+  const directories = new Map();
+  for (const member of [...match[1].matchAll(/"([^"]+)"/g)].map(entry => entry[1])) {
+    const name = /^name\s*=\s*"([^"]+)"$/m.exec(readMemberManifest(member))?.[1];
+    if (name) directories.set(name, member);
+  }
+  return directories;
+}
+
+export function registeredStorePackages(registry) {
+  if (!Array.isArray(registry?.apps)) {
+    throw new Error("app registry has no app array");
+  }
+  return registry.apps.map(app => {
+    if (typeof app?.package !== "string" || app.package.length === 0) {
+      throw new Error("registry app has no package name");
+    }
+    return app.package;
+  });
+}
+
+// The run that finds these changes is the one that decided there was nothing
+// to publish, so the report has to name the edit that makes it publish.
+export function unpublishedStoreChangeReport(channel, changes) {
+  return [
+    `${channel} is already published, but Store catalog inputs changed and this run is not publishing.`,
+    "These paths differ between the published catalog and this commit:",
+    ...changes.map(path => `  ${path}`),
+    "",
+    "No reader receives them while the catalog stays at the previous publication.",
+    "Bump each affected app to a strictly newer numeric version in apps/catalog.json,",
+    "push again, and Publish apps will sign a new beta catalog."
+  ].join("\n");
+}
+
+function argumentsFrom(argv) {
+  const allowed = ["--channel", "--root"];
+  const usage =
+    "usage: node tools/store-catalog-changes.mjs --channel TAG [--root PATH] < changed-paths";
+  const values = new Map([["--root", "."]]);
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (!allowed.includes(flag) || !value) throw new Error(usage);
+    values.set(flag, value);
+  }
+  if (!values.has("--channel")) throw new Error(usage);
+  return values;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    const values = argumentsFrom(process.argv.slice(2));
+    const root = values.get("--root");
+    const channel = values.get("--channel");
+    const registry = JSON.parse(readFileSync(join(root, "apps/catalog.json"), "utf8"));
+    const directories = storeWatchDirectories(
+      workspacePackageDirectories(readFileSync(join(root, "Cargo.toml"), "utf8"), member =>
+        readFileSync(join(root, member, "Cargo.toml"), "utf8")
+      ),
+      registeredStorePackages(registry)
+    );
+    const paths = readFileSync(0, "utf8").split("\n").filter(Boolean);
+    const changes = storeCatalogChanges(paths, directories);
+    if (changes.length > 0) {
+      console.error(unpublishedStoreChangeReport(channel, changes));
+      process.exitCode = 1;
+    } else {
+      console.log(
+        `No Store catalog input changed since ${channel}; ${paths.length} changed path(s) reach readers without a catalog publication.`
+      );
+    }
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/tools/store-catalog-changes.test.mjs
+++ b/tools/store-catalog-changes.test.mjs
@@ -1,0 +1,163 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  affectsDevicePackage,
+  devicePackageChanges
+} from "./device-package-changes.mjs";
+import {
+  affectsStoreCatalog,
+  registeredStorePackages,
+  storeCatalogChanges,
+  storeWatchDirectories,
+  unpublishedStoreChangeReport,
+  workspacePackageDirectories
+} from "./store-catalog-changes.mjs";
+
+function directoriesOfThisTree() {
+  return storeWatchDirectories(
+    workspacePackageDirectories(readFileSync("Cargo.toml", "utf8"), member =>
+      readFileSync(`${member}/Cargo.toml`, "utf8")
+    ),
+    registeredStorePackages(JSON.parse(readFileSync("apps/catalog.json", "utf8")))
+  );
+}
+
+test("Store-only sources and the registry reach readers only in a catalog publication", () => {
+  const directories = directoriesOfThisTree();
+  for (const path of [
+    "apps/backgammon/src/main.rs",
+    "apps/backgammon/Cargo.toml",
+    "apps/catalog.json",
+    "apps/arxiv/src/atom.rs",
+    "examples/todo/src/main.rs",
+    "examples/chat/src/conversation.rs"
+  ]) {
+    assert.equal(affectsStoreCatalog(path, directories), true, path);
+  }
+});
+
+test("platform crates, device-only examples and documentation do not force a catalog publication", () => {
+  const directories = directoriesOfThisTree();
+  for (const path of [
+    "crates/kobo-profile/src/lib.rs",
+    "crates/kobo-ui/src/lib.rs",
+    "crates/kobo-sim/src/lib.rs",
+    "crates/kobod/src/main.rs",
+    "examples/launcher/src/main.rs",
+    "examples/settings/src/main.rs",
+    "examples/store/src/main.rs",
+    "examples/terminal/src/main.rs",
+    "examples/hello/src/main.rs",
+    "Cargo.toml",
+    "Cargo.lock",
+    "rust-toolchain.toml",
+    ".cargo/config.toml",
+    "README.md",
+    "docs/index.html",
+    "docs/apps/backgammon/index.html",
+    ".github/workflows/beta-release.yml",
+    "tools/check-app-versions.mjs"
+  ]) {
+    assert.equal(affectsStoreCatalog(path, directories), false, path);
+  }
+});
+
+test("directory names are matched whole", () => {
+  const directories = ["apps", "examples/todo"];
+  assert.equal(affectsStoreCatalog("apps-notes.md", directories), false);
+  assert.equal(affectsStoreCatalog("examples/todo-old/src/main.rs", directories), false);
+  assert.equal(affectsStoreCatalog("docs/apps/backgammon/index.html", directories), false);
+  assert.equal(affectsStoreCatalog("examples/todo", directories), true);
+});
+
+test("a mixed push reports only the Store catalog inputs", () => {
+  const directories = directoriesOfThisTree();
+  assert.deepEqual(
+    storeCatalogChanges(
+      [
+        "docs/index.html",
+        "crates/kobo-profile/src/lib.rs",
+        "apps/backgammon/src/main.rs",
+        "README.md",
+        "Cargo.lock",
+        "apps/backgammon/src/main.rs"
+      ],
+      directories
+    ),
+    ["apps/backgammon/src/main.rs"]
+  );
+  assert.deepEqual(
+    storeCatalogChanges(
+      ["crates/kobo-profile/src/lib.rs", "Cargo.toml", "examples/launcher/src/main.rs"],
+      directories
+    ),
+    []
+  );
+});
+
+test("every catalog package in this tree is inside the gate", () => {
+  const directories = directoriesOfThisTree();
+  const packages = registeredStorePackages(
+    JSON.parse(readFileSync("apps/catalog.json", "utf8"))
+  );
+  const packageDirectories = workspacePackageDirectories(
+    readFileSync("Cargo.toml", "utf8"),
+    member => readFileSync(`${member}/Cargo.toml`, "utf8")
+  );
+  assert.ok(packages.length > 1, "the catalog should name several packages");
+  for (const name of packages) {
+    const directory = packageDirectories.get(name);
+    assert.ok(directory, `${name} must name a workspace member`);
+    assert.ok(
+      directories.includes(directory) || directories.includes("apps"),
+      `${name} in ${directory} is not watched`
+    );
+    assert.equal(affectsStoreCatalog(`${directory}/src/main.rs`, directories), true, name);
+  }
+  assert.throws(
+    () => storeWatchDirectories(new Map(), ["kobo-notes"]),
+    /kobo-notes is in the Store catalog but names no workspace member/
+  );
+  assert.deepEqual(
+    storeWatchDirectories(new Map([["kobo-notes", "apps/notes"]]), ["kobo-notes"]),
+    ["apps", "apps/notes"]
+  );
+});
+
+test("the report names the catalog publication that carries the change", () => {
+  const report = unpublishedStoreChangeReport("app-catalog-beta", [
+    "apps/backgammon/src/main.rs"
+  ]);
+  assert.match(report, /app-catalog-beta is already published/);
+  assert.match(report, /^ {2}apps\/backgammon\/src\/main\.rs$/m);
+  assert.match(report, /Publish apps will sign a new beta catalog/);
+});
+
+// The two gates are the independence proof. A Store-only landing must stay
+// quiet for the platform, and a platform-only landing must stay quiet for the
+// catalog. #101 (kobo-profile) is the historical case that rebuilt every app
+// and then failed the publish job because no Store version had moved.
+test("Store-only and platform-only changes do not block each other", () => {
+  const directories = directoriesOfThisTree();
+
+  const storeOnly = ["apps/backgammon/src/main.rs", "docs/apps/backgammon/index.html"];
+  assert.deepEqual(devicePackageChanges(storeOnly), []);
+  assert.deepEqual(storeCatalogChanges(storeOnly, directories), [
+    "apps/backgammon/src/main.rs"
+  ]);
+
+  const platformOnly = ["crates/kobo-profile/src/lib.rs"];
+  assert.deepEqual(devicePackageChanges(platformOnly), [
+    "crates/kobo-profile/src/lib.rs"
+  ]);
+  assert.deepEqual(storeCatalogChanges(platformOnly, directories), []);
+
+  const platformBump = ["Cargo.toml", "Cargo.lock"];
+  assert.deepEqual(devicePackageChanges(platformBump), ["Cargo.lock", "Cargo.toml"]);
+  assert.deepEqual(storeCatalogChanges(platformBump, directories), []);
+
+  const bundledStoreApp = ["examples/todo/src/main.rs"];
+  assert.equal(affectsDevicePackage(bundledStoreApp[0]), true);
+  assert.deepEqual(storeCatalogChanges(bundledStoreApp, directories), bundledStoreApp);
+});


### PR DESCRIPTION
## Summary

`Publish apps` and `Publish beta platform` both fire on every push to `beta`, but they were still coupled in one direction. A Store-only landing already leaves the platform run quiet (#111). A platform-only crate change still marked every Store app as a release input, so the catalog job rebuilt all sixteen apps and then failed the version gate. That is run `33807793949` on #101: `crates/kobo-profile/src/lib.rs` only, every matrix leg green, publish red with `backgammon: package inputs changed (release inputs) but version 0.1.0 is not newer than 0.1.0`.

Store catalog inputs are now `apps/` plus the workspace directory of each registered Store package. `crates/`, device-only `examples/`, `Cargo.toml`, `Cargo.lock` and the toolchain pin are not among them. A platform bump publishes `beta-vX.Y.Z` without requiring every Store app to bump. A Store-only merge publishes `app-catalog-beta` without a workspace version bump.

When the catalog run decides there is nothing to publish, it still verifies the already-published `app-catalog-beta` (#109) and now fails if Store inputs moved anyway, the same way the platform fails when packaged paths moved and the version did not (#111).

`docs/RELEASE-TRAIN.md` now names the two promotion workflows and the exact `workflow_dispatch` fields so a human can promote the beta platform to `main` without promoting the Store catalog, and the other way around.

## Demonstration

Replaying path lists through both gates the way GitHub runs a `run:` block.

Store-only landing. Platform stays quiet; the catalog gate names the file that must publish:

    changed: apps/backgammon/src/main.rs
    changed: docs/apps/backgammon/index.html
    No device package input changed since beta-v0.3.5; 2 changed path(s) reach readers without a release.
    step exit=0

    app-catalog-beta is already published, but Store catalog inputs changed and this run is not publishing.
    These paths differ between the published catalog and this commit:
      apps/backgammon/src/main.rs
    step exit=1

Platform-only landing, the #101 case. Catalog stays quiet; the platform gate names the version bump:

    changed: crates/kobo-profile/src/lib.rs
    No Store catalog input changed since app-catalog-beta; 1 changed path(s) reach readers without a catalog publication.
    step exit=0

    beta-v0.3.5 is already published, but the device package is not what beta now builds.
    These paths differ between the published tag and this commit:
      crates/kobo-profile/src/lib.rs
    Raise version in [workspace.package] in Cargo.toml from 0.3.5 to 0.3.6
    step exit=1

A workspace version bump is the same split: platform red until the new `beta-v` is cut, catalog green.

Current `beta` since the last catalog publication (`626cc8b`, also `beta-v0.3.5`) has moved `crates/kobo-sim` and CI tooling. `check-app-versions --publish-needed` is `false` and `--list-packages` is `[]`. The catalog run stays quiet. The platform run is already red on `kobo-sim` from #111; this change does not reopen that.

## Promotion

Both promotions require the tested commit on `main` (merge `beta` without squashing). They do not promote each other.

Promote the Store catalog only, from `main`:

    gh workflow run "Promote tested beta apps" --ref main \
      -f tested_commit=COMMIT \
      -f expected_catalog_sha256=DIGEST \
      -f confirmation=promote-apps-SHORTSHA

Promote the platform only, from `main`:

    gh workflow run "Promote tested beta" --ref main \
      -f version=X.Y.Z \
      -f tested_commit=COMMIT \
      -f expected_archive_sha256=DIGEST \
      -f confirmation=promote-beta-vX.Y.Z

Re-run a quiet beta channel with the `beta` branch selected:

    gh workflow run "Publish apps" --ref beta
    gh workflow run "Publish beta platform" --ref beta

## Remaining coupling

A Store landing that also edits `Cargo.lock` still runs the existing consumer walk. A shared lock identity still marks every Store app that depends on it. That is the conservative cargo-graph rule, not a new architecture.

The reuse path from `060918d` is still in `apps.yml`: the `verified-app-set-<attempt>` artifact is filtered out of the per-app comparison, and a later run with `previous_artifact=set` reuses that complete set instead of rebuilding every app. A unit test now asserts those two lines are still present.

A bundled Store app that still lives under `examples/` (`kobo-todo`, `kobo-chat`, …) is both a device-package input and a catalog input. Changing one of those still requires a platform version bump and a Store version bump. Device-only examples (launcher, settings, store, terminal, hello) do not.

## Tests

`node --test tools/*.test.mjs`: 67 tests, 67 pass, 0 fail (38 after #111; this change adds the Store gate and the independence cases). `bash -n` passes on every `run:` block in `apps.yml`, `beta-release.yml`, `promote-beta.yml` and `promote-beta-apps.yml`. All four workflow files parse, with the same job names as before.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791073596&installation_model_id=20525&pr_number=113&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F113&signature=bc7dc8d02fd1323571b13882d05d7e6fe550d8e0c9744f164c1403ad680df143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
