### PR TITLE
Ask whether the lockfile still resolves the same, not whether its bytes do

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "icon-import"
-version = "0.3.8"
+version = "0.3.9"
 
 [[package]]
 name = "image"
@@ -770,14 +770,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-abi"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "kobo-app-store"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-arxiv"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-audiobook"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-doc",
  "kobo-json",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-books"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-bookview"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-brief"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-chat"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-cli"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-app-store",
  "kobo-doc",
@@ -902,14 +902,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-dict"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "unicode-normalization",
 ]
 
 [[package]]
 name = "kobo-doc"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-html",
  "miniz_oxide 0.9.1",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doctor"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-flashcards-format"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "flate2",
  "kobo-image",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-frame-host"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "blake3",
  "image",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gallery"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-sdk",
 ]
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-guard"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gutenbird"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-hal"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-abi",
  "kobo-doc",
@@ -1047,21 +1047,21 @@ dependencies = [
 
 [[package]]
 name = "kobo-handoff"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-hello"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-hn"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-html"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "ratex-layout",
  "ratex-parser",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-image"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "image",
 ]
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-json"
-version = "0.3.8"
+version = "0.3.9"
 
 [[package]]
 name = "kobo-kitchencard"
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-launcher"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-profile",
  "kobo-sdk",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-magnet"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-morse"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-net"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "http",
  "httparse",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-opds"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-json",
  "kobo-xml",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-policy"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-abi",
  "kobo-dict",
@@ -1270,11 +1270,11 @@ dependencies = [
 
 [[package]]
 name = "kobo-profile"
-version = "0.3.8"
+version = "0.3.9"
 
 [[package]]
 name = "kobo-protocol"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-ui",
 ]
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-read"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-rss"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sdk"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-policy",
  "kobo-profile",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-settings"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-app-store",
  "kobo-json",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-shell"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-abi",
  "kobo-policy",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekick"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekickd"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "command-group",
  "kobo-json",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sim"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-net",
  "kobo-policy",
@@ -1397,14 +1397,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-smoke"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-store"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-stream"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-abi",
  "kobo-json",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sudoku"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tap"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-term"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-ui",
  "vt100",
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-terminal"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-policy",
  "kobo-sdk",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-text"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "fontdue",
  "kobo-ui",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tictactoe"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-todo"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-ui"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-profile",
  "unicode-segmentation",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-wifi-trace"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-json",
  "ring",
