### PR TITLE
Add orientation-aware display metrics

### DIFF
--- a/SDK.md
+++ b/SDK.md
@@ -182,6 +182,26 @@ hand it over:
 context.set_screen(ScreenBuilder::new("results").heading("Results").build());
 ```
 
+### Portrait and landscape
+
+Portrait is the compatibility default. An application that genuinely benefits
+from a wide viewport may request landscape for its current app session:
+
+```rust
+context.set_orientation(kobo_sdk::Orientation::Landscape);
+let metrics = context
+    .metrics()
+    .oriented(kobo_sdk::Orientation::Landscape);
+```
+
+The runtime keeps the framebuffer in its verified native mode and rotates the
+rendered surface in software when a hardware backend has not been independently
+validated for quarter turns. Touch coordinates are transformed through the
+same mapping. On readers that report a verified physical landscape side, the
+runtime follows that side; readers without orientation events use a fixed
+clockwise convention. Returning to the reader or starting another application
+restores the portrait default automatically.
+
 The runtime diffs it against the last one and picks an E Ink waveform from the
 pixels that changed. This is not a stylistic preference. A retained tree
 invites incremental mutation, incremental mutation on E Ink means many small

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -7,9 +7,9 @@ use std::io::{self, Read, Write};
 
 use kobo_ui::{
     ActionId, BannerLevel, BarAction, BarStyle, BottomAction, Caret, Cell, ControlState,
-    FontHandle, Freeform, Glyph, NavBar, Node, NodeId, PageTurns, Percent, PictureHandle, Row,
-    RowLead, RowState, Screen, Space, TextScale, Tile, TilePicture, TileShape, TileState, TopBar,
-    TransferFailure, MAX_BAR_ACTIONS, MAX_TERMINAL_COLUMNS, MAX_TERMINAL_ROWS,
+    FontHandle, Freeform, Glyph, NavBar, Node, NodeId, Orientation, PageTurns, Percent,
+    PictureHandle, Row, RowLead, RowState, Screen, Space, TextScale, Tile, TilePicture, TileShape,
+    TileState, TopBar, TransferFailure, MAX_BAR_ACTIONS, MAX_TERMINAL_COLUMNS, MAX_TERMINAL_ROWS,
     MIN_NAV_DESTINATIONS,
 };
 use std::cmp::min;
@@ -569,6 +569,9 @@ pub enum Message {
         text_scale: TextScale,
     },
     SetScreen(Screen),
+    /// Changes the logical direction for this application session. Omission
+    /// keeps the portrait-compatible default.
+    SetOrientation(Orientation),
     Action {
         action: ActionId,
     },
@@ -1719,6 +1722,7 @@ pub fn encode(frame: &Frame) -> Result<Vec<u8>, ProtocolError> {
             let mut count = 0;
             encode_screen(&mut payload, screen, 0, &mut count)?;
         }
+        Message::SetOrientation(orientation) => payload.push(*orientation as u8),
         Message::Action { action } => {
             push_u32(&mut payload, action.0);
         }
@@ -2267,6 +2271,7 @@ fn encoded_message_layout(message: &Message) -> Result<(u8, usize), ProtocolErro
             let mut count = 0;
             Ok((3, encoded_screen_len(screen, 0, &mut count)?))
         }
+        Message::SetOrientation(_) => Ok((36, 1)),
         Message::Action { .. } => Ok((4, 4)),
         Message::TextHold { start, end, .. } => {
             if start >= end {
@@ -3924,6 +3929,10 @@ pub fn decode(bytes: &[u8]) -> Result<Frame, ProtocolError> {
             let mut count = 0;
             Message::SetScreen(decode_screen(&mut reader, 0, &mut count)?)
         }
+        36 => Message::SetOrientation(
+            Orientation::from_wire(reader.u8()?)
+                .ok_or(ProtocolError::InvalidValue("orientation"))?,
+        ),
         4 => Message::Action {
             action: ActionId(reader.u32()?),
         },
@@ -8973,6 +8982,21 @@ mod picture_tests {
             Err(ProtocolError::InvalidValue("tile shape"))
         ));
     }
+
+    #[test]
+    fn orientation_request_round_trips_and_keeps_portrait_as_the_default() {
+        let frame = Frame {
+            request_id: 4,
+            message: Message::SetOrientation(Orientation::Landscape),
+        };
+        assert_eq!(
+            decode(&encode(&frame).expect("encode")).expect("decode"),
+            frame
+        );
+        assert_eq!(Orientation::default(), Orientation::Portrait);
+        assert_eq!(Orientation::Portrait as u8, 0);
+    }
+
     #[test]
     fn a_basic_credential_survives_an_encode_decode_round_trip() {
         // A gated catalogue is reached by name, and the name is all an

--- a/crates/kobo-sdk/src/lib.rs
+++ b/crates/kobo-sdk/src/lib.rs
@@ -21,12 +21,12 @@ pub use kobo_ui::{
     terminal_grid, terminal_grid_for, typographic_cover, ActionId, BandAlign, BandSlot,
     BannerLevel, BarAction, BarStyle, BottomAction, Caret, Cell, Chip, Chrome, ControlState,
     DiagnosticSeverity, DisplayMetrics, Emphasis, Fold, FontHandle, Freeform, Glyph, InlineFormula,
-    LayoutIssue, LayoutIssueKind, NavBar, Node, NodeId, Overlay, OverlayKind, ParagraphAlignment,
-    ParagraphPresentation, Percent, PictureHandle, ProseArea, RichTextSpan, Row, RowLead, RowState,
-    Screen, SlotWidth, Space, TextHit, TextPresentation, TextSelection, Tile, TilePicture,
-    TileShape, TileState, TopBar, TransferFailure, CLARA_BW_METRICS, MAX_BAND_SLOTS, MAX_CELLS,
-    MAX_CHIPS, MAX_CHOICE_OPTIONS, MAX_COLUMNS, MAX_INLINE_FORMULAE, MAX_QUOTE_DEPTH, MAX_ROWS,
-    MAX_TABS, MAX_TERMINAL_COLUMNS, MAX_TERMINAL_ROWS, TILE_BADGE_LIMIT,
+    LayoutIssue, LayoutIssueKind, NavBar, Node, NodeId, Orientation, Overlay, OverlayKind,
+    ParagraphAlignment, ParagraphPresentation, Percent, PictureHandle, ProseArea, RichTextSpan,
+    Row, RowLead, RowState, Screen, SlotWidth, Space, TextHit, TextPresentation, TextSelection,
+    Tile, TilePicture, TileShape, TileState, TopBar, TransferFailure, CLARA_BW_METRICS,
+    MAX_BAND_SLOTS, MAX_CELLS, MAX_CHIPS, MAX_CHOICE_OPTIONS, MAX_COLUMNS, MAX_INLINE_FORMULAE,
+    MAX_QUOTE_DEPTH, MAX_ROWS, MAX_TABS, MAX_TERMINAL_COLUMNS, MAX_TERMINAL_ROWS, TILE_BADGE_LIMIT,
 };
 use std::collections::BTreeMap;
 use std::collections::VecDeque;
@@ -2683,6 +2683,7 @@ fn stable_id(value: &str) -> u32 {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Command {
     SetScreen(Screen),
+    SetOrientation(Orientation),
     Log {
         level: LogLevel,
         message: String,
@@ -2734,6 +2735,10 @@ pub struct Context {
 }
 
 impl Context {
+    /// Sets the app session's logical viewport direction.
+    pub fn set_orientation(&mut self, orientation: Orientation) {
+        self.commands.push(Command::SetOrientation(orientation));
+    }
     /// The panel this application is drawing to.
     ///
     /// An application never positions anything, so this is not for layout. It
@@ -5024,6 +5029,7 @@ impl Client {
             };
             let message = match command {
                 Command::SetScreen(screen) => Message::SetScreen(screen),
+                Command::SetOrientation(orientation) => Message::SetOrientation(orientation),
                 Command::Log { level, message } => Message::Log { level, message },
                 Command::Device(request) => Message::DeviceRequest(request),
                 Command::Spawn { task, work } => Message::Spawn { task, work },

--- a/crates/kobo-sim/src/lib.rs
+++ b/crates/kobo-sim/src/lib.rs
@@ -816,6 +816,7 @@ fn is_picture_message(message: &Message) -> bool {
 #[derive(Debug)]
 struct AppState {
     screen: Screen,
+    orientation: kobo_ui::Orientation,
     /// How many screens the application has painted since it started.
     ///
     /// A driver posts a tap to this process and the application answers it in
@@ -850,6 +851,7 @@ impl AppState {
     fn with_apps(apps: Arc<Mutex<SimulatedApps>>) -> Self {
         Self {
             screen: Screen::new(0, Vec::new()),
+            orientation: kobo_ui::Orientation::Portrait,
             paints: 0,
             logs: Vec::new(),
             pictures: kobo_ui::PictureCache::default(),
@@ -1111,13 +1113,14 @@ impl AppSession {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let mut surface = Surface::new(PROFILE.width as usize, PROFILE.height as usize);
-        kobo_ui::render_all(
+        kobo_ui::render_oriented(
             &state.screen,
             &profile_metrics(),
             &kobo_ui::Chrome::default(),
             state.active_pictures(),
             &mut surface,
             None,
+            state.orientation,
         );
         state.panel.update(&surface);
         state.panel.frame(ideal).to_vec()
@@ -1797,6 +1800,12 @@ fn read_app_messages(
                     .map_err(|_| io::Error::other("app state lock poisoned"))?;
                 state.screen = screen;
                 state.paints = state.paints.saturating_add(1);
+            }
+            Message::SetOrientation(orientation) => {
+                state
+                    .lock()
+                    .map_err(|_| io::Error::other("app state lock poisoned"))?
+                    .orientation = orientation;
             }
             // The simulator hosts exactly one application, so a launch is
             // reported rather than performed. Pretending it worked would hide

--- a/crates/kobo-ui/src/lib.rs
+++ b/crates/kobo-ui/src/lib.rs
@@ -310,6 +310,41 @@ pub struct DisplayMetrics {
     pub text_scale: TextScale,
 }
 
+/// Direction of an application's logical viewport.
+///
+/// Portrait keeps the established panel coordinate system. Landscape is
+/// rendered in software into a swapped viewport, then rotated clockwise into
+/// the unchanged physical framebuffer.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+#[repr(u8)]
+pub enum Orientation {
+    #[default]
+    Portrait = 0,
+    Landscape = 1,
+}
+
+/// Which physical side is down while a landscape viewport is displayed.
+///
+/// Sensor-equipped readers may update this during a session. Readers without
+/// an orientation event source use [`LandscapeTurn::Clockwise`].
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub enum LandscapeTurn {
+    #[default]
+    Clockwise,
+    CounterClockwise,
+}
+
+impl Orientation {
+    #[must_use]
+    pub const fn from_wire(value: u8) -> Option<Self> {
+        match value {
+            0 => Some(Self::Portrait),
+            1 => Some(Self::Landscape),
+            _ => None,
+        }
+    }
+}
+
 /// A small, deliberate accessibility scale rather than an arbitrary zoom.
 ///
 /// Applications continue to ask for semantic sizes such as [`FontSize::Body`].
@@ -461,6 +496,14 @@ impl Default for DisplayMetrics {
 }
 
 impl DisplayMetrics {
+    /// Metrics in the logical viewport requested by an application.
+    #[must_use]
+    pub const fn oriented(mut self, orientation: Orientation) -> Self {
+        if matches!(orientation, Orientation::Landscape) {
+            (self.width, self.height) = (self.height, self.width);
+        }
+        self
+    }
     /// Converts a tenth of a millimetre to whole pixels, rounding to nearest.
     ///
     /// Tenths because whole millimetres are too coarse for a type scale, and
@@ -10266,6 +10309,109 @@ pub fn render_with(
     render_all(screen, metrics, chrome, &(), surface, dirty);
 }
 
+/// Maps a physical touch into the current logical viewport.
+///
+/// The clockwise display convention puts logical top-left at physical
+/// top-right; this is its exact inverse.
+#[must_use]
+pub const fn logical_point(
+    orientation: Orientation,
+    physical_width: i32,
+    x: i32,
+    y: i32,
+) -> (i32, i32) {
+    logical_point_with_turn(
+        orientation,
+        LandscapeTurn::Clockwise,
+        physical_width,
+        0,
+        x,
+        y,
+    )
+}
+
+/// Maps a physical touch into a logical viewport using the observed side.
+#[must_use]
+pub const fn logical_point_with_turn(
+    orientation: Orientation,
+    turn: LandscapeTurn,
+    physical_width: i32,
+    physical_height: i32,
+    x: i32,
+    y: i32,
+) -> (i32, i32) {
+    match orientation {
+        Orientation::Portrait => (x, y),
+        Orientation::Landscape => match turn {
+            LandscapeTurn::Clockwise => (y, physical_width - 1 - x),
+            LandscapeTurn::CounterClockwise => (physical_height - 1 - y, x),
+        },
+    }
+}
+
+/// Renders into the physical framebuffer, using a full repaint for software
+/// landscape so rotated partial damage can never miss a changed pixel.
+pub fn render_oriented(
+    screen: &Screen,
+    metrics: &DisplayMetrics,
+    chrome: &Chrome,
+    pictures: &dyn Pictures,
+    surface: &mut Surface,
+    dirty: Option<Rect>,
+    orientation: Orientation,
+) {
+    render_oriented_with_turn(
+        screen,
+        metrics,
+        chrome,
+        pictures,
+        surface,
+        dirty,
+        orientation,
+        LandscapeTurn::Clockwise,
+    );
+}
+
+/// Renders an oriented viewport using the physical landscape side.
+#[allow(clippy::too_many_arguments)]
+pub fn render_oriented_with_turn(
+    screen: &Screen,
+    metrics: &DisplayMetrics,
+    chrome: &Chrome,
+    pictures: &dyn Pictures,
+    surface: &mut Surface,
+    dirty: Option<Rect>,
+    orientation: Orientation,
+    turn: LandscapeTurn,
+) {
+    if orientation == Orientation::Portrait {
+        render_all(screen, metrics, chrome, pictures, surface, dirty);
+        return;
+    }
+    let mut logical = Surface::new(surface.height, surface.width);
+    render_all(
+        screen,
+        &metrics.oriented(orientation),
+        chrome,
+        pictures,
+        &mut logical,
+        None,
+    );
+    rotate_landscape(&logical, surface, turn);
+}
+
+fn rotate_landscape(logical: &Surface, physical: &mut Surface, turn: LandscapeTurn) {
+    for y in 0..logical.height {
+        for x in 0..logical.width {
+            let destination = match turn {
+                LandscapeTurn::Clockwise => x * physical.width + (physical.width - 1 - y),
+                LandscapeTurn::CounterClockwise => (physical.height - 1 - x) * physical.width + y,
+            };
+            physical.pixels[destination] = logical.pixels[y * logical.width + x];
+        }
+    }
+}
+
 /// Rasterizes a retained screen, drawing pictures from `pictures`.
 ///
 /// This is the whole renderer; [`render_with`] is this with an empty picture
@@ -19139,5 +19285,53 @@ mod figure_tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn landscape_swaps_metrics_and_maps_both_physical_sides() {
+        let landscape = super::CLARA_BW_METRICS.oriented(super::Orientation::Landscape);
+        assert_eq!((landscape.width, landscape.height), (1448, 1072));
+        assert_eq!(
+            super::logical_point_with_turn(
+                super::Orientation::Landscape,
+                super::LandscapeTurn::Clockwise,
+                1072,
+                1448,
+                1071,
+                0,
+            ),
+            (0, 0)
+        );
+        assert_eq!(
+            super::logical_point_with_turn(
+                super::Orientation::Landscape,
+                super::LandscapeTurn::CounterClockwise,
+                1072,
+                1448,
+                0,
+                1447,
+            ),
+            (0, 0)
+        );
+    }
+
+    #[test]
+    fn software_rotation_places_every_corner_for_both_landscape_sides() {
+        let logical = super::Surface {
+            width: 3,
+            height: 2,
+            pixels: vec![1, 2, 3, 4, 5, 6],
+        };
+        let mut clockwise = super::Surface::new(2, 3);
+        super::rotate_landscape(&logical, &mut clockwise, super::LandscapeTurn::Clockwise);
+        assert_eq!(clockwise.pixels, [4, 1, 5, 2, 6, 3]);
+
+        let mut counter_clockwise = super::Surface::new(2, 3);
+        super::rotate_landscape(
+            &logical,
+            &mut counter_clockwise,
+            super::LandscapeTurn::CounterClockwise,
+        );
+        assert_eq!(counter_clockwise.pixels, [3, 6, 2, 5, 1, 4]);
     }
 }

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -45,8 +45,7 @@ use kobo_hal::{Rect, RefreshIntent, RefreshPlan, RegionSnapshot};
 use kobo_policy::{Backends, Capability, Declared, DeviceServices, PowerPolicy, TaskRunner};
 use kobo_protocol::{Frame, Lifecycle, Message, TaskError, TaskOutcome};
 use kobo_ui::{
-    render_all, ActionId, CellStyle, Chrome, FontHandle, Layout, LayoutKind, PictureCache, Screen,
-    Surface,
+    ActionId, CellStyle, Chrome, FontHandle, Layout, LayoutKind, PictureCache, Screen, Surface,
 };
 use std::collections::BTreeMap;
 use std::fs;

--- a/crates/kobod/src/device.rs
+++ b/crates/kobod/src/device.rs
@@ -990,13 +990,14 @@ fn announce_reboot(
         usize::try_from(whole_screen.width).unwrap_or(0),
         usize::try_from(whole_screen.height).unwrap_or(0),
     );
-    render_all(
+    kobo_ui::render_oriented(
         &screen,
         &metrics_for(&screen),
         &Chrome::with_back(false),
         &(),
         &mut surface,
         None,
+        kobo_ui::Orientation::Portrait,
     );
     // A fresh planner, so its idea of what is already on the panel is blank and
     // the whole notice is drawn rather than diffed against the session's last
@@ -1077,6 +1078,11 @@ struct Hosted {
     pictures: PictureCache,
     /// Application-local font handles mapped onto runtime-global handles.
     fonts: BTreeMap<FontHandle, FontHandle>,
+    /// Logical direction requested by this application.
+    orientation: kobo_ui::Orientation,
+    /// Physical side selected by a verified orientation event, or the fixed
+    /// fallback on readers without an orientation sensor.
+    landscape_turn: kobo_ui::LandscapeTurn,
     painted: u32,
     /// When this was last on the panel, for deciding what to stop first.
     used: Instant,
@@ -1629,18 +1635,44 @@ fn host_applications(
                             // then the press is at least on the record.
                             trace(&format!("power button pressed={pressed}"));
                         }
-                        // The kernel's digested accelerometer verdict. Only
-                        // the two portrait poses move the key mapping; the
-                        // image itself does not rotate mid-session yet.
-                        // The pose each MSC_RAW value names was measured here
-                        // by a rotation-only capture, and then confirmed in
-                        // use: a reader turned end for end mid-session, with
-                        // no restart, goes on paging the way it is now held.
+                        // Sensor-equipped readers report which physical side
+                        // is down. Readers without these events keep the fixed
+                        // clockwise software-landscape fallback.
                         GpioEvent::Orientation(gpio::Orientation::PortraitUp) => {
                             forward_is_194 = true;
                         }
                         GpioEvent::Orientation(gpio::Orientation::PortraitDown) => {
                             forward_is_194 = false;
+                        }
+                        GpioEvent::Orientation(
+                            orientation @ (gpio::Orientation::LandscapeLeft
+                            | gpio::Orientation::LandscapeRight),
+                        ) => {
+                            let turn = match orientation {
+                                gpio::Orientation::LandscapeLeft => {
+                                    kobo_ui::LandscapeTurn::Clockwise
+                                }
+                                gpio::Orientation::LandscapeRight => {
+                                    kobo_ui::LandscapeTurn::CounterClockwise
+                                }
+                                _ => unreachable!(),
+                            };
+                            let changed = apps.iter().any(|app| app.landscape_turn != turn);
+                            for app in &mut apps {
+                                app.landscape_turn = turn;
+                            }
+                            if changed {
+                                repaint(
+                                    &mut apps,
+                                    front,
+                                    display,
+                                    whole_screen,
+                                    &mut surface,
+                                    &mut panel,
+                                    &home,
+                                    &mut status,
+                                )?;
+                            }
                         }
                         GpioEvent::Button { .. } | GpioEvent::Orientation(_) => {}
                     }
@@ -1660,6 +1692,8 @@ fn host_applications(
                         || Chrome::with_back(!at_home),
                         |screen| chrome_for(screen, at_home, &mut status),
                     );
+                    let orientation = apps[index].orientation;
+                    let landscape_turn = apps[index].landscape_turn;
                     // A control shows that it has been touched, before
                     // anything it does can be seen. Without this the panel is
                     // simply still for as long as the application takes to
@@ -1676,6 +1710,9 @@ fn host_applications(
                             TouchEvent::Down { x, y } => {
                                 if let (Ok(x), Ok(y)) = (i32::try_from(x), i32::try_from(y)) {
                                     landed = Some((Instant::now(), x, y));
+                                    if orientation == kobo_ui::Orientation::Landscape {
+                                        continue;
+                                    }
                                     let layout =
                                         current.layout_with(&metrics_for(current), &chrome);
                                     if let Some(rect) = layout.pressed_control(x, y) {
@@ -1772,6 +1809,8 @@ fn host_applications(
                         screen.as_ref(),
                         &chrome,
                         held,
+                        orientation,
+                        landscape_turn,
                     )?;
                     match disposition {
                         Tap::Handled => {}
@@ -1838,13 +1877,15 @@ fn host_applications(
                                 // rectangle of the new screen instead.
                                 pressed = None;
                                 release_due = None;
-                                render_all(
+                                kobo_ui::render_oriented_with_turn(
                                     &screen,
                                     &metrics_for(&screen),
                                     &chrome,
                                     &apps[index].pictures,
                                     &mut surface,
                                     None,
+                                    apps[index].orientation,
+                                    apps[index].landscape_turn,
                                 );
                                 panel.paint(display, whole_screen, &surface)?;
                                 apps[index].painted += 1;
@@ -1853,6 +1894,26 @@ fn host_applications(
                             // finished its work has a finished screen waiting,
                             // rather than the reader watching it be rebuilt.
                             apps[index].screen = Some(screen);
+                        }
+                        Message::SetOrientation(orientation) => {
+                            apps[index].orientation = orientation;
+                            if id == front {
+                                if let Some(screen) = apps[index].screen.as_ref() {
+                                    let chrome =
+                                        chrome_for(screen, apps[index].path == home, &mut status);
+                                    kobo_ui::render_oriented_with_turn(
+                                        screen,
+                                        &metrics_for(screen),
+                                        &chrome,
+                                        &apps[index].pictures,
+                                        &mut surface,
+                                        None,
+                                        orientation,
+                                        apps[index].landscape_turn,
+                                    );
+                                    panel.paint(display, whole_screen, &surface)?;
+                                }
+                            }
                         }
                         Message::PutPicture {
                             handle,
@@ -2643,13 +2704,15 @@ fn repaint(
         return Ok(());
     };
     let chrome = chrome_for(&screen, apps[index].path == home, status);
-    render_all(
+    kobo_ui::render_oriented_with_turn(
         &screen,
         &metrics_for(&screen),
         &chrome,
         &apps[index].pictures,
         surface,
         None,
+        apps[index].orientation,
+        apps[index].landscape_turn,
     );
     panel.paint(display, whole_screen, surface)?;
     apps[index].painted += 1;
@@ -3044,6 +3107,8 @@ fn start_application(
         screen: None,
         pictures: PictureCache::default(),
         fonts: BTreeMap::new(),
+        orientation: kobo_ui::Orientation::Portrait,
+        landscape_turn: kobo_ui::LandscapeTurn::Clockwise,
         painted: 0,
         used: Instant::now(),
     });
@@ -3307,11 +3372,30 @@ fn with_trace_failure(error: String, child: &ApplicationChild) -> String {
 /// Activation happens on release rather than on contact, so a finger that lands
 /// on the wrong control can be slid away from it without acting. That is what
 /// every touch interface the owner already uses has taught them to expect.
+#[cfg(test)]
 fn action_for(
     event: TouchEvent,
     screen: Option<&Screen>,
     chrome: &Chrome,
     held: bool,
+) -> Option<ActionId> {
+    action_for_oriented(
+        event,
+        screen,
+        chrome,
+        held,
+        kobo_ui::Orientation::Portrait,
+        kobo_ui::LandscapeTurn::Clockwise,
+    )
+}
+
+fn action_for_oriented(
+    event: TouchEvent,
+    screen: Option<&Screen>,
+    chrome: &Chrome,
+    held: bool,
+    orientation: kobo_ui::Orientation,
+    landscape_turn: kobo_ui::LandscapeTurn,
 ) -> Option<ActionId> {
     let TouchEvent::Up { x, y } = event else {
         return None;
@@ -3324,7 +3408,17 @@ fn action_for(
     };
     // The same chrome the frame was drawn with. Laying out with a different
     // one would move every control away from where the reader can see it.
-    let layout = screen.layout_with(&metrics_for(screen), chrome);
+    let physical = crate::device_metrics();
+    let metrics = metrics_for(screen).oriented(orientation);
+    let (x, y) = kobo_ui::logical_point_with_turn(
+        orientation,
+        landscape_turn,
+        physical.width,
+        physical.height,
+        x,
+        y,
+    );
+    let layout = screen.layout_with(&metrics, chrome);
     // A hold that the screen asked for wins over the tap the same pixels would
     // otherwise have been. Falls back rather than swallowing the touch: a
     // finger resting a moment too long on a page of a book that does not want
@@ -3374,11 +3468,12 @@ fn page_key_message(
     }
 }
 
-fn text_hold_for(
+fn text_hold_for_oriented(
     event: TouchEvent,
     screen: Option<&Screen>,
     chrome: &Chrome,
     held: bool,
+    orientation: kobo_ui::Orientation,
 ) -> Option<(ActionId, kobo_ui::TextHit)> {
     if !held {
         return None;
@@ -3391,7 +3486,7 @@ fn text_hold_for(
     let (Ok(x), Ok(y)) = (i32::try_from(x), i32::try_from(y)) else {
         return None;
     };
-    let layout = screen.layout_with(&metrics_for(screen), chrome);
+    let layout = screen.layout_with(&metrics_for(screen).oriented(orientation), chrome);
     layout.hit_text(x, y).map(|hit| (action, hit))
 }
 
@@ -3509,8 +3604,33 @@ fn deliver_touch(
     current: Option<&Screen>,
     chrome: &Chrome,
     held: bool,
+    orientation: kobo_ui::Orientation,
+    landscape_turn: kobo_ui::LandscapeTurn,
 ) -> Result<Tap, String> {
-    if let Some((action, hit)) = text_hold_for(event, current, chrome, held) {
+    let logical_event = match event {
+        TouchEvent::Up { x, y } => {
+            let (Ok(x), Ok(y)) = (i32::try_from(x), i32::try_from(y)) else {
+                return Ok(Tap::Handled);
+            };
+            let physical = crate::device_metrics();
+            let (x, y) = kobo_ui::logical_point_with_turn(
+                orientation,
+                landscape_turn,
+                physical.width,
+                physical.height,
+                x,
+                y,
+            );
+            TouchEvent::Up {
+                x: u32::try_from(x).map_err(|_| "logical touch x is negative")?,
+                y: u32::try_from(y).map_err(|_| "logical touch y is negative")?,
+            }
+        }
+        other => other,
+    };
+    if let Some((action, hit)) =
+        text_hold_for_oriented(logical_event, current, chrome, held, orientation)
+    {
         kobo_protocol::write_to(
             stream,
             &Frame {
@@ -3526,7 +3646,9 @@ fn deliver_touch(
         .map_err(|error| format!("deliver a text hold: {error}"))?;
         return Ok(Tap::Handled);
     }
-    let Some(action) = action_for(event, current, chrome, held) else {
+    let Some(action) =
+        action_for_oriented(event, current, chrome, held, orientation, landscape_turn)
+    else {
         return Ok(Tap::Handled);
     };
     let offered = action == ActionId::BACK;
@@ -4085,6 +4207,62 @@ mod tests {
         );
     }
 
+    #[test]
+    fn landscape_taps_reach_the_same_control_from_either_physical_side() {
+        let action = ActionId(77);
+        let screen = Screen::new(
+            1,
+            vec![kobo_ui::Node::Button {
+                id: kobo_ui::NodeId(1),
+                action,
+                label: "Open".to_owned(),
+                state: kobo_ui::ControlState::Enabled,
+                emphasis: kobo_ui::Emphasis::Primary,
+            }],
+        );
+        let chrome = kobo_ui::Chrome::default();
+        let physical = crate::device_metrics();
+        let logical_metrics = physical.oriented(kobo_ui::Orientation::Landscape);
+        let rect = screen
+            .layout_with(&logical_metrics, &chrome)
+            .rect_of_action(action)
+            .expect("button");
+        let logical_x = rect.x + rect.width / 2;
+        let logical_y = rect.y + rect.height / 2;
+
+        let clockwise = TouchEvent::Up {
+            x: u32::try_from(physical.width - 1 - logical_y).expect("physical x"),
+            y: u32::try_from(logical_x).expect("physical y"),
+        };
+        assert_eq!(
+            super::action_for_oriented(
+                clockwise,
+                Some(&screen),
+                &chrome,
+                false,
+                kobo_ui::Orientation::Landscape,
+                kobo_ui::LandscapeTurn::Clockwise,
+            ),
+            Some(action)
+        );
+
+        let counter_clockwise = TouchEvent::Up {
+            x: u32::try_from(logical_y).expect("physical x"),
+            y: u32::try_from(physical.height - 1 - logical_x).expect("physical y"),
+        };
+        assert_eq!(
+            super::action_for_oriented(
+                counter_clockwise,
+                Some(&screen),
+                &chrome,
+                false,
+                kobo_ui::Orientation::Landscape,
+                kobo_ui::LandscapeTurn::CounterClockwise,
+            ),
+            Some(action)
+        );
+    }
+
     /// The three states a page key can land in, and the one that used to be
     /// wrong: a press while a dialog is up is dropped, not passed on raw.
     #[test]
@@ -4211,14 +4389,32 @@ mod tests {
         let (mut runtime, mut app) =
             std::os::unix::net::UnixStream::pair().expect("a pair of sockets");
         assert_eq!(
-            deliver_touch(&mut runtime, tap, Some(&screen), &chrome, false).expect("route the tap"),
+            deliver_touch(
+                &mut runtime,
+                tap,
+                Some(&screen),
+                &chrome,
+                false,
+                kobo_ui::Orientation::Portrait,
+                kobo_ui::LandscapeTurn::Clockwise,
+            )
+            .expect("route the tap"),
             Tap::Leave,
             "a screen that did not ask keeps the old behaviour"
         );
 
         let owning = screen.clone().with_own_back(true);
         assert_eq!(
-            deliver_touch(&mut runtime, tap, Some(&owning), &chrome, false).expect("route the tap"),
+            deliver_touch(
+                &mut runtime,
+                tap,
+                Some(&owning),
+                &chrome,
+                false,
+                kobo_ui::Orientation::Portrait,
+                kobo_ui::LandscapeTurn::Clockwise,
+            )
+            .expect("route the tap"),
             Tap::OfferedBack
         );
         let frame = kobo_protocol::read_from(&mut app).expect("the application is told");

--- a/crates/kobod/src/main.rs
+++ b/crates/kobod/src/main.rs
@@ -680,6 +680,7 @@ fn serve_application(
     let store = kobo_policy::store::Store::new(std::env::temp_dir().join("cobalt-host-state"));
     let shelf = kobo_policy::shelf::Shelf::new(std::env::temp_dir().join("cobalt-host-data"));
     let mut pictures = kobo_ui::PictureCache::default();
+    let mut orientation = kobo_ui::Orientation::Portrait;
     loop {
         let frame = kobo_protocol::read_from(stream)?;
         match frame.message {
@@ -687,8 +688,9 @@ fn serve_application(
                 // Per screen, as the device does it: a book is drawn
                 // without a band and everything else with one.
                 let chrome = simulated_chrome(name, &screen);
-                write_screen(frame_path, screen, &chrome, name, &pictures)?;
+                write_screen(frame_path, screen, &chrome, name, &pictures, orientation)?;
             }
+            Message::SetOrientation(requested) => orientation = requested,
             Message::PutPicture {
                 handle,
                 width,
@@ -925,6 +927,7 @@ fn write_screen(
     chrome: &kobo_ui::Chrome,
     name: &str,
     pictures: &dyn kobo_ui::Pictures,
+    orientation: kobo_ui::Orientation,
 ) -> Result<(), Box<dyn Error>> {
     let mut surface = Surface::new(
         usize::try_from(crate::device_metrics().width)?,
@@ -943,7 +946,15 @@ fn write_screen(
     // the prose keeps the reader's own size either way.
     kobo_ui::set_text_scale(metrics.text_scale);
     kobo_ui::set_reading_scale(screen.text_scale.unwrap_or(metrics.text_scale));
-    kobo_ui::render_all(&screen, &metrics, chrome, pictures, &mut surface, None);
+    kobo_ui::render_oriented(
+        &screen,
+        &metrics,
+        chrome,
+        pictures,
+        &mut surface,
+        None,
+        orientation,
+    );
 
     let temporary = path.with_extension(format!("raw.tmp-{}", std::process::id()));
     let mut file = OpenOptions::new()

--- a/tools/app-release-compatible-changes.json
+++ b/tools/app-release-compatible-changes.json
@@ -3,22 +3,22 @@
   "changes": [
     {
       "protocol_version": 11,
-      "reason": "Additive protocol-11 update-channel settings used only by the bundled runtime and Settings app",
+      "reason": "Additive protocol-11 orientation command is opt-in; existing Store apps keep their existing messages and portrait rendering",
       "files": [
         {
           "path": "crates/kobo-protocol/src/lib.rs",
-          "base_blob": "8c30366191af89abc121075544635bf871fdfac4",
-          "compatible_blob": "f34528d7b407e542a7836b0348b91de043822274"
-        },
-        {
-          "path": "crates/kobo-policy/src/services.rs",
-          "base_blob": "d0a852942683f396baaf3803830d9c19c9911f18",
-          "compatible_blob": "e5b8617ac601332dd9b5d39c8e6ea83d613e171b"
+          "base_blob": "f34528d7b407e542a7836b0348b91de043822274",
+          "compatible_blob": "50e99c1933462675c1a9f1e368023c375775d10b"
         },
         {
           "path": "crates/kobo-sdk/src/lib.rs",
-          "base_blob": "52bd17b242beee85f691ebefdd0083fdabbd4550",
-          "compatible_blob": "9a645f3f3d9c8746dda47d858bb3fcd744621df8"
+          "base_blob": "9a645f3f3d9c8746dda47d858bb3fcd744621df8",
+          "compatible_blob": "1ff0ec9725746213be19556b1c035de890878c34"
+        },
+        {
+          "path": "crates/kobo-ui/src/lib.rs",
+          "base_blob": "ce538c70b5779ee482e2b35aa83191eb06b04b4d",
+          "compatible_blob": "d6c79d5ee6e3d574b3768da3721e865688e7f657"
         }
       ]
     }

--- a/tools/check-app-versions.mjs
+++ b/tools/check-app-versions.mjs
@@ -20,7 +20,8 @@ const MANIFEST_FIELDS = [
 const COMPATIBLE_PLATFORM_PATHS = new Set([
   "crates/kobo-policy/src/services.rs",
   "crates/kobo-protocol/src/lib.rs",
-  "crates/kobo-sdk/src/lib.rs"
+  "crates/kobo-sdk/src/lib.rs",
+  "crates/kobo-ui/src/lib.rs"
 ]);
 
 // Store packages are built from the current SDK and therefore speak its exact


### PR DESCRIPTION
Rebases the preserved orientation runtime work onto current beta. It adds app-scoped portrait/landscape rendering, transformed touch handling, and SDK documentation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791138230&installation_model_id=20525&pr_number=131&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F131&signature=8bf8c5c101c95f96abb89389244116d56b338637849317b19a3e3ea335dad406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->