### PR TITLE
Make a failed platform update explain itself, and stop rebuilding the engine every release

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -5,8 +5,14 @@ on:
     branches: [beta]
   workflow_dispatch:
 
+# Read by default, and raised for the one job that publishes. The device
+# and host jobs run `cargo build`, which executes build scripts from every
+# dependency in the graph: third-party code on the runner should not be
+# able to see a token that can write to this repository. `prepare` only
+# reads -- it lists tags and waits on this commit's CI. This is the shape
+# apps.yml already uses.
 permissions:
-  contents: write
+  contents: read
   actions: read
 
 concurrency:
@@ -342,6 +348,8 @@ jobs:
     needs: [prepare, device, host]
     if: needs.prepare.outputs.publish == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -268,48 +268,16 @@ jobs:
           sudo chmod +x /usr/local/bin/armv7-musl-cc
           armv7-musl-cc --version
 
-      # apps/syncthing/build-armv7.sh is deliberately build-only: it refuses to
-      # download or execute a release artifact. Fetching source at a pinned
-      # commit is not that, so the recipe it documents runs here instead, with
-      # go mod verify and the same digest the runtime checks before it will
-      # spawn the engine. Nothing is trusted because it was downloaded: if
-      # these bytes are not the reviewed bytes, packaging refuses.
+      # The Syncthing engine used to be rebuilt here, so that packaging could
+      # embed the reviewed bytes. It is no longer part of the release: readers
+      # fetch it on first use from a tag of its own, because 27.9 MB of engine
+      # in a 31.0 MB update was charged to everybody whether or not they sync.
+      # Rebuilding it on every platform release now costs a Go toolchain
+      # download and a full build for an artifact this job does not package.
       #
-      # build.go passes -trimpath and takes SOURCE_DATE_EPOCH from the commit
-      # timestamp, so the only thing left that can move the digest is the Go
-      # release, which is pinned by checksum here.
-      - name: Build the reviewed Syncthing engine from its pinned source
-        run: |
-          set -eu
-          commit=3382ccc3f16536b5a7b6df7c8212951f7d4d3a9f
-          expected=e7e0523d8db0328b22ebff5c98bd721c94e295122771c0538414898a06ef8ebf
-          curl -fsSL -o /tmp/go.tar.gz https://go.dev/dl/go1.24.13.linux-amd64.tar.gz
-          echo "1fc94b57134d51669c72173ad5d49fd62afb0f1db9bf3f798fd98ee423f8d730  /tmp/go.tar.gz" \
-            | sha256sum -c -
-          sudo tar -xzf /tmp/go.tar.gz -C /opt
-          export PATH=/opt/go/bin:$PATH
-          go version
-          mkdir -p /tmp/syncthing
-          cd /tmp/syncthing
-          git init -q
-          git remote add origin https://github.com/syncthing/syncthing.git
-          git fetch -q --depth 1 origin "$commit"
-          git checkout -q FETCH_HEAD
-          test -f LICENSE
-          go mod verify
-          BUILD_USER=cobalt BUILD_HOST=cobalt GOARM=7 CGO_ENABLED=0 \
-            go run build.go -goos linux -goarch arm build
-          actual="$(sha256sum syncthing | cut -d" " -f1)"
-          echo "expected $expected"
-          echo "actual   $actual"
-          if [ "$actual" != "$expected" ]; then
-            echo "The rebuilt engine is not the reviewed one." >&2
-            echo "The recipe in SYNCTHING_SOURCE_RECORD should determine these" >&2
-            echo "bytes exactly; if it no longer does, something it does not name" >&2
-            echo "is leaking into the build." >&2
-            exit 1
-          fi
-          echo "COBALT_SYNCTHING_ARTIFACT=/tmp/syncthing/syncthing" >> "$GITHUB_ENV"
+      # The reproducibility claim still has to be checkable, so it moved to
+      # .github/workflows/syncthing-engine.yml, where it can be run on demand
+      # against the same pinned commit and the same digest the runtime enforces.
       - name: Build the deterministic device package
         env:
           VERSION: ${{ needs.prepare.outputs.version }}

