### PR TITLE
Fix browser installer stopping after Kobo drive selection

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,6 +39,9 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
+      - name: Test the browser installer before publishing
+        run: node --test docs/install/*.test.mjs
+
       # Everything the site serves today, unchanged. This job replaces the
       # branch publication that used to do it, so anything missed here stops
       # being reachable -- install.sh included, which is the one file the
@@ -48,6 +51,7 @@ jobs:
           set -eu
           mkdir -p _site
           cp -R docs/. _site/
+          rm -f _site/install/*.test.mjs
           test -f _site/install.sh
           test -f _site/index.html
 

--- a/.github/workflows/release-train-policy.yml
+++ b/.github/workflows/release-train-policy.yml
@@ -45,12 +45,14 @@ jobs:
           # arrives only by going there; routing it through beta would mean no
           # fix to the website could ship without also shipping whatever else
           # beta is carrying that day. It is held to the site: the check below
-          # refuses one that touches anything a reader runs.
+          # refuses one that touches anything a reader runs. Codex's default
+          # branch names use the same site-only restriction; the prefix does
+          # not grant permission to ship device or host code directly to main.
           case "$HEAD_REF" in
             beta|release/v*) exit 0 ;;
-            site/*) ;;
+            site/*|codex/*) ;;
             *)
-              echo "Pull requests into main must come from beta, release/v*, or site/*." >&2
+              echo "Pull requests into main must come from beta, release/v*, or a site-only site/* or codex/* branch." >&2
               exit 1
               ;;
           esac
@@ -58,7 +60,7 @@ jobs:
           outside="$(git diff --name-only "origin/${BASE_REF}...HEAD" \
             | grep -Ev '^(docs/|\.github/workflows/(pages|release-train-policy)\.yml$)' || true)"
           if [ -n "$outside" ]; then
-            echo "A site/* branch may change only the site and how it is published." >&2
+            echo "A site/* or codex/* branch into main may change only the site and how it is published." >&2
             echo "These fall outside that:" >&2
             # Quoted, and fed by line rather than by word: a path with a space
             # in it would otherwise be reported as two, and one holding a glob
@@ -67,3 +69,6 @@ jobs:
             printf '  %s\n' "$outside" >&2
             exit 1
           fi
+      - name: Test the browser installer
+        if: ${{ hashFiles('docs/install/*.test.mjs') != '' }}
+        run: node --test docs/install/*.test.mjs

--- a/docs/install/install.js
+++ b/docs/install/install.js
@@ -102,6 +102,57 @@ function refuseUnsupportedBrowser() {
   return true;
 }
 
+// These reads are optional metadata: a fresh reader has no Cobalt folders,
+// and an unavailable device list must not prevent choosing a valid Kobo.
+async function readInstalledVersion(handle) {
+  try {
+    const adds = await handle.getDirectoryHandle(MENU_FOLDER);
+    const cobalt = await adds.getDirectoryHandle("cobalt");
+    const file = await (await cobalt.getFileHandle("VERSION")).getFile();
+    return (await file.text()).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function readInstalledApps(handle) {
+  const present = new Set();
+  try {
+    const adds = await handle.getDirectoryHandle(MENU_FOLDER);
+    const cobalt = await adds.getDirectoryHandle("cobalt");
+    const apps = await cobalt.getDirectoryHandle("apps");
+    for await (const [name, entry] of apps.entries()) {
+      // Staged .next and .prev folders are not installed applications.
+      if (entry.kind === "directory" && !name.includes(".")) present.add(name);
+    }
+  } catch { /* nothing installed */ }
+  return present;
+}
+
+async function readReaderIdentity(handle) {
+  try {
+    const system = await handle.getDirectoryHandle(SLOT_FOLDER);
+    const text = await (await (await system.getFileHandle("version")).getFile()).text();
+    // The serial's first four characters identify the model; field three is
+    // the firmware version. Do not send the reader's serial to the server.
+    const fields = text.trim().split(",");
+    const serial = (fields[0] || "").trim();
+    return { model: serial.slice(0, 4), firmware: (fields[2] || "").trim() };
+  } catch {
+    return null;
+  }
+}
+
+async function readTestedDevices() {
+  try {
+    const response = await fetch("devices.json", { cache: "no-store" });
+    if (!response.ok) return [];
+    return await response.json();
+  } catch {
+    return [];
+  }
+}
+
 async function chooseDrive() {
   let handle;
   try {

--- a/docs/install/install.test.mjs
+++ b/docs/install/install.test.mjs
@@ -4,8 +4,8 @@ import { readFile } from "node:fs/promises";
 import { createContext, runInContext } from "node:vm";
 import { createHash, webcrypto } from "node:crypto";
 
-const script = await readFile(new URL("../docs/install/install.js", import.meta.url), "utf8");
-const html = await readFile(new URL("../docs/install/index.html", import.meta.url), "utf8");
+const script = await readFile(new URL("./install.js", import.meta.url), "utf8");
+const html = await readFile(new URL("./index.html", import.meta.url), "utf8");
 const payload = new TextEncoder().encode("test release archive");
 const release = {
   version: "0.3.10", archive: "cobalt-KoboRoot.tgz", bytes: payload.length,

--- a/tools/browser-installer.test.mjs
+++ b/tools/browser-installer.test.mjs
@@ -1,0 +1,202 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { createContext, runInContext } from "node:vm";
+import { createHash, webcrypto } from "node:crypto";
+
+const script = await readFile(new URL("../docs/install/install.js", import.meta.url), "utf8");
+const html = await readFile(new URL("../docs/install/index.html", import.meta.url), "utf8");
+const payload = new TextEncoder().encode("test release archive");
+const release = {
+  version: "0.3.10", archive: "cobalt-KoboRoot.tgz", bytes: payload.length,
+  sha256: createHash("sha256").update(payload).digest("hex"), nickelmenu: "0.6.0"
+};
+const profiles = [{ code: "N249", model: "Kobo Clara HD", firmware: ["4.38.23697"], ready: true }];
+
+// Exercise the shipped script and its registered click handlers without USB
+// hardware. Handles retain writes in memory and reject missing entries like
+// File System Access does on a fresh reader.
+function directory(name, contents = {}) {
+  const entries = new Map(Object.entries(contents).map(([key, value]) => [key,
+    typeof value === "string" ? {
+      kind: "file",
+      bytes: new TextEncoder().encode(value),
+      async getFile() { return new Blob([this.bytes]); },
+      async createWritable() {
+        return { write: async bytes => { this.bytes = bytes; }, close: async () => {} };
+      }
+    } : directory(key, value)
+  ]));
+  return {
+    name, kind: "directory",
+    async queryPermission() { return "granted"; },
+    async getDirectoryHandle(key, options = {}) {
+      if (!entries.has(key) && options.create) entries.set(key, directory(key));
+      const entry = entries.get(key);
+      if (entry?.kind !== "directory") throw new DOMException(key, "NotFoundError");
+      return entry;
+    },
+    async getFileHandle(key, options = {}) {
+      if (!entries.has(key) && options.create) {
+        const source = directory("", { [key]: "" });
+        entries.set(key, await source.getFileHandle(key));
+      }
+      const entry = entries.get(key);
+      if (entry?.kind !== "file") throw new DOMException(key, "NotFoundError");
+      return entry;
+    },
+    async *entries() { yield* entries; }
+  };
+}
+
+function reader(extra = {}, serial = "N249000000000") {
+  return directory("KOBOeReader", { ".kobo": { version: `${serial},4.1.15,4.38.23697\n` }, ...extra });
+}
+
+function page(drive = reader(), { devices, pickerError } = {}) {
+  function element() {
+    return {
+      dataset: {}, attributes: {}, handlers: {}, children: [], style: {},
+      disabled: false, hidden: false, innerHTML: "",
+      set textContent(value) {
+        this.innerHTML = String(value).replaceAll("&", "&amp;").replaceAll("<", "&lt;")
+          .replaceAll(">", "&gt;").replaceAll('"', "&quot;");
+      },
+      setAttribute(name, value) { this.attributes[name] = value; },
+      removeAttribute(name) { delete this.attributes[name]; },
+      addEventListener(name, handler) { this.handlers[name] = handler; },
+      querySelector() { return element(); },
+      append(child) { this.children.push(child); }
+    };
+  }
+  const nodes = new Map([...html.matchAll(/<[^>]*\bid="([^"]+)"[^>]*>/g)].map(([tag, id]) => {
+    const node = element();
+    node.disabled = /\sdisabled(?:\s|>)/.test(tag);
+    if (tag.includes('aria-disabled="true"')) node.attributes["aria-disabled"] = "true";
+    return [`#${id}`, node];
+  }));
+  const consent = element();
+  const context = createContext({
+    document: {
+      querySelector(selector) {
+        if (selector === "#untested-ok") {
+          return nodes.get("#pick-note").innerHTML.includes('id="untested-ok"') ? consent : null;
+        }
+        return nodes.get(selector) || null;
+      },
+      querySelectorAll() { return []; },
+      createElement: element
+    },
+    window: {
+      async showDirectoryPicker(options) {
+        assert.equal(options.mode, "readwrite");
+        if (pickerError) throw pickerError;
+        return drive;
+      },
+      FileSystemFileHandle: { prototype: { createWritable() {} } },
+      FileSystemDirectoryHandle: { prototype: { getDirectoryHandle() {} } }
+    },
+    async fetch(url) {
+      if (url === "devices.json") return devices ? devices() : Response.json(profiles);
+      if (url === "manifest.json") return Response.json(release);
+      if (url === release.archive) return new Response(payload);
+      if (url === "apps.json") return Response.json([]);
+      throw new Error(`Unexpected fetch: ${url}`);
+    },
+    TextEncoder, TextDecoder, crypto: webcrypto
+  });
+  runInContext(script, context, { filename: "install.js" });
+  return {
+    node: selector => nodes.get(selector), consent,
+    click: selector => nodes.get(selector).handlers.click(),
+    evaluate: expression => runInContext(expression, context)
+  };
+}
+
+function assertConnected(ui) {
+  assert.equal(ui.node("#step-connect").dataset.state, "done");
+  assert.equal(ui.node("#step-download").attributes["aria-disabled"], undefined);
+  assert.equal(ui.node("#fetch").disabled, false);
+}
+
+test("a fresh Clara HD advances from selection through verified download and write", async () => {
+  const drive = reader();
+  const ui = page(drive);
+  await ui.click("#pick");
+  assertConnected(ui);
+  assert.match(ui.node("#pick-note").innerHTML, /Cobalt is not installed yet/);
+  assert.match(ui.node("#pick-note").innerHTML, /Kobo Clara HD, firmware 4.38.23697/);
+  await assert.rejects(drive.getDirectoryHandle(".adds"), { name: "NotFoundError" });
+
+  await ui.click("#fetch");
+  assert.equal(ui.node("#write").disabled, false);
+  assert.match(ui.node("#fetch-note").innerHTML, /0.3.10 verified/);
+  await ui.click("#write");
+  assert.equal(ui.node("#step-write").dataset.state, "done");
+  assert.equal(ui.node("#step-finish").attributes["aria-disabled"], undefined);
+  const system = await drive.getDirectoryHandle(".kobo");
+  assert.equal(await (await (await system.getFileHandle("KoboRoot.tgz")).getFile()).text(), "test release archive");
+  const adds = await drive.getDirectoryHandle(".adds");
+  const nm = await adds.getDirectoryHandle("nm");
+  assert.match(await (await (await nm.getFileHandle("cobalt")).getFile()).text(), /menu_item :main :Cobalt/);
+});
+
+test("existing version and apps are read, excluding staging directories and files", async () => {
+  const ui = page(reader({ ".adds": { cobalt: {
+    VERSION: " 0.3.9\n", apps: { rss: {}, "rss.next": {}, "rss.prev": {}, "notes.txt": "" }
+  } } }));
+  await ui.click("#pick");
+  assertConnected(ui);
+  assert.match(ui.node("#pick-note").innerHTML, /Cobalt 0.3.9 installed/);
+  assert.deepEqual(Array.from(ui.evaluate("installedApps")), ["rss"]);
+  await ui.click("#fetch");
+  assert.match(ui.node("#fetch-note").innerHTML, /This reader has 0.3.9/);
+});
+
+for (const [name, devices] of [
+  ["HTTP error", () => new Response("missing", { status: 404 })],
+  ["network error", () => { throw new Error("offline"); }],
+  ["invalid JSON", () => new Response("invalid JSON")]
+]) {
+  test(`device profile ${name} does not block drive selection`, async () => {
+    const ui = page(reader(), { devices });
+    await ui.click("#pick");
+    assertConnected(ui);
+  });
+}
+
+test("an untested model still requires consent before writing", async () => {
+  const ui = page(reader({}, "N999000000000"));
+  await ui.click("#pick");
+  assertConnected(ui);
+  assert.match(ui.node("#pick-note").innerHTML, /has not been tested/);
+  await ui.click("#fetch");
+  assert.equal(ui.node("#write").disabled, true);
+  ui.consent.checked = true;
+  ui.consent.handlers.change();
+  assert.equal(ui.node("#write").disabled, false);
+});
+
+test("an ordinary drive is refused", async () => {
+  const ui = page(directory("USB"));
+  await ui.click("#pick");
+  assert.equal(ui.node("#fetch").disabled, true);
+  assert.match(ui.node("#pick-note").innerHTML, /it is not a Kobo/);
+});
+
+test("picker cancellation leaves download disabled", async () => {
+  const ui = page(reader(), { pickerError: new DOMException("cancelled", "AbortError") });
+  await ui.click("#pick");
+  assert.equal(ui.node("#fetch").disabled, true);
+  assert.equal(ui.node("#pick-note").innerHTML, "");
+});
+
+test("denied write permission leaves download disabled", async () => {
+  const drive = reader();
+  drive.queryPermission = async () => "denied";
+  drive.requestPermission = async () => "denied";
+  const ui = page(drive);
+  await ui.click("#pick");
+  assert.equal(ui.node("#fetch").disabled, true);
+  assert.match(ui.node("#pick-note").innerHTML, /Writing was not allowed/);
+});


### PR DESCRIPTION
Selecting a valid Kobo drive on the browser installer throws `ReferenceError: readInstalledVersion is not defined` and leaves step 1 incomplete. The failure was reported on a Kobo Clara HD using Chrome 152.0.7977.83 on macOS 26.4.1.

Restore all four metadata helpers accidentally removed when the uninstall page was separated: installed Cobalt version, installed applications, reader identity, and tested device profiles. Valid drive selection now enables downloading, while missing optional metadata remains non-blocking.

Regression tests beside the installer execute the shipped script through its registered click handlers. They cover a simulated Clara HD installation through download verification and writing, existing installations, unavailable device profiles, untested-model consent, invalid drives, cancellation, and denied permissions. The release-policy PR check and the Pages workflow run these tests; tests are excluded from the published site.

The release policy now accepts standard `codex/*` branch names under exactly the same website-only path restriction as `site/*`. The allowed paths are unchanged; host/device source and tools remain forbidden for these branches into main.

Validation:
- Reproduced the exact reported exception before the fix.
- All 109 JavaScript tests pass: `node --test tools/*.test.mjs docs/install/*.test.mjs`.
- Both workflow YAML files parse. Nine routing cases pass, including rejection of device source, host tools, forks, and unrecognized branches.
- JavaScript syntax and diff checks pass.

Device access was simulated; physical hardware and the reported Chrome/macOS combination were not tested. The original macOS Intel CI failure was a runner DNS error resolving `index.crates.io`; the updated commit triggers a fresh CI run.
