### PR TITLE
Read a paper's mathematics and its tables as what they are

### DIFF
--- a/apps/arxiv/Cargo.toml
+++ b/apps/arxiv/Cargo.toml
@@ -7,10 +7,10 @@ license.workspace = true
 publish = false
 
 [dependencies]
-kobo-bookview = { path = "../../crates/kobo-bookview" }
-kobo-doc = { path = "../../crates/kobo-doc", features = ["raster"] }
+kobo-bookview = { path = "../../crates/kobo-bookview", features = ["raster"] }
+kobo-doc = { path = "../../crates/kobo-doc" }
 kobo-html = { path = "../../crates/kobo-html" }
-kobo-read = { path = "../../crates/kobo-read", features = ["raster"] }
+kobo-read = { path = "../../crates/kobo-read" }
 kobo-sdk = { path = "../../crates/kobo-sdk" }
 kobo-xml = { path = "../../crates/kobo-xml" }
 

--- a/apps/arxiv/cobalt-app.json
+++ b/apps/arxiv/cobalt-app.json
@@ -3,10 +3,10 @@
   "display_name": "arXiv",
   "short_label": "arXiv",
   "summary": "Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo.",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "glyph": "note",
   "capabilities": [
     "network"
   ],
-  "release_notes": "Update shared controls and page layout for Cobalt 0.3.12."
+  "release_notes": "Typeset a paper's mathematics all the way through instead of stopping after the first few dozen formulae, set figures and equations apart from the prose, and close the gap before a formula's comma."
 }

--- a/apps/arxiv/cobalt-app.json
+++ b/apps/arxiv/cobalt-app.json
@@ -8,5 +8,5 @@
   "capabilities": [
     "network"
   ],
-  "release_notes": "Typeset a paper's numbered equations, which were read as tables of symbols, carry its mathematics all the way through, set figures apart from the prose, and close the gap before a formula's comma."
+  "release_notes": "Typeset a paper's numbered equations, line up a results table's columns under the headings that name them, carry the mathematics all the way through instead of stopping early, and close the gap before a comma."
 }

--- a/apps/arxiv/cobalt-app.json
+++ b/apps/arxiv/cobalt-app.json
@@ -8,5 +8,5 @@
   "capabilities": [
     "network"
   ],
-  "release_notes": "Typeset a paper's mathematics all the way through instead of stopping after the first few dozen formulae, set figures and equations apart from the prose, and close the gap before a formula's comma."
+  "release_notes": "Typeset a paper's numbered equations, which were read as tables of symbols, carry its mathematics all the way through, set figures apart from the prose, and close the gap before a formula's comma."
 }

--- a/apps/fanshelf/cobalt-app.json
+++ b/apps/fanshelf/cobalt-app.json
@@ -5,7 +5,7 @@
   "summary": "Save public AO3 works to a shelf made for offline reading.",
   "page_description": "Add an AO3 work and keep it ready for comfortable reading on your Kobo.",
   "version": "0.2.2",