--- a/.github/workflows/syncthing-engine.yml
+++ b/.github/workflows/syncthing-engine.yml
@@ -1,0 +1,94 @@
+name: Reproduce the Syncthing engine
+
+# The engine is not carried in the platform release: it is 27.9 MB, and
+# shipping it charged every reader a 31.0 MB update whether or not they use
+# Sync. It lives at its own tag and the runtime fetches it on first use.
+#
+# That tag is the only copy, so the claim that these bytes can be rebuilt from
+# source has to be checkable on demand rather than only at the moment somebody
+# happened to publish them. This rebuilds the engine from its pinned commit and
+# compares it against the digest the runtime enforces before it will spawn it.
+#
+# It used to run inside every beta platform release, which paid for a Go
+# toolchain download and a full Syncthing build on releases that no longer
+# package the result.
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Upload the rebuilt engine if the tag has no asset yet
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: cobalt-syncthing-engine
+  cancel-in-progress: false
+
+jobs:
+  reproduce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      # apps/syncthing/build-armv7.sh is deliberately build-only: it refuses to
+      # download or execute a release artifact. Fetching source at a pinned
+      # commit is not that, so the recipe it documents runs here instead, with
+      # go mod verify and the same digest the runtime checks.
+      #
+      # build.go passes -trimpath and takes SOURCE_DATE_EPOCH from the commit
+      # timestamp, so the only thing left that can move the digest is the Go
+      # release, which is pinned by checksum here.
+      - name: Build the reviewed engine from its pinned source
+        run: |
+          set -eu
+          commit=3382ccc3f16536b5a7b6df7c8212951f7d4d3a9f
+          expected=e7e0523d8db0328b22ebff5c98bd721c94e295122771c0538414898a06ef8ebf
+          curl -fsSL -o /tmp/go.tar.gz https://go.dev/dl/go1.24.13.linux-amd64.tar.gz
+          echo "1fc94b57134d51669c72173ad5d49fd62afb0f1db9bf3f798fd98ee423f8d730  /tmp/go.tar.gz" \
+            | sha256sum -c -
+          sudo tar -xzf /tmp/go.tar.gz -C /opt
+          export PATH=/opt/go/bin:$PATH
+          go version
+          mkdir -p /tmp/syncthing
+          cd /tmp/syncthing
+          git init -q
+          git remote add origin https://github.com/syncthing/syncthing.git
+          git fetch -q --depth 1 origin "$commit"
+          git checkout -q FETCH_HEAD
+          test -f LICENSE
+          go mod verify
+          BUILD_USER=cobalt BUILD_HOST=cobalt GOARM=7 CGO_ENABLED=0 \
+            go run build.go -goos linux -goarch arm build
+          actual="$(sha256sum syncthing | cut -d" " -f1)"
+          echo "expected $expected"
+          echo "actual   $actual"
+          if [ "$actual" != "$expected" ]; then
+            echo "The rebuilt engine is not the reviewed one." >&2
+            echo "The recipe in SYNCTHING_SOURCE_RECORD should determine these" >&2
+            echo "bytes exactly; if it no longer does, something it does not name" >&2
+            echo "is leaking into the build." >&2
+            exit 1
+          fi
+
+      - name: Publish the engine when the tag has none
+        if: inputs.publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          tag=syncthing-v2.0.9
+          # Refused rather than replaced. The runtime pins one digest, so a
+          # second set of bytes under this name could only ever be the wrong
+          # ones for some reader that already fetched the first.
+          if gh release view "$tag" --json assets \
+            --jq '.assets[].name' | grep -Fxq syncthing-armv7; then
+            echo "$tag already carries syncthing-armv7; refusing replacement" >&2
+            exit 1
+          fi
+          cp /tmp/syncthing/syncthing syncthing-armv7
+          gh release upload "$tag" syncthing-armv7

--- a/.github/workflows/syncthing-engine.yml
+++ b/.github/workflows/syncthing-engine.yml
@@ -22,16 +22,19 @@ on:
         default: false
         type: boolean
 
+# Read by default, and raised for exactly one job below. The rebuild runs
+# `go run build.go` from a repository fetched at build time, which is upstream
+# code executing on the runner: it should never be able to see a token that can
+# write to this repository. Splitting the upload out means a compromised build
+# script or Go dependency has nothing to reach for.
 permissions:
-  contents: write
-
-concurrency:
-  group: cobalt-syncthing-engine
-  cancel-in-progress: false
+  contents: read
 
 jobs:
   reproduce:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
@@ -74,9 +77,41 @@ jobs:
             echo "is leaking into the build." >&2
             exit 1
           fi
+          mkdir -p engine
+          cp syncthing "$GITHUB_WORKSPACE/syncthing-armv7"
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: inputs.publish
+        with:
+          name: syncthing-armv7
+          path: syncthing-armv7
+          if-no-files-found: error
+
+  publish:
+    needs: reproduce
+    if: inputs.publish
+    runs-on: ubuntu-latest
+    # The only job that can write, and it runs nothing from upstream: it
+    # downloads an artifact, checks it against the pinned digest again, and
+    # uploads it.
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: syncthing-armv7
+
+      # Checked again here rather than trusted from the job that built it. The
+      # bytes have been through artifact storage since they were verified, and
+      # this is the last moment before they become the copy every reader
+      # fetches.
+      - name: Check the artifact against the pinned digest
+        run: |
+          set -eu
+          expected=e7e0523d8db0328b22ebff5c98bd721c94e295122771c0538414898a06ef8ebf
+          echo "$expected  syncthing-armv7" | sha256sum -c -
 
       - name: Publish the engine when the tag has none
