### PR TITLE
Run the device profile script from a file, not from a shell argument

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -175,54 +175,68 @@ jobs:
       # against the one that matters, and a device list that is quietly wrong
       # tells somebody their working reader is untested. Anything this cannot
       # read stops the build instead of publishing a gap.
+      # The reviewed devices, taken from the profiles the runtime enforces rather
+      # than from a list kept beside the page. A copy would go stale against the
+      # one that matters, and a device list that is quietly wrong tells somebody
+      # their working reader is untested. Anything this cannot read stops the
+      # build rather than publishing a gap.
+      #
+      # Written to a file through a quoted heredoc rather than passed to node -e.
+      # The script matches Rust string literals, so it contains single quotes,
+      # and one of those inside a shell's single-quoted argument ends the
+      # argument: the first attempt failed with a syntax error from bash that
+      # had nothing to do with the profiles.
       - name: Take the reviewed device profiles
         run: |
           set -eu
-          node --input-type=module -e '
-            import { readFileSync } from "node:fs";
-            const src = readFileSync("crates/kobo-profile/src/lib.rs", "utf8");
+          mkdir -p _site/install
+          cat > device-profiles.mjs <<'PROFILES'
+          import { readFileSync } from "node:fs";
+          const src = readFileSync("crates/kobo-profile/src/lib.rs", "utf8");
 
