### PR TITLE
Check the browser can write, not just that it can ask

### DIFF
--- a/docs/install/install.js
+++ b/docs/install/install.js
@@ -62,14 +62,32 @@ function done(element) {
 // Said once, at the top, rather than left for the reader to discover when a
 // button does nothing. The directory picker is the part browsers disagree
 // about; everything else here is ordinary.
+function missingCapability() {
+  if (typeof window.showDirectoryPicker !== "function") return "picker";
+  // The write side is a separate interface and is what the install needs. A
+  // browser offering the picker without it would get as far as a chosen reader
+  // and a verified download, and fail at the only step that matters.
+  const file = window.FileSystemFileHandle;
+  if (!file || typeof file.prototype.createWritable !== "function") return "writing";
+  const folder = window.FileSystemDirectoryHandle;
+  if (!folder || typeof folder.prototype.getDirectoryHandle !== "function") return "folders";
+  return null;
+}
+
 function refuseUnsupportedBrowser() {
-  if (typeof window.showDirectoryPicker === "function") return false;
+  const missing = missingCapability();
+  if (!missing) return false;
   const banner = document.querySelector("#unsupported");
+  const detail = missing === "picker"
+    ? "cannot open a drive"
+    : missing === "writing"
+      ? "can open a drive but cannot write to one"
+      : "cannot read the folders on a drive";
   document.querySelector("#unsupported-why").innerHTML =
-    "Writing to a plugged-in drive needs <strong>Chrome, Edge or Opera on a " +
-    "computer</strong>. Firefox and Safari cannot do it, and neither can any " +
-    "browser on a phone or tablet. The ways below install exactly the same " +
-    "thing and work anywhere.";
+    `This browser ${detail}. Installing this way needs <strong>Chrome, Edge or ` +
+    "Opera on a computer</strong>: Firefox and Safari cannot do it, and neither " +
+    "can any browser on a phone or tablet. The ways below install exactly the " +
+    "same thing and work anywhere.";
   banner.hidden = false;
   pickButton.disabled = true;
   // The steps are the whole page and none of them can be followed here. Left
@@ -92,7 +110,14 @@ async function chooseDrive() {
     // Dismissing the picker is a choice, not a fault, and should not be
     // reported as one.
     if (error && error.name === "AbortError") return;
-    pickNote.innerHTML = `<span class="bad">The drive could not be opened: ${escapeText(error.message)}</span>`;
+    // Whatever went wrong here, this browser has just failed at the first step,
+    // so the routes that do not depend on it are opened rather than left folded
+    // away. A button that does nothing and says nothing is the worst of the
+    // outcomes available.
+    pickNote.innerHTML =
+      `<span class="bad">The drive could not be opened: ${escapeText(error.message || error.name || "no reason given")}. ` +
+      "The other ways to install, below, do not need this.</span>";
+    document.querySelector("#by-hand").open = true;
     return;
   }
 


### PR DESCRIPTION
Safari opens the drive picker and then nothing happens. No message, no warning
at the top, and "Other ways to install" still folded away.

The page tested `typeof window.showDirectoryPicker === "function"` and treated
that as permission to run the whole flow. The picker is the first of three
things this needs, and the only one it checked.

## What it checks now

| interface | used for |
| --- | --- |
| `showDirectoryPicker` | choosing the reader |
| **`FileSystemFileHandle.createWritable`** | **writing, which is the point** |
| `FileSystemDirectoryHandle.getDirectoryHandle` | reaching `.kobo` and `.adds` |

A browser offering the picker without the writable stream would take somebody
through choosing a reader, downloading 18 MB and verifying a checksum, and then
fail at the only step that matters. The message names which one is missing,
because "this browser cannot" is not something anybody can act on.

## No more dead ends

If the picker fails for any other reason, the failure is named and the routes
that do not depend on it are opened. A button that does nothing and says nothing
was the worst outcome available, and it was the one being produced.

## Support is narrower than the page claimed

caniuse puts the File System Access API at about 31% of users. No browser on a
phone or tablet has it, Chrome for Android included, so the message asks for
**Chrome, Edge or Opera on a computer** rather than naming a browser somebody may
already be holding. The steps are dimmed when they cannot be followed.

`queryPermission` and `requestPermission` are Chromium's own and are not in the
specification; they are called only where they exist.

## Checked

A harness loads the page's script against its own markup and reports what threw
and what got wired:

```
picker + writing:  errors none   wired: pick:click, fetch:click, write:click
picker alone:      errors none   wired: NOTHING          <- warning instead
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791380091&installation_model_id=20525&pr_number=159&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F159&signature=74a2261c4f49a255b70d2e717fe83e6ae4a662d8b2f46db2a4a2905aa44e3bcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->