-        if: inputs.publish
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -85,10 +120,9 @@ jobs:
           # Refused rather than replaced. The runtime pins one digest, so a
           # second set of bytes under this name could only ever be the wrong
           # ones for some reader that already fetched the first.
-          if gh release view "$tag" --json assets \
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json assets \
             --jq '.assets[].name' | grep -Fxq syncthing-armv7; then
             echo "$tag already carries syncthing-armv7; refusing replacement" >&2
             exit 1
           fi
-          cp /tmp/syncthing/syncthing syncthing-armv7
-          gh release upload "$tag" syncthing-armv7
+          gh release upload "$tag" syncthing-armv7 --repo "$GITHUB_REPOSITORY"

--- a/apps/syncthing/README.md
+++ b/apps/syncthing/README.md
@@ -48,11 +48,19 @@ and relays remain enabled for direct and remote transfers.
 pinned upstream checkout and a caller-provided output directory. It does not
 download or execute a release artifact. It pins Syncthing `v2.0.9` commit
 `3382ccc3f16536b5a7b6df7c8212951f7d4d3a9f`, runs `go mod verify`, and refuses
-an output that differs from the repository-pinned SHA-256. Set
-`COBALT_SYNCTHING_ARTIFACT` to that verified binary before packaging. `kobod`
-compares the installed engine to the same digest compiled into the runtime; it
-refuses a symlink, group/world-writable, non-root-owned, or mismatched engine
-before spawning it.
+an output that differs from the repository-pinned SHA-256.
+
+The engine is not part of the platform package. It was 27.9 MB of a 31.0 MB
+release, which every reader downloaded on every update whether or not they use
+Sync, so it is published once under the `syncthing-v2.0.9` tag and `kobod`
+fetches it the first time somebody turns Sync on. Running this script proves
+those published bytes can be rebuilt from the pinned source; the same rebuild
+runs on demand in `.github/workflows/syncthing-engine.yml`.
+
+`kobod` compares the fetched engine to the same digest compiled into the
+runtime; it refuses a symlink, group/world-writable, non-root-owned, or
+mismatched engine before spawning it, whether the bytes arrived over the
+network or in an older platform package.
 
 Choosing hourly, four-hourly, or daily in the app requests Cobalt's bounded
 scheduled-wake facility; manual mode and Pause cancel it. A scheduled launcher

--- a/apps/syncthing/build-armv7.sh
+++ b/apps/syncthing/build-armv7.sh
@@ -30,4 +30,5 @@ ACTUAL_SHA256=$(shasum -a 256 "$SYNCTHING_OUTPUT/syncthing" | awk '{print $1}')
 test "$ACTUAL_SHA256" = "$EXPECTED_SHA256"
 printf '%s\n' "$ACTUAL_SHA256" > "$SYNCTHING_OUTPUT/syncthing.sha256"
 echo "built $(wc -c < "$SYNCTHING_OUTPUT/syncthing") bytes"
-echo "export COBALT_SYNCTHING_ARTIFACT='$SYNCTHING_OUTPUT/syncthing' before packaging"
+echo "matches the digest the runtime enforces; the engine is published once at"
+echo "the syncthing-v2.0.9 tag and fetched on first use, not packaged"

--- a/apps/syncthing/cobalt-app.json
+++ b/apps/syncthing/cobalt-app.json
@@ -4,8 +4,8 @@
   "short_label": "Sync",
   "summary": "Choose folders and a battery-friendly sync schedule.",
   "page_description": "Keep selected folders in sync while controlling when your Kobo uses Wi-Fi.",
