### PR TITLE
Fix unsupported browser messaging

### DIFF
--- a/docs/install/index.html
+++ b/docs/install/index.html
@@ -137,7 +137,7 @@ kbd { border: 1px solid var(--rule); border-bottom-width: 2px; padding: 0 5px; b
   <p class="lede">Writes Cobalt and NickelMenu to a Kobo plugged into this computer. No terminal, nothing uploaded.</p>
 
   <div class="banner" id="unsupported" hidden>
-    <strong>This browser cannot write to the reader.</strong>
+    <strong>This browser cannot install Cobalt.</strong>
     <p id="unsupported-why"></p>
   </div>
 
@@ -146,14 +146,14 @@ kbd { border: 1px solid var(--rule); border-bottom-width: 2px; padding: 0 5px; b
     <div>
       <section class="way">
         <h3><span class="tag">Terminal</span> One command</h3>
-        <p>Plug the reader in, open Terminal, paste this:</p>
+        <p>Plug the Kobo into a computer and tap <strong>Connect</strong> on the reader's screen. Then in Terminal:</p>
         <pre>curl -fsSL https://bandarlabs.github.io/Cobalt/install.sh | sh</pre>
         <p class="note">Installs Cobalt and NickelMenu, adds the menu entry, ejects the drive. Keeps what is already on the reader.</p>
       </section>
 
       <section class="way">
         <h3><span class="tag">From source</span> Build it yourself</h3>
-        <p>Needs Rust. Builds the same thing the others download.</p>
+        <p>Needs Rust. Builds the same thing the others download. Plug the Kobo in and tap <strong>Connect</strong> on its screen first.</p>
         <pre>git clone https://github.com/BandarLabs/Cobalt.git
 cd Cobalt
 rustup target add armv7-unknown-linux-musleabihf

--- a/docs/install/install.js
+++ b/docs/install/install.js
@@ -78,15 +78,17 @@ function refuseUnsupportedBrowser() {
   const missing = missingCapability();
   if (!missing) return false;
   const banner = document.querySelector("#unsupported");
-  // Said once. The heading already says it cannot be done here, so this says
-  // what is needed instead, and the colon that used to sit between them landed
-  // at the start of a line whenever the bolded part wrapped.
-  const detail = missing === "writing" ? "can open a drive but cannot write to one"
+  // Which of the three is missing matters for working out why, and not to
+  // somebody who wants to install a reading application: the answer is the same
+  // either way. It goes to the console for anyone looking, and the line on the
+  // page says what to do instead.
+  console.info(`Cobalt: this browser ${
+    missing === "writing" ? "opens a drive but cannot write to one"
     : missing === "folders" ? "cannot read folders on a drive"
-    : "cannot open a drive";
+    : "cannot open a drive"}.`);
   document.querySelector("#unsupported-why").innerHTML =
-    `It ${detail}. Installing this way needs Chrome, Edge or Opera on a computer. ` +
-    "The ways below install the same thing and work anywhere.";
+    "Try Chrome, Edge or Opera on a computer. Or use one of the ways below: " +
+    "one command in a terminal, or copy a single file with no terminal at all.";
   banner.hidden = false;
   pickButton.disabled = true;
   // The steps are the whole page and none of them can be followed here. Left

--- a/docs/install/install.js
+++ b/docs/install/install.js
@@ -78,16 +78,15 @@ function refuseUnsupportedBrowser() {
   const missing = missingCapability();
   if (!missing) return false;
   const banner = document.querySelector("#unsupported");
-  const detail = missing === "picker"
-    ? "cannot open a drive"
-    : missing === "writing"
-      ? "can open a drive but cannot write to one"
-      : "cannot read the folders on a drive";
+  // Said once. The heading already says it cannot be done here, so this says
+  // what is needed instead, and the colon that used to sit between them landed
+  // at the start of a line whenever the bolded part wrapped.
+  const detail = missing === "writing" ? "can open a drive but cannot write to one"
+    : missing === "folders" ? "cannot read folders on a drive"
+    : "cannot open a drive";
   document.querySelector("#unsupported-why").innerHTML =
-    `This browser ${detail}. Installing this way needs <strong>Chrome, Edge or ` +
-    "Opera on a computer</strong>: Firefox and Safari cannot do it, and neither " +
-    "can any browser on a phone or tablet. The ways below install exactly the " +
-    "same thing and work anywhere.";
+    `It ${detail}. Installing this way needs Chrome, Edge or Opera on a computer. ` +
+    "The ways below install the same thing and work anywhere.";
   banner.hidden = false;
   pickButton.disabled = true;
   // The steps are the whole page and none of them can be followed here. Left


### PR DESCRIPTION
The warning on an unsupported browser said the same thing twice, and the colon
joining its two halves landed at the start of a line whenever the bolded phrase
wrapped:

> **This browser cannot write to the reader.**
> This browser cannot open a drive. Installing this way needs
> **Chrome, Edge or Opera on a computer**
> : Firefox and Safari cannot do it...

The heading already says it cannot be done here. The line under it now says only
what is needed instead:

> **This browser cannot install Cobalt.**
> It cannot open a drive. Installing this way needs Chrome, Edge or Opera on a
> computer. The ways below install the same thing and work anywhere.

## Every route now mentions Connect

Only the copy-a-file route mentioned it. The other two said "plug the reader in",
which is not enough: `docs/INSTALL.md` calls this the step people get stuck on,
because until the prompt on the reader is answered it only charges, nothing
mounts, and a script that goes looking for a volume reports that it cannot find
one.

```
One command        Connect: 1
Build it yourself  Connect: 1
Copy one file      Connect: 1
```

The wording is "Plug the Kobo into a computer and tap **Connect** on the reader's
screen. Then in Terminal:" rather than the suggested phrasing, which read as two
instructions run together.

Page still loads and wires up: `errors: none, wired: pick:click, fetch:click,
write:click`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791381613&installation_model_id=20525&pr_number=163&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F163&signature=7ba5f4e5f129078ea596f41ccc9e6cdbb5de6c0b9f22551042b27dafd6f99380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->