### PR TITLE
Release beta platform 0.3.11

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -244,10 +244,27 @@ jobs:
       - name: Install the musl cross-compiler the device C needs
         run: |
           set -eu
-          curl -fsSL -o /tmp/zig.tar.xz \
-            https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz
-          echo "70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00  /tmp/zig.tar.xz" \
-            | sha256sum -c -
+          # Community mirrors listed at https://ziglang.org/download/community-mirrors.txt.
+          # Every source must match the same reviewed digest before extraction.
+          # Bound each attempt: ziglang.org has stalled indefinitely on CI runners.
+          zig_downloaded=false
+          for zig_url in \
+            'https://pkg.hexops.org/zig/zig-x86_64-linux-0.16.0.tar.xz?source=cobalt-ci' \
+            'https://ziglang.freetls.fastly.net/zig-x86_64-linux-0.16.0.tar.xz?source=cobalt-ci' \
+            'https://ziglang.org/download/0.16.0/zig-x86_64-linux-0.16.0.tar.xz'; do
+            if curl -fL --connect-timeout 15 --max-time 120 \
+              --speed-limit 1024 --speed-time 20 -o /tmp/zig.tar.xz "$zig_url" \
+              && echo "70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00  /tmp/zig.tar.xz" \
+                | sha256sum -c -; then
+              zig_downloaded=true
+              break
+            fi
+            echo "::warning::Could not obtain the pinned Zig archive from $zig_url"
+          done
+          if [ "$zig_downloaded" != true ]; then
+            echo "No source supplied the pinned Zig archive" >&2
+            exit 1
+          fi
           sudo tar -xJf /tmp/zig.tar.xz -C /opt
           sudo tee /usr/local/bin/armv7-musl-cc >/dev/null <<'CC'
           #!/bin/sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "icon-import"
-version = "0.3.10"
+version = "0.3.11"
 
 [[package]]
 name = "image"
@@ -770,14 +770,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-abi"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "kobo-app-store"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-json",
  "kobo-net",
@@ -787,7 +787,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-arxiv"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-audiobook"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-doc",
  "kobo-json",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-books"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -827,7 +827,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-bookview"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-brief"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -854,7 +854,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-chat"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -863,7 +863,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-cli"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-app-store",
  "kobo-doc",
@@ -902,14 +902,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-dict"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "unicode-normalization",
 ]
 
 [[package]]
 name = "kobo-doc"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-html",
  "miniz_oxide 0.9.1",
@@ -918,7 +918,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doctor"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-flashcards-format"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "flate2",
  "kobo-image",
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-frame-host"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "blake3",
  "image",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gallery"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-sdk",
 ]
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-guard"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-hal",
  "kobo-profile",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-gutenbird"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-hal"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-abi",
  "kobo-doc",
@@ -1047,21 +1047,21 @@ dependencies = [
 
 [[package]]
 name = "kobo-handoff"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-hello"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-sdk",
 ]
 
 [[package]]
 name = "kobo-hn"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-html"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "ratex-layout",
  "ratex-parser",
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-image"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "image",
 ]
@@ -1105,7 +1105,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-json"
-version = "0.3.10"
+version = "0.3.11"
 
 [[package]]
 name = "kobo-kitchencard"
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-launcher"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-profile",
  "kobo-sdk",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-magnet"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1153,7 +1153,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-morse"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-net"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "http",
  "httparse",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-opds"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-json",
  "kobo-xml",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-policy"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-abi",
  "kobo-dict",
@@ -1270,11 +1270,11 @@ dependencies = [
 
 [[package]]
 name = "kobo-profile"
-version = "0.3.10"
+version = "0.3.11"
 
 [[package]]
 name = "kobo-protocol"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-ui",
 ]
@@ -1290,7 +1290,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-read"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-doc",
  "kobo-image",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-rss"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-html",
  "kobo-json",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sdk"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-policy",
  "kobo-profile",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-settings"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-app-store",
  "kobo-json",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-shell"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-abi",
  "kobo-policy",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekick"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-json",
  "kobo-sdk",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sidekickd"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "command-group",
  "kobo-json",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sim"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-net",
  "kobo-policy",
