### PR TITLE
Assemble the binary set from the collected registry

### DIFF
--- a/.github/workflows/apps.yml
+++ b/.github/workflows/apps.yml
@@ -543,7 +543,7 @@ jobs:
           fi
           node -e '
             const fs = require("fs");
-            const registry = JSON.parse(fs.readFileSync("apps/catalog.json", "utf8"));
+            const registry = JSON.parse(fs.readFileSync("generated-app-registry.json", "utf8"));
             for (const app of registry.apps) console.log(app.package);
           ' | while IFS= read -r package; do
             artifact="verified-app-${package}"

--- a/tools/app-registry.test.mjs
+++ b/tools/app-registry.test.mjs
@@ -144,13 +144,16 @@ test("no workflow checks the empty base catalog instead of the collected registr
     "the collected registry must carry more than the base catalog"
   );
 
+  // Not just `--registry`: the publish job read the file inline with
+  // readFileSync, emitted no packages, copied nothing, and failed on an empty
+  // upload. Any mention outside a comment is the same mistake.
   for (const name of readdirSync(".github/workflows")) {
     const workflow = readFileSync(`.github/workflows/${name}`, "utf8");
-    for (const [line] of workflow.matchAll(/^.*--registry\s+\S+.*$/gm)) {
-      assert.doesNotMatch(
-        line,
-        /--registry\s+apps\/catalog\.json/,
-        `${name} checks the empty base catalog: ${line.trim()}`
+    for (const line of workflow.split("\n")) {
+      if (line.trimStart().startsWith("#")) continue;
+      assert.ok(
+        !line.includes("apps/catalog.json"),
+        `${name} reads the empty base catalog instead of the collected registry: ${line.trim()}`
       );
     }
   }


### PR DESCRIPTION
## Summary
The publish job assembles the complete verified binary set by naming each registered package and copying its artifact. It read `apps/catalog.json` inline to get those names.

That file is the base the per-app manifests are collected onto, and the migration left it empty. The loop named no package, copied nothing into `dist/artifacts`, and the upload failed with "No files were found". All 44 applications built successfully and none of them reached the catalog.

## Why the existing guard missed it
The test added with the migration only looked for a `--registry` flag, so a `readFileSync` of the same path was invisible to it. It now refuses any mention of the base catalog outside a comment, and I confirmed it fails when the old read is put back.

## Test plan
- [x] `node --test tools/app-registry.test.mjs`
- [x] Restoring the inline read fails the guard
- [ ] Publish apps reaches the catalog on beta

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791222890&installation_model_id=20525&pr_number=134&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F134&signature=6937b47a79c25a01988ffad62792446c32a245fb0ac8806ac686e75ec1a1a14b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->