### PR TITLE
Offer the browser install on every application page

### DIFF
--- a/docs/apps/arxiv/index.html
+++ b/docs/apps/arxiv/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/arxiv.png" width="1072" height="1448" alt="The newest machine learning preprints listed in the arXiv app on a Kobo">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/arxiv/index.html
+++ b/docs/apps/arxiv/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/arxiv.png" width="1072" height="1448" alt="The newest machine learning preprints listed in the arXiv app on a Kobo">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/audiobook/index.html
+++ b/docs/apps/audiobook/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/audiobook.png" width="1072" height="1448" alt="An audiobook player with cover art and playback controls on a Kobo">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/audiobook/index.html
+++ b/docs/apps/audiobook/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/audiobook.png" width="1072" height="1448" alt="An audiobook player with cover art and playback controls on a Kobo">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/backgammon/index.html
+++ b/docs/apps/backgammon/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/backgammon.png" width="1072" height="1448" alt="Backgammon board on a Kobo showing White's opening roll and 24 touchable points.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/backgammon/index.html
+++ b/docs/apps/backgammon/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/backgammon.png" width="1072" height="1448" alt="Backgammon board on a Kobo showing White's opening roll and 24 touchable points.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/brief/index.html
+++ b/docs/apps/brief/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/brief.png" width="1072" height="1448" alt="A numbered daily news brief on a Kobo">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/brief/index.html
+++ b/docs/apps/brief/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/brief.png" width="1072" height="1448" alt="A numbered daily news brief on a Kobo">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/calibre-web/index.html
+++ b/docs/apps/calibre-web/index.html
@@ -114,16 +114,17 @@
         <code class="setup-command">kobo trust set calibre --device &lt;address&gt;</code></li>
     </ol>
   </section>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -138,17 +139,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/calibre-web/index.html
+++ b/docs/apps/calibre-web/index.html
@@ -114,6 +114,14 @@
         <code class="setup-command">kobo trust set calibre --device &lt;address&gt;</code></li>
     </ol>
   </section>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/chat/index.html
+++ b/docs/apps/chat/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/chat.png" width="1072" height="1448" alt="An answer displayed for touch-friendly reading on a Kobo">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/chat/index.html
+++ b/docs/apps/chat/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/chat.png" width="1072" height="1448" alt="An answer displayed for touch-friendly reading on a Kobo">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/crossword/index.html
+++ b/docs/apps/crossword/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/crossword.png" width="1072" height="1448" alt="Crossword grid on a Kobo with a selected cell containing C and touch controls for letters and clues.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/crossword/index.html
+++ b/docs/apps/crossword/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/crossword.png" width="1072" height="1448" alt="Crossword grid on a Kobo with a selected cell containing C and touch controls for letters and clues.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/deck/index.html
+++ b/docs/apps/deck/index.html
@@ -114,6 +114,14 @@
         <code class="setup-command">kobo trust set sidekick --device &lt;address&gt;</code></li>
     </ol>
   </section>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/deck/index.html
+++ b/docs/apps/deck/index.html
@@ -114,16 +114,17 @@
         <code class="setup-command">kobo trust set sidekick --device &lt;address&gt;</code></li>
     </ol>
   </section>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -138,17 +139,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/fanshelf/index.html
+++ b/docs/apps/fanshelf/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/fanshelf.png" width="1072" height="1448" alt="Fanshelf's empty shelf, with Add, Followed tags, and Check updates controls.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/fanshelf/index.html
+++ b/docs/apps/fanshelf/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/fanshelf.png" width="1072" height="1448" alt="Fanshelf's empty shelf, with Add, Followed tags, and Check updates controls.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/fieldbook/index.html
+++ b/docs/apps/fieldbook/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/fieldbook.png" width="1072" height="1448" alt="Fieldbook sighting log showing a selected bird, count controls, and a saved lifer notice.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/fieldbook/index.html
+++ b/docs/apps/fieldbook/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/fieldbook.png" width="1072" height="1448" alt="Fieldbook sighting log showing a selected bird, count controls, and a saved lifer notice.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/flashcards/index.html
+++ b/docs/apps/flashcards/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/flashcards.png" width="1072" height="1448" alt="Flashcards deck list showing four due cards, today's review count, and a Stats row.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/flashcards/index.html
+++ b/docs/apps/flashcards/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/flashcards.png" width="1072" height="1448" alt="Flashcards deck list showing four due cards, today's review count, and a Stats row.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/frame/index.html
+++ b/docs/apps/frame/index.html
@@ -115,6 +115,14 @@
         <code class="setup-command">kobo frame push ~/Pictures/family --device &lt;address&gt;</code></li>
     </ol>
   </section>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/frame/index.html
