### PR TITLE
Release 0.3.10 to beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          # The reviewed-change check compares Cargo.lock against the blob that
+          # was reviewed, which a depth-1 clone does not contain. Without the
+          # history it cannot ask whether the lockfile still resolves the same
+          # way and falls back to comparing bytes, which a version bump always
+          # fails -- so every release would need the manual re-pin the check
+          # was changed to remove. The other jobs here already fetch history.
+          fetch-depth: 0
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           toolchain: 1.85.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "icon-import"
-version = "0.3.9"
+version = "0.3.10"
 
 [[package]]
 name = "image"
@@ -770,14 +770,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-abi"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "kobo-app-store"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-arxiv"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-audiobook"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-doc",
  "kobo-json",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-books"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-bookview"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-brief"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-chat"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-cli"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-app-store",
  "kobo-doc",
@@ -902,14 +902,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-dict"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "unicode-normalization",
 ]
 
 [[package]]
 name = "kobo-doc"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-html",
  "miniz_oxide 0.9.1",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doctor"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-flashcards-format"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "flate2",
  "kobo-image",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-frame-host"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "blake3",
  "image",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gallery"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-sdk",
 ]
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-guard"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gutenbird"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-hal"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-abi",
  "kobo-doc",
@@ -1047,21 +1047,21 @@ dependencies = [
 
 [[package]]
 name = "kobo-handoff"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-hello"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-hn"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-html"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "ratex-layout",
  "ratex-parser",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-image"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "image",
 ]
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-json"
-version = "0.3.9"
+version = "0.3.10"
 
 [[package]]
 name = "kobo-kitchencard"
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-launcher"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-profile",
  "kobo-sdk",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-magnet"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-morse"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-net"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "http",
  "httparse",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-opds"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-json",
  "kobo-xml",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-policy"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-abi",
  "kobo-dict",
@@ -1270,11 +1270,11 @@ dependencies = [
 
 [[package]]
 name = "kobo-profile"
-version = "0.3.9"
+version = "0.3.10"
 
 [[package]]
 name = "kobo-protocol"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-ui",
 ]
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-read"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-rss"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sdk"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-policy",
  "kobo-profile",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-settings"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-app-store",
  "kobo-json",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-shell"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-abi",
  "kobo-policy",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekick"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekickd"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "command-group",
  "kobo-json",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sim"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-net",
  "kobo-policy",
@@ -1397,14 +1397,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-smoke"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-store"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-stream"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-abi",
  "kobo-json",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sudoku"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1439,7 +1439,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tap"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-term"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-ui",
  "vt100",
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-terminal"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-policy",
  "kobo-sdk",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-text"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "fontdue",
  "kobo-ui",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tictactoe"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-todo"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1493,7 +1493,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-ui"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-profile",
  "unicode-segmentation",
@@ -1523,7 +1523,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-wifi-trace"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-json",
  "ring",
@@ -1531,11 +1531,11 @@ dependencies = [
 
 [[package]]
 name = "kobo-xml"
-version = "0.3.9"
+version = "0.3.10"
 
 [[package]]
 name = "kobo-zotero-reader"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -1546,7 +1546,7 @@ dependencies = [
 
 [[package]]
 name = "kobod"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "base64",
  "kobo-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.9"
+version = "0.3.10"
 edition = "2021"
 rust-version = "1.85.1"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Cut so that a reader running 0.3.9 has something newer to fail to update to.

The update failure has now survived every explanation offered for it:

- **not size** -- 18.2 MB fails exactly as 31.0 MB did
- **not TLS or the host** -- the catalog and application packages download from
  the same host and work
- **not a networking regression** between 0.3.5 and beta -- the only change in
  that area is a `#[cfg(test)]` fixture
- **not the channel** -- stable failed identically to beta, and they take
  different discovery paths, so the fault is in the code they share
- **not the update logic** -- 0.3.5's own `fetch`, digest check and gzip
  expansion run against the real archive from a workstation and succeed:
  `fetch OK: 19093044 bytes / digest matches / expand OK: 36722688 bytes`

It survived all of them because the reader recorded nothing. 0.3.9 is the first
build that writes down why, and it needs a target to attempt: the tracing lives
in the version doing the downloading, not the version being downloaded, which
is why testing it from 0.3.5 could never have produced an answer.

## Nothing but the version moved

First release in this line that needed no hand re-pin of
`tools/app-release-compatible-changes.json`. The lockfile still resolves to the
packages it resolved to when it was reviewed, and #146 made the check ask that
rather than compare bytes, so the bump passed on its own. The seven releases
before this one each needed the manual step, and forgetting it would have told
all 44 applications to publish a new version.

## Verified

`cargo fmt --check`, `sh -n` over five scripts, generated pages current,
`node --test tools/*.test.mjs` 100 passed, and
`cargo +1.85.1 clippy --workspace --all-targets --all-features -- -D warnings`
clean.

The known order-dependent `supporting_screens_fit_without_dense_or_clipped_controls`
still fails locally in a full run and passes alone, identically on untouched
beta; it passes in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791309615&installation_model_id=20525&pr_number=148&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F148&signature=e254a363185a8a2150691514299eb82670361b563226301e71d348463cfd6566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->