### PR TITLE
Keep the Skip buttons inside their slots, on weekdays too

### DIFF
--- a/apps/habits/cobalt-app.json
+++ b/apps/habits/cobalt-app.json
@@ -4,8 +4,8 @@
   "short_label": "Habits",
   "summary": "Track daily and weekday habits with local streaks.",
   "page_description": "An offline-first habit tracker that puts today's commitments and streaks on a calm paper display.",
-  "version": "0.1.1",
-  "release_notes": "An offline-first habit tracker that puts today's commitments and streaks on a calm paper display.",
+  "version": "0.1.2",
+  "release_notes": "Keep the Skip button labels inside their buttons when more than one habit is due, which they were not from Monday to Friday.",
   "glyph": "check",
   "capabilities": []
 }

--- a/apps/habits/src/main.rs
+++ b/apps/habits/src/main.rs
@@ -11,7 +11,7 @@ use model::{
 use std::process::ExitCode;
 const HABITS: &str = "habits-v1";
 const ROWS_PER_PAGE: usize = 3;
-const ACTION_NAME_CHARS: usize = 24;
+const ACTION_NAME_CHARS: usize = 12;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Page {
     Today,
@@ -865,7 +865,7 @@ mod tests {
         runner.store_result(StoreResult::Loaded {
             key: HABITS.into(),
             value: Some(
-                format!("0\td\t{long}\t\t\n0\tw\t{spaced}\t\t\n0\td\t  \t\t\n").into_bytes(),
+                format!("0\td\t{long}\t\t\n0\td\t{spaced}\t\t\n0\td\t  \t\t\n").into_bytes(),
             ),
         });
 
@@ -1025,5 +1025,32 @@ mod tests {
                 .done
                 .is_empty()
         );
+    }
+
+    // A page holds ROWS_PER_PAGE habits, and each due habit puts a Skip button
+    // in one shared band, so the widest label has to fit a third of the width
+    // rather than all of it. It did not: with three long names the buttons
+    // overflowed their slots and the label ran past the edge of the button.
+    //
+    // Nothing caught it because the schedules decided how many buttons there
+    // were. A weekdays habit is not due at a weekend, so the second button only
+    // appeared from Monday, and the test that would have failed was run on a
+    // Saturday and passed. This one holds the count itself.
+    #[test]
+    fn a_full_page_of_long_names_keeps_every_button_inside_its_slot() {
+        let long = "x".repeat(MAX_HABIT_NAME_CHARS);
+        let mut runner = AppRunner::new(Habits::default());
+        runner.start();
+        runner.store_result(StoreResult::Loaded {
+            key: HABITS.into(),
+            value: Some(
+                format!("0\td\t{long}\t\t\n0\td\t{long}\t\t\n0\td\t{long}\t\t\n").into_bytes(),
+            ),
+        });
+        assert_eq!(runner.app().items.len(), ROWS_PER_PAGE);
+        let screen = runner.app().screen();
+        let diagnostics =
+            screen.diagnostics(&kobo_ui::CLARA_BW_METRICS, &kobo_ui::Chrome::default());
+        assert!(diagnostics.issues.is_empty(), "{:#?}", diagnostics.issues);
     }
 }

--- a/docs/apps/habits/index.html
+++ b/docs/apps/habits/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="An offline-first habit tracker that puts today's commitments and streaks on a calm paper display. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/habits.png">
 <meta name="twitter:image:alt" content="Habits today screen on a Kobo Clara BW, with daily and weekday streak tasks.">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-4TIxfJnFGTuAC5k47i1ntXVIJ23MpUcuhsZM36tSXRg='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-h8WkEZ5aO7OrWit4A/gwoQUsEkZWZiFnWJ9LtOEHkiQ='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "0.1.1",
+      "softwareVersion": "0.1.2",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Habits</h1>
       <p class="summary">An offline-first habit tracker that puts today's commitments and streaks on a calm paper display.</p>
-      <div class="meta"><span>Version 0.1.1</span><span>No additional permissions</span></div>
+      <div class="meta"><span>Version 0.1.2</span><span>No additional permissions</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/habits.png" width="1072" height="1448" alt="Habits today screen on a Kobo Clara BW, with daily and weekday streak tasks.">


### PR DESCRIPTION
CI has been failing on a test that looks flaky and is not. It is the calendar.

## What was happening

The Today page gives every due habit a Skip button, and the buttons share one
band, so three due habits means each label gets a third of the width. `"Skip "`
plus 24 characters of habit name does not fit a third, and does not fit a half
either — the label ran past the edge of its own button:

```
ISSUE TextOverflow node=NodeId(5)
Band { slots: [ Button { label: "Skip xxxxxxxxxxxxxxxxxxxxxxx…" },
                Button { label: "Skip Read before bed" } ] }
```

Nobody saw it because the schedules decide how many buttons there are. A
weekdays habit is not due at a weekend, so a reader with one daily and one
weekday habit sees one button on Saturday and two on Monday. The overflow
appears on Monday and goes away on Saturday.

## Why it read as flakiness

The test built exactly that pair, so its screen depended on the day the suite
ran:

| date | weekday habit due | CI |
| --- | --- | --- |
| 5–6 Sept (Sat–Sun) | false | passed |
| 7 Sept (Mon) | **true** | **failed** |

Same commit, same runner image `20260831.293.1`, opposite results. I re-ran the
job to check and it failed again, which is what a calendar does and a flake does
not.

## The fix

`ACTION_NAME_CHARS` is held to what fits a full page rather than a single row.
Measured, not guessed:

| due habits | longest name that fits |
| --- | --- |
| 2 buttons | 20 |
| 3 buttons — a full page | **12** |

`ROWS_PER_PAGE` is 3, so 12 is the bound that holds. The fixture no longer asks
the day of the week what it should contain, and the new test holds three due
habits itself — the most a page can show. It fails at the old length and passes
at the new one; I checked both directions rather than assuming.

## Worth knowing

I got this wrong twice before getting it right, and both mistakes are the kind
worth naming. I first bisected a constant with a regex that matched two call
sites, so the measurement was of a different change. I then widened the fixture
to three habits, which broke the test's earlier `items.len()` assertion, so it
panicked before reaching the layout check and reported "no overflow" for a run
that never looked. The numbers above are from a probe that printed the failing
node.

`kobo-flashcards` has a test failing the same way — `TextOverflow` from
`diagnostics.issues`, passing alone and failing in a full run. It is not fixed
here, and it is probably not the same cause, but it is worth the same look.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791352633&installation_model_id=20525&pr_number=150&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F150&signature=dac26c881324ab50148205d6a7d52953b8196f44875334d76ba981a1daf9700c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->