+++ b/docs/apps/frame/index.html
@@ -115,16 +115,17 @@
         <code class="setup-command">kobo frame push ~/Pictures/family --device &lt;address&gt;</code></li>
     </ol>
   </section>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -139,17 +140,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/gallery/index.html
+++ b/docs/apps/gallery/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/components.png" width="1072" height="1448" alt="Cobalt typography and interface components on a Kobo">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/gallery/index.html
+++ b/docs/apps/gallery/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/components.png" width="1072" height="1448" alt="Cobalt typography and interface components on a Kobo">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/grimoire/index.html
+++ b/docs/apps/grimoire/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/grimoire.png" width="1072" height="1448" alt="Grimoire initiative order showing the active combatant and round counter on a Kobo.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/grimoire/index.html
+++ b/docs/apps/grimoire/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/grimoire.png" width="1072" height="1448" alt="Grimoire initiative order showing the active combatant and round counter on a Kobo.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/gutenbird/index.html
+++ b/docs/apps/gutenbird/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/gutenbird.png" width="1072" height="1448" alt="A shelf of books from an OPDS library on a Kobo">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/gutenbird/index.html
+++ b/docs/apps/gutenbird/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/gutenbird.png" width="1072" height="1448" alt="A shelf of books from an OPDS library on a Kobo">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/habits/index.html
+++ b/docs/apps/habits/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/habits.png" width="1072" height="1448" alt="Habits today screen on a Kobo Clara BW, with daily and weekday streak tasks.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/habits/index.html
+++ b/docs/apps/habits/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/habits.png" width="1072" height="1448" alt="Habits today screen on a Kobo Clara BW, with daily and weekday streak tasks.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/hn/index.html
+++ b/docs/apps/hn/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/hackernews.png" width="1072" height="1448" alt="A ranked list of Hacker News stories on a Kobo">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/hn/index.html
+++ b/docs/apps/hn/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/hackernews.png" width="1072" height="1448" alt="A ranked list of Hacker News stories on a Kobo">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/homepanel/index.html
+++ b/docs/apps/homepanel/index.html
@@ -114,16 +114,17 @@
         <code class="setup-command">kobo trust set homeassistant --device &lt;address&gt;</code></li>
     </ol>
   </section>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -138,17 +139,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/homepanel/index.html
+++ b/docs/apps/homepanel/index.html
@@ -114,6 +114,14 @@
         <code class="setup-command">kobo trust set homeassistant --device &lt;address&gt;</code></li>
     </ol>
   </section>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/inkling/index.html
+++ b/docs/apps/inkling/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/inkling.png" width="1072" height="1448" alt="A solved Inkling five-letter daily puzzle with grayscale shape feedback.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/inkling/index.html
+++ b/docs/apps/inkling/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/inkling.png" width="1072" height="1448" alt="A solved Inkling five-letter daily puzzle with grayscale shape feedback.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/install.css
+++ b/docs/apps/install.css
@@ -215,3 +215,39 @@ footer nav { display: flex; gap: 18px; flex-wrap: wrap; }
 @media (prefers-reduced-motion: no-preference) {
   button { transition: background-color 150ms ease, opacity 150ms ease; }
 }