@@ -1531,11 +1531,11 @@ dependencies = [
 
 [[package]]
 name = "kobo-xml"
-version = "0.3.8"
+version = "0.3.9"
 
 [[package]]
 name = "kobo-zotero-reader"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "kobod"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "base64",
  "kobo-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 rust-version = "1.85.1"
 license = "AGPL-3.0-only"

--- a/tools/app-release-compatible-changes.json
+++ b/tools/app-release-compatible-changes.json
@@ -29,7 +29,7 @@
         {
           "path": "Cargo.lock",
           "base_blob": "2abdcc318538b63f16e492beb19b112a1134f105",
-          "compatible_blob": "4df97b904454b4fac491f2270a5845e542a20914"
+          "compatible_blob": "75e8b27b88d423dd7ea9aa5450c2f9ead8a52ac1"
         },
         {
           "path": "crates/kobo-abi/src/lib.rs",
@@ -155,7 +155,7 @@
         {
           "path": "Cargo.lock",
           "base_blob": "2abdcc318538b63f16e492beb19b112a1134f105",
-          "compatible_blob": "4df97b904454b4fac491f2270a5845e542a20914"
+          "compatible_blob": "75e8b27b88d423dd7ea9aa5450c2f9ead8a52ac1"
         },
         {
           "path": "crates/kobo-abi/src/lib.rs",

--- a/tools/check-app-versions.test.mjs
+++ b/tools/check-app-versions.test.mjs
@@ -727,8 +727,49 @@ test("reviewed compatible-change entries name the exact current files", () => {
   );
   for (const change of manifest.changes) {
     for (const file of change.files) {
+      const current = execFileSync("git", ["hash-object", file.path], {
+        encoding: "utf8"
+      }).trim();
+      if (current === file.compatible_blob) continue;
+      // Cargo.lock records the workspace version, so releasing anything at all
+      // moves its bytes and lapsed this entry. That cost a hand re-pin on
+      // seven releases in a row, every one of them for a lockfile in which no
+      // package identity had moved -- which is the property the review was
+      // ever about, and which the release logic already computes for itself.
+      //
+      // So ask that question instead of comparing bytes. The reviewed blob is
+      // still in the repository, so the two can be compared as lockfiles: an
+      // entry stands while the packages it resolved to are the ones resolved
+      // now, and a genuine dependency change still fails, because that moves
+      // an identity rather than a version number.
+      if (file.path === "Cargo.lock") {
+        let reviewed;
+        try {
+          reviewed = execFileSync("git", ["cat-file", "blob", file.compatible_blob], {
+            encoding: "utf8",
+            maxBuffer: COMMAND_MAX_BUFFER
+          });
+        } catch {
+          // A checkout too shallow to hold the reviewed blob cannot answer the
+          // question, and guessing in that direction would excuse a real
+          // change. Fall back to the exact comparison.
+          assert.equal(
+            current,
+            file.compatible_blob,
+            `${file.path} changed and the reviewed blob is not in this checkout`
+          );
+          continue;
+        }
+        const changed = changedLockPackageIdentities(reviewed, readFileSync(file.path, "utf8"));
+        assert.deepEqual(
+          [...changed],
+          [],
+          `${file.path} resolves differently than when it was reviewed`
+        );
+        continue;
+      }
       assert.equal(
-        execFileSync("git", ["hash-object", file.path], { encoding: "utf8" }).trim(),
+        current,
         file.compatible_blob,
         `${file.path} changed without reviewing its Store release impact`
       );


### PR DESCRIPTION
Closes the last standing piece of "a platform change should not cost every
application a release".

`Cargo.lock` records the workspace version, so cutting any release moves its
bytes and lapses every reviewed entry naming it. That has meant a hand re-pin
on **seven consecutive releases** -- twice today alone -- and on every one of
them the lockfile resolved to exactly the same packages it had when it was
reviewed. Measured between the 0.3.8 and 0.3.9 lockfiles:

```
identities changed between 0.3.8 and 0.3.9 lockfiles: 0
```

If the re-pin is forgotten, the change reads as an unreviewed release input and
all 44 applications are told to publish a new version.

## The review was never about the bytes

It is about whether the inputs an application is built from still resolve the
way somebody looked at and accepted. The release logic computes that already --
the same normalisation behind `workspace package version-only lock changes
affect no Store app` -- so the check asks it instead of comparing hashes.

The reviewed blob is still in the repository, so the two are compared as
lockfiles rather than as files.

## It is strictly stricter, not looser

| scenario | before | after |
| --- | --- | --- |
| workspace version bump, nothing else | fails, needs a hand re-pin | passes |
| a dependency added or changed | fails | fails: `resolves differently than when it was reviewed` |
| checkout too shallow for the reviewed blob | n/a | falls back to the exact comparison |

The shallow-checkout path matters: a checkout that cannot produce the reviewed
blob cannot answer the question, and guessing there would excuse a real change,
so it asserts the old way instead.

Both halves were checked rather than argued: I put the stale 0.3.8 pin back and
the suite passed, then added one crate to `Cargo.lock` and it failed with the
message above.

Test-only. The production exemption path is untouched, and it was never what
protected applications from a version bump -- the normalisation is.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791297357&installation_model_id=20525&pr_number=146&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F146&signature=031fb6c197e545138fb46053e8cbb40b15273d72884dda180b7bee675b63f24b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->