### PR TITLE
Build the reviewed Syncthing engine in the release

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -268,6 +268,46 @@ jobs:
           sudo chmod +x /usr/local/bin/armv7-musl-cc
           armv7-musl-cc --version
 
+      # apps/syncthing/build-armv7.sh is deliberately build-only: it refuses to
+      # download or execute a release artifact. Fetching source at a pinned
+      # commit is not that, so the recipe it documents runs here instead, with
+      # go mod verify and the same digest the runtime checks before it will
+      # spawn the engine. Nothing is trusted because it was downloaded: if
+      # these bytes are not the reviewed bytes, packaging refuses.
+      #
+      # build.go passes -trimpath and takes SOURCE_DATE_EPOCH from the commit
+      # timestamp, so the only thing left that can move the digest is the Go
+      # release, which is pinned by checksum here.
+      - name: Build the reviewed Syncthing engine from its pinned source
+        run: |
+          set -eu
+          commit=3382ccc3f16536b5a7b6df7c8212951f7d4d3a9f
+          expected=845336fa67494f38ecb69dfaa0a81de6e33e9b5427bd707385d85051596641a1
+          curl -fsSL -o /tmp/go.tar.gz https://go.dev/dl/go1.24.13.linux-amd64.tar.gz
+          echo "1fc94b57134d51669c72173ad5d49fd62afb0f1db9bf3f798fd98ee423f8d730  /tmp/go.tar.gz" \
+            | sha256sum -c -
+          sudo tar -xzf /tmp/go.tar.gz -C /opt
+          export PATH=/opt/go/bin:$PATH
+          go version
+          mkdir -p /tmp/syncthing
+          cd /tmp/syncthing
+          git init -q
+          git remote add origin https://github.com/syncthing/syncthing.git
+          git fetch -q --depth 1 origin "$commit"
+          git checkout -q FETCH_HEAD
+          test -f LICENSE
+          go mod verify
+          GOARM=7 CGO_ENABLED=0 go run build.go -goos linux -goarch arm build
+          actual="$(sha256sum syncthing | cut -d" " -f1)"
+          echo "expected $expected"
+          echo "actual   $actual"
+          if [ "$actual" != "$expected" ]; then
+            echo "The rebuilt engine is not the reviewed one." >&2
+            echo "The source record names a commit but not a Go release, so a" >&2
+            echo "different toolchain reproduces different bytes." >&2
+            exit 1
+          fi
+          echo "COBALT_SYNCTHING_ARTIFACT=/tmp/syncthing/syncthing" >> "$GITHUB_ENV"
       - name: Build the deterministic device package
         env:
           VERSION: ${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
## Why 0.3.7 still could not be packaged
The device job now compiles and links everything — all 44 apps and the runtime for armv7 — and then stops on the last step:

```
kobo: COBALT_SYNCTHING_ARTIFACT must name the reviewed Syncthing v2.0.9 ARM artifact
```

Packaging refuses without a Syncthing binary matching the digest `kobod` re-checks before it will spawn the engine. Nothing in the release supplied one.

## Why build rather than download
`apps/syncthing/build-armv7.sh` is explicit: *"deliberately build-only... It does not download or execute a release artifact."* Fetching **source at a pinned commit** is not that, so this runs the recipe that script documents — pinned commit `3382ccc3`, `go mod verify`, `GOARM=7 CGO_ENABLED=0` — and then applies the same digest check. Nothing is trusted because it was downloaded: bytes that are not the reviewed bytes stop the package.

The alternatives were storing an opaque binary outside the repo, or shipping beta without the Sync app. This keeps the review where it is: in the pinned digest.

## The one thing the provenance record is missing
`build.go` passes `-trimpath` and takes `SOURCE_DATE_EPOCH` from the **commit timestamp**, so nothing wall-clock leaks in. The only remaining variable is the **Go release**, and `SYNCTHING_SOURCE_RECORD` names a commit but no toolchain. Go 1.24.13 is pinned here by checksum.

If that is not the toolchain the reviewed digest came from, this step fails and prints both digests — which is the information needed either to pin the right one or to record it. Failing closed is the correct outcome for a binary the runtime will execute.

## Test plan
- [ ] The rebuilt engine matches the pinned digest
- [ ] `beta-v0.3.7` is cut and published

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791272710&installation_model_id=20525&pr_number=138&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F138&signature=4c1ae688b38dd674540154f7837ced52e3ac8e87806a00f78a01202f1678ab1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->