### PR TITLE
Open Books on a shelf that has bought books on it

### DIFF
--- a/crates/kobo-policy/src/library.rs
+++ b/crates/kobo-policy/src/library.rs
@@ -608,6 +608,44 @@ mod tests {
         assert_eq!(Kind::Kepub.badge(), "KEPUB");
     }
 
+    /// The wire is the seam this crate answers across, and a listing is
+    /// encoded as one value. An entry the encoder refuses is not a missing
+    /// tile: it fails the whole reply, and the host ends the session rather
+    /// than deliver a half-written one. So every kind this module can produce
+    /// is checked against the encoder, not just the one the shelf shows most.
+    #[test]
+    fn every_kind_a_listing_can_produce_survives_the_wire() {
+        let root = scratch("wire");
+        for name in [
+            "Bleak House.epub",
+            "Piranesi.kepub.epub",
+            "notes.md",
+            "page.html",
+            "plain.txt",
+            "scan.pdf",
+        ] {
+            fs::write(root.join(name), b"body").expect("the file");
+        }
+        let entries: Vec<_> = list_in(&[root])
+            .entries
+            .into_iter()
+            .map(super::to_wire)
+            .collect();
+        assert_eq!(entries.len(), 6, "the walk did not find every kind");
+        let frame = kobo_protocol::Frame {
+            version: kobo_protocol::VERSION,
+            request_id: 1,
+            message: kobo_protocol::Message::DeviceResult(kobo_protocol::DeviceResult::Library {
+                entries,
+                truncated: false,
+            }),
+        };
+        assert!(
+            kobo_protocol::encode(&frame).is_ok(),
+            "a kind this module lists cannot be sent, which ends the session showing the shelf"
+        );
+    }
+
     #[test]
     fn a_listing_names_documents_and_ignores_everything_else() {
         let root = scratch("kinds");

--- a/crates/kobo-protocol/src/lib.rs
+++ b/crates/kobo-protocol/src/lib.rs
@@ -1554,7 +1554,7 @@ pub const MAX_LIBRARY_DOCUMENT_BYTES: usize = 4 * 1024 * 1024;
 pub struct LibraryEntry {
     pub id: String,
     pub title: String,
-    /// 1 EPUB, 2 Markdown, 3 HTML, 4 text, 5 PDF.
+    /// 1 EPUB, 2 Markdown, 3 HTML, 4 text, 5 PDF, 6 Kepub.
     pub kind: u8,
     pub bytes: u32,
     /// False for a Kobo Store title that is in the stock library but whose
@@ -1563,9 +1563,14 @@ pub struct LibraryEntry {
 }
 
 impl LibraryEntry {
+    /// Whether the built-in reader can page this.
+    ///
+    /// PDF nothing here parses, and a Kepub is EPUB with the stock reader's
+    /// own spans threaded through the markup: opening one as plain EPUB shows
+    /// the spans rather than the book.
     #[must_use]
     pub const fn is_readable(&self) -> bool {
-        self.on_card && self.kind != 5
+        self.on_card && self.kind != 5 && self.kind != 6
     }
 }
 
@@ -3642,11 +3647,19 @@ fn valid_library_id(id: &str) -> bool {
         && !id.split('/').any(|part| part == "..")
 }
 
+/// The kinds a shelf entry may name: EPUB, Markdown, HTML, text, PDF, Kepub.
+///
+/// Kept beside both halves of the entry codec because the two ends disagreeing
+/// about it is not a dropped tile. The listing is encoded as one value, so an
+/// entry the encoder refuses fails the whole reply, and a reply that cannot be
+/// written ends the session that was hosting the shelf.
+const LIBRARY_KINDS: std::ops::RangeInclusive<u8> = 1..=6;
+
 fn encode_library_entry(output: &mut Vec<u8>, entry: &LibraryEntry) -> Result<(), ProtocolError> {
     if !valid_library_id(&entry.id)
         || entry.title.is_empty()
         || entry.title.len() > MAX_LIBRARY_TITLE_LEN
-        || !(1..=5).contains(&entry.kind)
+        || !LIBRARY_KINDS.contains(&entry.kind)
     {
         return Err(ProtocolError::InvalidValue("library entry"));
     }
@@ -3667,7 +3680,7 @@ fn decode_library_entry(reader: &mut Reader<'_>) -> Result<LibraryEntry, Protoco
     if !valid_library_id(&id)
         || title.is_empty()
         || title.len() > MAX_LIBRARY_TITLE_LEN
-        || !(1..=5).contains(&kind)
+        || !LIBRARY_KINDS.contains(&kind)
     {
         return Err(ProtocolError::InvalidValue("library entry"));
     }
@@ -7525,6 +7538,45 @@ mod tests {
             let bytes = encode(&frame).expect("encode");
             assert_eq!(decode(&bytes).expect("decode"), frame);
         }
+    }
+
+    /// A Kepub is the kind most Kobo owners have most of, and the encoder
+    /// used to refuse it. A refused entry is not a missing tile: encoding is
+    /// the whole listing, so one purchased book took the shelf, the launcher
+    /// and the session down with it.
+    #[test]
+    fn a_kepub_listing_survives_the_wire() {
+        let frame = Frame {
+            version: VERSION,
+            request_id: 11,
+            message: Message::DeviceResult(DeviceResult::Library {
+                entries: vec![LibraryEntry {
+                    id: "n//mnt/onboard/Piranesi.kepub.epub".to_owned(),
+                    title: "Piranesi".to_owned(),
+                    kind: 6,
+                    bytes: 900_000,
+                    on_card: true,
+                }],
+                truncated: false,
+            }),
+        };
+        let bytes = encode(&frame).expect("a Kepub entry the wire refuses takes the session down");
+        assert_eq!(decode(&bytes).expect("decode"), frame);
+    }
+
+    #[test]
+    fn a_kepub_is_listed_and_not_offered_as_readable() {
+        let kepub = LibraryEntry {
+            id: "n//mnt/onboard/Piranesi.kepub.epub".to_owned(),
+            title: "Piranesi".to_owned(),
+            kind: 6,
+            bytes: 900_000,
+            on_card: true,
+        };
+        assert!(
+            !kepub.is_readable(),
+            "a Kepub on the card was offered to a reader that shows its markup"
+        );
     }
 
     #[test]

--- a/examples/launcher/src/main.rs
+++ b/examples/launcher/src/main.rs
@@ -316,23 +316,42 @@ impl KoboApp for Launcher {
         self.show(context);
     }
 
-    /// Returns to the list whenever the panel comes back to the launcher.
+    /// Puts the list back the moment the panel is handed over.
     ///
     /// Leaving an entry paints "Starting…" so the wait is explained, and the
     /// runtime repaints a returning application from the last screen it drew
     /// rather than waiting for a new one, which is what makes coming back
     /// instant. Together those two correct decisions meant that tapping back
     /// out of an application landed on a "Starting…" screen for an application
-    /// that had already started and already finished, with no way forward. The
-    /// transient has to be cleared by the only party that knows it was a
-    /// transient.
+    /// that had already started and already finished.
+    ///
+    /// Clearing it on the way back in is a round trip too late: the runtime has
+    /// already repainted what it held, and on this panel that is a full refresh
+    /// of a splash for something that started a minute ago. So the launcher
+    /// clears the transient on the way out instead, while it still owns what
+    /// the runtime will hold.
+    ///
+    /// Only losing the panel means the launch succeeded. A missing binary or an
+    /// application that exits before it draws never takes the panel, the
+    /// launcher is never told to go behind, and the splash stays up with the
+    /// way back on it, which is exactly what that screen is for.
+    fn on_background(&mut self, context: &mut Context) {
+        let View::Starting(index) = self.view else {
+            return;
+        };
+        // The entry took the panel, which on this platform means it is now
+        // running behind the launcher rather than gone. Remember which, so its
+        // tile can say so.
+        self.working = Some(index);
+        self.view = View::Home;
+        self.show(context);
+    }
+
+    /// Refreshes the list whenever the panel comes back to the launcher.
+    ///
+    /// The catalogue can have changed while the panel was elsewhere: the Store
+    /// is one of the applications the owner can leave for, and it installs.
     fn on_foreground(&mut self, context: &mut Context) {
-        if let View::Starting(index) = self.view {
-            // Control came back while an entry was starting, which on this
-            // platform means it is now running behind the launcher rather than
-            // gone. Remember which, so its tile can say so.
-            self.working = Some(index);
-        }
         if !matches!(self.view, View::Home) {
             self.view = View::Home;
         }
@@ -718,8 +737,9 @@ mod tests {
         let mut runner = AppRunner::new(Launcher::default());
         runner.start();
         runner.action(action_id(&opening(ENTRIES[0].name)));
-        runner.lifecycle(Lifecycle::Background);
-        let screen = painted(runner.lifecycle(Lifecycle::Foreground));
+        // The list the runtime holds while the panel is elsewhere, which is
+        // the one it repaints when the owner comes back.
+        let screen = painted(runner.lifecycle(Lifecycle::Background));
         let layout = screen.layout_with(&CLARA_BW_METRICS, &Chrome::with_back(false));
         let text = layout
             .nodes
@@ -912,9 +932,12 @@ mod tests {
 
     /// Tapping back out of an application used to land on "Starting Terminal",
     /// for a terminal that had already started and already been left, with no
-    /// control on the screen that went anywhere. The runtime repaints a
-    /// returning application from the last screen it drew (that is what makes
-    /// coming back instant) so the transient has to be cleared here.
+    /// control on the screen that went anywhere.
+    ///
+    /// The list is now left behind on the way out, so coming back has nothing
+    /// to redraw and asks no refresh of the panel. What it does do is ask the
+    /// runtime what is installed, because the Store is one of the places the
+    /// owner can have been.
     #[test]
     fn coming_back_from_an_application_shows_the_list_again() {
         let mut runner = AppRunner::new(Launcher::default());
@@ -922,7 +945,7 @@ mod tests {
         runner.action(action_id(&opening(ENTRIES[0].name)));
         assert!(matches!(runner.app().view, View::Starting(0)));
 
-        runner.lifecycle(Lifecycle::Background);
+        let left_behind = painted(runner.lifecycle(Lifecycle::Background));
         let commands = runner.lifecycle(Lifecycle::Foreground);
 
         assert!(
@@ -932,19 +955,45 @@ mod tests {
         assert!(commands
             .iter()
             .any(|command| matches!(command, Command::Device(DeviceRequest::ListInstalledApps))));
-        let painted = commands
-            .iter()
-            .find_map(|command| match command {
-                Command::SetScreen(screen) => Some(screen),
-                _ => None,
-            })
-            .expect("coming back has to repaint, or the stale screen stays on the panel");
         assert!(
-            painted
+            left_behind
                 .nodes
                 .iter()
                 .any(|node| matches!(node, Node::TileGrid { .. })),
             "the list came back without any entries on it"
+        );
+    }
+
+    /// Clearing the transient when the panel comes back is a round trip too
+    /// late. The runtime repaints a returning application from the screen it
+    /// holds, and what it held for the launcher was "Starting…", so backing
+    /// out of an application spent a full E Ink refresh on a splash for
+    /// something that had already started before the list replaced it. The
+    /// screen the runtime holds has to be the list before the launcher is ever
+    /// asked for it.
+    #[test]
+    fn leaving_for_an_application_leaves_the_list_behind_not_the_splash() {
+        let mut runner = AppRunner::new(Launcher::default());
+        let list = painted(runner.start()).id;
+        runner.action(action_id(&opening(ENTRIES[0].name)));
+
+        let commands = runner.lifecycle(Lifecycle::Background);
+
+        let held = commands
+            .iter()
+            .rev()
+            .find_map(|command| match command {
+                Command::SetScreen(screen) => Some(screen),
+                _ => None,
+            })
+            .expect("the launcher left the splash as the screen the runtime holds");
+        assert_eq!(
+            held.id, list,
+            "coming back repaints this, and it is not the list"
+        );
+        assert!(
+            matches!(runner.app().view, View::Home),
+            "the launcher stayed on the screen it painted while leaving"
         );
     }
 
@@ -956,15 +1005,7 @@ mod tests {
         let mut runner = AppRunner::new(Launcher::default());
         runner.start();
         runner.action(action_id(&opening(ENTRIES[0].name)));
-        runner.lifecycle(Lifecycle::Background);
-        let commands = runner.lifecycle(Lifecycle::Foreground);
-        let home = commands
-            .into_iter()
-            .find_map(|command| match command {
-                Command::SetScreen(screen) => Some(screen),
-                _ => None,
-            })
-            .expect("coming back repaints the list");
+        let home = painted(runner.lifecycle(Lifecycle::Background));
         let home_layout = home.layout_with(&CLARA_BW_METRICS, &Chrome::with_back(false));
         let home_text = home_layout
             .nodes


### PR DESCRIPTION
Two bugs, both of which show up on a device with books on it and on none of the empty ones the tests ran against.

## Tapping Books ended the session

Not the Books application: the session. The launcher and everything else running went with it and the owner was returned to the Kobo reader.

1. Books asks the runtime for the library.
2. `kobo-policy` walks the card, merges `KoboReader.sqlite`, and gives a Kepub its own kind on the wire (`crates/kobo-policy/src/library.rs:233`).
3. The protocol encoder never learned that kind and refused anything outside EPUB, Markdown, HTML, text and PDF (`crates/kobo-protocol/src/lib.rs:3649`).
4. A listing is encoded as one value, so the refusal failed the whole reply. `write_to` propagated it out of `reply()` and out of `host_applications`, which ends the session hosting every app.

Kepub is what most Kobo owners have most of, so the shelf was unreachable on very nearly every real device. It came in with 8837dc2, which added the kind on the policy side and left the wire behind.

The accepted kinds are now one named range that both halves of the entry codec read. A test walks every kind the lister can produce through the real encoder, so a kind added on one side and not the other fails at the seam rather than on a reader. The same change stops `LibraryEntry::is_readable` offering to page a Kepub, which would have rendered the stock reader's own spans instead of the book.

## Coming back from an application arrived at "Starting…"

Leaving an entry paints a splash so the wait is explained, and the runtime repaints a returning application from the last screen it drew rather than waiting for a new one, which is what makes coming back instant. Together those two correct decisions meant backing out of an application spent a full E Ink refresh on a splash for something that had started a minute earlier.

Clearing it in `on_foreground` was a round trip too late: the runtime had already painted what it held. The launcher now clears the transient in `on_background`, while it still owns what the runtime will hold. Coming back then has nothing to redraw and costs no refresh at all.

Only losing the panel means the launch succeeded, so the splash still stays up with its way back when a binary is missing or an application exits before it draws, which is what that screen is for.

Residency is unchanged. Applications still stay resident when you leave them, and `MAX_HOSTED` still governs when one is evicted.

## Checks

- `kobo-protocol` 96, `kobo-policy` 131, `kobo-launcher` 17, `kobo-books` 130, `kobo-sdk` 152, `kobod` 123 — all pass.
- Clippy and rustfmt clean on the three changed crates.
- Both new tests were confirmed to fail before the fix: the encoder one with `InvalidValue("library entry")`, the launcher one on the splash being the screen left behind.

Not yet run on hardware. Worth a check against a real library before this rides out in a release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/BandarLabs/codesmith/Cobalt/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791664534&installation_model_id=20525&pr_number=179&repository=BandarLabs%2FCobalt&return_to=https%3A%2F%2Fgithub.com%2FBandarLabs%2FCobalt%2Fpull%2F179&signature=e0386aea7dcef1f8667f4b8776663d05ef1e5d0766bd0d4f2dc7f8876b3f514c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->