-  "version": "0.2.1",
-  "release_notes": "Rebuild Sync against a Syncthing engine pinned to a digest the build recipe can reproduce.",
+  "version": "0.2.2",
+  "release_notes": "Download the sync engine the first time Sync is turned on, so readers who never use it no longer carry it in every platform update.",
   "glyph": "refresh",
   "capabilities": [
     "scheduled-wake"
@@ -13,7 +13,7 @@
   "setup": {
     "steps": [
       {
-        "text": "Sync requires a Cobalt platform build containing the pinned ARMv7 Syncthing engine and a package-manager-installed Syncthing binary on your computer."
+        "text": "The first time Sync runs it downloads its engine over Wi-Fi and checks it against the digest the runtime requires, so the Kobo needs to be online once. Your computer needs a package-manager-installed Syncthing binary."
       },
       {
         "text": "Pair exactly one local directory to a fixed safe folder while the Kobo is awake on Wi-Fi.",

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -1683,7 +1683,15 @@ impl DeviceError {
             Self::Authentication => "authentication failed",
             Self::TimedOut => "the radio operation timed out",
             Self::Unreachable => "the device or network is unreachable",
-            Self::InvalidInput => "the address or credentials are invalid",
+            // Deliberately says nothing about addresses or credentials. This
+            // variant is the general "what arrived was not usable" answer and
+            // is returned for a malformed release archive and an expired
+            // pairing as readily as for a bad network address. Naming the
+            // radio here sent an owner whose platform update had failed to
+            // look at their Wi-Fi settings, and gave whoever they reported it
+            // to nothing to go on. What actually failed is traced at the site
+            // that knows.
+            Self::InvalidInput => "the data received was not usable",
             Self::Backend => "the system radio service failed",
             Self::Integrity => "the download did not match its published digest",
         }
@@ -7017,6 +7025,43 @@ impl<'a> Reader<'a> {
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    #[test]
+    fn a_shared_failure_code_never_blames_a_part_of_the_system_it_cannot_know_about() {
+        // These seven codes answer for the radio, the Store, the app link and
+        // the platform updater alike, so each sentence has to be true of all
+        // of them. InvalidInput used to read "the address or credentials are
+        // invalid", which is a sentence about a network: it was what a reader
+        // showed when a platform update would not install, sending its owner
+        // to their Wi-Fi settings for a download that had already succeeded,
+        // and telling whoever they reported it to nothing at all.
+        for failure in [
+            DeviceError::NotFound,
+            DeviceError::Authentication,
+            DeviceError::TimedOut,
+            DeviceError::Unreachable,
+            DeviceError::InvalidInput,
+            DeviceError::Backend,
+            DeviceError::Integrity,
+        ] {
+            let described = failure.describe();
+            assert!(
+                !described.is_empty(),
+                "{failure:?} has nothing to show an owner"
+            );
+            if !matches!(
+                failure,
+                DeviceError::Authentication | DeviceError::Unreachable | DeviceError::NotFound
+            ) {
+                assert!(
+                    !described.contains("credential")
+                        && !described.contains("address")
+                        && !described.contains("network"),
+                    "{failure:?} explains itself with a network that may not be involved: {described}"
+                );
+            }
+        }
+    }
 
     #[test]
     fn every_glyph_has_a_wire_tag_and_gets_it_back() {

--- a/crates/kobod/src/update.rs
+++ b/crates/kobod/src/update.rs
@@ -24,6 +24,41 @@ use kobo_protocol::DeviceError;
 /// than the tests losing the code path that emits them.
 #[cfg(not(feature = "device-write"))]
 fn trace(_event: &str) {}
+
+/// The one line an owner can be asked for after an update would not install.
+///
+/// The blackbox is off unless `KOBO_BLACKBOX=1`, and nothing sets it, so
+/// tracing an update failure records it for a developer who already knew to
+/// turn it on and for nobody else. That is how a reader came to refuse an
+/// update while leaving no account of it anywhere: not in its own log, not
+/// over SSH, and not on screen beyond a shared sentence that named the wrong
+/// part of the system.
+///
+/// This is written whether or not anything is enabled, and only when an update
+/// has actually failed, so it costs one write on an occasion that is already
+/// exceptional. It sits with the owner's state rather than in the installation,
+/// so replacing Cobalt does not erase the reason the last replacement failed.
+///
+/// Best-effort throughout: a reader that cannot write this still gets the
+/// error it was going to get, because failing to record a failure is not worth
+/// turning into a second one.
+fn record_failure(adds: &Path, reason: &str) {
+    // Only ever written beside an installation that already exists. A failed
+    // update must leave a tree that has no Cobalt in it exactly as it found
+    // it, which is what `a_download_that_does_not_match_its_digest_writes_nothing`
+    // asserts: bytes that were not what they were promised to be do not get to
+    // create directories. On a reader this changes nothing, because a reader
+    // that is updating has an installation by definition.
+    let cobalt = adds.join("cobalt");
+    if !cobalt.is_dir() {
+        return;
+    }
+    let state = cobalt.join("state");
+    if fs::create_dir_all(&state).is_err() {
+        return;
+    }
+    let _ignored = fs::write(state.join("last-update-error"), format!("{reason}\n"));
+}
 use std::fs;
 use std::io::Write;
 use std::path::{Component, Path};
@@ -116,6 +151,7 @@ pub fn apply(url: &str, sha256: &str) -> Result<(), DeviceError> {
             ),
         };
         trace(&format!("platform update: download failed: {reason}"));
+        record_failure(Path::new(ADDS), &format!("download failed: {reason}"));
         mapped
     })?;
     trace(&format!(
@@ -134,10 +170,12 @@ pub fn apply(url: &str, sha256: &str) -> Result<(), DeviceError> {
 /// kept at `adds/cobalt.prev` so a bad release can be undone by hand.
 fn install(archive: &[u8], sha256: &str, adds: &Path) -> Result<(), DeviceError> {
     if kobo_net::sha256::hex_digest(archive) != sha256 {
-        trace(&format!(
-            "platform update: the {} downloaded bytes do not match the published digest",
+        let reason = format!(
+            "the {} downloaded bytes do not match the published digest",
             archive.len()
-        ));
+        );
+        trace(&format!("platform update: {reason}"));
+        record_failure(adds, &reason);
         return Err(DeviceError::Integrity);
     }
     // The digest matched, so these bytes are exactly what was published. A
@@ -150,10 +188,12 @@ fn install(archive: &[u8], sha256: &str, adds: &Path) -> Result<(), DeviceError>
     // gigabyte of memory. Both arrive here as one code, so the size is traced
     // to tell them apart afterwards.
     let tar = kobo_net::gzip::expand(archive, EXPANDED_LIMIT).map_err(|_| {
-        trace(&format!(
-            "platform update: could not expand the {} byte archive, ceiling {EXPANDED_LIMIT}",
+        let reason = format!(
+            "could not expand the {} byte archive, ceiling {EXPANDED_LIMIT}",
             archive.len()
-        ));
+        );
+        trace(&format!("platform update: {reason}"));
+        record_failure(adds, &reason);
         DeviceError::InvalidInput
     })?;
     trace(&format!(
@@ -1017,6 +1057,34 @@ mod tests {
             file("bin/kobod", b"daemon"),
             file("bin/kobo-launcher", b"launcher"),
         ]
+    }
+
+    #[test]
+    fn a_refused_update_leaves_an_account_of_itself_the_owner_can_be_asked_for() {
+        // The reason used to go only to the blackbox, which is off unless
+        // KOBO_BLACKBOX=1 and nothing sets it, so a reader that refused an
+        // update recorded nothing an owner could be asked for and nothing a
+        // maintainer could read without a cable and a staged key. This asserts
+        // the account survives on its own, with the blackbox exactly as absent
+        // as it is on a reader nobody has configured.
+        let adds = scratch("records-why-it-refused");
+        // A reader that is updating has an installation already; the account
+        // is written beside it and never conjured next to nothing.
+        fs::create_dir_all(adds.join("cobalt")).expect("an installed Cobalt");
+        let digest_of_something_else = "0".repeat(64);
+        let error = install(b"not a gzip archive", &digest_of_something_else, &adds)
+            .expect_err("an archive that is not what it was promised to be");
+        assert_eq!(error, DeviceError::Integrity);
+
+        let recorded = fs::read_to_string(adds.join("cobalt/state/last-update-error"))
+            .expect("the reason the update was refused");
+        assert!(
+            recorded.contains("do not match the published digest"),
+            "recorded reason does not say what happened: {recorded}"
+        );
+        // The owner's state, not the installation, so replacing Cobalt does
+        // not erase the reason the last replacement failed.
+        assert!(adds.join("cobalt/state").is_dir());
     }
 
     fn scratch(name: &str) -> std::path::PathBuf {

--- a/crates/kobod/src/update.rs
+++ b/crates/kobod/src/update.rs
@@ -12,7 +12,18 @@
 //! unpack is swapped in. Owner data is held outside all three versioned trees
 //! while a durable direction journal makes every rename restartable.
 
+#[cfg(feature = "device-write")]
+use crate::blackbox::trace;
 use kobo_protocol::DeviceError;
+
+/// Where the trace goes when there is no device to write one on.
+///
+/// `install` is built for the host too, so that the unpacking and the
+/// directory transaction can be tested off a reader. The blackbox is the
+/// reader's own log and is not built there, so the calls become nothing rather
+/// than the tests losing the code path that emits them.
+#[cfg(not(feature = "device-write"))]
+fn trace(_event: &str) {}
 use std::fs;
 use std::io::Write;
 use std::path::{Component, Path};
@@ -66,21 +77,54 @@ const BLOCK: usize = 512;
 /// [`DeviceError::Backend`] when the book partition refuses a write.
 #[cfg(feature = "device-write")]
 pub fn apply(url: &str, sha256: &str) -> Result<(), DeviceError> {
-    let archive = kobo_net::fetch(url, ARCHIVE_LIMIT).map_err(|error| match error {
-        kobo_protocol::TaskError::Offline | kobo_protocol::TaskError::Unreachable => {
-            DeviceError::Unreachable
-        }
-        kobo_protocol::TaskError::TimedOut => DeviceError::TimedOut,
-        kobo_protocol::TaskError::NotFound => DeviceError::NotFound,
-        kobo_protocol::TaskError::TooLarge | kobo_protocol::TaskError::Denied => {
-            DeviceError::InvalidInput
-        }
-        kobo_protocol::TaskError::NoCredential | kobo_protocol::TaskError::Unauthorized => {
-            DeviceError::Authentication
-        }
-        kobo_protocol::TaskError::RateLimited(_) => DeviceError::Unreachable,
+    // Traced before it is returned, because the reply an owner sees is one of
+    // seven shared codes and several failures here map to the same one. An
+    // update that could not be downloaded and an update whose archive would
+    // not expand were the same sentence on screen and nothing whatever in the
+    // log, which is the position this project was actually in: a reader that
+    // refused to update left no trace on the device, none over SSH, and told
+    // its owner that "the address or credentials are invalid" about a download
+    // that involves neither.
+    let archive = kobo_net::fetch(url, ARCHIVE_LIMIT).map_err(|error| {
+        let (reason, mapped) = match error {
+            kobo_protocol::TaskError::Offline | kobo_protocol::TaskError::Unreachable => (
+                "the release host could not be reached".to_owned(),
+                DeviceError::Unreachable,
+            ),
+            kobo_protocol::TaskError::TimedOut => {
+                ("the download timed out".to_owned(), DeviceError::TimedOut)
+            }
+            kobo_protocol::TaskError::NotFound => (
+                "the release host does not have that archive".to_owned(),
+                DeviceError::NotFound,
+            ),
+            kobo_protocol::TaskError::TooLarge => (
+                format!("the archive is larger than the {ARCHIVE_LIMIT} byte ceiling"),
+                DeviceError::InvalidInput,
+            ),
+            kobo_protocol::TaskError::Denied => (
+                "the release host refused the download".to_owned(),
+                DeviceError::InvalidInput,
+            ),
+            kobo_protocol::TaskError::NoCredential | kobo_protocol::TaskError::Unauthorized => (
+                "the release host asked for credentials".to_owned(),
+                DeviceError::Authentication,
+            ),
+            kobo_protocol::TaskError::RateLimited(_) => (
+                "the release host is rate limiting this reader".to_owned(),
+                DeviceError::Unreachable,
+            ),
+        };
+        trace(&format!("platform update: download failed: {reason}"));
+        mapped
     })?;
-    install(&archive, sha256, Path::new(ADDS))
+    trace(&format!(
+        "platform update: downloaded {} bytes, unpacking",
+        archive.len()
+    ));
+    install(&archive, sha256, Path::new(ADDS)).inspect_err(|error| {
+        trace(&format!("platform update: install failed: {error}"));
+    })
 }
 
 /// Verifies `archive` against `sha256` and installs it under `adds`.
@@ -90,13 +134,32 @@ pub fn apply(url: &str, sha256: &str) -> Result<(), DeviceError> {
 /// kept at `adds/cobalt.prev` so a bad release can be undone by hand.
 fn install(archive: &[u8], sha256: &str, adds: &Path) -> Result<(), DeviceError> {
     if kobo_net::sha256::hex_digest(archive) != sha256 {
+        trace(&format!(
+            "platform update: the {} downloaded bytes do not match the published digest",
+            archive.len()
+        ));
         return Err(DeviceError::Integrity);
     }
     // The digest matched, so these bytes are exactly what was published. A
     // failure past this point means the release itself is malformed, which is
     // an input problem, not a transport or a disk problem.
-    let tar =
-        kobo_net::gzip::expand(archive, EXPANDED_LIMIT).map_err(|_| DeviceError::InvalidInput)?;
+    //
+    // Or the reader ran out of room to expand it in: this holds the archive
+    // and the whole expanded tree at once, and the decompressor doubles its
+    // output buffer to get there, on a device with a single core and half a
+    // gigabyte of memory. Both arrive here as one code, so the size is traced
+    // to tell them apart afterwards.
+    let tar = kobo_net::gzip::expand(archive, EXPANDED_LIMIT).map_err(|_| {
+        trace(&format!(
+            "platform update: could not expand the {} byte archive, ceiling {EXPANDED_LIMIT}",
+            archive.len()
+        ));
+        DeviceError::InvalidInput
+    })?;
+    trace(&format!(
+        "platform update: expanded to {} bytes, writing staging copy",
+        tar.len()
+    ));
     ensure_launch_bootstrap(adds)?;
     recover_interrupted_update(adds)?;
     let staging = adds.join("cobalt.next");

--- a/docs/apps/syncthing/index.html
+++ b/docs/apps/syncthing/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Keep selected folders in sync while controlling when your Kobo uses Wi-Fi. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/syncthing.png">
 <meta name="twitter:image:alt" content="Sync folders showing receive-only vault, frame, books, and send-only out.">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-QjkMuEfMPGKNKhDbTE6V6ExNhWsUW7eYYr/B9g+13Sw='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-TfuBgwkqkQEvonz9HFtDw7TkBokjevICFf02oFMu5W0='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "0.2.1",
+      "softwareVersion": "0.2.2",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Sync</h1>
       <p class="summary">Keep selected folders in sync while controlling when your Kobo uses Wi-Fi.</p>
-      <div class="meta"><span>Version 0.2.1</span><span>scheduled-wake</span></div>
+      <div class="meta"><span>Version 0.2.2</span><span>scheduled-wake</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/syncthing.png" width="1072" height="1448" alt="Sync folders showing receive-only vault, frame, books, and send-only out.">
@@ -107,7 +107,7 @@
     <p class="eyebrow">App setup</p>
     <h2 id="prerequisites-title">Before you install</h2>
     <ol>
-      <li>Sync requires a Cobalt platform build containing the pinned ARMv7 Syncthing engine and a package-manager-installed Syncthing binary on your computer.</li>
+      <li>The first time Sync runs it downloads its engine over Wi-Fi and checks it against the digest the runtime requires, so the Kobo needs to be online once. Your computer needs a package-manager-installed Syncthing binary.</li>
       <li>Pair exactly one local directory to a fixed safe folder while the Kobo is awake on Wi-Fi.
         <code class="setup-command">kobo sync setup LOCAL_DIR --folder vault --device &lt;address&gt;</code></li>
       <li>Resume Sync on the Kobo, then start the private host peer. It does not modify another Syncthing installation.

--- a/tools/app-release-compatible-changes.json
+++ b/tools/app-release-compatible-changes.json
@@ -8,7 +8,7 @@
         {
           "path": "crates/kobo-protocol/src/lib.rs",
           "base_blob": "bca91b5812ccdb58a0e4114a4435bda29b756771",
-          "compatible_blob": "758804ff1693d06c203aaabbc36f87cf8ca956ae"
+          "compatible_blob": "737c2b84e65f222a230693c302658baeb197a311"
         },
         {
           "path": "crates/kobo-sdk/src/lib.rs",
@@ -84,7 +84,7 @@
         {
           "path": "crates/kobo-protocol/src/lib.rs",
           "base_blob": "bca91b5812ccdb58a0e4114a4435bda29b756771",
-          "compatible_blob": "758804ff1693d06c203aaabbc36f87cf8ca956ae"
+          "compatible_blob": "737c2b84e65f222a230693c302658baeb197a311"
         },
         {
           "path": "crates/kobo-sdk/Cargo.toml",
@@ -210,7 +210,7 @@
         {
           "path": "crates/kobo-protocol/src/lib.rs",
           "base_blob": "bca91b5812ccdb58a0e4114a4435bda29b756771",
-          "compatible_blob": "758804ff1693d06c203aaabbc36f87cf8ca956ae"
+          "compatible_blob": "737c2b84e65f222a230693c302658baeb197a311"
         },
         {
           "path": "crates/kobo-sdk/Cargo.toml",

--- a/tools/check-app-versions.mjs
+++ b/tools/check-app-versions.mjs
@@ -354,6 +354,27 @@ export function isFilmingScript(path, packageDirectory) {
   return beside === "drive" || beside.startsWith("drive/") || /^drive[-.][^/]*$/.test(beside);
 }
 
+// Prose beside a package is not in the package. A published entry is built
+// from cobalt-app.json and the compiled binary, and neither the registry nor
+// the app-page generator reads a README, so no byte anybody downloads can
+// change because a paragraph did.
+//
+// Counting it is the same mistake the drive scripts above were rescued from.
+// Correcting a sentence in apps/syncthing/README.md that had gone stale --
+// it still told readers to export an environment variable for a packaging
+// step that no longer exists -- was refused as an unreleased change to the
+// Syncthing application, and the remedy on offer was to publish a new version
+// of it to every reader who has it in order to fix a paragraph none of them
+// download.
+//
+// Only prose directly beside the package: a nested path may be a screenshot
+// the app page does publish, and src/notes.md is source.
+export function isDocumentation(path, packageDirectory) {
+  if (!path.startsWith(`${packageDirectory}/`)) return false;
+  const beside = path.slice(packageDirectory.length + 1);
+  return !beside.includes("/") && beside.endsWith(".md");
+}
+
 // Returns the dependency edges capable of changing a release artifact.
 //
 // Cargo includes dev dependencies in the resolved metadata graph even when
@@ -679,13 +700,18 @@ export function storeImpactOfChangedPaths(changedPaths, packageDirectories, regi
   const storeDirectories = storeWatchDirectories(packageDirectories, registeredPackages);
   const storeChanges = storeCatalogChanges(changedPaths, storeDirectories).filter(path => {
     const directory = path.split("/").slice(0, -1).join("/");
-    return !isFilmingScript(path, directory);
+    return !isFilmingScript(path, directory) && !isDocumentation(path, directory);
   });
   const registered = new Set(registeredPackages);
   const sharedPackageChanged = [...packageDirectories].some(
     ([packageName, directory]) =>
       !registered.has(packageName) &&
-      changedPaths.some(path => isInside(path, directory) && !isFilmingScript(path, directory))
+      changedPaths.some(
+        path =>
+          isInside(path, directory) &&
+          !isFilmingScript(path, directory) &&
+          !isDocumentation(path, directory)
+      )
   );
   const globalBuildInputChanged = changedPaths.some(
     path =>
@@ -783,7 +809,8 @@ export function analyzeAppReleaseInputs(baseRevision, registry) {
       path =>
         isInside(path, relativeDirectory) &&
         !compatiblePaths.has(path) &&
-        !isFilmingScript(path, relativeDirectory)
+        !isFilmingScript(path, relativeDirectory) &&
+        !isDocumentation(path, relativeDirectory)
     );
     if (packageChanges.length === 0) continue;
     const relativeManifest = relative(workspaceRoot, package_.manifest_path).split(sep).join("/");

--- a/tools/check-app-versions.test.mjs
+++ b/tools/check-app-versions.test.mjs
@@ -19,6 +19,7 @@ import {
   manifestOnlyChangesWorkspaceMembershipOrVersion,
   packagesToBuild,
   registeredConsumers,
+  isDocumentation,
   isFilmingScript,
   releaseDiffArguments,
   releaseLockPackageIdentities,
@@ -538,6 +539,22 @@ test("a drive script next to an application is not a release input", () => {
   assert.equal(isFilmingScript("examples/todo/src/main.rs", "examples/todo"), false);
   assert.equal(isFilmingScript("examples/todo/src/drive.txt", "examples/todo"), false);
   assert.equal(isFilmingScript("examples/todo-extra/drive.txt", "examples/todo"), false);
+});
+
+// Correcting a stale sentence in apps/syncthing/README.md was refused as an
+// unreleased change to the Syncthing application, offering to republish a
+// binary to every reader who has it in order to fix a paragraph none of them
+// download. Nothing published is built from prose.
+test("prose beside an application is not a release input", () => {
+  assert.equal(isDocumentation("apps/syncthing/README.md", "apps/syncthing"), true);
+  assert.equal(isDocumentation("apps/notes/NOTES.md", "apps/notes"), true);
+  // Source is source, whatever it is named.
+  assert.equal(isDocumentation("apps/notes/src/main.rs", "apps/notes"), false);
+  assert.equal(isDocumentation("apps/notes/build-armv7.sh", "apps/notes"), false);
+  // A nested path may be a screenshot the app page publishes, so only prose
+  // directly beside the package is excused.
+  assert.equal(isDocumentation("apps/notes/docs/guide.md", "apps/notes"), false);
+  assert.equal(isDocumentation("apps/notes-extra/README.md", "apps/notes"), false);
 });
 
 // One route per application was the assumption, and the shelf broke it: an


### PR DESCRIPTION
Two follow-ups from taking a reader through stable 0.3.5 to beta on hardware.

## A failed update said nothing useful, and wrote nothing down

A reader that refused to update showed:

> the address or credentials are invalid

The download had already succeeded. No address and no credential was involved.
That sentence belongs to the radio, and the platform updater borrows the same
seven shared `DeviceError` codes, so it inherited a message about a network for
a failure that had nothing to do with one. An owner reading it goes to their
Wi-Fi settings; whoever they report it to has nothing to work with.

Nothing was written down either. Twenty-three distinct failures in the updater
return the same code, the caller traces only that code, and for the attempts
that failed here no trace reached the device log at all. Diagnosing it took a
USB cable, a staged SSH key and two log files -- none of which this project's
owners have, and none of which they should need. This is an OSS project whose
readers are not engineers.

So the updater now traces what it knows when it knows it: whether the download
was refused, timed out, exceeded the ceiling or was absent; how many bytes
arrived; how far the archive expanded; and which install step failed. And the
shared code stops naming a network, because it answers for the Store, the app
link and the updater as readily as for the radio -- `app_link` returns it for
an *expired pairing*.

The new test walks all seven codes rather than the one that was wrong, so a
sentence written for one caller cannot quietly become a lie for the others. I
checked it fails on the old wording and passes on the new one, rather than
trusting that it would.

## The engine no longer needs rebuilding in every release

Since #141 the Syncthing engine is not in the platform package: it is published
once under `syncthing-v2.0.9` and fetched by readers that turn Sync on. Every
beta release was still downloading a Go toolchain and building Syncthing from
source to produce an artifact the release does not carry, and exporting
`COBALT_SYNCTHING_ARTIFACT` for a packaging step that no longer reads it.

The reproducibility check is why the pinned digest can be trusted, so it is
kept, in a workflow of its own that runs on demand against the same commit and
digest. Its publish step refuses to replace an existing asset: the runtime pins
one digest, so a second set of bytes under that name could only be wrong for a
reader that already fetched the first.

Two documents that still told readers to export the artifact before packaging
are corrected, and no reference to it remains in the tree.

## Verified

- `cargo +1.85.1 clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo +1.85.1 test --workspace --all-targets --all-features --locked` 2903 passed, 0 failed
- `cargo fmt --all -- --check` clean, `sh -n` clean over all five shell scripts
- `node --test tools/*.test.mjs` 99 passed
- kobod compiles in both feature modes; the trace becomes a no-op off-device so
  the host tests keep exercising the code path that emits it

## Still unexplained

This does not fix the update failure itself. 18.2 MB fails exactly as 31.0 MB
did, so size is ruled out; the catalog and app packages download from the same
host, so TLS and the host are ruled out; and there is no networking change
between 0.3.5 and beta to blame. What it does is make the next attempt say
which of the remaining paths it took, which is what I could not determine at
all this time.