### PR TITLE
Release 0.3.8 to beta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "icon-import"
-version = "0.3.7"
+version = "0.3.8"
 
 [[package]]
 name = "image"
@@ -770,14 +770,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-abi"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "kobo-app-store"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-arxiv"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-audiobook"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-doc",
  "kobo-json",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-books"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-bookview"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-brief"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-chat"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-cli"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-app-store",
  "kobo-doc",
@@ -902,14 +902,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-dict"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "unicode-normalization",
 ]
 
 [[package]]
 name = "kobo-doc"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-html",
  "miniz_oxide 0.9.1",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doctor"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-flashcards-format"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "flate2",
  "kobo-image",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-frame-host"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "blake3",
  "image",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gallery"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-sdk",
 ]
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-guard"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gutenbird"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-hal"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-abi",
  "kobo-doc",
@@ -1047,21 +1047,21 @@ dependencies = [
 
 [[package]]
 name = "kobo-handoff"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-hello"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-hn"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-html"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "ratex-layout",
  "ratex-parser",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-image"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "image",
 ]
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-json"
-version = "0.3.7"
+version = "0.3.8"
 
 [[package]]
 name = "kobo-kitchencard"
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-launcher"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-profile",
  "kobo-sdk",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-magnet"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-morse"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-net"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "http",
  "httparse",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-opds"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-json",
  "kobo-xml",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-policy"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-abi",
  "kobo-dict",
@@ -1270,11 +1270,11 @@ dependencies = [
 
 [[package]]
 name = "kobo-profile"
-version = "0.3.7"
+version = "0.3.8"
 
 [[package]]
 name = "kobo-protocol"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-ui",
 ]
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-read"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-rss"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sdk"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-policy",
  "kobo-profile",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-settings"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-app-store",
  "kobo-json",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-shell"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-abi",
  "kobo-policy",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekick"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekickd"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "command-group",
  "kobo-json",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sim"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-net",
  "kobo-policy",
@@ -1397,14 +1397,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-smoke"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-store"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-stream"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-abi",
  "kobo-json",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sudoku"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tap"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-term"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-ui",
  "vt100",
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-terminal"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-policy",
  "kobo-sdk",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-text"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "fontdue",
  "kobo-ui",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tictactoe"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-todo"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-ui"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-profile",
  "unicode-segmentation",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-wifi-trace"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-json",
  "ring",
@@ -1531,11 +1531,11 @@ dependencies = [
 
 [[package]]
 name = "kobo-xml"
-version = "0.3.7"
+version = "0.3.8"
 
 [[package]]
 name = "kobo-zotero-reader"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "kobod"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "base64",
  "kobo-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 rust-version = "1.85.1"
 license = "AGPL-3.0-only"

--- a/tools/app-release-compatible-changes.json
+++ b/tools/app-release-compatible-changes.json
@@ -29,7 +29,7 @@
         {
           "path": "Cargo.lock",
           "base_blob": "2abdcc318538b63f16e492beb19b112a1134f105",
-          "compatible_blob": "65efde40df9512b30939ae00b6c6c0aacac73e04"
+          "compatible_blob": "4df97b904454b4fac491f2270a5845e542a20914"
         },
         {
           "path": "crates/kobo-abi/src/lib.rs",
@@ -155,7 +155,7 @@
         {
           "path": "Cargo.lock",
           "base_blob": "2abdcc318538b63f16e492beb19b112a1134f105",
-          "compatible_blob": "65efde40df9512b30939ae00b6c6c0aacac73e04"
+          "compatible_blob": "4df97b904454b4fac491f2270a5845e542a20914"
         },
         {
           "path": "crates/kobo-abi/src/lib.rs",


### PR DESCRIPTION
Publishes the smaller platform payload as `beta-v0.3.8`.

| | compressed | expanded |
| --- | --- | --- |
| 0.3.5, which updated over the air | 15.0 MB | 26.9 MB |
| 0.3.7, which did not | 31.0 MB | 63.0 MB |
| 0.3.8 | 18.2 MB | 35.1 MB |

The Syncthing engine is fetched on first use from `syncthing-v2.0.9` instead of
being carried in every release, and the runtime still checks its digest before
executing it.

Also carries the corrected protocol table from #141, so applications built
against protocol 13 are offered only to readers that can run them.

## No application is disturbed by this

Checked against the published beta catalog rather than assumed:

```
distinct app minimums: 0.3.7
RESULT: platform 0.3.8 demands no app version bumps
```

All 44 apps keep their versions. The Store catalog is published by a separate
workflow and is not touched by this release, so the untested apps stay in the
beta catalog only.

## Verified locally with the toolchain CI pins

- `cargo fmt --all -- --check` clean
- `sh -n` over the four shell scripts clean
- `node --test tools/*.test.mjs` 99 passed
- generated app pages already current
- `cargo +1.85.1 clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo +1.85.1 test --workspace --all-targets --all-features --locked` 2902 passed, 0 failed

## One thing worth fixing separately

`tools/app-release-compatible-changes.json` needed its `Cargo.lock` pin moved
again, for the fifth time, for a change that alters no application. The pin is
on the file's bytes rather than on what changed in it, so every workspace
version bump reads as an unreviewed release input and has to be re-blessed by
hand.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791287285&installation_model_id=20525&pr_number=142&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F142&signature=828bf0b42d3e1b651e76b22935de2c884e2b0b19f9ce9901dabb3c09f6ce1620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->