@@ -1398,14 +1398,14 @@ dependencies = [
 
 [[package]]
 name = "kobo-smoke"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-hal",
 ]
 
 [[package]]
 name = "kobo-store"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-stream"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-abi",
  "kobo-json",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-sudoku"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tap"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-abi",
  "kobo-hal",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-term"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-ui",
  "vt100",
@@ -1457,7 +1457,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-terminal"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-policy",
  "kobo-sdk",
@@ -1468,7 +1468,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-text"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "fontdue",
  "kobo-ui",
@@ -1478,7 +1478,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-tictactoe"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-todo"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-sdk",
  "kobo-ui",
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-ui"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-profile",
  "unicode-segmentation",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-wifi-trace"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-json",
  "ring",
@@ -1532,11 +1532,11 @@ dependencies = [
 
 [[package]]
 name = "kobo-xml"
-version = "0.3.10"
+version = "0.3.11"
 
 [[package]]
 name = "kobo-zotero-reader"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-bookview",
  "kobo-doc",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "kobod"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "base64",
  "kobo-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.10"
+version = "0.3.11"
 edition = "2021"
 rust-version = "1.85.1"
 license = "AGPL-3.0-only"

--- a/apps/frame/drive.kobo
+++ b/apps/frame/drive.kobo
@@ -3,7 +3,9 @@ expect Frame
 expect Photographs
 expect-missing Your frame is empty
 expect-missing kobo frame
-wait-for Open
+# "Open" also matches the loading message "Opening this photograph".
+# Next appears alongside the real Open button after the photo has loaded.
+wait-for Next
 clean
 shot shelf
 tap Open

--- a/apps/frame/drive.txt
+++ b/apps/frame/drive.txt
@@ -1,5 +1,6 @@
 expect Photographs
-wait-for Open
+# Wait for the loaded-photo controls, not "Opening this photograph".
+wait-for Next
 clean
 shot shelf
 tap Open

--- a/crates/kobo-flashcards-import/Cargo.lock
+++ b/crates/kobo-flashcards-import/Cargo.lock
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-doc"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "kobo-html",
  "miniz_oxide 0.9.1",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-flashcards-format"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "flate2",
  "kobo-image",
@@ -1626,18 +1626,18 @@ dependencies = [
 
 [[package]]
 name = "kobo-html"
-version = "0.3.10"
+version = "0.3.11"
 
 [[package]]
 name = "kobo-image"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "image",
 ]
 
 [[package]]
 name = "kobo-text"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "fontdue",
  "kobo-ui",
@@ -1647,7 +1647,7 @@ dependencies = [
 
 [[package]]
 name = "kobo-ui"
-version = "0.3.10"
+version = "0.3.11"
 dependencies = [
  "unicode-segmentation",
  "unicode-width",


### PR DESCRIPTION
The beta platform publisher rejects the merged beta tree because `beta-v0.3.10` already exists and its packaged inputs differ. Advance the workspace to 0.3.11 and refresh the root and standalone importer lockfiles for the local crate versions. This preserves release immutability and leaves Store app versions unchanged.

Reuse CI's bounded, checksum-verified Zig mirror fallbacks in the platform publisher so its device build cannot hang indefinitely on the direct download.

The full CI sweep also exposed a Frame route race: `wait-for Open` matched the loading text “Opening this photograph”. Wait for the accompanying Next control before tapping Open; the repaired fresh-state route passes, and the same correction is applied to the legacy drive script. This is a simulator-route change, with no app runtime or version change.

Validation: all 102 tooling tests and 24 importer tests pass, formatting and shell syntax pass, and the app release gate passes against the current published beta catalog. Neither lockfile changes third-party dependency versions. `beta-v0.3.11` is not already published. The publisher's exact immutable-version shell step, run with GNU coreutils, returns `publish=true`. All CI jobs pass on the final branch and merge tree, including both simulator sweeps, ARM checks and the app release gate; merging into beta will trigger publication of the new beta candidate.

Fixes the prepare failure in https://github.com/BandarLabs/Cobalt/actions/runs/34160009507.

Green merge-tree CI: https://github.com/BandarLabs/Cobalt/actions/runs/34161788243

Green branch CI: https://github.com/BandarLabs/Cobalt/actions/runs/34161786102