-            function block(name) {
-              const m = src.match(new RegExp(`(?:pub )?(?:static|const) ${name}\\s*:\\s*DeviceProfile\\s*=\\s*DeviceProfile\\s*\\{([\\s\\S]*?)\\n\\};`));
-              if (!m) throw new Error(`no profile named ${name}`);
-              return m[1];
-            }
-            function read(name, seen = new Set()) {
-              if (seen.has(name)) throw new Error(`profile ${name} inherits from itself`);
-              seen.add(name);
-              const body = block(name);
-              // `..BASE` copies every field not written here, so the base must be read
-              // first and then written over. Missing this is what produced a profile with
-              // no model and no serial prefix.
-              const base = body.match(/\.\.\s*([A-Z0-9_]+)\s*$/m);
-              const value = base ? { ...read(base[1], seen) } : {};
-              const one = (field, re) => { const m = body.match(new RegExp(`\\b${field}:\\s*${re}`)); return m ? m[1] : undefined; };
-              const id = one("id", '"([^"]*)"'); if (id !== undefined) value.id = id;
-              const model = one("model", '"([^"]*)"'); if (model !== undefined) value.model = model;
-              const prefix = one("serial_prefix", '"([^"]*)"'); if (prefix !== undefined) value.serial_prefix = prefix;
-              const ready = one("write_ready", "(true|false)"); if (ready !== undefined) value.write_ready = ready === "true";
-              const fw = body.match(/\bfirmware_versions:\s*&\[([\s\S]*?)\]/);
-              if (fw) value.firmware = (fw[1].match(/"[^"]*"/g) || []).map(s => s.slice(1, -1));
-              return value;
-            }
+          function block(name) {
+            const m = src.match(new RegExp(`(?:pub )?(?:static|const) ${name}\\s*:\\s*DeviceProfile\\s*=\\s*DeviceProfile\\s*\\{([\\s\\S]*?)\\n\\};`));
+            if (!m) throw new Error(`no profile named ${name}`);
+            return m[1];
+          }
+          function read(name, seen = new Set()) {
+            if (seen.has(name)) throw new Error(`profile ${name} inherits from itself`);
+            seen.add(name);
+            const body = block(name);
+            // `..BASE` copies every field not written here, so the base must be read
+            // first and then written over. Missing this is what produced a profile with
+            // no model and no serial prefix.
+            const base = body.match(/\.\.\s*([A-Z0-9_]+)\s*$/m);
+            const value = base ? { ...read(base[1], seen) } : {};
+            const one = (field, re) => { const m = body.match(new RegExp(`\\b${field}:\\s*${re}`)); return m ? m[1] : undefined; };
+            const id = one("id", '"([^"]*)"'); if (id !== undefined) value.id = id;
+            const model = one("model", '"([^"]*)"'); if (model !== undefined) value.model = model;
+            const prefix = one("serial_prefix", '"([^"]*)"'); if (prefix !== undefined) value.serial_prefix = prefix;
+            const ready = one("write_ready", "(true|false)"); if (ready !== undefined) value.write_ready = ready === "true";
+            const fw = body.match(/\bfirmware_versions:\s*&\[([\s\S]*?)\]/);
+            if (fw) value.firmware = (fw[1].match(/"[^"]*"/g) || []).map(s => s.slice(1, -1));
+            return value;
+          }
 
-            const listed = src.match(/pub const SUPPORTED_PROFILES[^=]*=\s*&\[([\s\S]*?)\]/)[1]
-              .split(",").map(s => s.trim().replace(/^&/, "")).filter(Boolean);
-            const profiles = listed.map(n => read(n));
+          const listed = src.match(/pub const SUPPORTED_PROFILES[^=]*=\s*&\[([\s\S]*?)\]/)[1]
+            .split(",").map(s => s.trim().replace(/^&/, "")).filter(Boolean);
+          const profiles = listed.map(n => read(n));
 
-            // A matrix that is quietly incomplete is worse than no matrix: it would tell
-            // somebody their working reader is untested. Anything unreadable stops the build.
-            const faults = [];
-            for (const [i, p] of profiles.entries()) {
-              for (const field of ["id", "model", "serial_prefix", "write_ready"]) {
-                if (p[field] === undefined || p[field] === null) faults.push(`${listed[i]}: no ${field}`);
-              }
-              if (!p.firmware || p.firmware.length === 0) faults.push(`${listed[i]}: no firmware versions`);
+          // A matrix that is quietly incomplete is worse than no matrix: it would tell
+          // somebody their working reader is untested. Anything unreadable stops the build.
+          const faults = [];
+          for (const [i, p] of profiles.entries()) {
+            for (const field of ["id", "model", "serial_prefix", "write_ready"]) {
+              if (p[field] === undefined || p[field] === null) faults.push(`${listed[i]}: no ${field}`);
             }
-            if (faults.length > 0) { console.error("could not read the device profiles:\n  " + faults.join("\n  ")); process.exit(1); }
-            console.log(JSON.stringify(profiles.map(p => ({ model: p.model, code: p.serial_prefix, firmware: p.firmware, ready: p.write_ready }))));
-          ' > _site/install/devices.json
-          node -e 'const d=require("./_site/install/devices.json"); console.log(`  ${d.length} reviewed device profiles`)'
+            if (!p.firmware || p.firmware.length === 0) faults.push(`${listed[i]}: no firmware versions`);
+          }
+          if (faults.length > 0) { console.error("could not read the device profiles:\n  " + faults.join("\n  ")); process.exit(1); }
+          console.log(JSON.stringify(profiles.map(p => ({ model: p.model, code: p.serial_prefix, firmware: p.firmware, ready: p.write_ready }))));
+          PROFILES
+          node device-profiles.mjs > _site/install/devices.json
+          rm -f device-profiles.mjs
+          node -e 'const d = require("./_site/install/devices.json"); console.log(`  ${d.length} reviewed device profiles`)'
 
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:


### PR DESCRIPTION
The site workflow has already run on main and failed. The build job never got as
far as publishing anything:

```
build: failure   step: Take the reviewed device profiles
deploy: skipped
/home/runner/work/_temp/....sh: line 21: syntax error near unexpected token `)'
```

The script was passed to `node -e` as a single-quoted argument, and it matches
Rust string literals, so it contains single quotes of its own:

```js
const id = one("id", '"([^"]*)"');
```

The first of those ended the shell argument and bash tried to run the rest. The
error named a temporary file and a bracket, so it read like a problem with the
profiles; it was quoting. The script was correct all along.

It is written to a file through a quoted heredoc now, indented so YAML strips
exactly the block indent and the shell still sees `PROFILES` at the start of a
line.

## Verified by running it

The step, parsed out of the workflow rather than retyped, executed as the runner
receives it:

```
8 reviewed device profiles
step exited 0

Kobo Clara BW      N365  4.45.23697
Kobo Clara BW      P365  4.45.23697
Kobo Clara HD      N249  4.38.23684,4.38.23697
Kobo Clara Colour  N367  4.45.23697
Kobo Elipsa 2E     N605  4.38.23697
Kobo Libra 2       N418  4.38.23697
Kobo Libra Colour  N428  4.45.23697
Kobo Libra Colour  N428  4.46.23836
```

And every `run:` block in the file now passes `bash -n`: 7 steps, 0 syntax
errors. Both checks are ones I should have run before the first version reached
main.

**This blocks the Pages switch.** Changing the source to GitHub Actions while the
build fails would take the site down, `install.sh` included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791376373&installation_model_id=20525&pr_number=157&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F157&signature=184eebb853d01917e1ebbe95eb7118b38db4f12c8f7b7befe3c5d23efc01fc57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->