+
+/* Every application page is a place somebody can arrive without having Cobalt
+   at all. The pairing panel below assumes they already do, so this offers the
+   step before it, and is deliberately the brightest thing on the page after
+   the screenshot. */
+.get-cobalt {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px 28px;
+  flex-wrap: wrap;
+  border-color: var(--blue);
+  border-left-width: 4px;
+  background: linear-gradient(180deg, #fff, var(--paper-deep));
+}
+.get-cobalt h2 { margin: 6px 0 0; font-size: clamp(21px, 3vw, 26px); letter-spacing: -.01em; }
+.get-cobalt p { margin: 9px 0 0; color: var(--muted); max-width: 34em; }
+.get-cobalt .eyebrow { color: var(--blue); }
+.get-cobalt-go {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 13px 24px;
+  background: var(--blue);
+  color: #fff;
+  font-size: 17px;
+  border: 1px solid var(--blue);
+  white-space: nowrap;
+  transition: background .15s, transform .15s;
+}
+.get-cobalt-go:hover { background: var(--blue-dark); border-color: var(--blue-dark); text-decoration: none; transform: translateX(2px); }
+.get-cobalt-go span { font-size: 19px; line-height: 1; }
+@media (max-width: 620px) {
+  .get-cobalt { flex-direction: column; align-items: flex-start; }
+  .get-cobalt-go { width: 100%; justify-content: center; }
+}

--- a/docs/apps/kitchencard/index.html
+++ b/docs/apps/kitchencard/index.html
@@ -112,16 +112,17 @@
         <code class="setup-command">kobo secret set mealie --device &lt;address&gt;</code></li>
     </ol>
   </section>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -136,17 +137,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/kitchencard/index.html
+++ b/docs/apps/kitchencard/index.html
@@ -112,6 +112,14 @@
         <code class="setup-command">kobo secret set mealie --device &lt;address&gt;</code></li>
     </ol>
   </section>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/launcher/index.html
+++ b/docs/apps/launcher/index.html
@@ -102,6 +102,14 @@
       <img src="../../media/site/apps/launcher.png" width="1072" height="1448" alt="The Cobalt launcher showing installed apps on a Kobo">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel setup">
     <p class="eyebrow">No separate install needed</p>
     <h2>Available after Cobalt setup</h2>

--- a/docs/apps/launcher/index.html
+++ b/docs/apps/launcher/index.html
@@ -102,14 +102,6 @@
       <img src="../../media/site/apps/launcher.png" width="1072" height="1448" alt="The Cobalt launcher showing installed apps on a Kobo">
     </figure>
   </div>
-  <section class="panel get-cobalt">
-    <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
-      <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
-    </div>
-    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
-  </section>
   <section class="panel setup">
     <p class="eyebrow">No separate install needed</p>
     <h2>Available after Cobalt setup</h2>

--- a/docs/apps/lichess/index.html
+++ b/docs/apps/lichess/index.html
@@ -114,6 +114,14 @@
       <li>Official Lichess Board API. Rapid and Classical seeks.</li>
     </ol>
   </section>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/lichess/index.html
+++ b/docs/apps/lichess/index.html
@@ -114,16 +114,17 @@
       <li>Official Lichess Board API. Rapid and Classical seeks.</li>
     </ol>
   </section>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -138,17 +139,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/logicpack/index.html
+++ b/docs/apps/logicpack/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/logicpack.png" width="1072" height="1448" alt="Logic Pack's Minesweeper board after a revealed cell and contradiction check.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/logicpack/index.html
+++ b/docs/apps/logicpack/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/logicpack.png" width="1072" height="1448" alt="Logic Pack's Minesweeper board after a revealed cell and contradiction check.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/magnet/index.html
+++ b/docs/apps/magnet/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/magnet.png" width="1072" height="1448" alt="The Kobo hall sensor responding to a magnet">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/magnet/index.html
+++ b/docs/apps/magnet/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/magnet.png" width="1072" height="1448" alt="The Kobo hall sensor responding to a magnet">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/morse/index.html
+++ b/docs/apps/morse/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/morse.png" width="1072" height="1448" alt="A letter filling the Kobo screen while the front light sends Morse code">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/morse/index.html
+++ b/docs/apps/morse/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/morse.png" width="1072" height="1448" alt="A letter filling the Kobo screen while the front light sends Morse code">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/musicstand/index.html
+++ b/docs/apps/musicstand/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/musicstand.png" width="1072" height="1448" alt="Music Stand showing a marked half-page score view for Bach's Cello Suite No. 1.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/musicstand/index.html
+++ b/docs/apps/musicstand/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/musicstand.png" width="1072" height="1448" alt="Music Stand showing a marked half-page score view for Bach's Cello Suite No. 1.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/needles/index.html
+++ b/docs/apps/needles/index.html
@@ -114,16 +114,17 @@
         <code class="setup-command">kobo needles push PATTERN.pdf --device &lt;address&gt;</code></li>
     </ol>
   </section>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -138,17 +139,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/needles/index.html
+++ b/docs/apps/needles/index.html
@@ -114,6 +114,14 @@
         <code class="setup-command">kobo needles push PATTERN.pdf --device &lt;address&gt;</code></li>
     </ol>
   </section>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/nonograms/index.html
+++ b/docs/apps/nonograms/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/nonograms.png" width="1072" height="1448" alt="Nonogram puzzle on a Kobo showing numbered cells, row clues, and guided marking mode.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/nonograms/index.html
+++ b/docs/apps/nonograms/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/nonograms.png" width="1072" height="1448" alt="Nonogram puzzle on a Kobo showing numbered cells, row clues, and guided marking mode.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/panels/index.html
+++ b/docs/apps/panels/index.html
@@ -112,6 +112,14 @@
         <code class="setup-command">kobo secret set komga --device &lt;address&gt;</code></li>
     </ol>
   </section>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/panels/index.html
+++ b/docs/apps/panels/index.html
@@ -112,16 +112,17 @@
         <code class="setup-command">kobo secret set komga --device &lt;address&gt;</code></li>
     </ol>
   </section>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -136,17 +137,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/paperterm/index.html
+++ b/docs/apps/paperterm/index.html
@@ -110,16 +110,17 @@
       <li>Run kobo stream init on the computer, install its stream trust root on the Kobo, then start kobo stream.</li>
     </ol>
   </section>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -134,17 +135,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/paperterm/index.html
+++ b/docs/apps/paperterm/index.html
@@ -110,6 +110,14 @@
       <li>Run kobo stream init on the computer, install its stream trust root on the Kobo, then start kobo stream.</li>
     </ol>
   </section>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/parlor/index.html
+++ b/docs/apps/parlor/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/parlor.png" width="1072" height="1448" alt="Reversi opening board showing four legal moves and touch controls.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/parlor/index.html
+++ b/docs/apps/parlor/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/parlor.png" width="1072" height="1448" alt="Reversi opening board showing four legal moves and touch controls.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/parser/index.html
+++ b/docs/apps/parser/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/parser.png" width="1072" height="1448" alt="Parser's book-like transcript after taking a brass lamp and entering the garden.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/parser/index.html
+++ b/docs/apps/parser/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/parser.png" width="1072" height="1448" alt="Parser's book-like transcript after taking a brass lamp and entering the garden.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/post/index.html
+++ b/docs/apps/post/index.html
@@ -112,16 +112,17 @@
         <code class="setup-command">kobo secret set hermes-post --device &lt;address&gt;</code></li>
     </ol>
   </section>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -136,17 +137,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/post/index.html
+++ b/docs/apps/post/index.html
@@ -112,6 +112,14 @@
         <code class="setup-command">kobo secret set hermes-post --device &lt;address&gt;</code></li>
     </ol>
   </section>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/pubquiz/index.html
+++ b/docs/apps/pubquiz/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/pubquiz.png" width="1072" height="1448" alt="Pub Quiz pass-around question with four large answer choices for Ada.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/pubquiz/index.html
+++ b/docs/apps/pubquiz/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/pubquiz.png" width="1072" height="1448" alt="Pub Quiz pass-around question with four large answer choices for Ada.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/readlater/index.html
+++ b/docs/apps/readlater/index.html
@@ -112,6 +112,14 @@
         <code class="setup-command">kobo secret set wallabag --device &lt;address&gt;</code></li>
     </ol>
   </section>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/readlater/index.html
+++ b/docs/apps/readlater/index.html
@@ -112,16 +112,17 @@
         <code class="setup-command">kobo secret set wallabag --device &lt;address&gt;</code></li>
     </ol>
   </section>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -136,17 +137,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/rss-miniflux/index.html
+++ b/docs/apps/rss-miniflux/index.html
@@ -112,16 +112,17 @@
         <code class="setup-command">kobo secret set miniflux --device &lt;address&gt;</code></li>
     </ol>
   </section>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -136,17 +137,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/rss-miniflux/index.html
+++ b/docs/apps/rss-miniflux/index.html
@@ -112,6 +112,14 @@
         <code class="setup-command">kobo secret set miniflux --device &lt;address&gt;</code></li>
     </ol>
   </section>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/rss/index.html
+++ b/docs/apps/rss/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/feeds.png" width="1072" height="1448" alt="Subscribed feeds and articles in the Feeds app on a Kobo">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/rss/index.html
+++ b/docs/apps/rss/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/feeds.png" width="1072" height="1448" alt="Subscribed feeds and articles in the Feeds app on a Kobo">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/settings/index.html
+++ b/docs/apps/settings/index.html
@@ -102,6 +102,14 @@
       <img src="../../media/site/apps/settings.png" width="1072" height="1448" alt="Battery status and hardware information in Cobalt Settings">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel setup">
     <p class="eyebrow">No separate install needed</p>
     <h2>Available after Cobalt setup</h2>

--- a/docs/apps/settings/index.html
+++ b/docs/apps/settings/index.html
@@ -102,14 +102,6 @@
       <img src="../../media/site/apps/settings.png" width="1072" height="1448" alt="Battery status and hardware information in Cobalt Settings">
     </figure>
   </div>
-  <section class="panel get-cobalt">
-    <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
-      <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
-    </div>
-    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
-  </section>
   <section class="panel setup">
     <p class="eyebrow">No separate install needed</p>
     <h2>Available after Cobalt setup</h2>

--- a/docs/apps/sidekick/index.html
+++ b/docs/apps/sidekick/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/sidekick.png" width="1072" height="1448" alt="Sidekick multi-agent board showing distinct coding-agent sessions and pending approvals.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/sidekick/index.html
+++ b/docs/apps/sidekick/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/sidekick.png" width="1072" height="1448" alt="Sidekick multi-agent board showing distinct coding-agent sessions and pending approvals.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/store/index.html
+++ b/docs/apps/store/index.html
@@ -102,6 +102,14 @@
       <img src="../../media/site/apps/store.png" width="1072" height="1448" alt="The Cobalt App Store listing installed and available apps">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel setup">
     <p class="eyebrow">No separate install needed</p>
     <h2>Available after Cobalt setup</h2>

--- a/docs/apps/store/index.html
+++ b/docs/apps/store/index.html
@@ -102,14 +102,6 @@
       <img src="../../media/site/apps/store.png" width="1072" height="1448" alt="The Cobalt App Store listing installed and available apps">
     </figure>
   </div>
-  <section class="panel get-cobalt">
-    <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
-      <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
-    </div>
-    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
-  </section>
   <section class="panel setup">
     <p class="eyebrow">No separate install needed</p>
     <h2>Available after Cobalt setup</h2>

--- a/docs/apps/sudoku/index.html
+++ b/docs/apps/sudoku/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/sudoku.png" width="1072" height="1448" alt="A Sudoku game designed for the Kobo touch screen">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/sudoku/index.html
+++ b/docs/apps/sudoku/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/sudoku.png" width="1072" height="1448" alt="A Sudoku game designed for the Kobo touch screen">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/syncthing/index.html
+++ b/docs/apps/syncthing/index.html
@@ -114,16 +114,17 @@
         <code class="setup-command">kobo sync run</code></li>
     </ol>
   </section>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -138,17 +139,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/syncthing/index.html
+++ b/docs/apps/syncthing/index.html
@@ -114,6 +114,14 @@
         <code class="setup-command">kobo sync run</code></li>
     </ol>
   </section>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/terminal/index.html
+++ b/docs/apps/terminal/index.html
@@ -102,14 +102,6 @@
       <img src="../../media/site/apps/terminal.png" width="1072" height="1448" alt="A shell and touch keyboard on a Kobo">
     </figure>
   </div>
-  <section class="panel get-cobalt">
-    <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
-      <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
-    </div>
-    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
-  </section>
   <section class="panel setup">
     <p class="eyebrow">No separate install needed</p>
     <h2>Available after Cobalt setup</h2>

--- a/docs/apps/terminal/index.html
+++ b/docs/apps/terminal/index.html
@@ -102,6 +102,14 @@
       <img src="../../media/site/apps/terminal.png" width="1072" height="1448" alt="A shell and touch keyboard on a Kobo">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel setup">
     <p class="eyebrow">No separate install needed</p>
     <h2>Available after Cobalt setup</h2>

--- a/docs/apps/tictactoe/index.html
+++ b/docs/apps/tictactoe/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/tictactoe.png" width="1072" height="1448" alt="A completed game of tic-tac-toe on a Kobo">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/tictactoe/index.html
+++ b/docs/apps/tictactoe/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/tictactoe.png" width="1072" height="1448" alt="A completed game of tic-tac-toe on a Kobo">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/todo/index.html
+++ b/docs/apps/todo/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/todo.png" width="1072" height="1448" alt="A to-do list with completed items on a Kobo">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/todo/index.html
+++ b/docs/apps/todo/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/todo.png" width="1072" height="1448" alt="A to-do list with completed items on a Kobo">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/vault/index.html
+++ b/docs/apps/vault/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/vault.png" width="1072" height="1448" alt="Vault first-run screen on a Kobo Clara BW, showing the commands to push a note vault.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/vault/index.html
+++ b/docs/apps/vault/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/vault.png" width="1072" height="1448" alt="Vault first-run screen on a Kobo Clara BW, showing the commands to push a note vault.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/verses/index.html
+++ b/docs/apps/verses/index.html
@@ -103,16 +103,17 @@
       <img src="../../media/site/apps/verses.png" width="1072" height="1448" alt="Verses displaying a public-domain daily poem in a spacious Kobo reading layout.">
     </figure>
   </div>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -127,17 +128,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/verses/index.html
+++ b/docs/apps/verses/index.html
@@ -103,6 +103,14 @@
       <img src="../../media/site/apps/verses.png" width="1072" height="1448" alt="Verses displaying a public-domain daily poem in a spacious Kobo reading layout.">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/docs/apps/zotero-reader/index.html
+++ b/docs/apps/zotero-reader/index.html
@@ -115,16 +115,17 @@
       <li>Direct mode reads indexed text. Structured PDF layout, tables, figures, formulas, and OCR require the optional self-hosted conversion service. <a href="https://andreclerigo.github.io/cobalt-zotero-reader/self-hosting.html">Self-hosting guide</a></li>
     </ol>
   </section>
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -139,17 +140,6 @@
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>

--- a/docs/apps/zotero-reader/index.html
+++ b/docs/apps/zotero-reader/index.html
@@ -115,6 +115,14 @@
       <li>Direct mode reads indexed text. Structured PDF layout, tables, figures, formulas, and OCR require the optional self-hosted conversion service. <a href="https://andreclerigo.github.io/cobalt-zotero-reader/self-hosting.html">Self-hosting guide</a></li>
     </ol>
   </section>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>

--- a/tools/generate-app-pages.mjs
+++ b/tools/generate-app-pages.mjs
@@ -248,6 +248,14 @@ for (const app of catalog.apps) {
       <img src="../../media/site/apps/${screenshot}" width="1072" height="1448" alt="${escape(screenshotAlt)}">
     </figure>
   </div>${prerequisites}
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel" id="pair-panel">
     <p class="eyebrow">Install with Cobalt</p>
     <h2>Link your Kobo to install</h2>
@@ -374,6 +382,14 @@ for (const app of systemApps) {
       <img src="../../media/site/apps/${screenshot}" width="1072" height="1448" alt="${escape(screenshotAlt)}">
     </figure>
   </div>
+  <section class="panel get-cobalt">
+    <div class="get-cobalt-copy">
+      <p class="eyebrow">New to Cobalt?</p>
+      <h2>Install Cobalt directly from your browser</h2>
+      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+    </div>
+    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
+  </section>
   <section class="panel setup">
     <p class="eyebrow">No separate install needed</p>
     <h2>Available after Cobalt setup</h2>

--- a/tools/generate-app-pages.mjs
+++ b/tools/generate-app-pages.mjs
@@ -248,16 +248,17 @@ for (const app of catalog.apps) {
       <img src="../../media/site/apps/${screenshot}" width="1072" height="1448" alt="${escape(screenshotAlt)}">
     </figure>
   </div>${prerequisites}
-  <section class="panel get-cobalt">
+  <section class="panel get-cobalt" id="setup-panel">
     <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
+      <p class="eyebrow">Do not have Cobalt yet?</p>
       <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
+      <p>Plug your Kobo into this computer and the browser writes Cobalt across. About a minute, and no terminal. Applications after that arrive over Wi-Fi, with no cable.</p>
+      <p class="fine">Works in Chrome, Edge and Opera. <a href="https://github.com/BandarLabs/Cobalt/blob/main/docs/DEVICES.md#device-support-matrix">Check your Kobo is supported</a>.</p>
     </div>
     <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
   </section>
   <section class="panel" id="pair-panel">
-    <p class="eyebrow">Install with Cobalt</p>
+    <p class="eyebrow">Already have Cobalt?</p>
     <h2>Link your Kobo to install</h2>
     <p>On your Kobo, open <strong>App Store</strong>, then <strong>Install links</strong>. Scan the QR code, or enter the pairing code and verification key shown there.</p>
     <form id="pair-form">
@@ -272,17 +273,6 @@ for (const app of catalog.apps) {
       <button type="submit">Link Kobo</button>
     </form>
     <p class="status" id="pair-status" role="status" aria-live="polite"></p>
-  </section>
-  <section class="panel setup" id="setup-panel">
-    <p class="eyebrow">Cobalt not installed?</p>
-    <h2>Set up Cobalt first</h2>
-    <p>Install Cobalt once over USB, then return to this page. Future apps install and update over Wi-Fi without reconnecting the cable.</p>
-    <ol>
-      <li>Check that your Kobo model and firmware are supported.</li>
-      <li>Connect the charged Kobo to a Mac or Linux computer and follow the setup guide.</li>
-      <li>Restart your Kobo, open Cobalt App Store, and return here to link it.</li>
-    </ol>
-    <a class="button-link secondary" href="https://github.com/BandarLabs/Cobalt/blob/main/docs/INSTALL.md">Set up Cobalt</a>
   </section>
   <section class="panel" id="install-panel" hidden>
     <h2>Install on <span id="device-name">your Kobo</span></h2>
@@ -382,14 +372,6 @@ for (const app of systemApps) {
       <img src="../../media/site/apps/${screenshot}" width="1072" height="1448" alt="${escape(screenshotAlt)}">
     </figure>
   </div>
-  <section class="panel get-cobalt">
-    <div class="get-cobalt-copy">
-      <p class="eyebrow">New to Cobalt?</p>
-      <h2>Install Cobalt directly from your browser</h2>
-      <p>Plug your Kobo into this computer and the browser writes it across. No terminal, and it takes about a minute.</p>
-    </div>
-    <a class="get-cobalt-go" href="../../install/">Install Cobalt<span aria-hidden="true">&#8594;</span></a>
-  </section>
   <section class="panel setup">
     <p class="eyebrow">No separate install needed</p>
     <h2>Available after Cobalt setup</h2>


### PR DESCRIPTION
An application page is where somebody lands from a search, and it has always
assumed they already had Cobalt. The panel on it asks them to open the App Store
on their Kobo and pair, which they cannot do without Cobalt. Someone who has
just discovered the project had nothing to click.

Every page now carries the step before that one, above the pairing panel because
pairing depends on it: a short panel with the brand's blue, one line of copy,
and a button.

Generated, not written into the pages, so an application added later gets it
without anyone remembering to.

## Checked

- 48 of 48 application pages carry exactly one panel, none carry two
- Two consecutive generator runs produce identical trees, which is what the CI
  check requires
- `node --test tools/*.test.mjs`: 100 passed

## Worth knowing

My first version patched only the template that has a pairing panel. That left
the system applications, the launcher and the Store, without the offer, which
are the pages somebody new is most likely to read first. Both templates carry it
now, and the count above is what caught it.

## Order matters

The link points at `/install/`, which arrives with #149. **This should not reach
main before #149 does**, or every application page will link to a page that is
not there. Both are held for the next batched promotion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791362805&installation_model_id=20525&pr_number=152&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F152&signature=7871a52dbc0fb2df75c5813e8557fa04bc58585ca07f1d6118d3771a4e384445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->