### PR TITLE
Align catalog publication checks for simulator-only changes

### DIFF
--- a/tools/check-app-versions.mjs
+++ b/tools/check-app-versions.mjs
@@ -4,6 +4,8 @@ import { dirname, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { compatibilityPolicy, deriveMinimumCobalt } from "./app-registry.mjs";
 import {
+  isFilmingScript,
+  isDocumentation,
   storeCatalogChanges,
   storeWatchDirectories,
   unpublishedStoreChangeReport
@@ -338,43 +340,7 @@ function isInside(path, directory) {
 export function isContributionManifest(path, directory) {
   return path === `${directory}/cobalt-app.json`;
 }
-// A drive script is the host-side route used to film an application. It is
-// never compiled into the signed bundle, so adding or editing one must not
-// look like a Store package change. That mistake is what turned a simulator
-// recording script into a forced version bump of every example that grew one.
-//
-// Matching only drive.txt and drive.kobo let it happen again as soon as an
-// application needed more than one route: a shelf of thirty-six applications
-// grew drive.sh, drive-states.kobo, drive-empty.kobo, and a drive/ directory
-// of scenes, and every one of those counted as a release input. So the whole
-// family beside the package is named here, and only beside the package —
-// src/drive.txt is source and a sibling directory is another package.
-export function isFilmingScript(path, packageDirectory) {
-  if (!path.startsWith(`${packageDirectory}/`)) return false;
-  const beside = path.slice(packageDirectory.length + 1);
-  return beside === "drive" || beside.startsWith("drive/") || /^drive[-.][^/]*$/.test(beside);
-}
-
-// Prose beside a package is not in the package. A published entry is built
-// from cobalt-app.json and the compiled binary, and neither the registry nor
-// the app-page generator reads a README, so no byte anybody downloads can
-// change because a paragraph did.
-//
-// Counting it is the same mistake the drive scripts above were rescued from.
-// Correcting a sentence in apps/syncthing/README.md that had gone stale --
-// it still told readers to export an environment variable for a packaging
-// step that no longer exists -- was refused as an unreleased change to the
-// Syncthing application, and the remedy on offer was to publish a new version
-// of it to every reader who has it in order to fix a paragraph none of them
-// download.
-//
-// Only prose directly beside the package: a nested path may be a screenshot
-// the app page does publish, and src/notes.md is source.
-export function isDocumentation(path, packageDirectory) {
-  if (!path.startsWith(`${packageDirectory}/`)) return false;
-  const beside = path.slice(packageDirectory.length + 1);
-  return !beside.includes("/") && beside.endsWith(".md");
-}
+export { isFilmingScript, isDocumentation } from "./store-catalog-changes.mjs";
 
 // Returns the dependency edges capable of changing a release artifact.
 //

--- a/tools/check-app-versions.mjs
+++ b/tools/check-app-versions.mjs
@@ -665,10 +665,7 @@ export function lockfileOnlyAddsPackages(previousSource, currentSource) {
 // reached only when a Store catalog input actually changed.
 export function storeImpactOfChangedPaths(changedPaths, packageDirectories, registeredPackages) {
   const storeDirectories = storeWatchDirectories(packageDirectories, registeredPackages);
-  const storeChanges = storeCatalogChanges(changedPaths, storeDirectories).filter(path => {
-    const directory = path.split("/").slice(0, -1).join("/");
-    return !isFilmingScript(path, directory) && !isDocumentation(path, directory);
-  });
+  const storeChanges = storeCatalogChanges(changedPaths, storeDirectories);
   const registered = new Set(registeredPackages);
   const sharedPackageChanged = [...packageDirectories].some(
     ([packageName, directory]) =>

--- a/tools/check-app-versions.test.mjs
+++ b/tools/check-app-versions.test.mjs
@@ -1163,3 +1163,14 @@ test("the Flashcards test-only exemption refuses a changed production blob", () 
   assert.deepEqual(compatibleChangePaths(manifest, 13, [file.path], () => file.base_blob, () => file.compatible_blob), new Set([file.path]));
   assert.deepEqual(compatibleChangePaths(manifest, 13, [file.path], () => file.base_blob, () => "f".repeat(40)), new Set());
 });
+
+test("both catalog gates share package-root exclusions without hiding nested source", () => {
+  const packages = new Map([["kobo-frame", "apps/frame"]]);
+  const registered = ["kobo-frame"];
+  const hostOnly = ["apps/frame/drive.kobo", "apps/frame/drive/scenes.txt", "apps/frame/README.md"];
+  assert.equal(storeImpactOfChangedPaths(hostOnly, packages, registered).catalogQuiet, true);
+  const source = ["apps/frame/src/drive.txt", "apps/frame/src/notes.md", "apps/drive.kobo", "apps/drive/src/main.rs"];
+  const expected = [...source].sort();
+  assert.deepEqual(storeImpactOfChangedPaths([...hostOnly, ...source], packages, registered).storeChanges, expected);
+  assert.deepEqual(storeCatalogChanges([...hostOnly, ...source], storeWatchDirectories(packages, registered)), expected);
+});

--- a/tools/store-catalog-changes.mjs
+++ b/tools/store-catalog-changes.mjs
@@ -5,7 +5,8 @@ import { collectRegistry } from "./app-registry.mjs";
 
 // Everything whose content reaches a reader through the signed Store catalog.
 //
-// `apps/` is taken whole: it holds the registry and every Store-only package.
+// `apps/` holds the registry and every Store-only package. Host drive scripts
+// and package README files use the same exclusions as the release checker.
 // Registered packages that still live under `examples/` are watched by their
 // workspace directory, because those binaries are the same ones the catalog
 // signs. Device-only examples (launcher, settings, store, terminal, hello)
@@ -18,10 +19,54 @@ import { collectRegistry } from "./app-registry.mjs";
 // job. The next Store publication of an actually edited app compiles against
 // whatever the platform then is.
 
+// A drive script is the host-side route used to film an application. It is
+// never compiled into the signed bundle, so adding or editing one must not
+// look like a Store package change. That mistake is what turned a simulator
+// recording script into a forced version bump of every example that grew one.
+//
+// Matching only drive.txt and drive.kobo let it happen again as soon as an
+// application needed more than one route: a shelf of thirty-six applications
+// grew drive.sh, drive-states.kobo, drive-empty.kobo, and a drive/ directory
+// of scenes, and every one of those counted as a release input. So the whole
+// family beside the package is named here, and only beside the package —
+// src/drive.txt is source and a sibling directory is another package.
+export function isFilmingScript(path, packageDirectory) {
+  if (!path.startsWith(`${packageDirectory}/`)) return false;
+  const beside = path.slice(packageDirectory.length + 1);
+  return beside === "drive" || beside.startsWith("drive/") || /^drive[-.][^/]*$/.test(beside);
+}
+
+// Prose beside a package is not in the package. A published entry is built
+// from cobalt-app.json and the compiled binary, and neither the registry nor
+// the app-page generator reads a README, so no byte anybody downloads can
+// change because a paragraph did.
+//
+// Counting it is the same mistake the drive scripts above were rescued from.
+// Correcting a sentence in apps/syncthing/README.md that had gone stale --
+// it still told readers to export an environment variable for a packaging
+// step that no longer exists -- was refused as an unreleased change to the
+// Syncthing application, and the remedy on offer was to publish a new version
+// of it to every reader who has it in order to fix a paragraph none of them
+// download.
+//
+// Only prose directly beside the package: a nested path may be a screenshot
+// the app page does publish, and src/notes.md is source.
+export function isDocumentation(path, packageDirectory) {
+  if (!path.startsWith(`${packageDirectory}/`)) return false;
+  const beside = path.slice(packageDirectory.length + 1);
+  return !beside.includes("/") && beside.endsWith(".md");
+}
+
 export function affectsStoreCatalog(path, directories) {
   if (typeof path !== "string" || !Array.isArray(directories)) return false;
   const normalized = path.trim().split("\\").join("/");
   if (normalized.length === 0) return false;
+  // "apps" is the broad catch-all, not a package root. Applying an exclusion
+  // there would hide an actual app named drive or a new registry-level file.
+  const packageDirectories = directories.filter(directory => directory !== "apps");
+  if (packageDirectories.some(directory =>
+    isFilmingScript(normalized, directory) || isDocumentation(normalized, directory)
+  )) return false;
   return directories.some(
     directory => normalized === directory || normalized.startsWith(`${directory}/`)
   );

--- a/tools/store-catalog-changes.test.mjs
+++ b/tools/store-catalog-changes.test.mjs
@@ -160,3 +160,22 @@ test("Store-only and platform-only changes do not block each other", () => {
   assert.equal(affectsDevicePackage(bundledStoreApp[0]), true);
   assert.deepEqual(storeCatalogChanges(bundledStoreApp, directories), bundledStoreApp);
 });
+
+
+test("the no-publication guard excludes host routes and package prose without hiding source", () => {
+  const directories = directoriesOfThisTree();
+  const hostOnly = [
+    "apps/frame/drive.kobo", "apps/frame/drive.txt", "apps/frame/drive-empty.kobo",
+    "apps/frame/drive/scenes.txt", "apps/frame/README.md",
+    "examples/todo/drive.txt", "examples/todo/README.md"
+  ];
+  assert.deepEqual(storeCatalogChanges(hostOnly, directories), []);
+  const releaseInputs = [
+    "apps/frame/src/drive.txt", "apps/frame/src/notes.md", "apps/frame/Cargo.toml",
+    "apps/frame/cobalt-app.json", "apps/frame/drive-helper/src/main.rs",
+    "apps/drive/src/main.rs", "apps/drive.kobo", "apps/catalog.json",
+    "examples/todo/src/drive.txt"
+  ];
+  assert.deepEqual(storeCatalogChanges([...hostOnly, ...releaseInputs], directories),
+    [...releaseInputs].sort());
+});


### PR DESCRIPTION
The beta app publisher verified that its signed catalog matched all 44 apps, then failed because its separate no-publication guard counted Frame drive scripts as shipped app inputs. The version checker already excludes those scripts, so the two gates disagreed.

Share the existing package-level drive-script and Markdown exclusions between both gates. Keep the broad apps directory conservative: nested source files, contribution manifests, registry files, and apps named drive remain release inputs. Remove the redundant second filter in the version gate, which treated an arbitrary file parent as a package root and could hide nested source. Both gates now use the same classification. No app version bumps or catalog replacement are needed for host-only test edits.

Validation: all 104 tooling tests pass, including a regression for both Frame routes and source-path boundary cases. The exact changed-path list from the failed beta push now passes the publication guard, and the app release-version check passes against the published catalog.

Fixes https://github.com/BandarLabs/Cobalt/actions/runs/34162520043. This changes release tooling only and does not require another platform version.

The final merge-tree CI passes: https://github.com/BandarLabs/Cobalt/actions/runs/34163688451.
