### PR TITLE
Ask for the newest releases rather than all of them

### DIFF
--- a/crates/kobod/src/autoupdate.rs
+++ b/crates/kobod/src/autoupdate.rs
@@ -21,7 +21,20 @@ use kobo_protocol::{DeviceError, UpdateChannel};
 /// Where releases are published. The same address the settings screen asks,
 /// so the two paths cannot disagree about what "newest" means.
 const STABLE_RELEASES: &str = "https://api.github.com/repos/BandarLabs/Cobalt/releases/latest";
-const BETA_RELEASES: &str = "https://api.github.com/repos/BandarLabs/Cobalt/releases?per_page=100";
+/// The newest releases, rather than all of them.
+///
+/// GitHub cannot be asked for prereleases alone, so the newest beta has to be
+/// picked out of a listing that also carries the stable ones. Asking for every
+/// release meant a reply that grew with the project: at thirty-four releases it
+/// was 880 KB, against a ceiling of one megabyte on the readers that shipped
+/// before this, and the failure at the ceiling is silent -- an update check
+/// that finds nothing looks exactly like a reader that is up to date.
+///
+/// Twenty is chosen against how releases actually appear. Betas are the most
+/// frequent tag here, so the newest one has never been far from the top; the
+/// case this gives up on is twenty consecutive releases without a single beta,
+/// by which time nobody is waiting on a beta anyway.
+const BETA_RELEASES: &str = "https://api.github.com/repos/BandarLabs/Cobalt/releases?per_page=20";
 
 /// The most a release listing is allowed to be.
 ///


### PR DESCRIPTION
The beta update check downloads a listing of every release this repository has
ever published, because GitHub will not filter prereleases and the newest one
has to be found among the stable tags.

That reply grows with the project, and it is close to a limit:

```
34 releases -> 901,832 bytes   86% of the 1 MiB ceiling on readers before 0.3.9
~26,500 bytes added per release
```

**The failure at that ceiling is silent.** The check gives up quietly, so a
reader that can no longer find an update looks exactly like one that does not
need an update. Five more releases would have reached it, and the readers that
would break are the ones that cannot receive the raised ceiling, because their
check breaks first.

Asking for the newest twenty brings it to 682,623 bytes, 65% of the same
ceiling, and stops it growing.

## Verified against the real listing

```
newest beta from all 34 releases: beta-v0.3.10
newest beta from the newest 20:   beta-v0.3.10   (same answer)
```

Worth noting the API does not return releases in the order you would expect:
`beta-v0.3.10` sits at position 6, behind three older betas. It does not matter
here, because the code takes the highest version rather than the first match,
but it is the reason twenty is a real bound and not a guess about ordering.

## What it gives up

Twenty consecutive releases without a beta among them. Betas are the most
frequent tag here, and a project not cutting betas is not one anybody is waiting
on a beta from.

`cargo test -p kobod` autoupdate tests pass, `cargo fmt --check` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791362941&installation_model_id=20525&pr_number=153&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F153&signature=10714ca4a5fc35614b190ae17cd19a39f49e6de43c33b9ed1145684836e058d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->