### PR TITLE
Accept the package list the apps workflow validates

### DIFF
--- a/tools/check-app-versions.mjs
+++ b/tools/check-app-versions.mjs
@@ -807,58 +807,88 @@ export function affectedWorkspacePackages(baseRevision, registry, strictUnknown 
   return analyzeAppReleaseInputs(baseRevision, registry, strictUnknown).affected;
 }
 
+const DIFF_MODES = new Set(["--list-packages", "--publish-needed"]);
+const USAGE = [
+  "usage: node tools/check-app-versions.mjs [--list-packages|--publish-needed]",
+  "         --registry PATH --published-catalog PATH --base GIT_REVISION [--package NAME]",
+  "   or: node tools/check-app-versions.mjs --validate-packages",
+  "         --registry PATH --published-catalog PATH --packages JSON_ARRAY"
+].join("\n");
+
+// --validate-packages judges a package list the caller already settled on, so it
+// takes that list instead of deriving one from a base revision. The publish
+// workflow reaches it after it may have expanded an incremental selection back
+// to every package, at which point there is no single base the list came from.
 function argumentsFrom(argv) {
-  const mode = argv[0] === "--list-packages" || argv[0] === "--publish-needed" ? argv[0] : null;
+  const mode = DIFF_MODES.has(argv[0]) || argv[0] === "--validate-packages" ? argv[0] : null;
   if (mode) argv = argv.slice(1);
-  const required = ["--registry", "--published-catalog", "--base"];
-  const allowed = [...required, "--package"];
+  const validating = mode === "--validate-packages";
+  const required = validating
+    ? ["--registry", "--published-catalog", "--packages"]
+    : ["--registry", "--published-catalog", "--base"];
+  const allowed = validating ? required : [...required, "--package"];
   const values = new Map();
   for (let index = 0; index < argv.length; index += 2) {
     const flag = argv[index];
     const value = argv[index + 1];
-    if (!allowed.includes(flag) || !value) {
-      throw new Error(
-        "usage: node tools/check-app-versions.mjs --registry PATH --published-catalog PATH --base GIT_REVISION"
-      );
-    }
+    if (!allowed.includes(flag) || !value) throw new Error(USAGE);
     values.set(flag, value);
   }
-  if (!required.every(flag => values.has(flag))) {
-    throw new Error(
-      "usage: node tools/check-app-versions.mjs --registry PATH --published-catalog PATH --base GIT_REVISION"
-    );
-  }
+  if (!required.every(flag => values.has(flag))) throw new Error(USAGE);
   return { values, mode };
+}
+
+function requestedPackages(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("--packages must be a JSON array of package names");
+  }
+  if (!Array.isArray(parsed) || parsed.some(name => typeof name !== "string")) {
+    throw new Error("--packages must be a JSON array of package names");
+  }
+  return parsed;
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   try {
     const { values, mode } = argumentsFrom(process.argv.slice(2));
     const registry = readJson(resolve(values.get("--registry")), "app registry");
-    const selectedPackage = values.get("--package");
-    if (selectedPackage !== undefined) {
-      registry.apps = registry.apps.filter(app => app.package === selectedPackage);
-      if (registry.apps.length !== 1) {
-        throw new Error(`package ${selectedPackage} does not name exactly one registered app`);
-      }
-    }
     const published = readJson(resolve(values.get("--published-catalog")), "published catalog");
-    const { affected, storeChanges } = analyzeAppReleaseInputs(
-      values.get("--base"),
-      registry,
-      selectedPackage === undefined
-    );
-    checkProtocolMinimums(registry, currentProtocolVersion(), PROTOCOL_MINIMUMS, affected);
-    if (mode === "--list-packages") {
-      console.log(JSON.stringify(packagesToBuild(registry, published, affected)));
-    } else if (mode === "--publish-needed") {
-      console.log(releaseNeeded(registry, published, affected) ? "true" : "false");
+    if (mode === "--validate-packages") {
+      checkBuildPackages(
+        registry,
+        published,
+        requestedPackages(values.get("--packages")),
+        currentProtocolVersion()
+      );
+      console.log("Every selected app package is registered and carries a new version.");
     } else {
-      checkEntries(registry, published, affected);
-      if (storeChanges.length > 0 && !releaseNeeded(registry, published, affected)) {
-        throw new Error(unpublishedStoreChangeReport("the app catalog", storeChanges));
+      const selectedPackage = values.get("--package");
+      if (selectedPackage !== undefined) {
+        registry.apps = registry.apps.filter(app => app.package === selectedPackage);
+        if (registry.apps.length !== 1) {
+          throw new Error(`package ${selectedPackage} does not name exactly one registered app`);
+        }
       }
-      console.log("Every changed app package has a new version.");
+      const { affected, storeChanges } = analyzeAppReleaseInputs(
+        values.get("--base"),
+        registry,
+        selectedPackage === undefined
+      );
+      checkProtocolMinimums(registry, currentProtocolVersion(), PROTOCOL_MINIMUMS, affected);
+      if (mode === "--list-packages") {
+        console.log(JSON.stringify(packagesToBuild(registry, published, affected)));
+      } else if (mode === "--publish-needed") {
+        console.log(releaseNeeded(registry, published, affected) ? "true" : "false");
+      } else {
+        checkEntries(registry, published, affected);
+        if (storeChanges.length > 0 && !releaseNeeded(registry, published, affected)) {
+          throw new Error(unpublishedStoreChangeReport("the app catalog", storeChanges));
+        }
+        console.log("Every changed app package has a new version.");
+      }
     }
   } catch (error) {
     console.error(error.message);

--- a/tools/check-app-versions.test.mjs
+++ b/tools/check-app-versions.test.mjs
@@ -1,7 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   changedLockPackageIdentities,
   changedRegistryPackages,
@@ -432,6 +434,53 @@ test("apps workflow validates the final package matrix after fallback expansion"
     workflow.slice(validation, outputs),
     /--published-catalog published-app-catalog\.json \\\n\s+--packages "\$packages"/
   );
+});
+
+// Asserting the workflow's text kept passing while the command it describes
+// exited 1 on every publish run, because no test ever ran it. Read the flags
+// back out of the workflow and drive the real CLI with them, so a flag the tool
+// does not accept fails here rather than silently skipping app publication.
+test("the flags the apps workflow sends are ones the tool actually accepts", () => {
+  const workflow = readFileSync(".github/workflows/apps.yml", "utf8");
+  const validation = workflow.indexOf(
+    "node tools/check-app-versions.mjs --validate-packages"
+  );
+  const outputs = workflow.indexOf('echo "packages=$packages"');
+  const flags = [...workflow.slice(validation, outputs).matchAll(/--[a-z-]+/g)].map(
+    match => match[0]
+  );
+  assert.deepEqual(flags, [
+    "--validate-packages",
+    "--registry",
+    "--published-catalog",
+    "--packages"
+  ]);
+
+  const registry = collectRegistry();
+  const directory = mkdtempSync(join(tmpdir(), "check-app-versions-"));
+  const registryPath = join(directory, "generated-app-registry.json");
+  const publishedPath = join(directory, "published-app-catalog.json");
+  writeFileSync(registryPath, JSON.stringify(registry));
+  writeFileSync(publishedPath, '{"format_version":1,"entries":[]}\n');
+
+  const run = packages =>
+    execFileSync(
+      process.execPath,
+      [
+        "tools/check-app-versions.mjs",
+        "--validate-packages",
+        "--registry",
+        registryPath,
+        "--published-catalog",
+        publishedPath,
+        "--packages",
+        JSON.stringify(packages)
+      ],
+      { encoding: "utf8" }
+    );
+
+  assert.match(run(registry.apps.map(app => app.package)), /Every selected app package/);
+  assert.throws(() => run(["kobo-not-registered"]), /unknown build package/);
 });
 
 test("release inputs ignore exclusively dev-only dependency edges", () => {


### PR DESCRIPTION
## Summary
- `apps.yml` asked `check-app-versions.mjs` to validate the package list it had settled on, passing `--validate-packages` and `--packages`. The argument parser accepted neither flag and required a `--base` the workflow never sent, so the command exited 1 on every run.
- That failed the `trusted-tool` gate, which skipped `build-apps`, `publish` and `unbuilt-apps`. No app has been publishable from beta since the call was introduced in eb75e30.
- `checkBuildPackages` was already written and unit tested but unreachable from the command line. The validate mode now routes to it, taking the settled list rather than deriving one from a base revision.

## Why it was not caught
The test guarding this line only matched the workflow's text, so it stayed green while the command it described failed in production. It now reads the flags back out of `apps.yml` and runs the real tool.

## Test plan
- [x] `node --test tools/*.test.mjs`
- [x] Reverting the parser change fails only the new test
- [x] Valid list passes; unknown package and malformed `--packages` are rejected

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/133"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791220427&installation_model_id=20525&pr_number=133&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F133&signature=9179f619c95536587d6ec1035bb1a2412e47b19b494048968b7b2d053c9064e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->