### PR TITLE
Restore the function whose absence stopped the install page working

### DIFF
--- a/docs/install/index.html
+++ b/docs/install/index.html
@@ -34,6 +34,7 @@ h1 { font-size: 40px; line-height: 1.1; margin: 40px 0 10px; letter-spacing: -.0
 
 /* Steps */
 ol.steps { list-style: none; counter-reset: step; margin: 34px 0 0; padding: 0; }
+ol.steps[aria-disabled="true"] { opacity: .4; }
 ol.steps > li { counter-increment: step; display: grid; grid-template-columns: 46px 1fr; gap: 18px; padding: 26px 0; border-top: 1px solid var(--rule); }
 ol.steps > li::before {
   content: counter(step); font-family: var(--mono); font-size: 22px; line-height: 1;
@@ -176,7 +177,7 @@ cargo run -p kobo-cli -- setup</pre>
     </div>
   </details>
 
-  <ol class="steps">
+  <ol class="steps" id="steps">
     <li id="step-connect">
       <div>
         <h2>Connect your Kobo via USB</h2>

--- a/docs/install/install.js
+++ b/docs/install/install.js
@@ -424,13 +424,34 @@ async function writeFile(folder, name, bytes) {
   await target.close();
 }
 
+// The by-hand route shows the same archive and the same menu entry the steps
+// above would write, read from the same manifest and the same constant, so the
+// two cannot drift into installing different things.
+async function describeManualRoute() {
+  const entry = document.querySelector("#by-hand-entry");
+  if (entry) entry.textContent = MENU_ENTRY;
+  try {
+    const described = await fetch("manifest.json", { cache: "no-store" });
+    if (!described.ok) return;
+    const facts = await described.json();
+    const link = document.querySelector("#by-hand-archive");
+    if (link) link.setAttribute("href", facts.archive);
+    const size = document.querySelector("#by-hand-size");
+    if (size) {
+      size.textContent =
+        `Cobalt ${facts.version} with NickelMenu ${facts.nickelmenu}, ${(facts.bytes / 1048576).toFixed(1)} MB`;
+    }
+  } catch {
+    // The steps above report a manifest that cannot be read; the link still
+    // points at the archive.
+  }
+}
+
 function escapeText(value) {
   const holder = document.createElement("span");
   holder.textContent = String(value);
   return holder.innerHTML;
 }
-
-describeManualRoute();
 
 if (refuseUnsupportedBrowser()) {
   // The only route left, so it is opened rather than left to be discovered.
@@ -440,3 +461,9 @@ if (refuseUnsupportedBrowser()) {
   fetchButton.addEventListener("click", fetchRelease);
   writeButton.addEventListener("click", writeToReader);
 }
+
+// After the wiring, and its failure is its own. This filled in the by-hand
+// section and was called first; when it referred to something that no longer
+// existed it threw, the wiring below it never ran, and every button on the page
+// did nothing in every browser.
+describeManualRoute();

--- a/docs/install/install.js
+++ b/docs/install/install.js
@@ -66,12 +66,17 @@ function refuseUnsupportedBrowser() {
   if (typeof window.showDirectoryPicker === "function") return false;
   const banner = document.querySelector("#unsupported");
   document.querySelector("#unsupported-why").innerHTML =
-    "Writing to a plugged-in drive is something Chrome, Edge and Opera can do, " +
-    "and Firefox and Safari cannot. <strong>Open this page in Chrome</strong> " +
-    "to install straight from the browser. Otherwise the ways below install " +
-    "exactly the same thing.";
+    "Writing to a plugged-in drive needs <strong>Chrome, Edge or Opera on a " +
+    "computer</strong>. Firefox and Safari cannot do it, and neither can any " +
+    "browser on a phone or tablet. The ways below install exactly the same " +
+    "thing and work anywhere.";
   banner.hidden = false;
   pickButton.disabled = true;
+  // The steps are the whole page and none of them can be followed here. Left
+  // as they are they read as the thing to do, and the route that does work sits
+  // underneath them looking like an afterthought.
+  const steps = document.querySelector("#steps");
+  if (steps) steps.setAttribute("aria-disabled", "true");
   // The steps above cannot be followed here, so the ways that can be are
   // opened rather than left folded behind a heading somebody has to think to
   // click.
@@ -104,10 +109,15 @@ async function chooseDrive() {
     return;
   }
 
-  if ((await handle.queryPermission({ mode: "readwrite" })) !== "granted" &&
-      (await handle.requestPermission({ mode: "readwrite" })) !== "granted") {
-    pickNote.innerHTML = '<span class="bad">Writing was not allowed, so nothing was installed.</span>';
-    return;
+  if (typeof handle.queryPermission === "function") {
+    const already = await handle.queryPermission({ mode: "readwrite" });
+    const granted = already === "granted" ||
+      (typeof handle.requestPermission === "function" &&
+        (await handle.requestPermission({ mode: "readwrite" })) === "granted");
+    if (!granted) {
+      pickNote.innerHTML = '<span class="bad">Writing was not allowed, so nothing was installed.</span>';
+      return;
+    }
   }
 
   drive = handle;


### PR DESCRIPTION
The published install page does nothing. Every button is inert, in every
browser, and Safari is shown no warning about being unable to install.

```
Uncaught ReferenceError: describeManualRoute is not defined
    at install.js:433:1
```

Both symptoms are that one line. The call is the first statement that runs, and
the wiring that attaches the click handlers is below it, so no handler was ever
attached and `refuseUnsupportedBrowser` was never reached.

## How it got there

The function went when the uninstall flow moved to its own page. That edit
removed everything between a marker and the next function declaration, and this
had been inserted into the middle of that range. The call above it stayed.

`node --check` was the only check the file had. It parses without executing, so
a call to a function that does not exist reads exactly like a call to one that
does. Nothing else looked at the file before it was published.

## The fix

The function is back, and the wiring now runs before it. Filling in the by-hand
section is decoration; it must not be able to stop the page working. Its
failures are its own from here.

## What I checked, having not checked properly before

I wrote a small harness that loads each page's script against its own markup and
the smallest DOM that lets it run, and reports what threw and what got wired up:

```
docs/install/install.js       errors: none   wired: pick:click, fetch:click, write:click
docs/install/remove/remove.js errors: none   wired: remove-pick:click, remove-go:click
```

Removing the function again reproduces the published failure:

```
errors: ReferenceError: describeManualRoute is not defined
wired:  NOTHING
```

The harness is not in this pull request. It belongs with the tooling, which a
`site/*` branch may not touch, so it goes to beta separately and this stays a
one-file fix that can go out now.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791378795&installation_model_id=20525&pr_number=158&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F158&signature=0a076620ecd9a01394b1e5c9e97c1119a256e65bf34d84c6cde6d6088af90c27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->