-  "release_notes": "Typeset numbered equations, set figures and their captions apart from the prose, and carry a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
+  "release_notes": "Line up a table's columns under the headings that name them, typeset numbered equations, set figures apart from the prose, and carry a document's mathematics all the way through instead of stopping early.",
   "glyph": "book",
   "capabilities": [
     "network"

--- a/apps/fanshelf/cobalt-app.json
+++ b/apps/fanshelf/cobalt-app.json
@@ -4,8 +4,8 @@
   "short_label": "Fanshelf",
   "summary": "Save public AO3 works to a shelf made for offline reading.",
   "page_description": "Add an AO3 work and keep it ready for comfortable reading on your Kobo.",
-  "version": "0.2.1",
-  "release_notes": "Update shared controls and page layout for Cobalt 0.3.12.",
+  "version": "0.2.2",
+  "release_notes": "Set figures and their captions apart from the prose around them, and typeset a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
   "glyph": "book",
   "capabilities": [
     "network"

--- a/apps/fanshelf/cobalt-app.json
+++ b/apps/fanshelf/cobalt-app.json
@@ -5,7 +5,7 @@
   "summary": "Save public AO3 works to a shelf made for offline reading.",
   "page_description": "Add an AO3 work and keep it ready for comfortable reading on your Kobo.",
   "version": "0.2.2",
-  "release_notes": "Set figures and their captions apart from the prose around them, and typeset a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
+  "release_notes": "Typeset numbered equations, set figures and their captions apart from the prose, and carry a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
   "glyph": "book",
   "capabilities": [
     "network"

--- a/apps/needles/cobalt-app.json
+++ b/apps/needles/cobalt-app.json
@@ -5,7 +5,7 @@
   "summary": "Count rows, browse Ravelry collections, and read your synced patterns offline.",
   "page_description": "A knuckle-sized row counter, Ravelry library browser, and offline pattern reader.",
   "version": "0.1.2",
-  "release_notes": "Set figures and their captions apart from the prose around them, and typeset a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
+  "release_notes": "Typeset numbered equations, set figures and their captions apart from the prose, and carry a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
   "glyph": "bookmark",
   "capabilities": [
     "network",

--- a/apps/needles/cobalt-app.json
+++ b/apps/needles/cobalt-app.json
@@ -5,7 +5,7 @@
   "summary": "Count rows, browse Ravelry collections, and read your synced patterns offline.",
   "page_description": "A knuckle-sized row counter, Ravelry library browser, and offline pattern reader.",
   "version": "0.1.2",
-  "release_notes": "Typeset numbered equations, set figures and their captions apart from the prose, and carry a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
+  "release_notes": "Line up a table's columns under the headings that name them, typeset numbered equations, set figures apart from the prose, and carry a document's mathematics all the way through instead of stopping early.",
   "glyph": "bookmark",
   "capabilities": [
     "network",

--- a/apps/needles/cobalt-app.json
+++ b/apps/needles/cobalt-app.json
@@ -4,8 +4,8 @@
   "short_label": "Needles",
   "summary": "Count rows, browse Ravelry collections, and read your synced patterns offline.",
   "page_description": "A knuckle-sized row counter, Ravelry library browser, and offline pattern reader.",
-  "version": "0.1.1",
-  "release_notes": "Update shared controls and page layout for Cobalt 0.3.12.",
+  "version": "0.1.2",
+  "release_notes": "Set figures and their captions apart from the prose around them, and typeset a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
   "glyph": "bookmark",
   "capabilities": [
     "network",

--- a/apps/panels/cobalt-app.json
+++ b/apps/panels/cobalt-app.json
@@ -4,8 +4,8 @@
   "short_label": "Panels",
   "summary": "Read comics added from your computer or Komga library.",
   "page_description": "Enjoy your comics on Kobo with clear page controls and support for Komga libraries.",
-  "version": "0.1.1",
-  "release_notes": "Read CBZ comics with fit, zoom, page thumbnails and saved positions. Requires Cobalt 0.3.12.",
+  "version": "0.1.2",
+  "release_notes": "Set figures and their captions apart from the prose around them, and typeset a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
   "glyph": "reader",
   "capabilities": [
     "network"

--- a/apps/panels/cobalt-app.json
+++ b/apps/panels/cobalt-app.json
@@ -5,7 +5,7 @@
   "summary": "Read comics added from your computer or Komga library.",
   "page_description": "Enjoy your comics on Kobo with clear page controls and support for Komga libraries.",
   "version": "0.1.2",
-  "release_notes": "Typeset numbered equations, set figures and their captions apart from the prose, and carry a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
+  "release_notes": "Line up a table's columns under the headings that name them, typeset numbered equations, set figures apart from the prose, and carry a document's mathematics all the way through instead of stopping early.",
   "glyph": "reader",
   "capabilities": [
     "network"

--- a/apps/panels/cobalt-app.json
+++ b/apps/panels/cobalt-app.json
@@ -5,7 +5,7 @@
   "summary": "Read comics added from your computer or Komga library.",
   "page_description": "Enjoy your comics on Kobo with clear page controls and support for Komga libraries.",
   "version": "0.1.2",
-  "release_notes": "Set figures and their captions apart from the prose around them, and typeset a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
+  "release_notes": "Typeset numbered equations, set figures and their captions apart from the prose, and carry a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
   "glyph": "reader",
   "capabilities": [
     "network"

--- a/apps/zotero-reader/Cargo.toml
+++ b/apps/zotero-reader/Cargo.toml
@@ -7,10 +7,10 @@ license.workspace = true
 publish = false
 
 [dependencies]
-kobo-bookview = { path = "../../crates/kobo-bookview" }
-kobo-doc = { path = "../../crates/kobo-doc", features = ["raster"] }
+kobo-bookview = { path = "../../crates/kobo-bookview", features = ["raster"] }
+kobo-doc = { path = "../../crates/kobo-doc" }
 kobo-json = { path = "../../crates/kobo-json" }
-kobo-read = { path = "../../crates/kobo-read", features = ["raster"] }
+kobo-read = { path = "../../crates/kobo-read" }
 kobo-sdk = { path = "../../crates/kobo-sdk" }
 
 [lints]

--- a/apps/zotero-reader/cobalt-app.json
+++ b/apps/zotero-reader/cobalt-app.json
@@ -3,8 +3,8 @@
   "display_name": "Zotero Reader",
   "short_label": "Zotero",
   "summary": "Browse Zotero collections, read metadata and indexed paper text, and keep papers available offline.",
-  "version": "1.0.4",
-  "release_notes": "Update shared controls and page layout for Cobalt 0.3.12.",
+  "version": "1.0.5",
+  "release_notes": "Set figures and their captions apart from the prose around them, and typeset a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
   "glyph": "book",
   "capabilities": [
     "network",

--- a/apps/zotero-reader/cobalt-app.json
+++ b/apps/zotero-reader/cobalt-app.json
@@ -4,7 +4,7 @@
   "short_label": "Zotero",
   "summary": "Browse Zotero collections, read metadata and indexed paper text, and keep papers available offline.",
   "version": "1.0.5",
-  "release_notes": "Typeset numbered equations, set figures and their captions apart from the prose, and carry a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
+  "release_notes": "Line up a table's columns under the headings that name them, typeset numbered equations, set figures apart from the prose, and carry a document's mathematics all the way through instead of stopping early.",
   "glyph": "book",
   "capabilities": [
     "network",

--- a/apps/zotero-reader/cobalt-app.json
+++ b/apps/zotero-reader/cobalt-app.json
@@ -4,7 +4,7 @@
   "short_label": "Zotero",
   "summary": "Browse Zotero collections, read metadata and indexed paper text, and keep papers available offline.",
   "version": "1.0.5",
-  "release_notes": "Set figures and their captions apart from the prose around them, and typeset a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
+  "release_notes": "Typeset numbered equations, set figures and their captions apart from the prose, and carry a document's mathematics all the way through instead of stopping after the first few dozen formulae.",
   "glyph": "book",
   "capabilities": [
     "network",

--- a/crates/kobo-bookview/Cargo.toml
+++ b/crates/kobo-bookview/Cargo.toml
@@ -14,6 +14,13 @@ kobo-read = { path = "../kobo-read" }
 kobo-sdk = { path = "../kobo-sdk" }
 kobo-ui = { path = "../kobo-ui" }
 
+[features]
+# Sets a document's formulae as mathematics rather than leaving them the line
+# of text they are written as. Optional because the KaTeX faces and the
+# rasteriser behind it are some three megabytes, which only a reader of papers
+# has any use for.
+raster = ["kobo-doc/raster"]
+
 [lints]
 workspace = true
 

--- a/crates/kobo-bookview/src/lib.rs
+++ b/crates/kobo-bookview/src/lib.rs
@@ -41,6 +41,7 @@
 //! that block used to be on.
 
 use std::collections::{BTreeMap, VecDeque};
+use std::time::{Duration, Instant};
 
 pub mod comic;
 
@@ -86,6 +87,35 @@ pub const MAX_PICTURE_BYTES: u32 = 4 * 1024 * 1024;
 /// The longest a picture's address may be.
 const MAX_PICTURE_NAME: usize = 512;
 
+/// How long one pass may spend typesetting formulae.
+///
+/// Chosen by subtraction from the runtime's 250 ms callback deadline. A pass
+/// that spends its budget still finishes the formula it is on, which is 4.7 ms
+/// on a Clara BW; a pass that empties the queue then measures the batch, which
+/// is one repagination -- 4.8 ms here for a 73-page paper, and about twenty
+/// times that on the reader. Sixty milliseconds of drawing leaves a third of
+/// the deadline unspent in the worst of those.
+///
+/// Lower would be safer and slower: a whole paper's mathematics is around a
+/// second of typesetting on that machine, and every millisecond taken off this
+/// is another round trip through the runtime to get through it.
+const FORMULA_PASS: Duration = Duration::from_millis(60);
+
+/// Typesets one formula, or nothing when this build cannot draw.
+///
+/// Without the feature there is no rasteriser and no fonts to draw with, and
+/// every formula stays the line of text the document already carries for it.
+#[cfg(feature = "raster")]
+fn draw_formula(latex: &str) -> Option<Vec<u8>> {
+    kobo_doc::draw_formula(latex)
+}
+
+#[cfg(not(feature = "raster"))]
+#[allow(clippy::missing_const_for_fn)]
+fn draw_formula(_latex: &str) -> Option<Vec<u8>> {
+    None
+}
+
 /// The width a plate is fitted into, in millimetres.
 const PLATE_WIDTH_MM: u16 = 80;
 
@@ -130,6 +160,15 @@ pub struct BookView {
     /// Source bytes for pictures with room reserved and no pixels yet, in the
     /// order the text refers to them.
     plates: VecDeque<(String, Vec<u8>)>,
+    /// Formulae the document named and nothing has typeset yet, as the LaTeX
+    /// to set them from, in the order the text refers to them.
+    ///
+    /// A formula costs 4.7 ms to typeset on the reader and a paper carries
+    /// hundreds, so they are drawn here, a few per pass, rather than by the
+    /// parser: two hundred formulae is a second of work, and a second spent
+    /// inside one callback is a second in which nothing repaints, no touch is
+    /// read, and the watchdog counts.
+    unset: VecDeque<(String, String)>,
     /// A plate read and fitted, waiting for its greys.
     dithering: Option<(String, kobo_image::Picture)>,
     /// The task carrying the pipeline forward, if one is in flight.
@@ -226,19 +265,38 @@ impl BookView {
         // could name it.
         self.release(context);
         let images = std::mem::take(&mut document.images);
+        let formulae = std::mem::take(&mut document.formulae);
         let metrics = context.metrics();
         let mut reader = Reader::open(document, memory, &metrics);
         // Before the page count is read, because the sizes are what an
         // illustrated document is measured at.
+        //
+        // Counted separately from the plates. Both used to come out of one
+        // allowance of sixty-four, in the order the document happened to
+        // mention them, so a paper whose formulae outnumbered that lost its
+        // last few to its first three figures -- silently, because a formula
+        // with no picture reads as text and looks like a formula nobody chose
+        // to draw. They are different pictures with different costs: a plate
+        // is a megabyte off the radio, a formula is three kilobytes this
+        // machine already has everything it needs to make.
+        let mut wanted_formulae = 0;
         for name in reader
             .pictures_wanted()
             .into_iter()
-            .take(MAX_PICTURES)
             .map(str::to_owned)
             .collect::<Vec<_>>()
         {
-            if let Some(bytes) = images.get(&name) {
-                self.reserve(&name, bytes, &metrics);
+            if let Some(latex) = formulae.get(&name) {
+                if wanted_formulae < kobo_doc::MAX_FORMULA_PICTURES {
+                    wanted_formulae += 1;
+                    self.unset.push_back((name, latex.clone()));
+                }
+                continue;
+            }
+            if self.reserved.len() < MAX_PICTURES {
+                if let Some(bytes) = images.get(&name) {
+                    self.reserve(&name, bytes, &metrics);
+                }
             }
         }
         reader.set_pictures(self.reserved.clone(), &metrics);
@@ -466,7 +524,9 @@ impl BookView {
             Outcome::Elsewhere => return None,
             handled => handled,
         };
-        if self.plating.is_none() && (!self.plates.is_empty() || self.dithering.is_some()) {
+        if self.plating.is_none()
+            && (!self.plates.is_empty() || self.dithering.is_some() || !self.unset.is_empty())
+        {
             self.decode_more(context);
         }
         // A page turn is also the moment the pictures on the page turned to
@@ -521,6 +581,11 @@ impl BookView {
         reader
             .pictures_wanted()
             .into_iter()
+            // A formula names no file anywhere. It is drawn from the LaTeX the
+            // document carries, so asking the web for one turns `formula:12`
+            // into an address beside the paper and spends a fetch, and the
+            // reader's only connection, discovering there is nothing there.
+            .filter(|name| !name.starts_with(FORMULA_PICTURE_PREFIX))
             .take(MAX_PICTURES)
             .filter(|name| !self.reserved.contains_key(*name))
             .map(str::to_owned)
@@ -540,7 +605,18 @@ impl BookView {
         if bytes.is_empty() || self.reserved.contains_key(name) {
             return false;
         }
-        if self.reserved.len() + self.offered.len() >= MAX_PICTURES {
+        // Plates only, counted against the plate ceiling: this is for bytes
+        // that came off the radio, and a formula never does.
+        if name.starts_with(FORMULA_PICTURE_PREFIX) {
+            return false;
+        }
+        let plates = self
+            .reserved
+            .keys()
+            .chain(self.offered.keys())
+            .filter(|held| !held.starts_with(FORMULA_PICTURE_PREFIX))
+            .count();
+        if plates >= MAX_PICTURES {
             return false;
         }
         let wanted = self
@@ -607,7 +683,7 @@ impl BookView {
     /// is left out here and the page reads its description instead -- which is
     /// what a document with a broken figure should look like.
     fn reserve(&mut self, name: &str, bytes: &[u8], metrics: &DisplayMetrics) -> bool {
-        if self.reserved.len() >= MAX_PICTURES {
+        if !self.room_for(name) {
             return false;
         }
         let Some((width, height)) = plate_box(metrics) else {
@@ -642,10 +718,37 @@ impl BookView {
         true
     }
 
+    /// Whether there is room for one more picture of the kind `name` is.
+    ///
+    /// Two ceilings, because the two kinds cost different things. A plate is
+    /// a megabyte fetched over the radio and decoded from an arbitrary file,
+    /// and sixty-four of them is as many as the runtime should be asked to
+    /// hold. A formula is three and a half kilobytes this machine can make
+    /// for itself, and a paper wants hundreds: measured over a 163-page paper
+    /// carrying 231 of them, all of the mathematics together came to 764 KB.
+    ///
+    /// Sharing one ceiling meant a paper's figures and its formulae took
+    /// slots from each other in whatever order the document mentioned them.
+    fn room_for(&self, name: &str) -> bool {
+        let formula = name.starts_with(FORMULA_PICTURE_PREFIX);
+        let held = self
+            .reserved
+            .keys()
+            .filter(|held| held.starts_with(FORMULA_PICTURE_PREFIX) == formula)
+            .count();
+        held < if formula {
+            kobo_doc::MAX_FORMULA_PICTURES
+        } else {
+            MAX_PICTURES
+        }
+    }
+
     /// Asks the runtime to carry the pipeline forward, if there is anything
     /// left to carry and nothing already carrying it.
     fn kick(&mut self, context: &mut Context) {
-        if self.plating.is_some() || (self.plates.is_empty() && self.dithering.is_none()) {
+        if self.plating.is_some()
+            || (self.plates.is_empty() && self.dithering.is_none() && self.unset.is_empty())
+        {
             return;
         }
         self.plating = context.spawn(Task::Sleep { seconds: 0 });
@@ -676,6 +779,7 @@ impl BookView {
         let Some((width, height)) = plate_box(&metrics) else {
             self.plates.clear();
             self.dithering = None;
+            self.unset.clear();
             return Step::Quiet;
         };
         let showing: Vec<String> = self.reader.as_ref().map_or_else(Vec::new, |reader| {
@@ -685,6 +789,15 @@ impl BookView {
                 .map(str::to_owned)
                 .collect()
         });
+        // Formulae first, and their own pass. Typesetting one is a different
+        // shape of work from turning a photograph into sixteen greys -- small
+        // enough to do several of in the time one plate takes -- and mixing
+        // the two would make every pass as long as the slower of them.
+        if !self.unset.is_empty() {
+            let repaint = self.set_formulae(context, &showing);
+            self.kick(context);
+            return repaint;
+        }
         let mut on_this_page = false;
         if let Some((name, mut picture)) = self.dithering.take() {
             // The second half: the greys.
@@ -732,6 +845,62 @@ impl BookView {
         }
     }
 
+    /// Typesets as many formulae as fit in one pass, page being read first.
+    ///
+    /// Unlike a plate, a formula can be budgeted for by the clock. The
+    /// objection to a time budget over there is that one plate is itself over
+    /// the callback deadline, so a pass runs for the budget plus a whole
+    /// plate; a formula is 4.7 ms on a Clara BW, so a pass that checks the
+    /// clock before each one overruns by at most that.
+    ///
+    /// The batch is measured in one go rather than each formula on arrival,
+    /// for the reason [`BookView::settle_pictures`] gives: measuring is what
+    /// moves the text, and doing it two hundred times over would move the page
+    /// under somebody who is reading it. Settling is left until the queue
+    /// drains, unless something on the page in front of them was in the batch.
+    fn set_formulae(&mut self, context: &mut Context, showing: &[String]) -> Step {
+        self.wanted_first_unset(showing);
+        let until = Instant::now().checked_add(FORMULA_PASS);
+        let mut on_this_page = false;
+        while until.is_none_or(|until| Instant::now() < until) {
+            let Some((name, latex)) = self.unset.pop_front() else {
+                break;
+            };
+            // A formula that will not typeset is not an error and is not
+            // retried: the words it was written as are already in the text,
+            // so the sentence reads either way.
+            let Some(png) = draw_formula(&latex) else {
+                continue;
+            };
+            on_this_page |= showing.contains(&name);
+            self.offered.insert(name, png);
+        }
+        // Measured when the queue runs dry, or as soon as the batch holds
+        // something on the page in front of somebody. Everything else waits:
+        // a formula sixty pages ahead is not worth moving the text for, and
+        // measuring after every pass would move it a dozen times over.
+        if !self.unset.is_empty() && !on_this_page {
+            return Step::Quiet;
+        }
+        if self.settle_pictures(context) {
+            Step::Repaint
+        } else {
+            Step::Quiet
+        }
+    }
+
+    /// Moves the formulae on the page being read to the front of the queue.
+    fn wanted_first_unset(&mut self, names: &[String]) {
+        if names.is_empty() {
+            return;
+        }
+        let (wanted, rest): (VecDeque<_>, VecDeque<_>) = self
+            .unset
+            .drain(..)
+            .partition(|(name, _)| names.contains(name));
+        self.unset = wanted.into_iter().chain(rest).collect();
+    }
+
     /// Moves the named plates to the front of the queue, keeping their order.
     fn wanted_first(&mut self, names: &[String]) {
         if names.is_empty() {
@@ -759,6 +928,7 @@ impl BookView {
             context.drop_picture(handle);
         }
         self.plates.clear();
+        self.unset.clear();
         self.offered.clear();
         self.reserved.clear();
         self.dithering = None;
@@ -907,6 +1077,164 @@ mod tests {
     use kobo_doc::{Block, Document};
     use kobo_read::{Memory, Reader};
     use kobo_sdk::{Command, Context, PictureHandle, Task, TaskError, TaskId, TaskOutcome};
+    use std::collections::BTreeMap;
+
+    /// Opening a paper draws none of its mathematics.
+    ///
+    /// This is what the whole arrangement is for. Typesetting a formula costs
+    /// 4.7 ms on a Clara BW, and it used to happen while the markup was being
+    /// read -- inside the one callback that opens a document, which the
+    /// runtime allows 250 ms in total. Two hundred formulae is most of a
+    /// second there, so a paper of them was capped at sixty-four and the rest
+    /// of the paper read as text no matter how long its reader sat with it.
+    #[test]
+    fn opening_a_paper_draws_none_of_its_mathematics() {
+        let mut context = Context::default();
+        let mut view = BookView::new();
+
+        view.open(&mut context, mathematical(200), Memory::default());
+
+        assert!(
+            handed(&context.take_commands()).is_empty(),
+            "a formula was drawn while the paper was opening"
+        );
+        assert!(
+            view.reader()
+                .expect("a paper")
+                .picture_named("formula:0")
+                .is_none(),
+            "a formula had a picture before anything had drawn one"
+        );
+    }
+
+    /// And then every one of them is drawn, off the opening callback.
+    ///
+    /// Two hundred is over three times the sixty-four this used to stop at.
+    #[cfg(feature = "raster")]
+    #[test]
+    fn every_formula_in_a_paper_is_typeset_by_the_pipeline() {
+        let mut context = Context::default();
+        let mut view = BookView::new();
+
+        view.open(&mut context, mathematical(200), Memory::default());
+        let _ = context.take_commands();
+        drain(&mut view);
+
+        let reader = view.reader().expect("a paper");
+        let undrawn: Vec<String> = (0..200)
+            .map(|index| format!("{}{index}", kobo_doc::FORMULA_PICTURE_PREFIX))
+            .filter(|name| reader.picture_named(name).is_none())
+            .collect();
+        assert!(
+            undrawn.is_empty(),
+            "{} of two hundred formulae were never typeset: {:?}",
+            undrawn.len(),
+            &undrawn[..undrawn.len().min(5)]
+        );
+    }
+
+    /// No pass of the pipeline may run for as long as the runtime allows a
+    /// whole callback.
+    ///
+    /// This is the property that makes the ceiling above safe at any speed. A
+    /// machine that cannot typeset two hundred formulae quickly does fewer of
+    /// them per pass rather than holding the panel, so the assertion is the
+    /// runtime's own deadline rather than a number chosen for this machine:
+    /// where the budget matters, it is the budget that keeps this true.
+    #[cfg(feature = "raster")]
+    #[test]
+    fn no_pass_of_the_pipeline_holds_the_panel_past_its_deadline() {
+        let mut context = Context::default();
+        let mut view = BookView::new();
+
+        view.open(&mut context, mathematical(200), Memory::default());
+        let _ = context.take_commands();
+        let (passes, longest) = drain(&mut view);
+
+        assert!(passes > 1, "the whole pipeline ran in a single pass");
+        assert!(
+            longest < kobo_sdk::CALLBACK_DEADLINE,
+            "a pass ran for {longest:?}, against a {:?} deadline",
+            kobo_sdk::CALLBACK_DEADLINE
+        );
+    }
+
+    /// A formula is never asked for over the radio.
+    ///
+    /// It names no file anywhere: the document carries the LaTeX and the
+    /// reader draws it. Asking for one turns `formula:0` into an address
+    /// beside the paper and spends the device's only connection finding out
+    /// there is nothing there.
+    #[test]
+    fn a_formula_is_never_fetched_from_the_web() {
+        let mut context = Context::default();
+        let mut view = BookView::new();
+
+        assert!(view.open_html(
+            &mut context,
+            "<p>we take <math display=\"block\" alttext=\"x\"><mi>x</mi></math> as given.</p>\
+             <img src=\"x1.png\">",
+            "https://arxiv.org/html/2401.00001v2/",
+            Memory::default(),
+        ));
+
+        assert_eq!(
+            fetched(&context.take_commands()),
+            vec!["https://arxiv.org/html/2401.00001v2/x1.png".to_owned()],
+            "a formula was asked for over the radio"
+        );
+        assert!(
+            !view
+                .missing_pictures()
+                .iter()
+                .any(|name| name.starts_with(kobo_doc::FORMULA_PICTURE_PREFIX)),
+            "a formula was listed as a picture the web could supply: {:?}",
+            view.missing_pictures()
+        );
+    }
+
+    /// A paper's figures and its formulae do not take room from each other.
+    ///
+    /// They used to share one allowance of sixty-four, filled in whatever
+    /// order the document happened to mention them, so a paper with more
+    /// mathematics than that lost its last few formulae to its first figure --
+    /// silently, because a formula with no picture reads as text and looks
+    /// like one nobody chose to draw.
+    #[cfg(feature = "raster")]
+    #[test]
+    fn a_papers_figures_and_its_formulae_do_not_take_room_from_each_other() {
+        let plate = plate_bytes();
+        let mut context = Context::default();
+        let mut view = BookView::new();
+
+        let mut document = mathematical(super::MAX_PICTURES + 8);
+        document.blocks.push(Block::Picture {
+            name: "plate.png".to_owned(),
+            alt: "A figure".to_owned(),
+            illustration: true,
+        });
+        document
+            .images
+            .insert("plate.png".to_owned(), plate.clone());
+        view.open(&mut context, document, Memory::default());
+        let _ = context.take_commands();
+        drain(&mut view);
+
+        let reader = view.reader().expect("a paper");
+        let last = format!(
+            "{}{}",
+            kobo_doc::FORMULA_PICTURE_PREFIX,
+            super::MAX_PICTURES + 7
+        );
+        assert!(
+            reader.picture_named(&last).is_some(),
+            "the paper's last formula lost its room to a figure"
+        );
+        assert!(
+            reader.picture_named("plate.png").is_some(),
+            "the figure lost its room to the paper's formulae"
+        );
+    }
 
     /// A page can name anything at all, and most of it is not a picture this
     /// device is willing to go and get. The rule is the page's own host: what
@@ -1039,6 +1367,50 @@ mod tests {
 
     fn plate_bytes() -> Vec<u8> {
         kobo_image::encode_png_grey(1200, 2000, &vec![128; 1200 * 2000]).expect("a png of a plate")
+    }
+
+    /// A paper of `count` formulae, each set on a line of its own.
+    fn mathematical(count: usize) -> Document {
+        let mut blocks = prose(2);
+        let mut formulae = BTreeMap::new();
+        for index in 0..count {
+            let name = format!("{}{index}", kobo_doc::FORMULA_PICTURE_PREFIX);
+            formulae.insert(name.clone(), "\\frac{6\\pi}{11}".to_owned());
+            blocks.push(Block::Picture {
+                name,
+                alt: "(6 π)/11".to_owned(),
+                illustration: false,
+            });
+        }
+        Document {
+            blocks,
+            formulae,
+            ..Document::default()
+        }
+    }
+
+    /// Carries the pipeline to a standstill, answering every sleep it asks for.
+    ///
+    /// Returns how many passes it took and the longest any one of them ran,
+    /// which is the number the runtime's callback deadline is about.
+    ///
+    /// A fresh context per pass, because a bare [`Context`] counts work out and
+    /// never counts it back in: the lane a finished task occupied is freed by
+    /// the runtime dispatching its answer, and there is no runtime here. Left
+    /// on one context the pipeline stalls after four passes, which is a
+    /// property of the harness and not of the view.
+    fn drain(view: &mut BookView) -> (usize, std::time::Duration) {
+        let mut passes = 0;
+        let mut longest = std::time::Duration::ZERO;
+        while let Some(task) = view.plating {
+            let mut context = Context::default();
+            let started = std::time::Instant::now();
+            let _ = view.woke(&mut context, task, &TaskOutcome::Completed(Vec::new()));
+            longest = longest.max(started.elapsed());
+            passes += 1;
+            assert!(passes < 10_000, "the pipeline never came to rest");
+        }
+        (passes, longest)
     }
 
     fn illustrated(plate: &[u8]) -> Document {

--- a/crates/kobo-doc/src/epub.rs
+++ b/crates/kobo-doc/src/epub.rs
@@ -70,31 +70,31 @@ impl From<zip::Fault> for Fault {
     }
 }
 
-/// Gives one chapter's drawn formulae names the whole book can tell apart.
+/// Gives one chapter's formulae names the whole book can tell apart.
 ///
-/// A formula's picture is drawn while the chapter is read rather than read out
-/// of the archive, so it names no member and is numbered from one in every
-/// file. Two chapters would otherwise both call their first formula the same
-/// thing, and the second would quietly replace the first.
+/// A formula is named by the chapter that carried it rather than read out of
+/// the archive, so it names no member and is numbered from one in every file.
+/// Two chapters would otherwise both call their first formula the same thing,
+/// and the second would quietly replace the first.
 ///
-/// The pictures are moved into `drawn` and the renaming is answered back, so
+/// The sources are moved into `sources` and the renaming is answered back, so
 /// that the caller can leave these names out of the resolving it does to every
 /// other picture: resolved, a formula would name a member that is not there
 /// and the mathematics would be demoted to its own description.
 fn rename_formulae(
     part: &mut Document,
     chapter: usize,
-    drawn: &mut BTreeMap<String, Vec<u8>>,
+    sources: &mut BTreeMap<String, String>,
 ) -> BTreeMap<String, String> {
     let mut renamed = BTreeMap::new();
-    for (formula, png) in std::mem::take(&mut part.images) {
+    for (formula, latex) in std::mem::take(&mut part.formulae) {
         let book_wide = format!(
             "{}{chapter}-{}",
             crate::FORMULA_PICTURE_PREFIX,
             formula.trim_start_matches(crate::FORMULA_PICTURE_PREFIX)
         );
         renamed.insert(formula, book_wide.clone());
-        drawn.insert(book_wide, png);
+        sources.insert(book_wide, latex);
     }
     for styled in part.rich.values_mut() {
         for span in &mut styled.spans {
@@ -146,12 +146,12 @@ pub fn parse(bytes: &[u8]) -> Result<Document, Fault> {
     let mut starts: Vec<(String, usize)> = Vec::new();
     let mut anchors: BTreeMap<String, usize> = BTreeMap::new();
     let mut links: Vec<crate::Link> = Vec::new();
-    // The formulae drawn while the chapters were read, which are pictures the
-    // book carries without the archive holding a member for any of them.
-    let mut drawn: BTreeMap<String, Vec<u8>> = BTreeMap::new();
-    // One allowance for the whole spine: a clock started afresh on every
-    // chapter is thirty clocks, which is not a limit on how long a book takes
-    // to open.
+    // The formulae met while the chapters were read, which are pictures the
+    // book refers to without the archive holding a member for any of them.
+    let mut formulae: BTreeMap<String, String> = BTreeMap::new();
+    // One allowance for the whole spine: a count applied afresh to every
+    // chapter is thirty counts, which is not a limit on how many pictures a
+    // book asks for.
     let allowance = crate::html::Allowance::whole();
     for id in package.reading_order() {
         if parts >= MAX_PARTS {
@@ -174,8 +174,7 @@ pub fn parse(bytes: &[u8]) -> Result<Document, Fault> {
             &strip_toc(&text_of(&bytes)),
             &publisher_styles.css,
             crate::html::Allowance {
-                pictures: allowance.pictures.saturating_sub(drawn.len()),
-                ..allowance
+                pictures: allowance.pictures.saturating_sub(formulae.len()),
             },
         );
         truncated |= part.truncated;
@@ -198,7 +197,7 @@ pub fn parse(bytes: &[u8]) -> Result<Document, Fault> {
         // book with a broken link should read as.
         let mut part = part;
         let inside = directory_of(&name);
-        let renamed = rename_formulae(&mut part, parts, &mut drawn);
+        let renamed = rename_formulae(&mut part, parts, &mut formulae);
         for block in &mut part.blocks {
             if let Block::Picture { name: source, .. } = block {
                 match renamed.get(source.as_str()) {
@@ -242,11 +241,7 @@ pub fn parse(bytes: &[u8]) -> Result<Document, Fault> {
     builder.set_contents(contents_of(&archive, &package, &base, &starts, &anchors));
     builder.set_anchors(anchors);
     builder.set_links(links);
-    // The archive's own pictures, and then the ones drawn while reading it,
-    // which no archive member corresponds to.
-    let mut images = images_of(&archive, &builder);
-    images.append(&mut drawn);
-    builder.set_images(images);
+    builder.set_images(images_of(&archive, &builder));
     builder.set_fonts(fonts_of(
         &archive,
         &package,
@@ -254,6 +249,9 @@ pub fn parse(bytes: &[u8]) -> Result<Document, Fault> {
         &publisher_styles.font_families,
     ));
     let mut document = builder.finish();
+    // The formulae the chapters referred to, which no archive member
+    // corresponds to and which nothing has drawn yet.
+    document.formulae = formulae;
     document.truncated |= truncated;
     Ok(document)
 }
@@ -1309,15 +1307,15 @@ mod tests {
         );
     }
 
-    /// A formula in a book keeps the picture drawn for it, in every chapter.
+    /// A formula in a book keeps the source it is typeset from, in every
+    /// chapter.
     ///
-    /// A formula's picture is drawn while the chapter is read rather than read
-    /// out of the archive, so it has no member to be resolved against and it
-    /// is numbered from one in each file. Resolving it named a member that was
+    /// A formula is named by the chapter that carried it rather than read out
+    /// of the archive, so it has no member to be resolved against and it is
+    /// numbered from one in each file. Resolving it named a member that was
     /// not there and the mathematics was demoted to its own description, and
     /// keying it by number alone let the second chapter's first formula
     /// overwrite the first chapter's.
-    #[cfg(feature = "raster")]
     #[test]
     fn a_formula_in_a_chapter_keeps_the_picture_drawn_for_it() {
         let chapter = br#"<html><body><p>where <math alttext="x"><semantics><mi>x</mi>
@@ -1367,8 +1365,8 @@ mod tests {
                 "the name stopped saying it was a formula: {name}"
             );
             assert!(
-                document.images.contains_key(name),
-                "the picture was dropped: {name}"
+                document.formulae.contains_key(name),
+                "the source to typeset it from was dropped: {name}"
             );
         }
     }

--- a/crates/kobo-doc/src/html.rs
+++ b/crates/kobo-doc/src/html.rs
@@ -212,6 +212,44 @@ pub fn parse_within(source: &str, external_css: &str, allowance: Allowance) -> D
     state.finish()
 }
 
+/// Whether a row of groups belongs to the row of column names under it.
+///
+/// A group covers several columns and is written in the first of them, so its
+/// row has fewer cells filled than the row beneath. One cell reaching across
+/// a whole table is a title somebody drew with a row rather than a set of
+/// groups, and keeps a row of its own.
+fn heads_the_row_below(groups: &[String], names: &[String]) -> bool {
+    let filled = |cells: &[String]| cells.iter().filter(|cell| !cell.trim().is_empty()).count();
+    filled(groups) >= 2 && filled(groups) < filled(names)
+}
+
+/// Joins a row of group headings to the row that names the columns under it.
+///
+/// The names win; the groups fill the columns the names left empty, which is
+/// the column a group heading reached down over rather than across. So
+/// `Tokenizer` over a blank, and `Fidelity` over `rFID`, come out as
+/// `Tokenizer` and `rFID`: one heading for each column, which is what
+/// everything reading a table downstream is written for.
+///
+/// The groups are not kept beside the names. `Multimodal Learnability Text`
+/// is a column heading no panel this size can set, and the caption under a
+/// results table says what the groups were.
+fn join_headings(groups: Row, names: Row) -> Row {
+    let mut cells = names.cells;
+    for (column, group) in groups.cells.into_iter().enumerate() {
+        match cells.get_mut(column) {
+            Some(cell) if cell.trim().is_empty() => *cell = group,
+            Some(_) => {}
+            None => cells.push(group),
+        }
+    }
+    Row {
+        cells,
+        header: true,
+        ..Row::default()
+    }
+}
+
 /// Whether a string is a number a paper would label an equation with.
 ///
 /// `(1)`, `(2.3)`, `(A.1)`. Deliberately narrow: this is checked because the
@@ -381,6 +419,28 @@ struct State {
     /// worked inside prose -- entities, inline tags, links -- works inside a
     /// cell without a second implementation of any of it.
     row: Option<Row>,
+    /// How many further rows each column of the open table is still covered
+    /// for by a cell above it.
+    ///
+    /// A results table heads its first column once and lets it reach down
+    /// over the row that names the rest: `Tokenizer` is written with
+    /// `rowspan="2"`, so the row under it has no cell for that column at all.
+    /// Counted as one cell each, every heading below moved a column left and
+    /// the values came out labelled with their neighbour's name.
+    covered: Vec<usize>,
+    /// A row of group headings held back to be joined to the row that names
+    /// the columns under it.
+    ///
+    /// A results table heads itself twice, `Multimodal Learnability` written
+    /// once over the three columns called `Text`, `I2T` and `T2I`. Both rows
+    /// are headings, and everything downstream -- which row names the
+    /// columns, which rows to skip when the table is too wide to draw as one
+    /// -- is written for tables that head themselves once. They are joined
+    /// here, where the spans that say which row is which have just been read,
+    /// rather than guessed at again from the words further along.
+    held: Option<Row>,
+    /// How many rows of the open table have been pushed.
+    rows_seen: usize,
     /// The footnote body currently being read out of the running text.
     note: Option<OpenNote>,
     /// Footnotes lifted out of the paragraph being built, to be set after it.
@@ -405,6 +465,13 @@ struct Equation {
     number: String,
 }
 
+/// How many columns one cell may claim to span.
+///
+/// A paper's widest grouped header covers half a dozen; the bound is here
+/// because the number is written in the document and is otherwise a way to
+/// ask for a row of a million empty cells.
+const MAX_CELL_SPAN: usize = 32;
+
 /// A table row part way through being read.
 #[derive(Default)]
 struct Row {
@@ -415,6 +482,17 @@ struct Row {
     /// Whether a cell is open, so that the words collected since belong to it
     /// rather than to the row's stray text.
     open: bool,
+    /// How many columns the open cell covers.
+    ///
+    /// One for almost every cell. A grouped header is the exception and the
+    /// reason this is here: a results table writes `Multimodal Learnability`
+    /// once over the three columns it names, and a row that counted it as one
+    /// cell came out three columns short of every row below it.
+    span: usize,
+    /// How many rows down the open cell reaches.
+    down: usize,
+    /// Whether any cell in this row covered more than its own square.
+    spanned: bool,
 }
 
 impl State {
@@ -440,6 +518,9 @@ impl State {
             caption: false,
             titling: false,
             row: None,
+            covered: Vec::new(),
+            held: None,
+            rows_seen: 0,
             note: None,
             notes: Vec::new(),
             mark: None,
@@ -675,6 +756,10 @@ impl State {
             // forms: `L_(VQ) =||sg(f)-z||_2^2` with the script capitals as
             // holes, because those live in a block the reading face does not
             // cover. It is a displayed equation and is set as one.
+            "table" => {
+                self.end_table();
+                self.flush();
+            }
             "tr" if class_of(inside).contains("ltx_eqn_row") => {
                 self.end_row();
                 self.flush();
@@ -698,9 +783,19 @@ impl State {
                     self.row = Some(Row::default());
                 }
                 self.end_cell();
+                let reach = |spelling| {
+                    attribute(inside, spelling)
+                        .and_then(|value| value.trim().parse::<usize>().ok())
+                        .unwrap_or(1)
+                        .clamp(1, MAX_CELL_SPAN)
+                };
+                let (span, down) = (reach("colspan"), reach("rowspan"));
                 if let Some(row) = &mut self.row {
                     row.open = true;
                     row.header |= name == "th";
+                    row.span = span;
+                    row.down = down;
+                    row.spanned |= span > 1 || down > 1;
                 }
             }
             _ => {
@@ -787,7 +882,7 @@ impl State {
             // `</tr>` was never written, which is a page, not a corner.
             "table" | "thead" | "tbody" | "tfoot" => {
                 self.end_equation();
-                self.end_row();
+                self.end_table();
                 self.flush();
             }
             _ => {
@@ -833,10 +928,48 @@ impl State {
         }
         let cell = std::mem::take(&mut self.text);
         self.spans.clear();
-        if let Some(row) = &mut self.row {
-            row.open = false;
-            if row.cells.len() < crate::MAX_ROW_CELLS {
-                row.cells.push(cell);
+        let Some(row) = &mut self.row else { return };
+        row.open = false;
+        let (span, down) = (row.span.max(1), row.down.max(1));
+        row.span = 1;
+        row.down = 1;
+        // Past whatever a cell above still reaches over. Those columns are
+        // spoken for, and a cell written into one of them would sit under the
+        // wrong heading for the rest of the table.
+        while self
+            .covered
+            .get(row.cells.len())
+            .is_some_and(|rows| *rows > 0)
+        {
+            if row.cells.len() >= crate::MAX_ROW_CELLS {
+                break;
+            }
+            row.cells.push(String::new());
+        }
+        let at = row.cells.len();
+        if at < crate::MAX_ROW_CELLS {
+            row.cells.push(cell);
+        }
+        // The columns the cell covers besides its own. Kept empty rather than
+        // filled with a copy of the heading: a grouped header is written once
+        // over its columns in print too, and repeating it would put the same
+        // words in three cells of one row.
+        for _ in 1..span {
+            if row.cells.len() >= crate::MAX_ROW_CELLS {
+                break;
+            }
+            row.cells.push(String::new());
+        }
+        // And the rows it reaches down over, so the rows below leave its
+        // columns free. Counted from here because `end_row` takes one off
+        // every column at the end of the row this was written in.
+        if down > 1 {
+            let last = at.saturating_add(span);
+            if self.covered.len() < last {
+                self.covered.resize(last, 0);
+            }
+            for column in at..last {
+                self.covered[column] = down;
             }
         }
     }
@@ -916,15 +1049,83 @@ impl State {
         });
     }
 
-    /// Closes the row being read and pushes it, if there is one worth pushing.
-    fn end_row(&mut self) {
-        self.end_cell();
-        let Some(row) = self.row.take() else {
-            return;
-        };
+    /// Takes one row off every column a cell above is still reaching over.
+    ///
+    /// Called when a row ends, so that a `rowspan="2"` written in one row
+    /// covers exactly the one row under it.
+    fn age_covers(&mut self) {
+        for rows in &mut self.covered {
+            *rows = rows.saturating_sub(1);
+        }
+        while self.covered.last() == Some(&0) {
+            self.covered.pop();
+        }
+    }
+
+    /// Sets a finished row down as a block.
+    fn push_row(&mut self, row: Row) {
         if row.cells.is_empty() {
             return;
         }
+        self.builder.push(Block::Row {
+            header: row.header,
+            cells: row.cells,
+        });
+    }
+
+    /// Sets down a row of groups that never found a row to head.
+    ///
+    /// A table of one row, or one whose second row is data rather than column
+    /// names, keeps the groups as the row they were written as.
+    fn end_table(&mut self) {
+        self.end_row();
+        if let Some(groups) = self.held.take() {
+            self.push_row(groups);
+        }
+        // What one table's cells reached over says nothing about the next
+        // table's columns.
+        self.covered.clear();
+        self.rows_seen = 0;
+    }
+
+    /// Closes the row being read and pushes it, if there is one worth pushing.
+    fn end_row(&mut self) {
+        self.end_cell();
+        // No row to end means no row has passed. Both `</tr>` and the `<tr>`
+        // after it come through here, and ageing on the second would take two
+        // rows off a cell that reached over one.
+        let Some(mut row) = self.row.take() else {
+            return;
+        };
+        // A row whose last columns are all reached into from above ends
+        // before them, so they are filled in here: a row is as wide as the
+        // table rather than as wide as the cells somebody wrote into it.
+        while row.cells.len() < self.covered.len()
+            && row.cells.len() < crate::MAX_ROW_CELLS
+            && self.covered[row.cells.len()] > 0
+        {
+            row.cells.push(String::new());
+        }
+        self.age_covers();
+        if row.cells.is_empty() {
+            return;
+        }
+        // A table's first row, when its cells reach over their neighbours, is
+        // a row of groups rather than of column names. It waits for the row
+        // under it and the two are set down as one.
+        if self.rows_seen == 0 && row.spanned && self.held.is_none() {
+            self.rows_seen += 1;
+            self.held = Some(row);
+            return;
+        }
+        if let Some(groups) = self.held.take() {
+            if heads_the_row_below(&groups.cells, &row.cells) {
+                row = join_headings(groups, row);
+            } else {
+                self.push_row(groups);
+            }
+        }
+        self.rows_seen += 1;
         self.builder.push(Block::Row {
             header: row.header,
             cells: row.cells,
@@ -1617,6 +1818,101 @@ mod tests {
         assert!(
             alt.contains('\u{3c0}'),
             "the description lost the formula: {alt}"
+        );
+    }
+
+    /// A results table's headings stay over the columns they name.
+    ///
+    /// A paper heads its results twice: a row of groups over the row that
+    /// names the columns, `Multimodal Learnability` written once across three
+    /// of them, and the first column headed once with a heading that reaches
+    /// down over both rows. Counting every cell as one column put each row a
+    /// different width, and a reader too narrow for the table -- which a Kobo
+    /// always is -- wrote every value against its neighbour's heading:
+    /// `rFID: GigaTok-DINO`, then `Text: 0.51` for the number that is the
+    /// rFID.
+    #[test]
+    fn a_heading_that_spans_keeps_the_columns_under_it_lined_up() {
+        let document = parse(
+            "<table><tbody>\
+             <tr><td rowspan=\"2\">Tokenizer</td><td>Fidelity</td>\
+             <td colspan=\"3\">Multimodal Learnability</td>\
+             <td colspan=\"2\">Performance</td></tr>\
+             <tr><td>rFID</td><td>Text</td><td>I2T</td><td>T2I</td>\
+             <td>GenAI</td><td>VQAv2</td></tr>\
+             <tr><td>GigaTok-DINO</td><td>0.51</td><td>2.949</td><td>1.660</td>\
+             <td>7.437</td><td>0.720</td><td>51.31</td></tr>\
+             </tbody></table>",
+        );
+        let rows: Vec<&Vec<String>> = document
+            .blocks
+            .iter()
+            .filter_map(|block| match block {
+                Block::Row { cells, .. } => Some(cells),
+                _ => None,
+            })
+            .collect();
+        // The two heading rows come out as the one row of column names they
+        // amount to: the names win, and a group fills only the column it
+        // reached down over rather than across.
+        assert_eq!(rows.len(), 2, "the headings were not joined: {rows:?}");
+        assert_eq!(
+            rows[0],
+            &["Tokenizer", "rFID", "Text", "I2T", "T2I", "GenAI", "VQAv2"]
+        );
+        // So every value lines up under the heading that names it.
+        assert_eq!(rows[0].len(), rows[1].len(), "the values are out of step");
+        assert_eq!(rows[1][1], "0.51", "the rFID moved out of its column");
+    }
+
+    /// One cell reaching across a table is a title, not a set of groups, and
+    /// keeps the row it was written as.
+    #[test]
+    fn a_row_that_is_one_cell_wide_is_not_folded_into_the_row_below() {
+        let document = parse(
+            "<table><tbody>\
+             <tr><td colspan=\"3\">Ablations</td></tr>\
+             <tr><td>Model</td><td>Loss</td><td>Score</td></tr>\
+             <tr><td>base</td><td>1.2</td><td>3</td></tr>\
+             </tbody></table>",
+        );
+        let rows: Vec<&Vec<String>> = document
+            .blocks
+            .iter()
+            .filter_map(|block| match block {
+                Block::Row { cells, .. } => Some(cells),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(rows.len(), 3, "the title row was swallowed: {rows:?}");
+        assert_eq!(rows[0], &["Ablations"]);
+        assert_eq!(rows[1], &["Model", "Loss", "Score"]);
+    }
+
+    /// A cell that reaches down covers the rows under it and no more.
+    #[test]
+    fn a_heading_that_reaches_down_stops_where_it_said_it_would() {
+        let document = parse(
+            "<table><tbody>\
+             <tr><td rowspan=\"2\">Group</td><td>a</td></tr>\
+             <tr><td>b</td></tr>\
+             <tr><td>back</td><td>c</td></tr>\
+             </tbody></table>",
+        );
+        let rows: Vec<&Vec<String>> = document
+            .blocks
+            .iter()
+            .filter_map(|block| match block {
+                Block::Row { cells, .. } => Some(cells),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(rows[0], &["Group", "a"]);
+        assert_eq!(rows[1], &["", "b"], "the second row lost its blank column");
+        assert_eq!(
+            rows[2],
+            &["back", "c"],
+            "the third row was still being covered after the reach ended"
         );
     }
 

--- a/crates/kobo-doc/src/html.rs
+++ b/crates/kobo-doc/src/html.rs
@@ -24,7 +24,6 @@
 //! a saved web page, and it cannot get stuck, recurse or allocate a tree.
 
 use std::collections::BTreeMap;
-use std::time::Instant;
 
 use kobo_html::{attribute, decode_entities, element_name, skip_element};
 
@@ -32,16 +31,6 @@ use crate::{
     Block, BlockStyle, Builder, Document, InlineSpan, InlineStyle, RichBlock, TextAlignment,
     MAX_BLOCK_TEXT,
 };
-
-/// How large a displayed formula is drawn, in pixels to the em.
-///
-/// A formula is a picture and is scaled to the space it is given, so this
-/// decides how much detail is there to scale down rather than how big it
-/// looks. Deliberately generous, so that a subscript inside a fraction still
-/// has strokes of its own on a three-hundred-dot panel, and so that detail
-/// thrown away in the scaling is detail the panel never had to draw twice.
-#[cfg(feature = "raster")]
-const FORMULA_EM: f32 = crate::FORMULA_PICTURE_EM_F32;
 
 /// Elements whose contents are instructions rather than words.
 const OPAQUE: [&str; 3] = ["script", "style", "iframe"];
@@ -71,36 +60,32 @@ pub fn parse_with_css(source: &str, external_css: &str) -> Document {
     parse_within(source, external_css, Allowance::whole())
 }
 
-/// What a document may still spend on drawing formulae.
+/// How many formulae a document may still be given pictures for.
 ///
-/// Two limits, because they answer different questions. The count is how many
-/// pictures are worth keeping, and a reader can only ever show a few dozen.
-/// The clock is how long the reader is willing to be unresponsive for, and on
-/// real hardware it is the one that runs out first.
+/// A count and no clock. There used to be a clock too, and it was the one
+/// that mattered: the parser drew each formula as it met it, which is 4.7 ms
+/// apiece on a Clara BW inside a callback the runtime allows 250 ms. Drawing
+/// happens in the picture pipeline now, so nothing here spends time on a
+/// formula beyond noting that there is one, and the only question left is how
+/// many pictures are worth holding.
 #[derive(Clone, Copy)]
 pub struct Allowance {
-    /// How many more formulae may be drawn pictures.
+    /// How many more formulae may be given pictures.
     pub pictures: usize,
-    /// When drawing must stop, whatever the count says.
-    ///
-    /// `None` never stops, which is what a test that wants every formula on a
-    /// machine of any speed asks for.
-    pub until: Option<Instant>,
 }
 
 impl Allowance {
-    /// A whole document's worth, starting now.
+    /// A whole document's worth.
     #[must_use]
-    pub fn whole() -> Self {
+    pub const fn whole() -> Self {
         Self {
             pictures: crate::MAX_FORMULA_PICTURES,
-            until: Instant::now().checked_add(crate::FORMULA_DRAWING_BUDGET),
         }
     }
 
-    /// Whether there is anything left to draw a formula with.
-    fn open(self, drawn: usize) -> bool {
-        drawn < self.pictures && self.until.is_none_or(|until| Instant::now() < until)
+    /// Whether there is room for one more formula.
+    const fn open(self, taken: usize) -> bool {
+        taken < self.pictures
     }
 }
 
@@ -171,7 +156,15 @@ pub fn parse_within(source: &str, external_css: &str, allowance: Allowance) -> D
                 if !state.inline_formula(inside, &drawn) {
                     state.words(&drawn);
                 }
-                state.words(" ");
+                // Except where a mark of punctuation follows, which is set
+                // tight against whatever it ends. `LaTeXML` writes the comma
+                // straight onto the closing tag -- `</math>, we randomly` --
+                // so the space put here was one nothing in the document asked
+                // for: seventy lines of a 163-page paper read "the split
+                // 𝒯⁽ʲ⁾ . We write" and "0.91 , an absolute gain".
+                if !punctuation_follows(after) {
+                    state.words(" ");
+                }
             }
             rest = after;
             continue;
@@ -210,6 +203,37 @@ pub fn parse_within(source: &str, external_css: &str, allowance: Allowance) -> D
     }
     state.words(rest);
     state.finish()
+}
+
+/// Whether the next thing a reader will see binds to what came before it.
+///
+/// Only ever asked about the space after a formula. Tags are stepped over,
+/// because the mark may sit outside a span the formula was wrapped in, and so
+/// is whitespace: a document that wrote a space in front of its own comma
+/// still meant the comma to be set against the word, and a formula is a word.
+///
+/// Looking past the end of a block can at worst drop a space that was going to
+/// be trimmed off the end of it anyway.
+fn punctuation_follows(after: &str) -> bool {
+    const BINDS: [char; 11] = [
+        ',', '.', ';', ':', '!', '?', ')', ']', '}', '\u{2019}', '\u{201d}',
+    ];
+    let mut rest = after;
+    loop {
+        rest = rest.trim_start();
+        if rest.starts_with('<') {
+            if let Some(after_bracket) = skip_bracketed(rest) {
+                rest = after_bracket;
+                continue;
+            }
+            let Some(end) = rest.find('>') else {
+                return false;
+            };
+            rest = &rest[end + 1..];
+            continue;
+        }
+        return rest.starts_with(BINDS);
+    }
 }
 
 const MAX_CSS_BYTES: usize = 256 * 1024;
@@ -309,13 +333,13 @@ struct State {
     /// Whether the words being collected are the document's title rather than
     /// something to draw.
     titling: bool,
-    /// The formulae drawn so far, keyed by the name their block refers to.
+    /// The LaTeX of each formula met so far, keyed by the name the block or
+    /// run referring to it uses.
     ///
-    /// A displayed formula is a picture, and a picture is carried by name
-    /// rather than by its bytes, so the bytes wait here until the document is
-    /// finished and can be handed over whole.
-    formulae: BTreeMap<String, Vec<u8>>,
-    /// What this file may still spend drawing formulae.
+    /// The source, not a picture: what to draw rather than the drawing, so
+    /// that the parse costs a formula nothing but the note of it.
+    formulae: BTreeMap<String, String>,
+    /// How many more formulae this file may name.
     allowance: Allowance,
     /// The table row being read, once `<tr>` has opened one.
     ///
@@ -868,8 +892,8 @@ impl State {
     /// stay as the line of text [`kobo_html::math::render`] makes of them.
     ///
     /// The description carried beside the picture is that same line of text
-    /// rather than the LaTeX, so a formula that will not draw, or a reader
-    /// that cannot show pictures, still gets mathematics rather than source.
+    /// rather than the LaTeX, so a formula whose picture has not arrived yet,
+    /// or which nothing will draw, still gets mathematics rather than source.
     ///
     /// Returns whether the formula was taken; `false` leaves it to be read as
     /// text by the caller.
@@ -882,14 +906,11 @@ impl State {
         let Some(latex) = attribute(inside, "alttext") else {
             return false;
         };
-        let Some(png) = draw_formula(&decode_entities(latex)) else {
-            return false;
-        };
         // Whatever words were being collected belong to the paragraph in front
         // of the formula, not to the formula, so they are put down first.
         self.flush();
         let name = format!("{}{}", crate::FORMULA_PICTURE_PREFIX, self.formulae.len());
-        self.formulae.insert(name.clone(), png);
+        self.formulae.insert(name.clone(), decode_entities(latex));
         self.builder.push(Block::Picture {
             name,
             alt: drawn.trim().to_owned(),
@@ -914,14 +935,11 @@ impl State {
         let Some(latex) = attribute(inside, "alttext") else {
             return false;
         };
-        let Some(png) = draw_formula(&decode_entities(latex)) else {
-            return false;
-        };
         if self.text.len() > MAX_BLOCK_TEXT {
             return false;
         }
         let name = format!("{}{}", crate::FORMULA_PICTURE_PREFIX, self.formulae.len());
-        self.formulae.insert(name.clone(), png);
+        self.formulae.insert(name.clone(), decode_entities(latex));
         // The same two steps [`Self::words`] takes, because the words and the
         // styled runs have to stay the same string: a run that does not match
         // the block text costs the block every emphasis it had. Its own run
@@ -941,9 +959,9 @@ impl State {
         self.flush();
         let formulae = std::mem::take(&mut self.formulae);
         let mut document = self.builder.finish();
-        // Joined rather than assigned: a book brings its own pictures, and a
-        // formula is one more of them.
-        document.images.extend(formulae);
+        // Joined rather than assigned: a book read a file at a time brings the
+        // formulae of every file before this one.
+        document.formulae.extend(formulae);
         document
     }
 }
@@ -1360,21 +1378,6 @@ fn breaks_a_block(name: &str) -> bool {
     )
 }
 
-/// Draws a formula, when this build was compiled to be able to.
-///
-/// Without the feature there is no rasteriser and no fonts to draw with, and
-/// the caller falls back to reading the formula as a line of text.
-#[cfg(feature = "raster")]
-fn draw_formula(latex: &str) -> Option<Vec<u8>> {
-    kobo_html::math::raster(latex, FORMULA_EM)
-}
-
-#[cfg(not(feature = "raster"))]
-#[allow(clippy::missing_const_for_fn)]
-fn draw_formula(_latex: &str) -> Option<Vec<u8>> {
-    None
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1411,12 +1414,13 @@ mod tests {
         assert_eq!(text, "We take x1 as given.");
     }
 
-    /// A formula set on its own line becomes a picture of itself.
+    /// A formula set on its own line is named as a picture of itself, and the
+    /// source it will be typeset from is kept beside it.
     ///
-    /// Only when this build can draw one. Without the rasteriser there is
-    /// nothing to show, and the formula stays a line of text, which is the
-    /// behaviour every other consumer of this crate still gets.
-    #[cfg(feature = "raster")]
+    /// No rasteriser is involved here and none should be: drawing costs
+    /// milliseconds apiece on the reader and belongs to whatever owns a clock.
+    /// What the parse owes is the name, the source, and the line of text the
+    /// formula reads as until its picture arrives.
     #[test]
     fn a_displayed_formula_is_set_as_a_picture_of_itself() {
         let document = parse(
@@ -1433,10 +1437,17 @@ mod tests {
                 document.blocks
             );
         };
-        let drawn = document.images.get(name).expect("the drawing");
-        assert!(drawn.starts_with(b"\x89PNG"), "not a picture");
+        assert_eq!(
+            document.formulae.get(name).map(String::as_str),
+            Some("\\frac{6\\pi}{11}"),
+            "the source to typeset it from was not kept"
+        );
+        assert!(
+            document.images.is_empty(),
+            "the parse drew a formula it was only asked to name"
+        );
         // The description is the reading of the formula, never the source,
-        // because it is what a reader sees when the drawing will not arrive.
+        // because it is what a reader sees while the drawing has not arrived.
         assert!(
             !alt.contains('\\'),
             "the source became the description: {alt}"
@@ -1445,6 +1456,37 @@ mod tests {
             alt.contains('\u{3c0}'),
             "the description lost the formula: {alt}"
         );
+    }
+
+    /// A formula that a comma follows does not leave a space in front of it.
+    ///
+    /// `LaTeXML` writes the mark straight onto the closing tag, so the space
+    /// an equation needs on its right was being put in front of every comma
+    /// and full stop that followed one: seventy of them in a single 163-page
+    /// paper, reading "the split 𝒯⁽ʲ⁾ . We write" and "0.91 , an absolute
+    /// gain". The space is still owed to a word.
+    #[test]
+    fn a_formula_a_mark_of_punctuation_follows_is_set_tight_against_it() {
+        let document = parse(
+            "<p>the split <math alttext=\"T\"><mi>T</mi></math>. We take \
+             <math alttext=\"x\"><mi>x</mi></math>, and <math alttext=\"y\">\
+             <mi>y</mi></math> as given.</p>",
+        );
+        let Block::Paragraph(text) = &document.blocks[0] else {
+            panic!("not a paragraph: {:?}", document.blocks[0]);
+        };
+        assert_eq!(text, "the split T. We take x, and y as given.");
+    }
+
+    /// The mark still counts when a tag stands between it and the formula.
+    #[test]
+    fn punctuation_outside_the_span_a_formula_sits_in_still_counts() {
+        let document =
+            parse("<p>at most <span><math alttext=\"n\"><mi>n</mi></math></span>, we say.</p>");
+        let Block::Paragraph(text) = &document.blocks[0] else {
+            panic!("not a paragraph: {:?}", document.blocks[0]);
+        };
+        assert_eq!(text, "at most n, we say.");
     }
 
     /// A formula inside a sentence stays in the sentence.
@@ -1490,11 +1532,10 @@ mod tests {
         assert!(text.contains('\u{3c0}'), "the fraction was lost: {text}");
     }
 
-    /// A formula inside a sentence is typeset like one on its own line, and
-    /// the words it was written as stay in the paragraph underneath it: they
-    /// are what a search matches and what a reader gets if the picture never
-    /// arrives.
-    #[cfg(feature = "raster")]
+    /// A formula inside a sentence is named for typesetting like one on its
+    /// own line, and the words it was written as stay in the paragraph
+    /// underneath it: they are what a search matches and what a reader gets if
+    /// the picture never arrives.
     #[test]
     fn a_formula_inside_a_sentence_is_drawn_over_the_words_it_was_written_as() {
         let document = parse(
@@ -1515,9 +1556,10 @@ mod tests {
             .expect("a formula run");
         assert_eq!(formula.text.trim(), "K_G");
         let name = formula.formula.as_deref().expect("a picture name");
-        assert!(
-            document.images.contains_key(name),
-            "the picture was never stored: {name}"
+        assert_eq!(
+            document.formulae.get(name).map(String::as_str),
+            Some("K_{G}"),
+            "the source to typeset it from was not kept: {name}"
         );
         // Its own run, so that the picture covers the formula and not the
         // words either side of it.
@@ -1532,14 +1574,13 @@ mod tests {
         );
     }
 
-    /// A paper with more mathematics in it than can ever be shown stops being
-    /// drawn once it passes that point, and reads as words from there on.
+    /// A paper with more mathematics in it than can ever be held stops being
+    /// named once it passes that point, and reads as words from there on.
     ///
-    /// A survey with a thousand formulae in it spent five seconds drawing them
-    /// on a real reader, against a deadline of a quarter of one, and threw
-    /// away all but the few dozen it had room to show. The far end of such a
-    /// paper is set less handsomely now, and the paper opens.
-    #[cfg(feature = "raster")]
+    /// The ceiling is memory rather than time now that nothing here draws:
+    /// pictures for every formula of a very long survey would outlast the room
+    /// the runtime has to hold them. The far end of such a paper is set less
+    /// handsomely, and the paper opens.
     #[test]
     fn a_paper_with_more_formulae_than_can_be_shown_stops_drawing_them() {
         let one = "<p>a <math alttext=\"x\"><semantics><mi>x</mi>\
@@ -1548,9 +1589,9 @@ mod tests {
         let over = crate::MAX_FORMULA_PICTURES + 10;
         let document = parse(&one.repeat(over));
         assert_eq!(
-            document.images.len(),
+            document.formulae.len(),
             crate::MAX_FORMULA_PICTURES,
-            "more pictures were drawn than can ever be shown"
+            "more formulae were named than can ever be held"
         );
         // The ones past the limit are still read: they keep their words, they
         // simply have no picture set over them.
@@ -1568,60 +1609,45 @@ mod tests {
         assert!(text.contains('x'), "the formula was lost entirely: {text}");
     }
 
-    /// A reader too slow to draw a paper's mathematics reads it as words
-    /// rather than making the reader wait.
+    /// Reading a paper's markup costs nothing per formula.
     ///
-    /// The count above is a limit on how many pictures are worth keeping, and
-    /// on a development machine sixty-four of them cost fifty milliseconds
-    /// altogether. On a Clara BW the same sixty-four cost nine seconds, inside
-    /// the one callback that opens the document, because each formula there
-    /// takes about a hundred and forty milliseconds to draw. No count can
-    /// express that, because the right count is a property of the machine.
-    #[cfg(feature = "raster")]
+    /// This is the whole point of keeping the source rather than the picture.
+    /// Drawing used to happen here, inside the one callback that opens a
+    /// document, where the runtime allows 250 ms in total and a formula costs
+    /// 4.7 ms on a Clara BW: a paper of two hundred formulae could not be
+    /// opened without overrunning it several times over, and the limits that
+    /// held it back were really that deadline wearing a count's clothes.
+    ///
+    /// So a paper thick with mathematics must parse in the time a paper
+    /// without any does. The margin is generous because this runs on whatever
+    /// machine happens to be building; what it catches is drawing creeping
+    /// back into the parse, which would be a factor of hundreds, not tens.
     #[test]
-    fn a_reader_that_cannot_draw_a_formula_in_time_reads_it_as_words() {
-        let one = "<p>a <math alttext=\"x\"><semantics><mi>x</mi>\
-                   <annotation encoding=\"application/x-tex\">x</annotation>\
-                   </semantics></math> b</p>";
-        let source = one.repeat(4);
+    fn reading_the_markup_costs_nothing_per_formula() {
+        let plain = "<p>a x b</p>".repeat(200);
+        let mathematical = "<p>a <math alttext=\"\\frac{6\\pi}{11}\"><semantics>\
+                            <mfrac><mrow><mn>6</mn><mi>\u{3c0}</mi></mrow><mn>11</mn></mfrac>\
+                            <annotation encoding=\"application/x-tex\">\\frac{6\\pi}{11}\
+                            </annotation></semantics></math> b</p>"
+            .repeat(200);
 
-        // A clock that has already run out stands for a reader too slow to
-        // draw the first formula, which is the case this exists for.
-        let spent = parse_within(
-            &source,
-            "",
-            Allowance {
-                pictures: crate::MAX_FORMULA_PICTURES,
-                until: Some(Instant::now()),
-            },
+        let started = std::time::Instant::now();
+        let document = parse(&mathematical);
+        let with = started.elapsed();
+        let started = std::time::Instant::now();
+        let _ = parse(&plain);
+        let without = started.elapsed();
+
+        assert_eq!(document.formulae.len(), 200, "the formulae were not named");
+        assert!(
+            document.images.is_empty(),
+            "the parse drew {} formulae",
+            document.images.len()
         );
         assert!(
-            spent.images.is_empty(),
-            "a reader with no time left drew {} formulae anyway",
-            spent.images.len()
-        );
-
-        // And the words are still there, so the paper reads rather than
-        // arriving with holes in it.
-        let Block::Paragraph(text) = &spent.blocks[0] else {
-            panic!("not a paragraph: {:?}", spent.blocks[0]);
-        };
-        assert!(text.contains('x'), "the formula was lost entirely: {text}");
-
-        // A clock with time on it draws them, so the budget is what decided
-        // the difference rather than anything else about the source.
-        let afforded = parse_within(
-            &source,
-            "",
-            Allowance {
-                pictures: crate::MAX_FORMULA_PICTURES,
-                until: None,
-            },
-        );
-        assert_eq!(
-            afforded.images.len(),
-            4,
-            "a reader with time to spare left the mathematics undrawn"
+            with < without.max(core::time::Duration::from_millis(1)) * 50,
+            "two hundred formulae cost {with:?} to read against {without:?} \
+             without them, which is the cost of drawing rather than of reading"
         );
     }
 

--- a/crates/kobo-doc/src/html.rs
+++ b/crates/kobo-doc/src/html.rs
@@ -144,6 +144,13 @@ pub fn parse_within(source: &str, external_css: &str, allowance: Allowance) -> D
             let taken = rest.len().saturating_sub(after.len());
             let element = &tail[..(end + 1).saturating_add(taken)];
             let drawn = kobo_html::math::render(element);
+            // Inside an equation row every piece of it is one formula, and
+            // the pieces are set together rather than one at a time.
+            if state.equation.is_some() {
+                state.equation_piece(attribute(inside, "alttext").unwrap_or_default(), &drawn);
+                rest = after;
+                continue;
+            }
             if state.display_formula(inside, &drawn) {
                 rest = after;
                 continue;
@@ -203,6 +210,30 @@ pub fn parse_within(source: &str, external_css: &str, allowance: Allowance) -> D
     }
     state.words(rest);
     state.finish()
+}
+
+/// Whether a string is a number a paper would label an equation with.
+///
+/// `(1)`, `(2.3)`, `(A.1)`. Deliberately narrow: this is checked because the
+/// text is about to be handed to a typesetter as part of the formula, and the
+/// margin of an equation row is somewhere a document can put anything at all.
+fn is_equation_tag(number: &str) -> bool {
+    let Some(inner) = number
+        .strip_prefix('(')
+        .and_then(|rest| rest.strip_suffix(')'))
+    else {
+        return false;
+    };
+    !inner.is_empty()
+        && inner.len() <= 12
+        && inner
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '.')
+}
+
+/// The classes an element was given, or nothing when it was given none.
+fn class_of(inside: &str) -> &str {
+    attribute(inside, "class").unwrap_or_default()
 }
 
 /// Whether the next thing a reader will see binds to what came before it.
@@ -341,6 +372,8 @@ struct State {
     formulae: BTreeMap<String, String>,
     /// How many more formulae this file may name.
     allowance: Allowance,
+    /// The displayed equation being read, once an equation row has opened one.
+    equation: Option<Equation>,
     /// The table row being read, once `<tr>` has opened one.
     ///
     /// A cell's words are collected by the same machinery as a paragraph's
@@ -354,6 +387,22 @@ struct State {
     notes: Vec<(String, Vec<InlineSpan>)>,
     /// A list mark taken out of one block, waiting to lead the next.
     mark: Option<String>,
+}
+
+/// A displayed equation part way through being read out of its table.
+///
+/// An `align` environment sets one equation across several cells -- the left
+/// side in one, the relation and right side in the next -- so the pieces are
+/// gathered here and set as the single formula they are.
+#[derive(Default)]
+struct Equation {
+    /// The LaTeX of each piece, in the order the row sets them.
+    latex: String,
+    /// The line of text the same pieces read as, for a reader whose build
+    /// cannot draw or whose picture has not arrived.
+    drawn: String,
+    /// The number the paper gives the equation, when it numbers one.
+    number: String,
 }
 
 /// A table row part way through being read.
@@ -372,6 +421,7 @@ impl State {
     fn new(stylesheet: StyleSheet, allowance: Allowance) -> Self {
         Self {
             builder: Builder::new(),
+            equation: None,
             formulae: BTreeMap::new(),
             allowance,
             link: None,
@@ -400,6 +450,20 @@ impl State {
     fn words(&mut self, text: &str) {
         if text.is_empty() {
             // Two adjacent tags, which is most of an EPUB.
+            return;
+        }
+        // The only words in an equation row are the number in its margin.
+        // Kept apart from the formula so that "(1)" is not read as part of
+        // the mathematics, and so that it survives being drawn as a picture.
+        if let Some(equation) = &mut self.equation {
+            let decoded = decode_entities(text);
+            let number = decoded.trim();
+            if !number.is_empty() {
+                if !equation.number.is_empty() {
+                    equation.number.push(' ');
+                }
+                equation.number.push_str(number);
+            }
             return;
         }
         // A document with no block-level tags at all is one paragraph as long
@@ -602,11 +666,29 @@ impl State {
             // needed: a cell alone cannot be laid out, because how wide it is
             // depends on every other cell in its column, and a row alone
             // cannot say where one value ends and the next begins.
+            // A numbered equation is a table. `LaTeXML` sets one as a row of
+            // cells -- the left side, the right side, and the number off in
+            // the margin -- and marks every piece of mathematics in it
+            // `display="inline"`, because inside the row it is. Read as the
+            // table it is spelled as, a paper's central equation came out as a
+            // line of text in a bordered box, in the worst of the written
+            // forms: `L_(VQ) =||sg(f)-z||_2^2` with the script capitals as
+            // holes, because those live in a block the reading face does not
+            // cover. It is a displayed equation and is set as one.
+            "tr" if class_of(inside).contains("ltx_eqn_row") => {
+                self.end_row();
+                self.flush();
+                self.equation = Some(Equation::default());
+            }
             "tr" => {
                 self.end_row();
                 self.flush();
                 self.row = Some(Row::default());
             }
+            // Inside an equation the cells are the halves of one formula and
+            // the margin it is numbered in, none of which is a column of
+            // anything.
+            "td" | "th" if self.equation.is_some() => {}
             "td" | "th" => {
                 // A cell outside any row is a cell in a table written without
                 // one, which is common enough in hand-written HTML. It opens
@@ -695,11 +777,16 @@ impl State {
                 self.lists.pop();
             }
             "title" => self.flush(),
+            "td" | "th" if self.equation.is_some() => {}
             "td" | "th" => self.end_cell(),
-            "tr" => self.end_row(),
+            "tr" => {
+                self.end_equation();
+                self.end_row();
+            }
             // A table that ends with a row still open is a table whose last
             // `</tr>` was never written, which is a page, not a corner.
             "table" | "thead" | "tbody" | "tfoot" => {
+                self.end_equation();
                 self.end_row();
                 self.flush();
             }
@@ -752,6 +839,81 @@ impl State {
                 row.cells.push(cell);
             }
         }
+    }
+
+    /// Takes one piece of the equation being read out of its table.
+    ///
+    /// `\displaystyle` is dropped from each piece: `LaTeXML` writes it on
+    /// every cell because each cell is its own `<math>`, and a formula
+    /// assembled from three of them would carry the command three times over.
+    /// The renderer is already told to set a displayed formula as one.
+    fn equation_piece(&mut self, latex: &str, drawn: &str) {
+        let Some(equation) = &mut self.equation else {
+            return;
+        };
+        let piece = decode_entities(latex);
+        let piece = piece.trim().trim_start_matches("\\displaystyle").trim();
+        if !piece.is_empty() {
+            equation.latex.push_str(piece);
+        }
+        let drawn = drawn.trim();
+        if !drawn.is_empty() {
+            if !equation.drawn.is_empty() {
+                equation.drawn.push(' ');
+            }
+            equation.drawn.push_str(drawn);
+        }
+    }
+
+    /// Sets the equation that has been gathered, as a formula on its own line.
+    ///
+    /// The number is set at the end of the formula rather than dropped. A
+    /// paper refers back to its equations by number -- "as shown in (1)" is
+    /// the whole reason the number is printed -- and an equation drawn without
+    /// one leaves that sentence pointing at nothing a reader can find. It
+    /// costs a little width, which a formula already too wide for the column
+    /// pays for by being scaled to fit.
+    fn end_equation(&mut self) {
+        let Some(equation) = self.equation.take() else {
+            return;
+        };
+        let drawn = equation
+            .drawn
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        let mut latex = equation.latex.trim().to_owned();
+        if drawn.is_empty() && latex.is_empty() {
+            return;
+        }
+        // Whatever words were being collected belong to the paragraph in
+        // front of the equation rather than to it.
+        self.flush();
+        let number = equation.number.trim();
+        let alt = if number.is_empty() {
+            drawn
+        } else {
+            format!("{drawn}  {number}")
+        };
+        // Only a plain tag. Anything else is not a number this understands,
+        // and handing the typesetter something it cannot parse would lose the
+        // whole equation to save its label.
+        if !latex.is_empty() && is_equation_tag(number) {
+            latex.push_str("\\qquad");
+            latex.push_str(number);
+        }
+        let name = format!("{}{}", crate::FORMULA_PICTURE_PREFIX, self.formulae.len());
+        // Past the ceiling the equation keeps its block and its written form
+        // and simply never has a picture drawn for it, which is what a formula
+        // with nothing to draw it has always looked like.
+        if self.allowance.open(self.formulae.len()) && !latex.is_empty() {
+            self.formulae.insert(name.clone(), latex);
+        }
+        self.builder.push(Block::Picture {
+            name,
+            alt,
+            illustration: false,
+        });
     }
 
     /// Closes the row being read and pushes it, if there is one worth pushing.
@@ -1455,6 +1617,92 @@ mod tests {
         assert!(
             alt.contains('\u{3c0}'),
             "the description lost the formula: {alt}"
+        );
+    }
+
+    /// A numbered equation is a formula, not a table of one.
+    ///
+    /// `LaTeXML` sets a numbered equation as a row of cells -- the left side,
+    /// the relation and right side, the number off in the margin -- and marks
+    /// every piece of it `display="inline"`, because inside the row it is.
+    /// Read as the table it is spelled as, a paper's central equation came out
+    /// as a line of written mathematics in a bordered box: photographed off a
+    /// Clara BW, equation (1) of arXiv:2609.09143 read
+    /// `L_(VQ) =||sg(f)-z||_2^2` with the script capitals drawn as holes.
+    #[test]
+    fn a_numbered_equation_is_set_as_one_formula_rather_than_a_row_of_cells() {
+        let document = parse(
+            "<p>trained with:</p>\
+             <table class=\"ltx_equationgroup ltx_eqn_align ltx_eqn_table\"><tbody>\
+             <tr class=\"ltx_equation ltx_eqn_row ltx_align_baseline\">\
+             <td class=\"ltx_eqn_cell ltx_eqn_center_padleft\"></td>\
+             <td class=\"ltx_td ltx_align_right ltx_eqn_cell\">\
+             <math alttext=\"\\displaystyle\\mathcal{L}_{VQ}\" display=\"inline\">\
+             <msub><mi>\u{2112}</mi><mrow><mi>V</mi><mi>Q</mi></mrow></msub></math></td>\
+             <td class=\"ltx_td ltx_align_left ltx_eqn_cell\">\
+             <math alttext=\"\\displaystyle=\\beta\" display=\"inline\">\
+             <mrow><mo>=</mo><mi>\u{3b2}</mi></mrow></math></td>\
+             <td class=\"ltx_eqn_cell ltx_eqn_eqno ltx_align_right\">\
+             <span class=\"ltx_tag ltx_tag_equation\">(1)</span></td>\
+             </tr></tbody></table><p>where it holds.</p>",
+        );
+
+        let Some(Block::Picture { name, alt, .. }) = document
+            .blocks
+            .iter()
+            .find(|block| matches!(block, Block::Picture { .. }))
+        else {
+            panic!("the equation stayed a table: {:?}", document.blocks);
+        };
+        // Both halves, as one formula, with `\displaystyle` taken off each:
+        // the renderer is already told to set a displayed formula as one, and
+        // three cells would otherwise carry the command three times.
+        assert_eq!(
+            document.formulae.get(name).map(String::as_str),
+            Some("\\mathcal{L}_{VQ}=\\beta\\qquad(1)"),
+            "the equation was not gathered from its cells"
+        );
+        // The number is what a paper's cross-references point at, so it is
+        // kept beside the written form as well as drawn.
+        assert!(alt.contains("(1)"), "the equation lost its number: {alt}");
+        assert!(
+            !document
+                .blocks
+                .iter()
+                .any(|block| matches!(block, Block::Row { .. })),
+            "the equation left a table row behind it: {:?}",
+            document.blocks
+        );
+    }
+
+    /// An equation numbered with something this does not understand keeps its
+    /// mathematics.
+    ///
+    /// The margin of an equation row is somewhere a document may put anything
+    /// at all, and it is about to be handed to a typesetter as part of the
+    /// formula. Losing a whole equation to save its label is the wrong way
+    /// round.
+    #[test]
+    fn an_equation_labelled_with_something_strange_still_draws_its_mathematics() {
+        let document = parse(
+            "<table class=\"ltx_eqn_table\"><tbody>\
+             <tr class=\"ltx_eqn_row\">\
+             <td class=\"ltx_eqn_cell\">\
+             <math alttext=\"x=1\" display=\"inline\"><mi>x</mi></math></td>\
+             <td class=\"ltx_eqn_cell ltx_eqn_eqno\">\\dagger{}</td>\
+             </tr></tbody></table>",
+        );
+        let Some(Block::Picture { name, .. }) = document
+            .blocks
+            .iter()
+            .find(|block| matches!(block, Block::Picture { .. }))
+        else {
+            panic!("the equation was lost: {:?}", document.blocks);
+        };
+        assert_eq!(
+            document.formulae.get(name).map(String::as_str),
+            Some("x=1"),
+            "a label this does not understand was handed to the typesetter"
         );
     }
 

--- a/crates/kobo-doc/src/lib.rs
+++ b/crates/kobo-doc/src/lib.rs
@@ -265,47 +265,47 @@ pub const FORMULA_PICTURE_PREFIX: &str = "formula:";
 /// The pixels to the em a formula's picture was drawn at.
 pub const FORMULA_PICTURE_EM: u32 = 48;
 
-/// The most formulae one document will be typeset pictures for.
+/// The most formulae one document will be given pictures.
 ///
-/// A survey paper can carry a thousand pieces of mathematics, and a reader
-/// can only ever reserve room for a few dozen pictures at a time, so the
-/// nine hundred and fiftieth of them was never going to be shown to anybody.
-/// Drawing all one thousand and sixteen in one such paper took fifteen and a
-/// half seconds on a Clara BW — five to typeset them and nine more to turn
-/// them into something the panel could draw — and almost every picture that
-/// bought was thrown away unlooked at.
+/// This used to be sixty-four, and sixty-four was chosen when the parser drew
+/// every formula itself: the count was really a time budget wearing a
+/// count's clothes, because typesetting is 4.7 ms apiece on a Clara BW and
+/// the parser spends that inside a lifecycle callback the runtime allows 250
+/// ms in total. Sixty-four was as many as could be afforded there, and a
+/// paper's sixty-fifth formula onwards was read as text no matter how long
+/// the reader sat with it.
 ///
-/// Past this many, a formula is read as the line of text it has always fallen
-/// back to. That is a worse-looking page than a drawn one, at the far end of
-/// a paper nobody has scrolled to, and it is the difference between a paper
-/// that opens and a paper that does not.
-pub const MAX_FORMULA_PICTURES: usize = 64;
-
-/// How long one document may spend drawing formulae.
+/// Drawing now happens a few at a time in the picture pipeline, off the
+/// callback, so the question is no longer what fits in an open but what fits
+/// in memory. Measured over a 163-page paper carrying 231 formulae: every one
+/// of them together is 764 KB of panel grey, a mean of 3.4 KB each, against
+/// the 8 MB the runtime will hold. Five hundred and twelve is about 1.7 MB of
+/// that, comfortably clear of the plates a paper's figures also want, and
+/// more mathematics than any paper reached while this was being measured.
 ///
-/// The count above bounds how many pictures are worth keeping; it says
-/// nothing about how long making them takes, and a reader with a slower
-/// machine than the one this was written on should not be made to wait for a
-/// count that was chosen elsewhere.
-///
-/// Measured on a Clara BW, reading a 1.4 MB paper carrying 1016 formulae:
-/// the markup alone parses in about 290 ms, typesetting a formula costs
-/// 4.7 ms, and turning its picture into something the panel can draw costs
-/// 9.4 ms more. Opening that paper with every formula drawn takes fifteen
-/// and a half seconds. With sixty-four it takes two and a half, against nine
-/// and a half before any of this work — and sixty-four is already more
-/// mathematics than a page of it can show.
-///
-/// So the budget is set above what the count costs on this device — it is
-/// the count that should decide on hardware this work was measured on, and
-/// the clock that should decide on anything slower. A machine that cannot
-/// afford sixty-four draws what it can and reads the rest as the text they
-/// have always fallen back to, without having to be told which machine it is.
-pub const FORMULA_DRAWING_BUDGET: core::time::Duration = core::time::Duration::from_millis(500);
+/// Past this many a formula is still read as the line of text it has always
+/// fallen back to, which is a worse-looking page rather than a lost one.
+pub const MAX_FORMULA_PICTURES: usize = 512;
 
 /// The same, for the renderer, which measures type in fractions of a pixel.
 #[cfg(feature = "raster")]
-pub(crate) const FORMULA_PICTURE_EM_F32: f32 = 48.0;
+const FORMULA_PICTURE_EM_F32: f32 = 48.0;
+
+/// Typesets one formula, given the LaTeX [`Document::formulae`] kept for it.
+///
+/// Separated from parsing because of what it costs: 4.7 ms on a Clara BW, and
+/// a paper is hundreds of formulae. Called from whatever is drawing the
+/// document, a few at a time, so that no single callback spends more than the
+/// runtime allows one.
+///
+/// Returns `None` when the source will not parse or will not draw. There is
+/// no half-drawn formula, and no need for one: the written form of it is
+/// already in the text, so a formula that never draws simply reads.
+#[cfg(feature = "raster")]
+#[must_use]
+pub fn draw_formula(latex: &str) -> Option<Vec<u8>> {
+    kobo_html::math::raster(latex, FORMULA_PICTURE_EM_F32)
+}
 
 /// How big a formula's picture should be drawn, for a given reading em.
 ///
@@ -484,6 +484,24 @@ pub struct Document {
     /// drawing them rather than to the parser. A book of four hundred
     /// engravings should not cost four hundred decodes to open.
     pub images: BTreeMap<String, Vec<u8>>,
+    /// The LaTeX behind each formula the text refers to, keyed as its picture
+    /// is keyed in [`images`].
+    ///
+    /// Source rather than a picture, for the same reason the pictures above
+    /// arrive undecoded: typesetting one costs 4.7 ms on a Clara BW and a
+    /// paper carries hundreds of them, so a parser that drew them would spend
+    /// the whole of a lifecycle callback -- and several more after it --
+    /// before the first page could be shown. What the parser can afford is to
+    /// say which formula is which and what it says, and to leave the drawing
+    /// to whatever owns a clock and a picture queue.
+    ///
+    /// A name here and not in [`images`] is a formula nothing has drawn yet,
+    /// or one nothing will. Either way the page reads: the written form of
+    /// every formula stays in the text it belongs to, and the picture is laid
+    /// over those words rather than in place of them.
+    ///
+    /// [`images`]: Document::images
+    pub formulae: BTreeMap<String, String>,
     /// Outline fonts embedded by the publisher, keyed by their resolved
     /// archive name.
     ///

--- a/crates/kobo-html/src/math.rs
+++ b/crates/kobo-html/src/math.rs
@@ -300,11 +300,17 @@ fn draw_element(name: &str, children: &[Node], out: &mut String) {
         "math" | "semantics" | "mrow" | "mstyle" | "mpadded" | "menclose" => {
             draw_all(children, out);
         }
+        "msub" => script(children, out, "_"),
+        "msup" => script(children, out, "^"),
         // Limits sit under and over their operator in print and after it in
         // a line, which is how they are read aloud either way, so they are set
-        // exactly as a subscript and a superscript are.
-        "msub" | "munder" => script(children, out, "_"),
-        "msup" | "mover" => script(children, out, "^"),
+        // exactly as a subscript and a superscript are -- unless what is set
+        // over the base is an accent, which is a different thing wearing the
+        // same markup. `\hat{x}` is `<mover><mi>x</mi><mo>^</mo></mover>`, and
+        // read as a superscript it came out `x^^`: the marker this writes,
+        // then the mark itself. The mark alone says it.
+        "munder" => accented(children, out, "_"),
+        "mover" => accented(children, out, "^"),
         "msubsup" => {
             let (base, rest) = children
                 .split_first()
@@ -390,6 +396,39 @@ fn script(children: &[Node], out: &mut String, marker: &str) {
     draw(base, out);
     let attached = drawn(rest);
     attach(out, marker, &attached);
+}
+
+/// Sets what stands over or under a base, as an accent when it is one.
+///
+/// A hat and an exponent are the same markup in `MathML` and different things
+/// on the page: `\hat{x}` and `x^{2}` are both a base with something raised
+/// over it, and only the second is being raised. An accent is written as the
+/// mark alone, which is what a reader without the drawn form has to go on.
+fn accented(children: &[Node], out: &mut String, marker: &str) {
+    let Some((base, rest)) = children.split_first() else {
+        return;
+    };
+    let over = drawn(rest);
+    let over = over.trim();
+    draw(base, out);
+    if is_accent(over) {
+        out.push_str(over);
+        return;
+    }
+    attach(out, marker, over);
+}
+
+/// Whether a string is one of the marks a typesetter sets over a letter.
+///
+/// The ones `LaTeXML` writes for `\hat`, `\bar`, `\tilde`, `\dot`, `\ddot`,
+/// `\check`, `\breve`, `\acute`, `\grave` and `\vec`, in both the spacing and
+/// the plain spellings it chooses between.
+fn is_accent(over: &str) -> bool {
+    const MARKS: [&str; 15] = [
+        "^", "\u{2c6}", "\u{af}", "\u{203e}", "~", "\u{2dc}", "\u{2d9}", "\u{a8}", "\u{2c7}",
+        "\u{2d8}", "\u{b4}", "`", "\u{2192}", "\u{20d7}", "\u{2015}",
+    ];
+    MARKS.contains(&over)
 }
 
 /// Writes one `^` or `_` and its argument, grouping when the argument is more
@@ -592,6 +631,29 @@ mod tests {
         assert_eq!(render(markup), "E_y");
         let indicator = "<math><mn>\u{1d7d9}</mn></math>";
         assert_eq!(render(indicator), "1");
+    }
+
+    /// A hat is a hat and not an exponent, though the markup is the same.
+    ///
+    /// `\hat{x}` is `<mover><mi>x</mi><mo>^</mo></mover>`, exactly the shape
+    /// `x^{2}` has, and read as a superscript it wrote the marker and then the
+    /// mark: the reconstruction in arXiv:2609.09143 read `x^^` on a Clara BW.
+    /// A limit under a sum is the same markup again and is still a limit.
+    #[test]
+    fn an_accent_is_written_as_the_mark_rather_than_as_something_raised() {
+        let hat = "<math><mover accent=\"true\"><mi>x</mi><mo>^</mo></mover></math>";
+        assert_eq!(render(hat), "x^");
+        let bar = "<math><mover accent=\"true\"><mi>x</mi><mo>\u{af}</mo></mover></math>";
+        assert_eq!(render(bar), "x\u{af}");
+        let vector = "<math><mover accent=\"true\"><mi>v</mi><mo>\u{2192}</mo></mover></math>";
+        assert_eq!(render(vector), "v\u{2192}");
+        // Still a limit when what is over the base is not a mark.
+        let sum = "<math><munder><mo>\u{2211}</mo><mrow><mi>i</mi><mo>=</mo><mn>1</mn>\
+                   </mrow></munder></math>";
+        assert_eq!(render(sum), "\u{2211}_(i=1)");
+        // And still an exponent when it was written as one.
+        let square = "<math><msup><mi>x</mi><mn>2</mn></msup></math>";
+        assert_eq!(render(square), "x^2");
     }
 
     /// Including the letters that were given code points before that plane

--- a/crates/kobo-html/src/math.rs
+++ b/crates/kobo-html/src/math.rs
@@ -471,6 +471,9 @@ fn plain(character: char) -> Option<char> {
     // at the end. Anything irregular falls through to the letter tables.
     const DIGITS: u32 = 0x1D7CE;
     let code = character as u32;
+    if (0x2100..=0x214F).contains(&code) {
+        return letterlike(character);
+    }
     if !(0x1D400..=0x1D7FF).contains(&code) {
         return None;
     }
@@ -484,6 +487,48 @@ fn plain(character: char) -> Option<char> {
     } else {
         char::from_u32('a' as u32 + offset - 26)
     }
+}
+
+/// The same, for the letters given code points of their own before the
+/// alphabets above existed.
+///
+/// `\mathcal{L}` is `ℒ`, not the `𝓛` of the run above, and `\mathbb{R}` is
+/// `ℝ`: the letters mathematicians were already using went into Letterlike
+/// Symbols, and the later block was left with holes where they would have
+/// been. The reading face covers that block no better than the other, so a
+/// paper whose loss is called `\mathcal{L}` -- which it says on every second
+/// line -- came out as a row of boxes where it had written a name.
+///
+/// Letters only. The block also holds `№`, `℃` and the ounce sign, none of
+/// which is a letter wearing a style, and those are left as they are.
+fn letterlike(character: char) -> Option<char> {
+    Some(match character {
+        '\u{2102}' | '\u{212D}' => 'C',
+        '\u{2107}' | '\u{2130}' => 'E',
+        '\u{210A}' => 'g',
+        '\u{210B}' | '\u{210C}' | '\u{210D}' => 'H',
+        '\u{210E}' | '\u{210F}' => 'h',
+        '\u{2110}' | '\u{2111}' => 'I',
+        '\u{2112}' => 'L',
+        '\u{2113}' => 'l',
+        '\u{2115}' => 'N',
+        '\u{2118}' | '\u{2119}' => 'P',
+        '\u{211A}' => 'Q',
+        '\u{211B}' | '\u{211C}' | '\u{211D}' => 'R',
+        '\u{2124}' | '\u{2128}' => 'Z',
+        // Canonically the Greek letter, which the reading face does cover.
+        '\u{2126}' => '\u{3a9}',
+        '\u{212C}' => 'B',
+        '\u{212F}' | '\u{2147}' => 'e',
+        '\u{2131}' => 'F',
+        '\u{2133}' => 'M',
+        '\u{2134}' => 'o',
+        '\u{2145}' => 'D',
+        '\u{2146}' => 'd',
+        '\u{2148}' => 'i',
+        '\u{2149}' => 'j',
+        _ => return None,
+    })
 }
 
 #[cfg(test)]
@@ -547,6 +592,30 @@ mod tests {
         assert_eq!(render(markup), "E_y");
         let indicator = "<math><mn>\u{1d7d9}</mn></math>";
         assert_eq!(render(indicator), "1");
+    }
+
+    /// Including the letters that were given code points before that plane
+    /// existed, which is where `LaTeXML` writes the common ones.
+    ///
+    /// `\mathcal{L}` is `\u{2112}`, not the `\u{1d4db}` of the run above, and
+    /// `\mathbb{R}` is `\u{211d}`: Unicode put the letters mathematicians were
+    /// already using into Letterlike Symbols and left holes in the later block
+    /// where they would have been. Folding only the later block meant a paper
+    /// whose loss is called `\mathcal{L}` drew a box on every second line --
+    /// photographed off a Clara BW as `\u{2112}_(VQ)` reading `▯_(VQ)`.
+    #[test]
+    fn the_script_capitals_a_paper_names_its_losses_with_are_folded_too() {
+        let loss = "<math><msub><mi>\u{2112}</mi><mrow><mi>V</mi><mi>Q</mi></mrow></msub></math>";
+        assert_eq!(render(loss), "L_(VQ)");
+        let reals = "<math><msup><mi>\u{211d}</mi><mi>k</mi></msup></math>";
+        assert_eq!(render(reals), "R^k");
+        let script = "<math><mrow><mi>\u{212c}</mi><mi>\u{2130}</mi><mi>\u{2131}</mi>\
+                      <mi>\u{2133}</mi><mi>\u{2113}</mi></mrow></math>";
+        assert_eq!(render(script), "BEFMl");
+        // Not everything in the block is a letter wearing a style, and the
+        // ones that are not are left as the characters they are.
+        let numero = "<math><mtext>\u{2116}</mtext></math>";
+        assert_eq!(render(numero), "\u{2116}");
     }
 
     /// Nothing here may lose characters. A construction this does not know is

--- a/crates/kobo-read/Cargo.toml
+++ b/crates/kobo-read/Cargo.toml
@@ -17,9 +17,5 @@ kobo-image = { path = "../kobo-image" }
 kobo-profile = { path = "../kobo-profile" }
 kobo-text = { path = "../kobo-text" }
 
-[features]
-# Draws displayed formulae properly instead of describing them in words.
-raster = ["kobo-doc/raster"]
-
 [lints]
 workspace = true

--- a/crates/kobo-read/src/lib.rs
+++ b/crates/kobo-read/src/lib.rs
@@ -1438,6 +1438,21 @@ impl Reader {
         let mut at = 0;
         while let Some(piece) = pieces.get(at) {
             at += 1;
+            // A figure, the caption under it and the paragraph after it were
+            // separated by the one gap the layout puts between any two nodes,
+            // so a plate and its three lines of caption ran together into a
+            // single grey slab and none of it read as a thing set into the
+            // page rather than more of the page. The group is given air on
+            // both sides of it; the lines inside keep the gap they had.
+            //
+            // Nothing at the top or bottom of a page: the margin there is
+            // already the separation, and a spacer would spend a line of
+            // reading on saying so twice.
+            if at > 1 {
+                if let Some(space) = self.between(&pieces[at - 2], piece) {
+                    screen = screen.spacer(space);
+                }
+            }
             // Rows are gathered back into the table they were cut out of.
             // Every row of it has to be handed over at once, because the
             // columns can only be lined up by something that can see all of
@@ -1465,6 +1480,17 @@ impl Reader {
                         Some((drawn, true)) => screen.picture(drawn, MAX_PICTURE_MM),
                         Some((drawn, false)) => screen.unframed_picture(drawn, MAX_PICTURE_MM),
                         None if piece.text.is_empty() => screen,
+                        // A figure's description is writing *about* the page
+                        // and is set as such. A displayed formula's is the
+                        // page: it is the mathematics, written out in a line
+                        // instead of typeset, and setting it in the smaller
+                        // grey of a caption would demote a sentence of the
+                        // paper for the length of time its picture takes to
+                        // arrive -- or permanently, on a build that cannot
+                        // draw formulae at all.
+                        None if !self.illustration_at(piece.block) => {
+                            screen.text(piece.text.clone())
+                        }
                         None => screen.secondary(piece.text.clone()),
                     }
                 }
@@ -2142,6 +2168,54 @@ impl Reader {
             .collect()
     }
 
+    /// What kind of thing a piece is, for deciding what stands around it.
+    fn set_of(&self, piece: &Piece) -> Set {
+        match piece.kind {
+            Kind::Caption => Set::Plate,
+            Kind::Picture if self.illustration_at(piece.block) => Set::Plate,
+            Kind::Picture => Set::Formula,
+            _ => Set::Prose,
+        }
+    }
+
+    /// The air owed between two pieces that follow each other on a page.
+    ///
+    /// Only at the seam between a group and what is not in it. A plate asks
+    /// for more than a formula does: it is an illustration, a thing set into
+    /// the text, and the caption belongs to it rather than to the prose. A
+    /// displayed formula asks for less, because it *is* the text -- a
+    /// sentence of the paper, set as mathematics -- and wants to be told apart
+    /// from the paragraph it interrupts rather than lifted out of it.
+    fn between(&self, previous: &Piece, piece: &Piece) -> Option<kobo_ui::Space> {
+        let (before, after) = (self.set_of(previous), self.set_of(piece));
+        if before == after {
+            return None;
+        }
+        if before == Set::Plate || after == Set::Plate {
+            return Some(kobo_ui::Space::Small);
+        }
+        Some(kobo_ui::Space::Tight)
+    }
+
+    /// Whether a block is an illustration rather than a drawn piece of text.
+    ///
+    /// Asked when there is no picture to draw, which is exactly when
+    /// [`Self::picture_for`] cannot answer it.
+    fn illustration_at(&self, block: Locator) -> bool {
+        usize::try_from(block)
+            .ok()
+            .and_then(|at| self.document.blocks.get(at))
+            .is_some_and(|block| {
+                matches!(
+                    block,
+                    Block::Picture {
+                        illustration: true,
+                        ..
+                    }
+                )
+            })
+    }
+
     /// The picture to draw for a block, when one has been handed over, and
     /// whether it is an illustration rather than a drawn piece of the text.
     fn picture_for(&self, block: Locator) -> Option<(kobo_ui::TilePicture, bool)> {
@@ -2157,6 +2231,129 @@ impl Reader {
             .copied()
             .map(|drawn| (drawn, *illustration))
     }
+}
+
+#[cfg(test)]
+mod grouping_tests {
+    use super::{Memory, Reader};
+    use kobo_doc::{Block, Document};
+    use std::collections::BTreeMap;
+
+    fn panel() -> kobo_ui::DisplayMetrics {
+        kobo_ui::CLARA_BW_METRICS
+    }
+
+    /// A figure and its caption are set apart from the reading around them.
+    ///
+    /// Every node on a reading screen used to be separated by the one gap the
+    /// layout puts between any two of them, so a plate, the three lines of
+    /// caption under it and the paragraph after it ran together: the caption
+    /// stood as far from the figure it belongs to as from the body text it
+    /// does not, and a page carrying a figure read as one undifferentiated
+    /// column. The group gets air on both sides of it and keeps the tighter
+    /// gap inside.
+    #[test]
+    fn a_figure_and_its_caption_are_set_apart_from_the_prose_around_them() {
+        let document = Document {
+            blocks: vec![
+                Block::Paragraph("Before the figure.".into()),
+                Block::Picture {
+                    name: "plate.png".into(),
+                    alt: "A plot".into(),
+                    illustration: true,
+                },
+                Block::Caption("Figure 1: a plot.".into()),
+                Block::Paragraph("After the figure.".into()),
+            ],
+            ..Document::default()
+        };
+        let mut reader = Reader::open(document, Memory::default(), &panel());
+        reader.set_pictures(
+            [(
+                "plate.png".to_owned(),
+                kobo_ui::TilePicture::new(kobo_ui::PictureHandle(1), 400, 300),
+            )]
+            .into_iter()
+            .collect::<BTreeMap<_, _>>(),
+            &panel(),
+        );
+
+        let kinds: Vec<&'static str> = reader
+            .screen("A Paper")
+            .nodes
+            .iter()
+            .map(|node| match node {
+                kobo_sdk::Node::Spacer { .. } => "space",
+                kobo_sdk::Node::Picture { .. } => "picture",
+                kobo_sdk::Node::Secondary { .. } => "caption",
+                _ => "prose",
+            })
+            .collect();
+        assert_eq!(
+            kinds,
+            vec!["prose", "space", "picture", "caption", "space", "prose"],
+            "the figure group was not set apart from the prose"
+        );
+    }
+
+    /// A displayed formula is told apart from its paragraph without being
+    /// lifted out of it: it is a sentence of the paper, not an illustration.
+    #[test]
+    fn a_displayed_formula_is_told_apart_from_the_paragraph_it_interrupts() {
+        let document = Document {
+            blocks: vec![
+                Block::Paragraph("We write".into()),
+                Block::Picture {
+                    name: "formula:0".into(),
+                    alt: "V = U V^(j)".into(),
+                    illustration: false,
+                },
+                Block::Paragraph("for the union.".into()),
+            ],
+            ..Document::default()
+        };
+        let mut reader = Reader::open(document, Memory::default(), &panel());
+        reader.set_pictures(
+            [(
+                "formula:0".to_owned(),
+                kobo_ui::TilePicture::new(kobo_ui::PictureHandle(1), 300, 60),
+            )]
+            .into_iter()
+            .collect::<BTreeMap<_, _>>(),
+            &panel(),
+        );
+
+        let spaces: Vec<i32> = reader
+            .screen("A Paper")
+            .nodes
+            .iter()
+            .filter_map(|node| match node {
+                kobo_sdk::Node::Spacer { space, .. } => Some(panel().space(*space)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(spaces.len(), 2, "the formula was not set apart at all");
+        assert!(
+            spaces
+                .iter()
+                .all(|space| *space < panel().space(kobo_ui::Space::Small)),
+            "a formula was given the air an illustration gets: {spaces:?}"
+        );
+    }
+}
+
+/// What a piece of a page is, as far as the space around it is concerned.
+///
+/// Three kinds rather than the dozen [`Kind`] has, because this is only ever
+/// asked in order to find the seam between a figure and the reading around it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Set {
+    /// Prose, headings, quotes, rows: the body of the document.
+    Prose,
+    /// An illustration, or a caption belonging to one.
+    Plate,
+    /// A formula set on a line of its own.
+    Formula,
 }
 
 fn is_outline_font(bytes: &[u8]) -> bool {

--- a/docs/apps/arxiv/index.html
+++ b/docs/apps/arxiv/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/arxiv.png">
 <meta name="twitter:image:alt" content="The newest machine learning preprints listed in the arXiv app on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-LCyrxGtCyE3qkENSmXujmJ4WEuMfgPyiuSfaIm+Xovw='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-THCSCwRqnTgzlI2UY7KU0I9AsBgcBWaPwBgoM8Y+Lns='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.3.8",
+      "softwareVersion": "1.3.9",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>arXiv</h1>
       <p class="summary">Browse and search arXiv, keep preprints, and read their HTML versions on your Kobo.</p>
-      <div class="meta"><span>Version 1.3.8</span><span>network</span></div>
+      <div class="meta"><span>Version 1.3.9</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/arxiv.png" width="1072" height="1448" alt="The newest machine learning preprints listed in the arXiv app on a Kobo">

--- a/docs/apps/audiobook/index.html
+++ b/docs/apps/audiobook/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Turn a topic into an original narrated audiobook and listen on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/audiobook.png">
 <meta name="twitter:image:alt" content="An audiobook player with cover art and playback controls on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-nXtRVgxGuMssH16rayIOwfARXcA+ds9+bDTVWvTLijo='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-EVC5SnliEDIYtNEdiOhpKUAJ9fA7ZJoz6N9ndaPZJZo='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.8",
+      "softwareVersion": "1.0.9",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Audiobook Studio</h1>
       <p class="summary">Turn a topic into an original narrated audiobook and listen on your Kobo.</p>
-      <div class="meta"><span>Version 1.0.8</span><span>network, audio, bluetooth-audio, bluetooth-control</span></div>
+      <div class="meta"><span>Version 1.0.9</span><span>network, audio, bluetooth-audio, bluetooth-control</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/audiobook.png" width="1072" height="1448" alt="An audiobook player with cover art and playback controls on a Kobo">

--- a/docs/apps/fanshelf/index.html
+++ b/docs/apps/fanshelf/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Add an AO3 work and keep it ready for comfortable reading on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/fanshelf.png">
 <meta name="twitter:image:alt" content="Fanshelf's empty shelf, with Add, Followed tags, and Check updates controls.">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-YUPc+kPXTJ0vxB1V8d4x3pC93wQ0ytlCC21t0sicfHc='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-pTLo5tmq2BRyL45R2ueeLb0CfTk+VID4QDbTDEo4A1o='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "0.2.1",
+      "softwareVersion": "0.2.2",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Fanshelf</h1>
       <p class="summary">Add an AO3 work and keep it ready for comfortable reading on your Kobo.</p>
-      <div class="meta"><span>Version 0.2.1</span><span>network</span></div>
+      <div class="meta"><span>Version 0.2.2</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/fanshelf.png" width="1072" height="1448" alt="Fanshelf's empty shelf, with Add, Followed tags, and Check updates controls.">

--- a/docs/apps/gutenbird/index.html
+++ b/docs/apps/gutenbird/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Browse OPDS libraries and read their books on your Kobo. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/gutenbird.png">
 <meta name="twitter:image:alt" content="A shelf of books from an OPDS library on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-JJsj15YEQ3UKTYxWLmoSHjt2fMOwyAg5PUffXbNuCI8='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-gS69nNDQtTqDFn0dseu3ojbtKOI+CX5Z8GuHLLZ+RtA='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.8",
+      "softwareVersion": "1.0.9",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Gutenbird</h1>
       <p class="summary">Browse OPDS libraries and read their books on your Kobo.</p>
-      <div class="meta"><span>Version 1.0.8</span><span>network, frontlight-control</span></div>
+      <div class="meta"><span>Version 1.0.9</span><span>network, frontlight-control</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/gutenbird.png" width="1072" height="1448" alt="A shelf of books from an OPDS library on a Kobo">

--- a/docs/apps/needles/index.html
+++ b/docs/apps/needles/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="A knuckle-sized row counter, Ravelry library browser, and offline pattern reader. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/needles.png">
 <meta name="twitter:image:alt" content="Needles pattern screen with row and repeat counters and a large +1 row button.">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-j7hKY4/iwjdp7rWX+dWzS0uJ+rGiCpSLVtcsTBW8cKE='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-hXR0Opl/Yd7T4GTsXlwhNWF8gDK0vrpSQT1v5JSv/Sk='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "0.1.1",
+      "softwareVersion": "0.1.2",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Needles</h1>
       <p class="summary">A knuckle-sized row counter, Ravelry library browser, and offline pattern reader.</p>
-      <div class="meta"><span>Version 0.1.1</span><span>network, keep-awake</span></div>
+      <div class="meta"><span>Version 0.1.2</span><span>network, keep-awake</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/needles.png" width="1072" height="1448" alt="Needles pattern screen with row and repeat counters and a large +1 row button.">

--- a/docs/apps/panels/index.html
+++ b/docs/apps/panels/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Enjoy your comics on Kobo with clear page controls and support for Komga libraries. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/panels.png">
 <meta name="twitter:image:alt" content="Panels library with controls to open an added comic or browse Komga.">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-U1Sl943OO0XllG+ySd22EhNOItkgM6BF9JTCwowiPEs='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-WgqKa0YzO+mjc+J3NVDXlLntqZPLvpmk0b2dvwcceUQ='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "0.1.1",
+      "softwareVersion": "0.1.2",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Panels</h1>
       <p class="summary">Enjoy your comics on Kobo with clear page controls and support for Komga libraries.</p>
-      <div class="meta"><span>Version 0.1.1</span><span>network</span></div>
+      <div class="meta"><span>Version 0.1.2</span><span>network</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/panels.png" width="1072" height="1448" alt="Panels library with controls to open an added comic or browse Komga.">

--- a/docs/apps/zotero-reader/index.html
+++ b/docs/apps/zotero-reader/index.html
@@ -21,7 +21,7 @@
 <meta name="twitter:description" content="Browse Zotero collections, read metadata and indexed paper text, and keep papers available offline. Install it on a supported Kobo e-reader with Cobalt.">
 <meta name="twitter:image" content="https://bandarlabs.github.io/Cobalt/media/site/apps/zotero-reader.png">
 <meta name="twitter:image:alt" content="Reading a paper with structured layout and Zotero metadata on a Kobo">
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-sX+h0qmgksqXJ8AkporAHqgJt/OOQfhHxmjDiLYuo4A='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'sha256-tNKXGUIxVNRHQgNFrrV9f51b/fxY6Z/vxbl+iqsL0Fk='; style-src 'self'; img-src 'self'; connect-src https://cobalt-install-relay.anandabhishek.workers.dev; base-uri 'none'; form-action 'self'">
 <script type="application/ld+json">{
   "@context": "https://schema.org",
   "@graph": [
@@ -40,7 +40,7 @@
       "applicationSuite": "Cobalt",
       "applicationCategory": "SoftwareApplication",
       "operatingSystem": "Cobalt on supported Kobo e-readers",
-      "softwareVersion": "1.0.4",
+      "softwareVersion": "1.0.5",
       "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
@@ -97,7 +97,7 @@
       <p class="eyebrow">Kobo app</p>
       <h1>Zotero Reader</h1>
       <p class="summary">Browse Zotero collections, read metadata and indexed paper text, and keep papers available offline.</p>
-      <div class="meta"><span>Version 1.0.4</span><span>network, frontlight-control</span></div>
+      <div class="meta"><span>Version 1.0.5</span><span>network, frontlight-control</span></div>
     </div>
     <figure class="app-shot">
       <img src="../../media/site/apps/zotero-reader.png" width="1072" height="1448" alt="Reading a paper with structured layout and Zotero metadata on a Kobo">

--- a/examples/audiobook/cobalt-app.json
+++ b/examples/audiobook/cobalt-app.json
@@ -3,7 +3,7 @@
   "display_name": "Audiobook Studio",
   "short_label": "Audiobooks",
   "summary": "Turn a topic into an original narrated audiobook and listen on your Kobo.",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "glyph": "headphones",
   "capabilities": [
     "network",
@@ -11,5 +11,5 @@
     "bluetooth-audio",
     "bluetooth-control"
   ],
-  "release_notes": "Update shared controls and page layout for Cobalt 0.3.12."
+  "release_notes": "Set figures and their captions apart from the prose around them, and typeset a document's mathematics all the way through instead of stopping after the first few dozen formulae."
 }

--- a/examples/audiobook/cobalt-app.json
+++ b/examples/audiobook/cobalt-app.json
@@ -11,5 +11,5 @@
     "bluetooth-audio",
     "bluetooth-control"
   ],
-  "release_notes": "Set figures and their captions apart from the prose around them, and typeset a document's mathematics all the way through instead of stopping after the first few dozen formulae."
+  "release_notes": "Typeset numbered equations, set figures and their captions apart from the prose, and carry a document's mathematics all the way through instead of stopping after the first few dozen formulae."
 }

--- a/examples/audiobook/cobalt-app.json
+++ b/examples/audiobook/cobalt-app.json
@@ -11,5 +11,5 @@
     "bluetooth-audio",
     "bluetooth-control"
   ],
-  "release_notes": "Typeset numbered equations, set figures and their captions apart from the prose, and carry a document's mathematics all the way through instead of stopping after the first few dozen formulae."
+  "release_notes": "Line up a table's columns under the headings that name them, typeset numbered equations, set figures apart from the prose, and carry a document's mathematics all the way through instead of stopping early."
 }

--- a/examples/books/Cargo.toml
+++ b/examples/books/Cargo.toml
@@ -11,9 +11,9 @@ name = "kobo-books"
 path = "src/main.rs"
 
 [dependencies]
-kobo-bookview = { path = "../../crates/kobo-bookview" }
-kobo-doc = { path = "../../crates/kobo-doc", features = ["raster"] }
-kobo-read = { path = "../../crates/kobo-read", features = ["raster"] }
+kobo-bookview = { path = "../../crates/kobo-bookview", features = ["raster"] }
+kobo-doc = { path = "../../crates/kobo-doc" }
+kobo-read = { path = "../../crates/kobo-read" }
 kobo-sdk = { path = "../../crates/kobo-sdk" }
 
 [dev-dependencies]

--- a/examples/gutenbird/Cargo.toml
+++ b/examples/gutenbird/Cargo.toml
@@ -7,11 +7,11 @@ license.workspace = true
 publish = false
 
 [dependencies]
-kobo-bookview = { path = "../../crates/kobo-bookview" }
-kobo-doc = { path = "../../crates/kobo-doc", features = ["raster"] }
+kobo-bookview = { path = "../../crates/kobo-bookview", features = ["raster"] }
+kobo-doc = { path = "../../crates/kobo-doc" }
 kobo-image = { path = "../../crates/kobo-image" }
 kobo-opds = { path = "../../crates/kobo-opds" }
-kobo-read = { path = "../../crates/kobo-read", features = ["raster"] }
+kobo-read = { path = "../../crates/kobo-read" }
 kobo-sdk = { path = "../../crates/kobo-sdk" }
 
 [dev-dependencies]

--- a/examples/gutenbird/cobalt-app.json
+++ b/examples/gutenbird/cobalt-app.json
@@ -9,5 +9,5 @@
     "network",
     "frontlight-control"
   ],
-  "release_notes": "Set figures and their captions apart from the prose around them, and typeset a document's mathematics all the way through instead of stopping after the first few dozen formulae."
+  "release_notes": "Typeset numbered equations, set figures and their captions apart from the prose, and carry a document's mathematics all the way through instead of stopping after the first few dozen formulae."
 }

--- a/examples/gutenbird/cobalt-app.json
+++ b/examples/gutenbird/cobalt-app.json
@@ -3,11 +3,11 @@
   "display_name": "Gutenbird",
   "short_label": "Gutenbird",
   "summary": "Browse OPDS libraries and read their books on your Kobo.",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "glyph": "book",
   "capabilities": [
     "network",
     "frontlight-control"
   ],
-  "release_notes": "Update shared controls and page layout for Cobalt 0.3.12."
+  "release_notes": "Set figures and their captions apart from the prose around them, and typeset a document's mathematics all the way through instead of stopping after the first few dozen formulae."
 }

--- a/examples/gutenbird/cobalt-app.json
+++ b/examples/gutenbird/cobalt-app.json
@@ -9,5 +9,5 @@
     "network",
     "frontlight-control"
   ],
-  "release_notes": "Typeset numbered equations, set figures and their captions apart from the prose, and carry a document's mathematics all the way through instead of stopping after the first few dozen formulae."
+  "release_notes": "Line up a table's columns under the headings that name them, typeset numbered equations, set figures apart from the prose, and carry a document's mathematics all the way through instead of stopping early."
 }


### PR DESCRIPTION
The arXiv app typeset the first sixty-four formulae of a paper and wrote the rest out in a line, on a real reader often fewer. Nothing in the formula path had changed since it was written; the cause was where the drawing happened. `kobo_doc::html::parse` typeset each formula as it met it, inside the one callback that opens a document, where the runtime allows 250 ms in total and a formula costs 4.7 ms on a Clara BW. The 500 ms budget beside it was already twice what a callback may spend, and the count was that deadline wearing a count's clothes.

Measured over a 163-page paper carrying 231 formulae, all of them together are 764 KB against the 8 MB picture cache, and 2.2 seconds of typesetting. Memory was never the constraint. Parsing now records the LaTeX and draws none of it, and BookView typesets in the picture pipeline that already exists for figures: a bounded batch per pass, the page being read first, one measuring pass per batch. That paper now typesets all 178 formulae its text refers to, across nineteen pages instead of six, and opening it draws nothing at all.

Photographs off a Clara BW found the rest. LaTeXML writes a numbered equation as a table and marks its pieces `display="inline"`, so an equation was read as a row of cells; five on arXiv:2609.09143 were never drawn. `\mathcal{L}` is a Letterlike Symbol rather than a Mathematical Alphanumeric one, and only the latter block was folded onto plain letters, so a paper naming its loss `\mathcal{L}` drew a box on every second line. `\hat{x}` shares its markup with `x^{2}` and came out as `x^^`.

A results table heads itself twice and nothing read `colspan` or `rowspan`, so a seven-column table came out as a four-cell row over a six-cell row over seven-cell rows. Too narrow to draw as columns, the reader sets each value on its own line with the heading it sat under, and rows that did not line up put every value against its neighbour's name: `rFID: GigaTok-DINO`, then `Text: 0.51` for the number that is the rFID. Both spans are read now, and the two heading rows are joined into the one row of column names they amount to, so that table draws as the seven-column table it is.

Three smaller defects fall out of the same area. Figures and formulae shared one allowance of sixty-four filled in document order, so a paper with more mathematics than that silently lost its last formulae to its first figure. `missing_pictures` offered formula names to the fetcher, which resolved them against the paper's own address. And the space an equation needs on its right was going in front of every mark of punctuation that followed one, seventy times in a single paper. Figures, their captions and displayed equations are now given margins rather than the gap the layout puts between any two nodes.

Every change is in the reader; no application source is touched. Builds without the rasteriser gain the equation blocks, the lined-up tables, the folded letters and the accents too. Tests, clippy and fmt pass over the changed crates, with new cover for the callback deadline, the ceilings, the fetch guard, the equation gathering, the spans and the spacing. Store apps built from the changed crates are released with it: arxiv 1.3.9, zotero-reader 1.0.5, gutenbird 1.0.9, audiobook 1.0.9, fanshelf 0.2.2, needles 0.1.2, panels 0.1.2.

Known and left alone: a column narrower than a single word still breaks that word across lines, so `Tokenizer` over a narrow first column reads `Tokenize` / `r`. Fixing it means changing how column widths are shared out, which both pagination and layout depend on agreeing about.
